### PR TITLE
Removed devicetree.h from riscv.mk.in since it no longer exists

### DIFF
--- a/riscv/riscv.mk.in
+++ b/riscv/riscv.mk.in
@@ -11,7 +11,6 @@ riscv_hdrs = \
 	common.h \
 	decode.h \
 	devices.h \
-	devicetree.h \
 	disasm.h \
 	mmu.h \
 	processor.h \


### PR DESCRIPTION
Ok, so this one should work this time. Last time I made a mistake because our change was to an earlier commit, but the pull request was using master as the base. This time I made the commit on master and it compiles again. riscv.mk.in now includes all the header files in riscv/ and no extra header files that no longer exist.

This fixes issue #41  
