### PR TITLE
htif: catch proper store exception

### DIFF
--- a/riscv/htif.cc
+++ b/riscv/htif.cc
@@ -66,7 +66,7 @@ void htif_isasim_t::tick_once()
         reg_t addr = (hdr.addr + i) * HTIF_DATA_ALIGN;
         try {
           sim->debug_mmu->store_uint64(addr, buf[i]);
-        } catch (trap_load_access_fault& e) {
+        } catch (trap_store_access_fault& e) {
           fprintf(stderr, "HTIF: attempt to write to illegal address 0x%" PRIx64 "\n", addr);
           exit(-1);
         }


### PR DESCRIPTION
The sim's debug_mmu will generate a trap_load_access_fault if the load
fails, not a trap_store_access_fault.  This doesn't materially affect
exection, but results in a nicer log message.
