### PR TITLE
Comply with GNU coding standards.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -55,9 +55,9 @@ enable_stow  := @enable_stow@
 
 ifeq ($(enable_stow),yes)
   stow_pkg_dir := $(prefix)/pkgs
-  INSTALLDIR ?= $(DESTDIR)/$(stow_pkg_dir)/$(project_name)-$(project_ver)
+  INSTALLDIR ?= $(DESTDIR)$(stow_pkg_dir)/$(project_name)-$(project_ver)
 else
-  INSTALLDIR ?= $(DESTDIR)/$(prefix)
+  INSTALLDIR ?= $(DESTDIR)$(prefix)
 endif
 
 install_hdrs_dir := $(INSTALLDIR)/include/$(project_name)


### PR DESCRIPTION
Currently the DESTDIR variable is not used correctly which leads to
bogus RUNPATH entries.

https://www.gnu.org/prep/standards/html_node/DESTDIR.html