### PR TITLE
Put HTIF in the device tree

### DIFF
--- a/riscv/sim.cc
+++ b/riscv/sim.cc
@@ -300,6 +300,9 @@ void sim_t::make_dtb()
                      " 0x" << (clintsz >> 32) << " 0x" << (clintsz & (uint32_t)-1) << ">;\n"
          "    };\n"
          "  };\n"
+         "  htif {\n"
+         "    compatible = \"ucb,htif0\";\n"
+         "  };\n"
          "};\n";
 
   dts = s.str();


### PR DESCRIPTION
I wanted to actually put the address of the HTIF into the DTS, but that
seems to be a bit too much work: since the HTIF addresses are just
defined in an ELF file it's a bit awkward to make that work.

Instead, I'm just putting a dummy HTIF key in the DTS.