### PR TITLE
Eliminate non-portable sed usage

### DIFF
--- a/riscv/riscv.mk.in
+++ b/riscv/riscv.mk.in
@@ -251,7 +251,9 @@ icache.h: mmu.h
 	mv $@.tmp $@
 
 insn_list.h: $(src_dir)/riscv/riscv.mk.in
-	echo $(riscv_insn_list) | sed 's/\s\+\|$$/\n/g' | sed '/^$$/d' | sed 's/\./_/g' | sed 's/\(.*\)/DEFINE_INSN(\1)/' > $@.tmp
+	for insn in $(foreach insn,$(riscv_insn_list),$(subst .,_,$(insn))) ; do \
+		printf 'DEFINE_INSN(%s)\n' "$${insn}" ; \
+	done > $@.tmp
 	mv $@.tmp $@
 
 $(riscv_gen_srcs): %.cc: insns/%.h insn_template.cc


### PR DESCRIPTION
This fixes issue #30.  This has been tested on FreeBSD, which exhibits the same issue as OS X.

The problematic `sed(1)` command is

```
sed 's/\s\+\|$$/\n/g'
```

For future reference,
- Use the POSIX character class `[[:space:]]` instead of Perl-style `\s`.
- The `+` quantifier is part of ERE.  sed is guaranteed to support only BRE by default; replace this with `\{1,\}`.
- The `\n` escape sequence is not guaranteed to be respected in the replacement pattern.  Quoting POSIX on the `s` command: "The meaning of a '\' immediately followed by any character other than '&', '\', a digit, or the delimiter character used for this command, is unspecified."

Better yet, avoid shell commands and prefer GNU make's text functions where possible.
