### PR TITLE
Added missing header files to riscv.mk.in

### DIFF
--- a/riscv/riscv.mk.in
+++ b/riscv/riscv.mk.in
@@ -10,6 +10,8 @@ riscv_hdrs = \
 	htif.h \
 	common.h \
 	decode.h \
+	devices.h \
+	devicetree.h \
 	disasm.h \
 	mmu.h \
 	processor.h \
@@ -18,6 +20,7 @@ riscv_hdrs = \
 	encoding.h \
 	cachesim.h \
 	memtracer.h \
+	tracer.h \
 	extension.h \
 	rocc.h \
 	insn_template.h \


### PR DESCRIPTION
This pull request fixes missing include files in `<prefix>/include/spike` after doing `make install`.
