### PR TITLE
Ensure that g++ knows it is building a PCH

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -194,7 +194,7 @@ $(2)_deps := $$(patsubst %.o, %.d, $$($(2)_objs))
 $(2)_deps += $$(patsubst %.o, %.d, $$($(2)_c_objs))
 $(2)_deps += $$(patsubst %.h, %.h.d, $$($(2)_precompiled_hdrs))
 $$($(2)_pch) : %.h.gch : %.h
-	$(COMPILE) $$< -o $$@
+	$(COMPILE) -x c++-header $$< -o $$@
 # If using clang, don't depend (and thus don't build) precompiled headers
 $$($(2)_objs) : %.o : %.cc $$($(2)_gen_hdrs) $(if $(filter-out clang,$(CC)),$$($(2)_pch))
 	$(COMPILE) -c $$<


### PR DESCRIPTION
It seems that g++ 5.4 doesn't realize that it is building a precompiled 
header unless you pass it -x c++-header.