### PR TITLE
fix clang compile error

### DIFF
--- a/riscv/mmu.h
+++ b/riscv/mmu.h
@@ -9,6 +9,7 @@
 #include "config.h"
 #include "processor.h"
 #include "memtracer.h"
+#include <stdlib.h>
 #include <vector>
 
 // virtual memory configuration


### PR DESCRIPTION
mmu.cc uses abort() but none of the included headers contain it. This mimics the include pattern of other headers in the project.
