### PR TITLE
Fix gdb communication error

### DIFF
--- a/riscv/gdbserver.cc
+++ b/riscv/gdbserver.cc
@@ -325,7 +325,7 @@ void circular_buffer_t<T>::append(const T *src, unsigned int count)
   count -= copy;
   if (count > 0) {
     assert(count < contiguous_empty_size());
-    memcpy(contiguous_empty(), src, count * sizeof(T));
+    memcpy(contiguous_empty(), src+copy, count * sizeof(T));
     data_added(count);
   }
 }


### PR DESCRIPTION
When the send buffer wrapped around it would write the start of the packet again, rather than the end.