### PR TITLE
Fix bus_t bug with devices at 0x0

### DIFF
--- a/riscv/devices.cc
+++ b/riscv/devices.cc
@@ -2,29 +2,49 @@
 
 void bus_t::add_device(reg_t addr, abstract_device_t* dev)
 {
-  devices[-addr] = dev;
+  // Searching devices via lower_bound/upper_bound
+  // implicitly relies on the underlying std::map 
+  // container to sort the keys and provide ordered
+  // iteration over this sort, which it does. (python's
+  // SortedDict is a good analogy)
+  devices[addr] = dev;
 }
 
 bool bus_t::load(reg_t addr, size_t len, uint8_t* bytes)
 {
-  auto it = devices.lower_bound(-addr);
-  if (it == devices.end())
+  // Find the device with the base address closest to but
+  // less than addr (price-is-right search)
+  auto it = devices.upper_bound(addr);
+  if (devices.empty() || it == devices.begin()) {
+    // Either the bus is empty, or there weren't 
+    // any items with a base address <= addr
     return false;
-  return it->second->load(addr - -it->first, len, bytes);
+  }
+  // Found at least one item with base address <= addr
+  // The iterator points to the device after this, so
+  // go back by one item.
+  it--;
+  return it->second->load(addr - it->first, len, bytes);
 }
 
 bool bus_t::store(reg_t addr, size_t len, const uint8_t* bytes)
 {
-  auto it = devices.lower_bound(-addr);
-  if (it == devices.end())
+  // See comments in bus_t::load
+  auto it = devices.upper_bound(addr);
+  if (devices.empty() || it == devices.begin()) {
     return false;
-  return it->second->store(addr - -it->first, len, bytes);
+  }
+  it--;
+  return it->second->store(addr - it->first, len, bytes);
 }
 
 std::pair<reg_t, abstract_device_t*> bus_t::find_device(reg_t addr)
 {
-  auto it = devices.lower_bound(-addr);
-  if (it == devices.end() || addr < -it->first)
+  // See comments in bus_t::load
+  auto it = devices.upper_bound(addr);
+  if (devices.empty() || it == devices.begin()) {
     return std::make_pair((reg_t)0, (abstract_device_t*)NULL);
-  return std::make_pair(-it->first, it->second);
+  }
+  it--;
+  return std::make_pair(it->first, it->second);
 }


### PR DESCRIPTION
Fix a bug that prevented bus_t from storing to, loading from,
or finding a device that existed at address 0x0.

Resolves: #135