### PR TITLE
Update riscv.ac to set CPPFLAGS with fesvr include path

### DIFF
--- a/riscv/riscv.ac
+++ b/riscv/riscv.ac
@@ -3,7 +3,7 @@ AC_ARG_WITH([fesvr],
     [path to your fesvr installation if not in a standard location])],
   [
     LDFLAGS="-L$withval/lib $LDFLAGS"
-    CFLAGS="-I$withval/include $CFLAGS"
+    CPPFLAGS="-I$withval/include $CPPFLAGS"
   ]
 )
 


### PR DESCRIPTION
We need to set CPPFLAGS in riscv.ac in addition to configure, since configure is a generated file. This is a followup to commit 4d1c63ea2620dfbf125bef422501d641220b7b11 by @ucbjrl.

This fixes the build on Ubuntu and Mac for me.
