### PR TITLE
Add gdb support for RV32

### DIFF
--- a/riscv/gdbserver.h
+++ b/riscv/gdbserver.h
@@ -107,11 +107,9 @@ enum slot {
   SLOT_DATA_LAST,
 };
 
-// We know that this code just talks to a simulator with 64 bytes of debug RAM,
-// so can hardcode the offset to the last word.
-static const unsigned int slot_offset32[] = {0, 4, 5, 15};
-static const unsigned int slot_offset64[] = {0, 4, 6, 14};
-static const unsigned int slot_offset128[] = {0, 4, 8, 12};
+static const unsigned int slot_offset32[] = {0, 4, 5, DEBUG_RAM_SIZE/4 - 1};
+static const unsigned int slot_offset64[] = {0, 4, 6, DEBUG_RAM_SIZE/4 - 2};
+static const unsigned int slot_offset128[] = {0, 4, 8, DEBUG_RAM_SIZE/4 - 4};
 
 class gdbserver_t
 {


### PR DESCRIPTION
The debug code figures out what XLEN is by running a program in Debug RAM, just like we have to do on real hardware. Once figured out, the only real difference is to use lw/sw instead of ld/sd, but to make that nice required a bunch of refactoring.

I have testcases for this at https://github.com/timsifive/riscv-tests/tree/debug/debug

Once I get everything passing, I'll get that merged. Then I can remove the gdb tests from the riscv-isa-sim. They belong much more in riscv-tests since they test both gdb and spike. Additionally, the same tests are used to test gdb with openocd.
