### PR TITLE
various fixes to make riscv-isa-sim installable

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -55,14 +55,14 @@ enable_stow  := @enable_stow@
 
 ifeq ($(enable_stow),yes)
   stow_pkg_dir := $(prefix)/pkgs
-  DESTDIR ?= $(stow_pkg_dir)/$(project_name)-$(project_ver)
+  INSTALLDIR ?= $(DESTDIR)/$(stow_pkg_dir)/$(project_name)-$(project_ver)
 else
-  DESTDIR ?= $(prefix)
+  INSTALLDIR ?= $(DESTDIR)/$(prefix)
 endif
 
-install_hdrs_dir := $(DESTDIR)/include/$(project_name)
-install_libs_dir := $(DESTDIR)/lib
-install_exes_dir := $(DESTDIR)/bin
+install_hdrs_dir := $(INSTALLDIR)/include/$(project_name)
+install_libs_dir := $(INSTALLDIR)/lib
+install_exes_dir := $(INSTALLDIR)/bin
 
 #-------------------------------------------------------------------------
 # List of subprojects

--- a/Makefile.in
+++ b/Makefile.in
@@ -307,6 +307,7 @@ test_outs += $$($(2)_test_outs)
 install_hdrs += $$(addprefix $(src_dir)/$(1)/, $$($(2)_hdrs)) $$($(2)_gen_hdrs)
 install_libs += lib$(1).so
 install_exes += $$($(2)_install_prog_exes)
+install_pcs  += riscv-$(1).pc
 
 endef
 
@@ -358,7 +359,14 @@ install-exes : $(install_exes)
     $(INSTALL_EXE) $$file $(install_exes_dir); \
   done
 
-install : install-hdrs install-libs install-exes
+install-pc : $(install_pcs)
+	$(MKINSTALLDIRS) $(install_libs_dir)/pkgconfig/
+	for file in $^; \
+  do \
+    $(INSTALL_HDR) $$file $(install_libs_dir)/pkgconfig/; \
+  done
+
+install : install-hdrs install-libs install-exes install-pc
 ifeq ($(enable_stow),yes)
 	$(MKINSTALLDIRS) $(stow_pkg_dir)
 	cd $(stow_pkg_dir) && \

--- a/configure
+++ b/configure
@@ -4378,6 +4378,18 @@ ac_config_headers="$ac_config_headers config.h"
 
 ac_config_files="$ac_config_files Makefile"
 
+ac_config_files="$ac_config_files riscv-spike.pc"
+
+ac_config_files="$ac_config_files riscv-riscv.pc"
+
+ac_config_files="$ac_config_files riscv-hwacha.pc"
+
+ac_config_files="$ac_config_files riscv-softfloat.pc"
+
+ac_config_files="$ac_config_files riscv-dummy_rocc.pc"
+
+ac_config_files="$ac_config_files riscv-spike_main.pc"
+
 cat >confcache <<\_ACEOF
 # This file is a shell script that caches the results of configure
 # tests run on this system so they can be shared between configure
@@ -5075,6 +5087,12 @@ do
     "spike_main.mk") CONFIG_FILES="$CONFIG_FILES spike_main.mk:spike_main/spike_main.mk.in" ;;
     "config.h") CONFIG_HEADERS="$CONFIG_HEADERS config.h" ;;
     "Makefile") CONFIG_FILES="$CONFIG_FILES Makefile" ;;
+    "riscv-spike.pc") CONFIG_FILES="$CONFIG_FILES riscv-spike.pc" ;;
+    "riscv-riscv.pc") CONFIG_FILES="$CONFIG_FILES riscv-riscv.pc" ;;
+    "riscv-hwacha.pc") CONFIG_FILES="$CONFIG_FILES riscv-hwacha.pc" ;;
+    "riscv-softfloat.pc") CONFIG_FILES="$CONFIG_FILES riscv-softfloat.pc" ;;
+    "riscv-dummy_rocc.pc") CONFIG_FILES="$CONFIG_FILES riscv-dummy_rocc.pc" ;;
+    "riscv-spike_main.pc") CONFIG_FILES="$CONFIG_FILES riscv-spike_main.pc" ;;
 
   *) as_fn_error $? "invalid argument: \`$ac_config_target'" "$LINENO" 5;;
   esac

--- a/configure.ac
+++ b/configure.ac
@@ -100,4 +100,10 @@ MCPPBS_SUBPROJECTS([ riscv, hwacha, dummy_rocc, softfloat, spike_main ])
 
 AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_FILES([Makefile])
+AC_CONFIG_FILES([riscv-spike.pc])
+AC_CONFIG_FILES([riscv-riscv.pc])
+AC_CONFIG_FILES([riscv-hwacha.pc])
+AC_CONFIG_FILES([riscv-softfloat.pc])
+AC_CONFIG_FILES([riscv-dummy_rocc.pc])
+AC_CONFIG_FILES([riscv-spike_main.pc])
 AC_OUTPUT

--- a/riscv-dummy_rocc.pc.in
+++ b/riscv-dummy_rocc.pc.in
@@ -1,0 +1,11 @@
+prefix=@prefix@
+exec_prefix=@prefix@
+libdir=${prefix}/@libdir@
+includedir=${prefix}/@includedir@
+
+Name: riscv-dummy_rocc
+Description: Example RISC-V ROCC accelerator
+Version: git
+Libs: -Wl,-rpath,${libdir} -L${libdir} -ldummy_rocc
+Cflags: -I${includedir}
+URL: http://riscv.org/download.html#tab_spike

--- a/riscv-hwacha.pc.in
+++ b/riscv-hwacha.pc.in
@@ -1,0 +1,11 @@
+prefix=@prefix@
+exec_prefix=@prefix@
+libdir=${prefix}/@libdir@
+includedir=${prefix}/@includedir@
+
+Name: riscv-hwacha
+Description: RISC-V Hwacha binary library
+Version: git
+Libs: -Wl,-rpath,${libdir} -L${libdir} -lhwacha
+Cflags: -I${includedir}
+URL: http://riscv.org/download.html#tab_spike

--- a/riscv-riscv.pc.in
+++ b/riscv-riscv.pc.in
@@ -1,0 +1,11 @@
+prefix=@prefix@
+exec_prefix=@prefix@
+libdir=${prefix}/@libdir@
+includedir=${prefix}/@includedir@
+
+Name: riscv-riscv
+Description: RISC-V 
+Version: git
+Libs: -Wl,-rpath,${libdir} -L${libdir} -lriscv
+Cflags: -I${includedir}
+URL: http://riscv.org/download.html#tab_spike

--- a/riscv-softfloat.pc.in
+++ b/riscv-softfloat.pc.in
@@ -1,0 +1,11 @@
+prefix=@prefix@
+exec_prefix=@prefix@
+libdir=${prefix}/@libdir@
+includedir=${prefix}/@includedir@
+
+Name: riscv-softfloat
+Description: RISC-V softfloat library
+Version: git
+Libs: -Wl,-rpath,${libdir} -L${libdir} -lsoftfloat
+Cflags: -I${includedir}
+URL: http://riscv.org/download.html#tab_spike

--- a/riscv-spike.pc.in
+++ b/riscv-spike.pc.in
@@ -1,0 +1,10 @@
+prefix=@prefix@
+exec_prefix=@prefix@
+libdir=${prefix}/@libdir@
+includedir=${prefix}/@includedir@
+
+Name: riscv-spike
+Description: RISC-V spike meta library
+Version: git
+Depends: riscv-spike_main riscv-riscv riscv-hwacha riscv-softfloat
+URL: http://riscv.org/download.html#tab_spike

--- a/riscv-spike_main.pc.in
+++ b/riscv-spike_main.pc.in
@@ -1,0 +1,12 @@
+prefix=@prefix@
+exec_prefix=@prefix@
+libdir=${prefix}/@libdir@
+includedir=${prefix}/@includedir@
+
+Name: riscv-spike_main
+Description: RISC-V ISA simulator library
+Version: git
+Depends: riscv-riscv riscv-hwacha riscv-softfloat
+Libs: -Wl,-rpath,${libdir} -L${libdir} -lspike_main
+Cflags: -I${includedir}
+URL: http://riscv.org/download.html#tab_spike

--- a/riscv/riscv.mk.in
+++ b/riscv/riscv.mk.in
@@ -10,6 +10,7 @@ riscv_hdrs = \
 	htif.h \
 	common.h \
 	decode.h \
+	disasm.h \
 	mmu.h \
 	processor.h \
 	sim.h \


### PR DESCRIPTION
I want to build my extension library without touching the riscv-isa-sim source repo.  Without these changes it's kind of a pain to do so.
