### PR TITLE
Add support for virtual priv register.

### DIFF
--- a/riscv/gdbserver.h
+++ b/riscv/gdbserver.h
@@ -150,6 +150,8 @@ public:
   // Hex-encode a 32-bit value, and send it to gcc in target byte order (little
   // endian).
   void send(uint32_t value);
+  // Hex-encode an 8-bit value, and send it to gcc.
+  void send(uint8_t value);
   void send_packet(const char* data);
   uint8_t running_checksum;
   // Send "$" and clear running checksum.

--- a/riscv/insns/dret.h
+++ b/riscv/insns/dret.h
@@ -1,6 +1,9 @@
 require_privilege(PRV_M);
 set_pc_and_serialize(STATE.dpc);
-p->set_privilege(STATE.dcsr.prv);
+/* The debug spec says we can't crash when prv is set to an invalid value. */
+if (p->validate_priv(STATE.dcsr.prv)) {
+  p->set_privilege(STATE.dcsr.prv);
+}
 
 /* We're not in Debug Mode anymore. */
 STATE.dcsr.cause = 0;

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -179,7 +179,7 @@ void processor_t::take_interrupt()
     raise_interrupt(ctz(enabled_interrupts));
 }
 
-static bool validate_priv(reg_t priv)
+bool processor_t::validate_priv(reg_t priv)
 {
   return priv == PRV_U || priv == PRV_S || priv == PRV_M;
 }

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -118,6 +118,7 @@ public:
     if (ext >= 'a' && ext <= 'z') ext += 'A' - 'a';
     return ext >= 'A' && ext <= 'Z' && ((isa >> (ext - 'A')) & 1);
   }
+  bool validate_priv(reg_t priv);
   void set_privilege(reg_t);
   void yield_load_reservation() { state.load_reservation = (reg_t)-1; }
   void update_histogram(reg_t pc);


### PR DESCRIPTION
Users can use this register to inspect and change the privilege level of
the core. It doesn't make any assumptions about the actual underlying
debug mechanism (as opposed to having the user change DCSR directly,
which may not exist in all debug implementations).
