### PR TITLE
make check: Fail if the tests failed

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -339,10 +339,12 @@ junk += $(bintest_outs)
 	./$* < /dev/null 2>&1 | tee $@
 
 check-cpp : $(test_outs)
-	echo; grep -h -e'Unit Tests' -e'FAILED' -e'Segmentation' $^ < /dev/null; echo
+	@echo
+	! grep -h -e'Unit Tests' -e'FAILED' -e'Segmentation' $^ < /dev/null
+	@echo
 
 check-bin : $(bintest_outs)
-	tail -n 1 $^ < /dev/null
+	! tail -n 1 $^ < /dev/null 2>&1 | grep FAILED
 
 check : check-cpp check-bin
 


### PR DESCRIPTION
The goal is to integrate the spike tests into riscv-tools' .travis.yml and to properly detect test failures.
