### PR TITLE
Include math.h for NAN

### DIFF
--- a/riscv/interactive.cc
+++ b/riscv/interactive.cc
@@ -17,6 +17,7 @@
 #include <string>
 #include <vector>
 #include <algorithm>
+#include <math.h>
 
 DECLARE_TRAP(-1, interactive)
 


### PR DESCRIPTION
commit 85c40db208db3e26f507dc6a74a5dc540b504b5c introduced a NAN dependency but did not include the math.h header