### PR TITLE
Some bugfixes for CSR reading and setting FS for fflags updates

### DIFF
--- a/riscv/decode.h
+++ b/riscv/decode.h
@@ -184,7 +184,7 @@ private:
 #define require_fp require((STATE.mstatus & MSTATUS_FS) != 0)
 #define require_accelerator require((STATE.mstatus & MSTATUS_XS) != 0)
 
-#define set_fp_exceptions ({ if (softfloat_exceptionFlags & ~(STATE.fflags)) { \
+#define set_fp_exceptions ({ if (softfloat_exceptionFlags) { \
                                dirty_fp_state; \
                                STATE.fflags |= softfloat_exceptionFlags; \
                              } \

--- a/riscv/decode.h
+++ b/riscv/decode.h
@@ -184,7 +184,10 @@ private:
 #define require_fp require((STATE.mstatus & MSTATUS_FS) != 0)
 #define require_accelerator require((STATE.mstatus & MSTATUS_XS) != 0)
 
-#define set_fp_exceptions ({ STATE.fflags |= softfloat_exceptionFlags; \
+#define set_fp_exceptions ({ if (softfloat_exceptionFlags & ~(STATE.fflags)) { \
+                               dirty_fp_state; \
+                               STATE.fflags |= softfloat_exceptionFlags; \
+                             } \
                              softfloat_exceptionFlags = 0; })
 
 #define sext32(x) ((sreg_t)(int32_t)(x))

--- a/riscv/insns/csrrc.h
+++ b/riscv/insns/csrrc.h
@@ -1,4 +1,7 @@
-int csr = validate_csr(insn.csr(), true);
+bool write = insn.rs1() != 0;
+int csr = validate_csr(insn.csr(), write);
 reg_t old = p->get_csr(csr);
-p->set_csr(csr, old & ~RS1);
+if (write) {
+  p->set_csr(csr, old & ~RS1);
+}
 WRITE_RD(sext_xlen(old));

--- a/riscv/insns/csrrci.h
+++ b/riscv/insns/csrrci.h
@@ -1,4 +1,7 @@
-int csr = validate_csr(insn.csr(), true);
+bool write = insn.rs1() != 0;
+int csr = validate_csr(insn.csr(), write);
 reg_t old = p->get_csr(csr);
-p->set_csr(csr, old & ~(reg_t)insn.rs1());
+if (write) {
+  p->set_csr(csr, old & ~(reg_t)insn.rs1());
+}
 WRITE_RD(sext_xlen(old));

--- a/riscv/insns/csrrs.h
+++ b/riscv/insns/csrrs.h
@@ -1,4 +1,7 @@
-int csr = validate_csr(insn.csr(), insn.rs1() != 0);
+bool write = insn.rs1() != 0;
+int csr = validate_csr(insn.csr(), write);
 reg_t old = p->get_csr(csr);
-p->set_csr(csr, old | RS1);
+if (write) {
+  p->set_csr(csr, old | RS1);
+}
 WRITE_RD(sext_xlen(old));

--- a/riscv/insns/csrrsi.h
+++ b/riscv/insns/csrrsi.h
@@ -1,4 +1,7 @@
-int csr = validate_csr(insn.csr(), true);
+bool write = insn.rs1() != 0;
+int csr = validate_csr(insn.csr(), write);
 reg_t old = p->get_csr(csr);
-p->set_csr(csr, old | insn.rs1());
+if (write) {
+  p->set_csr(csr, old | insn.rs1());
+}
 WRITE_RD(sext_xlen(old));


### PR DESCRIPTION
These commits fix two problems in spike:
1) CSRRS, CSRRSI, CSRRC, and CSRRCI should only read when rs1/zimm == 1 and therefore not call set_csr.
2) FPU instructions that don't write to FPU registers should still set FS to dirty if they set fflag,

These fixes are mentioned in this conversation:
https://groups.google.com/a/groups.riscv.org/d/msg/isa-dev/Hh0wpsWtHsE/UdcbsKcHAgAJ
