### PR TITLE
Only read exception flag in gdb register read/write.

### DIFF
--- a/riscv/gdbserver.cc
+++ b/riscv/gdbserver.cc
@@ -648,7 +648,7 @@ class register_read_op_t : public operation_t
 
         case 1:
           {
-            unsigned result = gs.dr_read(SLOT_DATA_LAST);
+            unsigned result = gs.dr_read32(DEBUG_RAM_SIZE / 4 - 1);
             if (result) {
               gs.send_packet("E03");
               return true;
@@ -728,7 +728,7 @@ class register_write_op_t : public operation_t
 
         case 1:
           {
-            unsigned result = gs.dr_read(SLOT_DATA_LAST);
+            unsigned result = gs.dr_read32(DEBUG_RAM_SIZE / 4 - 1);
             if (result) {
               gs.send_packet("E03");
               return true;


### PR DESCRIPTION
The flag is 32 bits, and if we read 64/128 bits then we get fragments of
S1 too and can accidentally send an error.  Fixes #84.