### PR TITLE
Return success on writes to abstractauto

### DIFF
--- a/riscv/debug_module.cc
+++ b/riscv/debug_module.cc
@@ -463,9 +463,11 @@ bool debug_module_t::dmi_write(unsigned address, uint32_t value)
         return true;
 
       case DMI_ABSTRACTAUTO:
-        abstractauto.autoexecprogbuf = get_field(value, DMI_ABSTRACTAUTO_AUTOEXECPROGBUF);
-        abstractauto.autoexecdata = get_field(value, DMI_ABSTRACTAUTO_AUTOEXECDATA);
-        break;
+        abstractauto.autoexecprogbuf = get_field(value,
+            DMI_ABSTRACTAUTO_AUTOEXECPROGBUF);
+        abstractauto.autoexecdata = get_field(value,
+            DMI_ABSTRACTAUTO_AUTOEXECDATA);
+        return true;
     }
   }
   return false;


### PR DESCRIPTION
This bug was exposed by newer OpenOCD which actually checks the result.