### PR TITLE
Add a timer devicetree node

### DIFF
--- a/riscv/sim.cc
+++ b/riscv/sim.cc
@@ -272,6 +272,11 @@ void sim_t::make_dtb()
          "        interrupt-controller;\n"
          "        compatible = \"riscv,cpu-intc\";\n"
          "      };\n"
+         "      CPU" << i << "_timer: timer {\n"
+         "        #timer-cells = <1>;\n"
+         "        compatible = \"riscv,cpu-timer\";\n"
+         "        interrupts = <&CPU" << i << "_intc>;\n"
+         "      };\n"
          "    };\n";
   }
   s <<   "  };\n";


### PR DESCRIPTION
We tightly coupled a handful of drivers for ISA-defined devices (timer
and interrupts) to the RISC-V Linux port, but this isn't kosher so
upstream won't like it.  In order to decouple these drivers from the
RISC-V part of the part, we need device tree nodes so the drivers can
hook into those nodes to initialize themselves.

This adds device tree nodes for the ISA-mandated timer attached to each
hart, which I've also converted Linux to use.