### PR TITLE
fix cache line index offset in cachesim.cc

### DIFF
--- a/riscv/cachesim.cc
+++ b/riscv/cachesim.cc
@@ -45,7 +45,7 @@ void cache_sim_t::init()
     help();
 
   idx_shift = 0;
-  for (size_t x = linesz; x; x >>= 1)
+  for (size_t x = linesz; x>1; x >>= 1)
     idx_shift++;
 
   tags = new uint64_t[sets*ways]();


### PR DESCRIPTION
When define the cache block size using S:W:B, the conversion from B to index offset (idx_shift in cache_sim_t) seems wrong. For example, when B=64, the calculated idx_shift is 7, but it should be 6. This causes an under-estimated miss rate in caches.
