### PR TITLE
Fix debug reset.

### DIFF
--- a/riscv/debug_module.cc
+++ b/riscv/debug_module.cc
@@ -459,9 +459,15 @@ bool debug_module_t::dmi_write(unsigned address, uint32_t value)
               debug_rom_flags[dmcontrol.hartsel] |= (1 << DEBUG_ROM_FLAG_RESUME);
               resumeack[dmcontrol.hartsel] = false;
             }
-	    if (dmcontrol.ndmreset) {
+	    if (dmcontrol.hartreset) {
 	      proc->reset();
 	    }
+          }
+          if (dmcontrol.ndmreset) {
+            for (size_t i = 0; i < sim->nprocs(); i++) {
+              proc = sim->get_core(i);
+              proc->reset();
+            }
           }
         }
         return true;

--- a/riscv/debug_module.cc
+++ b/riscv/debug_module.cc
@@ -447,6 +447,7 @@ bool debug_module_t::dmi_write(unsigned address, uint32_t value)
           if (dmcontrol.dmactive) {
             dmcontrol.haltreq = get_field(value, DMI_DMCONTROL_HALTREQ);
             dmcontrol.resumereq = get_field(value, DMI_DMCONTROL_RESUMEREQ);
+            dmcontrol.hartreset = get_field(value, DMI_DMCONTROL_HARTRESET);
             dmcontrol.ndmreset = get_field(value, DMI_DMCONTROL_NDMRESET);
             dmcontrol.hartsel = get_field(value, DMI_DMCONTROL_HARTSEL);
           } else {


### PR DESCRIPTION
ndmreset now resets all harts (instead of just the current hart), and
hartreset resets the selected hart (instead of being ignored).