### PR TITLE
enable extlibs to register devices

### DIFF
--- a/riscv/devices.cc
+++ b/riscv/devices.cc
@@ -38,3 +38,14 @@ bool rom_device_t::store(reg_t addr, size_t len, const uint8_t* bytes)
 {
   return false;
 }
+
+std::map<reg_t, std::function<abstract_device_t*()>>& devices()
+{
+  static std::map<reg_t, std::function<abstract_device_t*()>> v;
+  return v;
+}
+
+void register_device(reg_t addr, std::function<abstract_device_t*()> f)
+{
+  devices()[addr] = f;
+}

--- a/riscv/devices.h
+++ b/riscv/devices.h
@@ -4,6 +4,7 @@
 #include "decode.h"
 #include <map>
 #include <vector>
+#include <functional>
 
 class abstract_device_t {
  public:
@@ -30,5 +31,14 @@ class rom_device_t : public abstract_device_t {
  private:
   std::vector<char> data;
 };
+
+std::map<reg_t, std::function<abstract_device_t*()>>& devices();
+void register_device(reg_t addr, std::function<abstract_device_t*()> f);
+
+#define REGISTER_DEVICE(name, addr, constructor) \
+  class register_##name { \
+    public: register_##name() { register_device(addr, constructor); } \
+  }; static register_##name dummy_##name;
+
 
 #endif

--- a/riscv/sim.cc
+++ b/riscv/sim.cc
@@ -9,6 +9,7 @@
 #include <cstdlib>
 #include <cassert>
 #include <signal.h>
+#include <functional>
 
 volatile bool ctrlc_pressed = false;
 static void handle_signal(int sig)
@@ -188,6 +189,10 @@ void sim_t::make_device_tree()
       }
     dt.end_node();
   dt.end_node();
+
+  for (auto &kv: devices()) {
+    bus.add_device(kv.first, kv.second());
+  }
 
   devicetree.reset(new rom_device_t(dt.finalize()));
   bus.add_device(memsz, devicetree.get());


### PR DESCRIPTION
This change enables shared libraries loaded via --extlib to register devices.
