### PR TITLE
Enable execution log generation in non-interactive mode.

### DIFF
--- a/riscv/sim.cc
+++ b/riscv/sim.cc
@@ -71,6 +71,8 @@ reg_t sim_t::get_scr(int which)
 
 int sim_t::run()
 {
+  if (!debug && log)
+    set_procs_debug(true);
   while (htif->tick())
   {
     if (debug || ctrlc_pressed)
@@ -121,6 +123,11 @@ void sim_t::stop()
 void sim_t::set_debug(bool value)
 {
   debug = value;
+}
+
+void sim_t::set_log(bool value)
+{
+  log = value;
 }
 
 void sim_t::set_histogram(bool value)

--- a/riscv/sim.h
+++ b/riscv/sim.h
@@ -24,6 +24,7 @@ public:
   bool running();
   void stop();
   void set_debug(bool value);
+  void set_log(bool value);
   void set_histogram(bool value);
   void set_procs_debug(bool value);
   htif_isasim_t* get_htif() { return htif.get(); }
@@ -53,6 +54,7 @@ private:
   size_t current_step;
   size_t current_proc;
   bool debug;
+  bool log;
   bool histogram_enabled; // provide a histogram of PCs
 
   // presents a prompt for introspection into the simulation

--- a/spike_main/spike.cc
+++ b/spike_main/spike.cc
@@ -21,6 +21,7 @@ static void help()
   fprintf(stderr, "  -m <n>             Provide <n> MiB of target memory [default 4096]\n");
   fprintf(stderr, "  -d                 Interactive debug mode\n");
   fprintf(stderr, "  -g                 Track histogram of PCs\n");
+  fprintf(stderr, "  -l                 Generate a log of execution\n");
   fprintf(stderr, "  -h                 Print this help message\n");
   fprintf(stderr, "  --isa=<name>       RISC-V ISA string [default RV64IMAFDC]\n");
   fprintf(stderr, "  --ic=<S>:<W>:<B>   Instantiate a cache model with S sets,\n");
@@ -35,6 +36,7 @@ int main(int argc, char** argv)
 {
   bool debug = false;
   bool histogram = false;
+  bool log = false;
   size_t nprocs = 1;
   size_t mem_mb = 0;
   std::unique_ptr<icache_sim_t> ic;
@@ -48,6 +50,7 @@ int main(int argc, char** argv)
   parser.option('h', 0, 0, [&](const char* s){help();});
   parser.option('d', 0, 0, [&](const char* s){debug = true;});
   parser.option('g', 0, 0, [&](const char* s){histogram = true;});
+  parser.option('l', 0, 0, [&](const char* s){log = true;});
   parser.option('p', 0, 1, [&](const char* s){nprocs = atoi(s);});
   parser.option('m', 0, 1, [&](const char* s){mem_mb = atoi(s);});
   parser.option(0, "ic", 1, [&](const char* s){ic.reset(new icache_sim_t(s));});
@@ -79,6 +82,7 @@ int main(int argc, char** argv)
   }
 
   s.set_debug(debug);
+  s.set_log(log);
   s.set_histogram(histogram);
   return s.run();
 }


### PR DESCRIPTION
There didn't seem to be an obvious way to do this using the existing options, so I added one.

Add an option (-l) to display a log of execution in non-interactive mode.   Interactive (-d) mode overrides this option when both are specified.
