### PR TITLE
dummy-rocc-test build fix

### DIFF
--- a/riscv/dummy-rocc-test.c
+++ b/riscv/dummy-rocc-test.c
@@ -1,11 +1,11 @@
 // The following is a RISC-V program to test the functionality of the
 // dummy RoCC accelerator.
-// Compile with riscv-gcc dummy.c
+// Compile with riscv-gcc dummy-rocc-test.c
 // Run with spike --extension=dummy pk a.out
 
 #include <assert.h>
 #include <stdio.h>
-#include <cstdint>
+#include <stdint.h>
 
 int main() {
   uint64_t x = 123, y = 456, z = 0;


### PR DESCRIPTION
I needed this change to build the dummy-rocc-test on Ubuntu 14.04. I also updated the gcc invocation comment.
