### PR TITLE
Configure should fail if device-tree-compiler is not installed

### DIFF
--- a/configure
+++ b/configure
@@ -3409,6 +3409,7 @@ done
   done
 IFS=$as_save_IFS
 
+  test -z "$ac_cv_path_DTC" && ac_cv_path_DTC="no"
   ;;
 esac
 fi
@@ -3422,6 +3423,9 @@ $as_echo "no" >&6; }
 fi
 
 
+if test x"$DTC" == xno; then :
+  as_fn_error $? "device-tree-compiler not found" "$LINENO" 5
+fi
 
 cat >>confdefs.h <<_ACEOF
 #define DTC "$DTC"

--- a/configure.ac
+++ b/configure.ac
@@ -51,7 +51,8 @@ AC_PROG_CC
 AC_PROG_CXX
 AC_CHECK_TOOL([AR],[ar])
 AC_CHECK_TOOL([RANLIB],[ranlib])
-AC_PATH_PROG([DTC],[dtc])
+AC_PATH_PROG([DTC],[dtc],[no])
+AS_IF([test x"$DTC" == xno],AC_MSG_ERROR([device-tree-compiler not found]))
 AC_DEFINE_UNQUOTED(DTC, ["$DTC"], [Path to the device-tree-compiler])
 
 AC_C_BIGENDIAN(AC_MSG_ERROR([Spike requires a little-endian host]))


### PR DESCRIPTION
Fixes #107