### PR TITLE
Add support for program buffer of size 2

### DIFF
--- a/riscv/debug_defines.h
+++ b/riscv/debug_defines.h
@@ -544,6 +544,19 @@
 #define CSR_ICOUNT_ACTION                   (0x3fULL << CSR_ICOUNT_ACTION_OFFSET)
 #define DMI_DMSTATUS                        0x11
 /*
+* Gets set if the Debug Module was accessed incorrectly.
+*
+* 0 (none): No error.
+*
+* 1 (badaddr): There was an access to an unimplemented Debug Module
+* address.
+*
+* 7 (other): An access failed for another reason.
+ */
+#define DMI_DMSTATUS_DMERR_OFFSET           24
+#define DMI_DMSTATUS_DMERR_LENGTH           3
+#define DMI_DMSTATUS_DMERR                  (0x7U << DMI_DMSTATUS_DMERR_OFFSET)
+/*
 * If 1, then there is an implicit {\tt ebreak} instruction at the
 * non-existent word immediately after the Program Buffer. This saves
 * the debugger from having to write the {\tt ebreak} itself, and
@@ -555,26 +568,27 @@
 #define DMI_DMSTATUS_IMPEBREAK_LENGTH       1
 #define DMI_DMSTATUS_IMPEBREAK              (0x1U << DMI_DMSTATUS_IMPEBREAK_OFFSET)
 /*
-* Gets set if the Debug Module was accessed incorrectly.
-*
-* 0 (none): No error.
-*
-* 1 (badaddr): There was an access to an unimplemented Debug Module
-* address.
-*
-* 7 (other): An access failed for another reason.
+* This field is 1 when all currently selected harts have been reset but the reset has not been acknowledged.
  */
-#define DMI_DMSTATUS_DMERR_OFFSET           18
-#define DMI_DMSTATUS_DMERR_LENGTH           3
-#define DMI_DMSTATUS_DMERR                  (0x7U << DMI_DMSTATUS_DMERR_OFFSET)
+#define DMI_DMSTATUS_ALLHAVERESET_OFFSET    19
+#define DMI_DMSTATUS_ALLHAVERESET_LENGTH    1
+#define DMI_DMSTATUS_ALLHAVERESET           (0x1U << DMI_DMSTATUS_ALLHAVERESET_OFFSET)
 /*
-* This field is 1 when all currently selected harts have acknowledged the previous \Fresumereq.
+* This field is 1 when any currently selected hart has been reset but the reset has not been acknowledged.
+ */
+#define DMI_DMSTATUS_ANYHAVERESET_OFFSET    18
+#define DMI_DMSTATUS_ANYHAVERESET_LENGTH    1
+#define DMI_DMSTATUS_ANYHAVERESET           (0x1U << DMI_DMSTATUS_ANYHAVERESET_OFFSET)
+/*
+* This field is 1 when all currently selected harts have acknowledged
+* the previous resume request.
  */
 #define DMI_DMSTATUS_ALLRESUMEACK_OFFSET    17
 #define DMI_DMSTATUS_ALLRESUMEACK_LENGTH    1
 #define DMI_DMSTATUS_ALLRESUMEACK           (0x1U << DMI_DMSTATUS_ALLRESUMEACK_OFFSET)
 /*
-* This field is 1 when any currently selected hart has acknowledged the previous \Fresumereq.
+* This field is 1 when any currently selected hart has acknowledged
+* the previous resume request.
  */
 #define DMI_DMSTATUS_ANYRESUMEACK_OFFSET    16
 #define DMI_DMSTATUS_ANYRESUMEACK_LENGTH    1
@@ -675,11 +689,12 @@
 #define DMI_DMSTATUS_VERSION                (0xfU << DMI_DMSTATUS_VERSION_OFFSET)
 #define DMI_DMCONTROL                       0x10
 /*
-* Halt request signal for all currently selected harts. When set to
-* 1, each selected hart will halt if it is not currently halted.
+* Writes the halt request bit for all currently selected harts.
+* When set to 1, each selected hart will halt if it is not currently
+* halted.
 *
 * Writing 1 or 0 has no effect on a hart which is already halted, but
-* the bit should be cleared to 0 before the hart is resumed.
+* the bit must be cleared to 0 before the hart is resumed.
 *
 * Writes apply to the new value of \Fhartsel and \Fhasel.
  */
@@ -687,10 +702,12 @@
 #define DMI_DMCONTROL_HALTREQ_LENGTH        1
 #define DMI_DMCONTROL_HALTREQ               (0x1U << DMI_DMCONTROL_HALTREQ_OFFSET)
 /*
-* Resume request signal for all currently selected harts. When set to 1,
-* each selected hart will resume if it is currently halted.
+* Writes the resume request bit for all currently selected harts.
+* When set to 1, each selected hart will resume if it is currently
+* halted.
 *
-* This bit is ignored while \Fhaltreq is set.
+* The resume request bit is ignored while the halt request bit is
+* set.
 *
 * Writes apply to the new value of \Fhartsel and \Fhasel.
  */
@@ -698,9 +715,9 @@
 #define DMI_DMCONTROL_RESUMEREQ_LENGTH      1
 #define DMI_DMCONTROL_RESUMEREQ             (0x1U << DMI_DMCONTROL_RESUMEREQ_OFFSET)
 /*
-* This optional bit controls reset to all the currently selected harts.
-* To perform a reset the debugger writes 1, and then writes 0 to
-* deassert the reset signal.
+* This optional field writes the reset bit for all the currently
+* selected harts.  To perform a reset the debugger writes 1, and then
+* writes 0 to deassert the reset signal.
 *
 * If this feature is not implemented, the bit always stays 0, so
 * after writing 1 the debugger can read the register back to see if
@@ -711,6 +728,15 @@
 #define DMI_DMCONTROL_HARTRESET_OFFSET      29
 #define DMI_DMCONTROL_HARTRESET_LENGTH      1
 #define DMI_DMCONTROL_HARTRESET             (0x1U << DMI_DMCONTROL_HARTRESET_OFFSET)
+/*
+* Writing 1 to this bit clears the {\tt havereset} bits for
+* any selected harts.
+*
+* Writes apply to the new value of \Fhartsel and \Fhasel.
+ */
+#define DMI_DMCONTROL_ACKHAVERESET_OFFSET   28
+#define DMI_DMCONTROL_ACKHAVERESET_LENGTH   1
+#define DMI_DMCONTROL_ACKHAVERESET          (0x1U << DMI_DMCONTROL_ACKHAVERESET_OFFSET)
 /*
 * Selects the  definition of currently selected harts.
 *

--- a/riscv/debug_defines.h
+++ b/riscv/debug_defines.h
@@ -4,13 +4,13 @@
  */
 #define DTM_IDCODE_VERSION_OFFSET           28
 #define DTM_IDCODE_VERSION_LENGTH           4
-#define DTM_IDCODE_VERSION                  (0xf << DTM_IDCODE_VERSION_OFFSET)
+#define DTM_IDCODE_VERSION                  (0xfU << DTM_IDCODE_VERSION_OFFSET)
 /*
 * Identifies the designer's part number of this part.
  */
 #define DTM_IDCODE_PARTNUMBER_OFFSET        12
 #define DTM_IDCODE_PARTNUMBER_LENGTH        16
-#define DTM_IDCODE_PARTNUMBER               (0xffff << DTM_IDCODE_PARTNUMBER_OFFSET)
+#define DTM_IDCODE_PARTNUMBER               (0xffffU << DTM_IDCODE_PARTNUMBER_OFFSET)
 /*
 * Identifies the designer/manufacturer of this part. Bits 6:0 must be
 * bits 6:0 of the designer/manufacturer's Identification Code as
@@ -20,10 +20,10 @@
  */
 #define DTM_IDCODE_MANUFID_OFFSET           1
 #define DTM_IDCODE_MANUFID_LENGTH           11
-#define DTM_IDCODE_MANUFID                  (0x7ff << DTM_IDCODE_MANUFID_OFFSET)
+#define DTM_IDCODE_MANUFID                  (0x7ffU << DTM_IDCODE_MANUFID_OFFSET)
 #define DTM_IDCODE_1_OFFSET                 0
 #define DTM_IDCODE_1_LENGTH                 1
-#define DTM_IDCODE_1                        (0x1 << DTM_IDCODE_1_OFFSET)
+#define DTM_IDCODE_1                        (0x1U << DTM_IDCODE_1_OFFSET)
 #define DTM_DTMCS                           0x10
 /*
 * Writing 1 to this bit does a hard reset of the DTM,
@@ -35,7 +35,7 @@
  */
 #define DTM_DTMCS_DMIHARDRESET_OFFSET       17
 #define DTM_DTMCS_DMIHARDRESET_LENGTH       1
-#define DTM_DTMCS_DMIHARDRESET              (0x1 << DTM_DTMCS_DMIHARDRESET_OFFSET)
+#define DTM_DTMCS_DMIHARDRESET              (0x1U << DTM_DTMCS_DMIHARDRESET_OFFSET)
 /*
 * Writing 1 to this bit clears the sticky error state
 * and allows the DTM to retry or complete the previous
@@ -43,7 +43,7 @@
  */
 #define DTM_DTMCS_DMIRESET_OFFSET           16
 #define DTM_DTMCS_DMIRESET_LENGTH           1
-#define DTM_DTMCS_DMIRESET                  (0x1 << DTM_DTMCS_DMIRESET_OFFSET)
+#define DTM_DTMCS_DMIRESET                  (0x1U << DTM_DTMCS_DMIRESET_OFFSET)
 /*
 * This is a hint to the debugger of the minimum number of
 * cycles a debugger should spend in
@@ -61,7 +61,7 @@
  */
 #define DTM_DTMCS_IDLE_OFFSET               12
 #define DTM_DTMCS_IDLE_LENGTH               3
-#define DTM_DTMCS_IDLE                      (0x7 << DTM_DTMCS_IDLE_OFFSET)
+#define DTM_DTMCS_IDLE                      (0x7U << DTM_DTMCS_IDLE_OFFSET)
 /*
 * 0: No error.
 *
@@ -74,24 +74,24 @@
  */
 #define DTM_DTMCS_DMISTAT_OFFSET            10
 #define DTM_DTMCS_DMISTAT_LENGTH            2
-#define DTM_DTMCS_DMISTAT                   (0x3 << DTM_DTMCS_DMISTAT_OFFSET)
+#define DTM_DTMCS_DMISTAT                   (0x3U << DTM_DTMCS_DMISTAT_OFFSET)
 /*
 * The size of \Faddress in \Rdmi.
  */
 #define DTM_DTMCS_ABITS_OFFSET              4
 #define DTM_DTMCS_ABITS_LENGTH              6
-#define DTM_DTMCS_ABITS                     (0x3f << DTM_DTMCS_ABITS_OFFSET)
+#define DTM_DTMCS_ABITS                     (0x3fU << DTM_DTMCS_ABITS_OFFSET)
 /*
 * 0: Version described in spec version 0.11.
 *
-* 1: Version described in spec version 0.12 (and later?), which
+* 1: Version described in spec version 0.13 (and later?), which
 * reduces the DMI data width to 32 bits.
 *
-* Other values are reserved for future use.
+* 15: Version not described in any available version of this spec.
  */
 #define DTM_DTMCS_VERSION_OFFSET            0
 #define DTM_DTMCS_VERSION_LENGTH            4
-#define DTM_DTMCS_VERSION                   (0xf << DTM_DTMCS_VERSION_OFFSET)
+#define DTM_DTMCS_VERSION                   (0xfU << DTM_DTMCS_VERSION_OFFSET)
 #define DTM_DMI                             0x11
 /*
 * Address used for DMI access. In Update-DR this value is used
@@ -106,11 +106,16 @@
  */
 #define DTM_DMI_DATA_OFFSET                 2
 #define DTM_DMI_DATA_LENGTH                 32
-#define DTM_DMI_DATA                        (0xffffffffL << DTM_DMI_DATA_OFFSET)
+#define DTM_DMI_DATA                        (0xffffffffULL << DTM_DMI_DATA_OFFSET)
 /*
 * When the debugger writes this field, it has the following meaning:
 *
-* 0: Ignore \Fdata. (nop)
+* 0: Ignore \Fdata and \Faddress. (nop)
+*
+* Don't send anything over the DMI during Update-DR.
+* This operation should never result in a busy or error response.
+* The address and data reported in the following Capture-DR
+* are undefined.
 *
 * 1: Read from \Faddress. (read)
 *
@@ -128,8 +133,10 @@
 * this access will be ignored.  This status is sticky and can be
 * cleared by writing \Fdmireset in \Rdtmcs.
 *
-* This indicates that the DM itself responded with an error, e.g.
-* in the System Bus and Serial Port overflow/underflow cases.
+* This indicates that the DM itself responded with an error.
+* Note: there are no specified cases in which the DM would
+* respond with an error, and DMI is not required to support
+* returning errors.
 *
 * 3: An operation was attempted while a DMI request is still in
 * progress. The data scanned into \Rdmi in this access will be
@@ -146,49 +153,58 @@
  */
 #define DTM_DMI_OP_OFFSET                   0
 #define DTM_DMI_OP_LENGTH                   2
-#define DTM_DMI_OP                          (0x3L << DTM_DMI_OP_OFFSET)
+#define DTM_DMI_OP                          (0x3ULL << DTM_DMI_OP_OFFSET)
 #define CSR_DCSR                            0x7b0
 /*
 * 0: There is no external debug support.
 *
-* 1: External debug support exists as it is described in this document.
+* 4: External debug support exists as it is described in this document.
 *
-* Other values are reserved for future standards.
+* 15: There is external debug support, but it does not conform to any
+* available version of this spec.
  */
-#define CSR_DCSR_XDEBUGVER_OFFSET           30
-#define CSR_DCSR_XDEBUGVER_LENGTH           2
-#define CSR_DCSR_XDEBUGVER                  (0x3 << CSR_DCSR_XDEBUGVER_OFFSET)
+#define CSR_DCSR_XDEBUGVER_OFFSET           28
+#define CSR_DCSR_XDEBUGVER_LENGTH           4
+#define CSR_DCSR_XDEBUGVER                  (0xfU << CSR_DCSR_XDEBUGVER_OFFSET)
 /*
 * When 1, {\tt ebreak} instructions in Machine Mode enter Debug Mode.
  */
 #define CSR_DCSR_EBREAKM_OFFSET             15
 #define CSR_DCSR_EBREAKM_LENGTH             1
-#define CSR_DCSR_EBREAKM                    (0x1 << CSR_DCSR_EBREAKM_OFFSET)
-/*
-* When 1, {\tt ebreak} instructions in Hypervisor Mode enter Debug Mode.
- */
-#define CSR_DCSR_EBREAKH_OFFSET             14
-#define CSR_DCSR_EBREAKH_LENGTH             1
-#define CSR_DCSR_EBREAKH                    (0x1 << CSR_DCSR_EBREAKH_OFFSET)
+#define CSR_DCSR_EBREAKM                    (0x1U << CSR_DCSR_EBREAKM_OFFSET)
 /*
 * When 1, {\tt ebreak} instructions in Supervisor Mode enter Debug Mode.
  */
 #define CSR_DCSR_EBREAKS_OFFSET             13
 #define CSR_DCSR_EBREAKS_LENGTH             1
-#define CSR_DCSR_EBREAKS                    (0x1 << CSR_DCSR_EBREAKS_OFFSET)
+#define CSR_DCSR_EBREAKS                    (0x1U << CSR_DCSR_EBREAKS_OFFSET)
 /*
 * When 1, {\tt ebreak} instructions in User/Application Mode enter
 * Debug Mode.
  */
 #define CSR_DCSR_EBREAKU_OFFSET             12
 #define CSR_DCSR_EBREAKU_LENGTH             1
-#define CSR_DCSR_EBREAKU                    (0x1 << CSR_DCSR_EBREAKU_OFFSET)
+#define CSR_DCSR_EBREAKU                    (0x1U << CSR_DCSR_EBREAKU_OFFSET)
+/*
+* 0: Interrupts are disabled during single stepping.
+*
+* 1: Interrupts are enabled during single stepping.
+*
+* Implementations may hard wire this bit to 0.
+* The debugger must read back the value it
+* writes to check whether the feature is supported. If not
+* supported, interrupt behavior can be emulated by the debugger.
+ */
+#define CSR_DCSR_STEPIE_OFFSET              11
+#define CSR_DCSR_STEPIE_LENGTH              1
+#define CSR_DCSR_STEPIE                     (0x1U << CSR_DCSR_STEPIE_OFFSET)
 /*
 * 0: Increment counters as usual.
 *
-* 1: Don't increment any counters while in Debug Mode.  This includes
-* the {\tt cycle} and {\tt instret} CSRs. This is preferred for most
-* debugging scenarios.
+* 1: Don't increment any counters while in Debug Mode or on {\tt
+* ebreak} instructions that cause entry into Debug Mode.  These
+* counters include the {\tt cycle} and {\tt instret} CSRs. This is
+* preferred for most debugging scenarios.
 *
 * An implementation may choose not to support writing to this bit.
 * The debugger must read back the value it writes to check whether
@@ -196,7 +212,7 @@
  */
 #define CSR_DCSR_STOPCOUNT_OFFSET           10
 #define CSR_DCSR_STOPCOUNT_LENGTH           1
-#define CSR_DCSR_STOPCOUNT                  (0x1 << CSR_DCSR_STOPCOUNT_OFFSET)
+#define CSR_DCSR_STOPCOUNT                  (0x1U << CSR_DCSR_STOPCOUNT_OFFSET)
 /*
 * 0: Increment timers as usual.
 *
@@ -208,7 +224,7 @@
  */
 #define CSR_DCSR_STOPTIME_OFFSET            9
 #define CSR_DCSR_STOPTIME_LENGTH            1
-#define CSR_DCSR_STOPTIME                   (0x1 << CSR_DCSR_STOPTIME_OFFSET)
+#define CSR_DCSR_STOPTIME                   (0x1U << CSR_DCSR_STOPTIME_OFFSET)
 /*
 * Explains why Debug Mode was entered.
 *
@@ -217,9 +233,9 @@
 *
 * 1: An {\tt ebreak} instruction was executed. (priority 3)
 *
-* 2: The Trigger Module caused a halt. (priority 4)
+* 2: The Trigger Module caused a breakpoint exception. (priority 4)
 *
-* 3: \Fhaltreq was set. (priority 2)
+* 3: The debugger requested entry to Debug Mode. (priority 2)
 *
 * 4: The hart single stepped because \Fstep was set. (priority 1)
 *
@@ -227,18 +243,17 @@
  */
 #define CSR_DCSR_CAUSE_OFFSET               6
 #define CSR_DCSR_CAUSE_LENGTH               3
-#define CSR_DCSR_CAUSE                      (0x7 << CSR_DCSR_CAUSE_OFFSET)
+#define CSR_DCSR_CAUSE                      (0x7U << CSR_DCSR_CAUSE_OFFSET)
 /*
 * When set and not in Debug Mode, the hart will only execute a single
 * instruction and then enter Debug Mode.
-* Interrupts are disabled when this bit is set.
 * If the instruction does not complete due to an exception,
 * the hart will immediately enter Debug Mode before executing
 * the trap handler, with appropriate exception registers set.
  */
 #define CSR_DCSR_STEP_OFFSET                2
 #define CSR_DCSR_STEP_LENGTH                1
-#define CSR_DCSR_STEP                       (0x1 << CSR_DCSR_STEP_OFFSET)
+#define CSR_DCSR_STEP                       (0x1U << CSR_DCSR_STEP_OFFSET)
 /*
 * Contains the privilege level the hart was operating in when Debug
 * Mode was entered. The encoding is described in Table
@@ -251,23 +266,13 @@
  */
 #define CSR_DCSR_PRV_OFFSET                 0
 #define CSR_DCSR_PRV_LENGTH                 2
-#define CSR_DCSR_PRV                        (0x3 << CSR_DCSR_PRV_OFFSET)
+#define CSR_DCSR_PRV                        (0x3U << CSR_DCSR_PRV_OFFSET)
 #define CSR_DPC                             0x7b1
 #define CSR_DPC_DPC_OFFSET                  0
 #define CSR_DPC_DPC_LENGTH                  XLEN
 #define CSR_DPC_DPC                         (((1L<<XLEN)-1) << CSR_DPC_DPC_OFFSET)
 #define CSR_DSCRATCH0                       0x7b2
 #define CSR_DSCRATCH1                       0x7b3
-#define CSR_PRIV                            virtual
-/*
-* Contains the privilege level the hart was operating in when Debug
-* Mode was entered. The encoding is described in Table
-* \ref{tab:privlevel}. A user can write this value to change the
-* hart's privilege level when exiting Debug Mode.
- */
-#define CSR_PRIV_PRV_OFFSET                 0
-#define CSR_PRIV_PRV_LENGTH                 2
-#define CSR_PRIV_PRV                        (0x3 << CSR_PRIV_PRV_OFFSET)
 #define CSR_TSELECT                         0x7a0
 #define CSR_TSELECT_INDEX_OFFSET            0
 #define CSR_TSELECT_INDEX_LENGTH            XLEN
@@ -292,7 +297,7 @@
  */
 #define CSR_TDATA1_TYPE_OFFSET              XLEN-4
 #define CSR_TDATA1_TYPE_LENGTH              4
-#define CSR_TDATA1_TYPE                     (0xfL << CSR_TDATA1_TYPE_OFFSET)
+#define CSR_TDATA1_TYPE                     (0xfULL << CSR_TDATA1_TYPE_OFFSET)
 /*
 * 0: Both Debug and M Mode can write the {\tt tdata} registers at the
 * selected \Rtselect.
@@ -302,9 +307,9 @@
 *
 * This bit is only writable from Debug Mode.
  */
-#define CSR_TDATA1_HMODE_OFFSET             XLEN-5
-#define CSR_TDATA1_HMODE_LENGTH             1
-#define CSR_TDATA1_HMODE                    (0x1L << CSR_TDATA1_HMODE_OFFSET)
+#define CSR_TDATA1_DMODE_OFFSET             XLEN-5
+#define CSR_TDATA1_DMODE_LENGTH             1
+#define CSR_TDATA1_DMODE                    (0x1ULL << CSR_TDATA1_DMODE_OFFSET)
 /*
 * Trigger-specific data.
  */
@@ -322,10 +327,10 @@
 #define CSR_MCONTROL                        0x7a1
 #define CSR_MCONTROL_TYPE_OFFSET            XLEN-4
 #define CSR_MCONTROL_TYPE_LENGTH            4
-#define CSR_MCONTROL_TYPE                   (0xfL << CSR_MCONTROL_TYPE_OFFSET)
+#define CSR_MCONTROL_TYPE                   (0xfULL << CSR_MCONTROL_TYPE_OFFSET)
 #define CSR_MCONTROL_DMODE_OFFSET           XLEN-5
 #define CSR_MCONTROL_DMODE_LENGTH           1
-#define CSR_MCONTROL_DMODE                  (0x1L << CSR_MCONTROL_DMODE_OFFSET)
+#define CSR_MCONTROL_DMODE                  (0x1ULL << CSR_MCONTROL_DMODE_OFFSET)
 /*
 * Specifies the largest naturally aligned powers-of-two (NAPOT) range
 * supported by the hardware. The value is the logarithm base 2 of the
@@ -336,7 +341,7 @@
  */
 #define CSR_MCONTROL_MASKMAX_OFFSET         XLEN-11
 #define CSR_MCONTROL_MASKMAX_LENGTH         6
-#define CSR_MCONTROL_MASKMAX                (0x3fL << CSR_MCONTROL_MASKMAX_OFFSET)
+#define CSR_MCONTROL_MASKMAX                (0x3fULL << CSR_MCONTROL_MASKMAX_OFFSET)
 /*
 * 0: Perform a match on the virtual address.
 *
@@ -345,7 +350,7 @@
  */
 #define CSR_MCONTROL_SELECT_OFFSET          19
 #define CSR_MCONTROL_SELECT_LENGTH          1
-#define CSR_MCONTROL_SELECT                 (0x1L << CSR_MCONTROL_SELECT_OFFSET)
+#define CSR_MCONTROL_SELECT                 (0x1ULL << CSR_MCONTROL_SELECT_OFFSET)
 /*
 * 0: The action for this trigger will be taken just before the
 * instruction that triggered it is executed, but after all preceding
@@ -373,14 +378,14 @@
  */
 #define CSR_MCONTROL_TIMING_OFFSET          18
 #define CSR_MCONTROL_TIMING_LENGTH          1
-#define CSR_MCONTROL_TIMING                 (0x1L << CSR_MCONTROL_TIMING_OFFSET)
+#define CSR_MCONTROL_TIMING                 (0x1ULL << CSR_MCONTROL_TIMING_OFFSET)
 /*
 * Determines what happens when this trigger matches.
 *
 * 0: Raise a breakpoint exception. (Used when software wants to use
 * the trigger module without an external debugger attached.)
 *
-* 1: Enter Debug Mode. (Only supported when \Fhmode is 1.)
+* 1: Enter Debug Mode. (Only supported when \Fdmode is 1.)
 *
 * 2: Start tracing.
 *
@@ -394,7 +399,7 @@
  */
 #define CSR_MCONTROL_ACTION_OFFSET          12
 #define CSR_MCONTROL_ACTION_LENGTH          6
-#define CSR_MCONTROL_ACTION                 (0x3fL << CSR_MCONTROL_ACTION_OFFSET)
+#define CSR_MCONTROL_ACTION                 (0x3fULL << CSR_MCONTROL_ACTION_OFFSET)
 /*
 * 0: When this trigger matches, the configured action is taken.
 *
@@ -403,7 +408,7 @@
  */
 #define CSR_MCONTROL_CHAIN_OFFSET           11
 #define CSR_MCONTROL_CHAIN_LENGTH           1
-#define CSR_MCONTROL_CHAIN                  (0x1L << CSR_MCONTROL_CHAIN_OFFSET)
+#define CSR_MCONTROL_CHAIN                  (0x1ULL << CSR_MCONTROL_CHAIN_OFFSET)
 /*
 * 0: Matches when the value equals \Rtdatatwo.
 *
@@ -411,9 +416,10 @@
 * \Rtdatatwo. M is XLEN-1 minus the index of the least-significant
 * bit containing 0 in \Rtdatatwo.
 *
-* 2: Matches when the value is greater than or equal to \Rtdatatwo.
+* 2: Matches when the value is greater than (unsigned) or equal to
+* \Rtdatatwo.
 *
-* 3: Matches when the value is less than \Rtdatatwo.
+* 3: Matches when the value is less than (unsigned) \Rtdatatwo.
 *
 * 4: Matches when the lower half of the value equals the lower half
 * of \Rtdatatwo after the lower half of the value is ANDed with the
@@ -427,57 +433,57 @@
  */
 #define CSR_MCONTROL_MATCH_OFFSET           7
 #define CSR_MCONTROL_MATCH_LENGTH           4
-#define CSR_MCONTROL_MATCH                  (0xfL << CSR_MCONTROL_MATCH_OFFSET)
+#define CSR_MCONTROL_MATCH                  (0xfULL << CSR_MCONTROL_MATCH_OFFSET)
 /*
 * When set, enable this trigger in M mode.
  */
 #define CSR_MCONTROL_M_OFFSET               6
 #define CSR_MCONTROL_M_LENGTH               1
-#define CSR_MCONTROL_M                      (0x1L << CSR_MCONTROL_M_OFFSET)
+#define CSR_MCONTROL_M                      (0x1ULL << CSR_MCONTROL_M_OFFSET)
 /*
 * When set, enable this trigger in H mode.
  */
 #define CSR_MCONTROL_H_OFFSET               5
 #define CSR_MCONTROL_H_LENGTH               1
-#define CSR_MCONTROL_H                      (0x1L << CSR_MCONTROL_H_OFFSET)
+#define CSR_MCONTROL_H                      (0x1ULL << CSR_MCONTROL_H_OFFSET)
 /*
 * When set, enable this trigger in S mode.
  */
 #define CSR_MCONTROL_S_OFFSET               4
 #define CSR_MCONTROL_S_LENGTH               1
-#define CSR_MCONTROL_S                      (0x1L << CSR_MCONTROL_S_OFFSET)
+#define CSR_MCONTROL_S                      (0x1ULL << CSR_MCONTROL_S_OFFSET)
 /*
 * When set, enable this trigger in U mode.
  */
 #define CSR_MCONTROL_U_OFFSET               3
 #define CSR_MCONTROL_U_LENGTH               1
-#define CSR_MCONTROL_U                      (0x1L << CSR_MCONTROL_U_OFFSET)
+#define CSR_MCONTROL_U                      (0x1ULL << CSR_MCONTROL_U_OFFSET)
 /*
 * When set, the trigger fires on the virtual address or opcode of an
 * instruction that is executed.
  */
 #define CSR_MCONTROL_EXECUTE_OFFSET         2
 #define CSR_MCONTROL_EXECUTE_LENGTH         1
-#define CSR_MCONTROL_EXECUTE                (0x1L << CSR_MCONTROL_EXECUTE_OFFSET)
+#define CSR_MCONTROL_EXECUTE                (0x1ULL << CSR_MCONTROL_EXECUTE_OFFSET)
 /*
 * When set, the trigger fires on the virtual address or data of a store.
  */
 #define CSR_MCONTROL_STORE_OFFSET           1
 #define CSR_MCONTROL_STORE_LENGTH           1
-#define CSR_MCONTROL_STORE                  (0x1L << CSR_MCONTROL_STORE_OFFSET)
+#define CSR_MCONTROL_STORE                  (0x1ULL << CSR_MCONTROL_STORE_OFFSET)
 /*
 * When set, the trigger fires on the virtual address or data of a load.
  */
 #define CSR_MCONTROL_LOAD_OFFSET            0
 #define CSR_MCONTROL_LOAD_LENGTH            1
-#define CSR_MCONTROL_LOAD                   (0x1L << CSR_MCONTROL_LOAD_OFFSET)
+#define CSR_MCONTROL_LOAD                   (0x1ULL << CSR_MCONTROL_LOAD_OFFSET)
 #define CSR_ICOUNT                          0x7a1
 #define CSR_ICOUNT_TYPE_OFFSET              XLEN-4
 #define CSR_ICOUNT_TYPE_LENGTH              4
-#define CSR_ICOUNT_TYPE                     (0xfL << CSR_ICOUNT_TYPE_OFFSET)
+#define CSR_ICOUNT_TYPE                     (0xfULL << CSR_ICOUNT_TYPE_OFFSET)
 #define CSR_ICOUNT_DMODE_OFFSET             XLEN-5
 #define CSR_ICOUNT_DMODE_LENGTH             1
-#define CSR_ICOUNT_DMODE                    (0x1L << CSR_ICOUNT_DMODE_OFFSET)
+#define CSR_ICOUNT_DMODE                    (0x1ULL << CSR_ICOUNT_DMODE_OFFSET)
 /*
 * When count is decremented to 0, the trigger fires. Instead of
 * changing \Fcount from 1 to 0, it is also acceptable for hardware to
@@ -486,42 +492,42 @@
  */
 #define CSR_ICOUNT_COUNT_OFFSET             10
 #define CSR_ICOUNT_COUNT_LENGTH             14
-#define CSR_ICOUNT_COUNT                    (0x3fffL << CSR_ICOUNT_COUNT_OFFSET)
+#define CSR_ICOUNT_COUNT                    (0x3fffULL << CSR_ICOUNT_COUNT_OFFSET)
 /*
 * When set, every instruction completed or exception taken in M mode decrements \Fcount
 * by 1.
  */
 #define CSR_ICOUNT_M_OFFSET                 9
 #define CSR_ICOUNT_M_LENGTH                 1
-#define CSR_ICOUNT_M                        (0x1L << CSR_ICOUNT_M_OFFSET)
+#define CSR_ICOUNT_M                        (0x1ULL << CSR_ICOUNT_M_OFFSET)
 /*
 * When set, every instruction completed or exception taken in in H mode decrements \Fcount
 * by 1.
  */
 #define CSR_ICOUNT_H_OFFSET                 8
 #define CSR_ICOUNT_H_LENGTH                 1
-#define CSR_ICOUNT_H                        (0x1L << CSR_ICOUNT_H_OFFSET)
+#define CSR_ICOUNT_H                        (0x1ULL << CSR_ICOUNT_H_OFFSET)
 /*
 * When set, every instruction completed or exception taken in S mode decrements \Fcount
 * by 1.
  */
 #define CSR_ICOUNT_S_OFFSET                 7
 #define CSR_ICOUNT_S_LENGTH                 1
-#define CSR_ICOUNT_S                        (0x1L << CSR_ICOUNT_S_OFFSET)
+#define CSR_ICOUNT_S                        (0x1ULL << CSR_ICOUNT_S_OFFSET)
 /*
 * When set, every instruction completed or exception taken in U mode decrements \Fcount
 * by 1.
  */
 #define CSR_ICOUNT_U_OFFSET                 6
 #define CSR_ICOUNT_U_LENGTH                 1
-#define CSR_ICOUNT_U                        (0x1L << CSR_ICOUNT_U_OFFSET)
+#define CSR_ICOUNT_U                        (0x1ULL << CSR_ICOUNT_U_OFFSET)
 /*
 * Determines what happens when this trigger matches.
 *
 * 0: Raise a breakpoint exception. (Used when software wants to use the
 * trigger module without an external debugger attached.)
 *
-* 1: Enter Debug Mode. (Only supported when \Fhmode is 1.)
+* 1: Enter Debug Mode. (Only supported when \Fdmode is 1.)
 *
 * 2: Start tracing.
 *
@@ -535,68 +541,92 @@
  */
 #define CSR_ICOUNT_ACTION_OFFSET            0
 #define CSR_ICOUNT_ACTION_LENGTH            6
-#define CSR_ICOUNT_ACTION                   (0x3fL << CSR_ICOUNT_ACTION_OFFSET)
+#define CSR_ICOUNT_ACTION                   (0x3fULL << CSR_ICOUNT_ACTION_OFFSET)
 #define DMI_DMSTATUS                        0x11
+/*
+* If 1, then there is an implicit {\tt ebreak} instruction at the
+* non-existent word immediately after the Program Buffer. This saves
+* the debugger from having to write the {\tt ebreak} itself, and
+* allows the Program Buffer to be one word smaller.
+*
+* This must be 1 when \Fprogbufsize is 1.
+ */
+#define DMI_DMSTATUS_IMPEBREAK_OFFSET       22
+#define DMI_DMSTATUS_IMPEBREAK_LENGTH       1
+#define DMI_DMSTATUS_IMPEBREAK              (0x1U << DMI_DMSTATUS_IMPEBREAK_OFFSET)
+/*
+* Gets set if the Debug Module was accessed incorrectly.
+*
+* 0 (none): No error.
+*
+* 1 (badaddr): There was an access to an unimplemented Debug Module
+* address.
+*
+* 7 (other): An access failed for another reason.
+ */
+#define DMI_DMSTATUS_DMERR_OFFSET           18
+#define DMI_DMSTATUS_DMERR_LENGTH           3
+#define DMI_DMSTATUS_DMERR                  (0x7U << DMI_DMSTATUS_DMERR_OFFSET)
 /*
 * This field is 1 when all currently selected harts have acknowledged the previous \Fresumereq.
  */
 #define DMI_DMSTATUS_ALLRESUMEACK_OFFSET    17
 #define DMI_DMSTATUS_ALLRESUMEACK_LENGTH    1
-#define DMI_DMSTATUS_ALLRESUMEACK           (0x1 << DMI_DMSTATUS_ALLRESUMEACK_OFFSET)
+#define DMI_DMSTATUS_ALLRESUMEACK           (0x1U << DMI_DMSTATUS_ALLRESUMEACK_OFFSET)
 /*
 * This field is 1 when any currently selected hart has acknowledged the previous \Fresumereq.
  */
 #define DMI_DMSTATUS_ANYRESUMEACK_OFFSET    16
 #define DMI_DMSTATUS_ANYRESUMEACK_LENGTH    1
-#define DMI_DMSTATUS_ANYRESUMEACK           (0x1 << DMI_DMSTATUS_ANYRESUMEACK_OFFSET)
+#define DMI_DMSTATUS_ANYRESUMEACK           (0x1U << DMI_DMSTATUS_ANYRESUMEACK_OFFSET)
 /*
 * This field is 1 when all currently selected harts do not exist in this system.
  */
 #define DMI_DMSTATUS_ALLNONEXISTENT_OFFSET  15
 #define DMI_DMSTATUS_ALLNONEXISTENT_LENGTH  1
-#define DMI_DMSTATUS_ALLNONEXISTENT         (0x1 << DMI_DMSTATUS_ALLNONEXISTENT_OFFSET)
+#define DMI_DMSTATUS_ALLNONEXISTENT         (0x1U << DMI_DMSTATUS_ALLNONEXISTENT_OFFSET)
 /*
 * This field is 1 when any currently selected hart does not exist in this system.
  */
 #define DMI_DMSTATUS_ANYNONEXISTENT_OFFSET  14
 #define DMI_DMSTATUS_ANYNONEXISTENT_LENGTH  1
-#define DMI_DMSTATUS_ANYNONEXISTENT         (0x1 << DMI_DMSTATUS_ANYNONEXISTENT_OFFSET)
+#define DMI_DMSTATUS_ANYNONEXISTENT         (0x1U << DMI_DMSTATUS_ANYNONEXISTENT_OFFSET)
 /*
 * This field is 1 when all currently selected harts are unavailable.
  */
 #define DMI_DMSTATUS_ALLUNAVAIL_OFFSET      13
 #define DMI_DMSTATUS_ALLUNAVAIL_LENGTH      1
-#define DMI_DMSTATUS_ALLUNAVAIL             (0x1 << DMI_DMSTATUS_ALLUNAVAIL_OFFSET)
+#define DMI_DMSTATUS_ALLUNAVAIL             (0x1U << DMI_DMSTATUS_ALLUNAVAIL_OFFSET)
 /*
 * This field is 1 when any currently selected hart is unavailable.
  */
 #define DMI_DMSTATUS_ANYUNAVAIL_OFFSET      12
 #define DMI_DMSTATUS_ANYUNAVAIL_LENGTH      1
-#define DMI_DMSTATUS_ANYUNAVAIL             (0x1 << DMI_DMSTATUS_ANYUNAVAIL_OFFSET)
+#define DMI_DMSTATUS_ANYUNAVAIL             (0x1U << DMI_DMSTATUS_ANYUNAVAIL_OFFSET)
 /*
 * This field is 1 when all currently selected harts are running.
  */
 #define DMI_DMSTATUS_ALLRUNNING_OFFSET      11
 #define DMI_DMSTATUS_ALLRUNNING_LENGTH      1
-#define DMI_DMSTATUS_ALLRUNNING             (0x1 << DMI_DMSTATUS_ALLRUNNING_OFFSET)
+#define DMI_DMSTATUS_ALLRUNNING             (0x1U << DMI_DMSTATUS_ALLRUNNING_OFFSET)
 /*
 * This field is 1 when any currently selected hart is running.
  */
 #define DMI_DMSTATUS_ANYRUNNING_OFFSET      10
 #define DMI_DMSTATUS_ANYRUNNING_LENGTH      1
-#define DMI_DMSTATUS_ANYRUNNING             (0x1 << DMI_DMSTATUS_ANYRUNNING_OFFSET)
+#define DMI_DMSTATUS_ANYRUNNING             (0x1U << DMI_DMSTATUS_ANYRUNNING_OFFSET)
 /*
 * This field is 1 when all currently selected harts are halted.
  */
 #define DMI_DMSTATUS_ALLHALTED_OFFSET       9
 #define DMI_DMSTATUS_ALLHALTED_LENGTH       1
-#define DMI_DMSTATUS_ALLHALTED              (0x1 << DMI_DMSTATUS_ALLHALTED_OFFSET)
+#define DMI_DMSTATUS_ALLHALTED              (0x1U << DMI_DMSTATUS_ALLHALTED_OFFSET)
 /*
 * This field is 1 when any currently selected hart is halted.
  */
 #define DMI_DMSTATUS_ANYHALTED_OFFSET       8
 #define DMI_DMSTATUS_ANYHALTED_LENGTH       1
-#define DMI_DMSTATUS_ANYHALTED              (0x1 << DMI_DMSTATUS_ANYHALTED_OFFSET)
+#define DMI_DMSTATUS_ANYHALTED              (0x1U << DMI_DMSTATUS_ANYHALTED_OFFSET)
 /*
 * 0 when authentication is required before using the DM.  1 when the
 * authentication check has passed. On components that don't implement
@@ -604,7 +634,7 @@
  */
 #define DMI_DMSTATUS_AUTHENTICATED_OFFSET   7
 #define DMI_DMSTATUS_AUTHENTICATED_LENGTH   1
-#define DMI_DMSTATUS_AUTHENTICATED          (0x1 << DMI_DMSTATUS_AUTHENTICATED_OFFSET)
+#define DMI_DMSTATUS_AUTHENTICATED          (0x1U << DMI_DMSTATUS_AUTHENTICATED_OFFSET)
 /*
 * 0: The authentication module is ready to process the next
 * read/write to \Rauthdata.
@@ -617,51 +647,56 @@
  */
 #define DMI_DMSTATUS_AUTHBUSY_OFFSET        6
 #define DMI_DMSTATUS_AUTHBUSY_LENGTH        1
-#define DMI_DMSTATUS_AUTHBUSY               (0x1 << DMI_DMSTATUS_AUTHBUSY_OFFSET)
-#define DMI_DMSTATUS_CFGSTRVALID_OFFSET     4
-#define DMI_DMSTATUS_CFGSTRVALID_LENGTH     1
-#define DMI_DMSTATUS_CFGSTRVALID            (0x1 << DMI_DMSTATUS_CFGSTRVALID_OFFSET)
+#define DMI_DMSTATUS_AUTHBUSY               (0x1U << DMI_DMSTATUS_AUTHBUSY_OFFSET)
 /*
-* Reserved for future use. Reads as 0.
- */
-#define DMI_DMSTATUS_VERSIONHI_OFFSET       2
-#define DMI_DMSTATUS_VERSIONHI_LENGTH       2
-#define DMI_DMSTATUS_VERSIONHI              (0x3 << DMI_DMSTATUS_VERSIONHI_OFFSET)
-/*
-* 00: There is no Debug Module present.
+* 0: \Rdevtreeaddrzero--\Rdevtreeaddrthree hold information which
+* is not relevant to the Device Tree.
 *
-* 01: There is a Debug Module and it conforms to version 0.11 of this
+* 1: \Rdevtreeaddrzero--\Rdevtreeaddrthree registers hold the address of the
+* Device Tree.
+ */
+#define DMI_DMSTATUS_DEVTREEVALID_OFFSET    4
+#define DMI_DMSTATUS_DEVTREEVALID_LENGTH    1
+#define DMI_DMSTATUS_DEVTREEVALID           (0x1U << DMI_DMSTATUS_DEVTREEVALID_OFFSET)
+/*
+* 0: There is no Debug Module present.
+*
+* 1: There is a Debug Module and it conforms to version 0.11 of this
 * specification.
 *
-* 10: There is a Debug Module and it conforms to version 0.13 of this
+* 2: There is a Debug Module and it conforms to version 0.13 of this
 * specification.
 *
-* 11: Reserved for future use.
+* 15: There is a Debug Module but it does not conform to any
+* available version of this spec.
  */
-#define DMI_DMSTATUS_VERSIONLO_OFFSET       0
-#define DMI_DMSTATUS_VERSIONLO_LENGTH       2
-#define DMI_DMSTATUS_VERSIONLO              (0x3 << DMI_DMSTATUS_VERSIONLO_OFFSET)
+#define DMI_DMSTATUS_VERSION_OFFSET         0
+#define DMI_DMSTATUS_VERSION_LENGTH         4
+#define DMI_DMSTATUS_VERSION                (0xfU << DMI_DMSTATUS_VERSION_OFFSET)
 #define DMI_DMCONTROL                       0x10
 /*
-* Halt request signal for all currently selected harts. When set to 1, the
-* hart will halt if it is not currently halted.
-* Setting both \Fhaltreq and \Fresumereq leads to undefined behavior.
+* Halt request signal for all currently selected harts. When set to
+* 1, each selected hart will halt if it is not currently halted.
+*
+* Writing 1 or 0 has no effect on a hart which is already halted, but
+* the bit should be cleared to 0 before the hart is resumed.
 *
 * Writes apply to the new value of \Fhartsel and \Fhasel.
  */
 #define DMI_DMCONTROL_HALTREQ_OFFSET        31
 #define DMI_DMCONTROL_HALTREQ_LENGTH        1
-#define DMI_DMCONTROL_HALTREQ               (0x1 << DMI_DMCONTROL_HALTREQ_OFFSET)
+#define DMI_DMCONTROL_HALTREQ               (0x1U << DMI_DMCONTROL_HALTREQ_OFFSET)
 /*
 * Resume request signal for all currently selected harts. When set to 1,
-* the hart will resume if it is currently halted.
-* Setting both \Fhaltreq and \Fresumereq leads to undefined behavior.
+* each selected hart will resume if it is currently halted.
+*
+* This bit is ignored while \Fhaltreq is set.
 *
 * Writes apply to the new value of \Fhartsel and \Fhasel.
  */
 #define DMI_DMCONTROL_RESUMEREQ_OFFSET      30
 #define DMI_DMCONTROL_RESUMEREQ_LENGTH      1
-#define DMI_DMCONTROL_RESUMEREQ             (0x1 << DMI_DMCONTROL_RESUMEREQ_OFFSET)
+#define DMI_DMCONTROL_RESUMEREQ             (0x1U << DMI_DMCONTROL_RESUMEREQ_OFFSET)
 /*
 * This optional bit controls reset to all the currently selected harts.
 * To perform a reset the debugger writes 1, and then writes 0 to
@@ -675,7 +710,7 @@
  */
 #define DMI_DMCONTROL_HARTRESET_OFFSET      29
 #define DMI_DMCONTROL_HARTRESET_LENGTH      1
-#define DMI_DMCONTROL_HARTRESET             (0x1 << DMI_DMCONTROL_HARTRESET_OFFSET)
+#define DMI_DMCONTROL_HARTRESET             (0x1U << DMI_DMCONTROL_HARTRESET_OFFSET)
 /*
 * Selects the  definition of currently selected harts.
 *
@@ -691,22 +726,26 @@
  */
 #define DMI_DMCONTROL_HASEL_OFFSET          26
 #define DMI_DMCONTROL_HASEL_LENGTH          1
-#define DMI_DMCONTROL_HASEL                 (0x1 << DMI_DMCONTROL_HASEL_OFFSET)
+#define DMI_DMCONTROL_HASEL                 (0x1U << DMI_DMCONTROL_HASEL_OFFSET)
 /*
 * The DM-specific index of the hart to select. This hart is always part of the
 * currently selected harts.
  */
 #define DMI_DMCONTROL_HARTSEL_OFFSET        16
 #define DMI_DMCONTROL_HARTSEL_LENGTH        10
-#define DMI_DMCONTROL_HARTSEL               (0x3ff << DMI_DMCONTROL_HARTSEL_OFFSET)
+#define DMI_DMCONTROL_HARTSEL               (0x3ffU << DMI_DMCONTROL_HARTSEL_OFFSET)
 /*
 * This bit controls the reset signal from the DM to the rest of the
-* system. To perform a reset the debugger writes 1, and then writes 0
+* system. The signal should reset every part of the system, including
+* every hart, except for the DM and any logic required to access the
+* DM.
+* To perform a system reset the debugger writes 1,
+* and then writes 0
 * to deassert the reset.
  */
 #define DMI_DMCONTROL_NDMRESET_OFFSET       1
 #define DMI_DMCONTROL_NDMRESET_LENGTH       1
-#define DMI_DMCONTROL_NDMRESET              (0x1 << DMI_DMCONTROL_NDMRESET_OFFSET)
+#define DMI_DMCONTROL_NDMRESET              (0x1U << DMI_DMCONTROL_NDMRESET_OFFSET)
 /*
 * This bit serves as a reset signal for the Debug Module itself.
 *
@@ -720,8 +759,8 @@
 * Debug Module after power up, including the platform's system reset
 * or Debug Transport reset signals.
 *
-* A debugger should pulse this bit low to ensure that the Debug
-* Module is fully reset and ready to use.
+* A debugger may pulse this bit low to get the debug module into a
+* known state.
 *
 * Implementations may use this bit to aid debugging, for example by
 * preventing the Debug Module from being power gated while debugging
@@ -729,7 +768,7 @@
  */
 #define DMI_DMCONTROL_DMACTIVE_OFFSET       0
 #define DMI_DMCONTROL_DMACTIVE_LENGTH       1
-#define DMI_DMCONTROL_DMACTIVE              (0x1 << DMI_DMCONTROL_DMACTIVE_OFFSET)
+#define DMI_DMCONTROL_DMACTIVE              (0x1U << DMI_DMCONTROL_DMACTIVE_OFFSET)
 #define DMI_HARTINFO                        0x12
 /*
 * Number of {\tt dscratch} registers available for the debugger
@@ -739,7 +778,7 @@
  */
 #define DMI_HARTINFO_NSCRATCH_OFFSET        20
 #define DMI_HARTINFO_NSCRATCH_LENGTH        4
-#define DMI_HARTINFO_NSCRATCH               (0xf << DMI_HARTINFO_NSCRATCH_OFFSET)
+#define DMI_HARTINFO_NSCRATCH               (0xfU << DMI_HARTINFO_NSCRATCH_OFFSET)
 /*
 * 0: The {\tt data} registers are shadowed in the hart by CSR
 * registers. Each CSR register is XLEN bits in size, and corresponds
@@ -750,7 +789,7 @@
  */
 #define DMI_HARTINFO_DATAACCESS_OFFSET      16
 #define DMI_HARTINFO_DATAACCESS_LENGTH      1
-#define DMI_HARTINFO_DATAACCESS             (0x1 << DMI_HARTINFO_DATAACCESS_OFFSET)
+#define DMI_HARTINFO_DATAACCESS             (0x1U << DMI_HARTINFO_DATAACCESS_OFFSET)
 /*
 * If \Fdataaccess is 0: Number of CSR registers dedicated to
 * shadowing the {\tt data} registers.
@@ -760,132 +799,129 @@
  */
 #define DMI_HARTINFO_DATASIZE_OFFSET        12
 #define DMI_HARTINFO_DATASIZE_LENGTH        4
-#define DMI_HARTINFO_DATASIZE               (0xf << DMI_HARTINFO_DATASIZE_OFFSET)
+#define DMI_HARTINFO_DATASIZE               (0xfU << DMI_HARTINFO_DATASIZE_OFFSET)
 /*
 * If \Fdataaccess is 0: The number of the first CSR dedicated to
 * shadowing the {\tt data} registers.
 *
 * If \Fdataaccess is 1: Signed address of RAM where the {\tt data}
-* registers are shadowed.
+* registers are shadowed, to be used to access relative to \Rzero.
  */
 #define DMI_HARTINFO_DATAADDR_OFFSET        0
 #define DMI_HARTINFO_DATAADDR_LENGTH        12
-#define DMI_HARTINFO_DATAADDR               (0xfff << DMI_HARTINFO_DATAADDR_OFFSET)
+#define DMI_HARTINFO_DATAADDR               (0xfffU << DMI_HARTINFO_DATAADDR_OFFSET)
 #define DMI_HALTSUM                         0x13
 #define DMI_HALTSUM_HALT1023_992_OFFSET     31
 #define DMI_HALTSUM_HALT1023_992_LENGTH     1
-#define DMI_HALTSUM_HALT1023_992            (0x1 << DMI_HALTSUM_HALT1023_992_OFFSET)
+#define DMI_HALTSUM_HALT1023_992            (0x1U << DMI_HALTSUM_HALT1023_992_OFFSET)
 #define DMI_HALTSUM_HALT991_960_OFFSET      30
 #define DMI_HALTSUM_HALT991_960_LENGTH      1
-#define DMI_HALTSUM_HALT991_960             (0x1 << DMI_HALTSUM_HALT991_960_OFFSET)
+#define DMI_HALTSUM_HALT991_960             (0x1U << DMI_HALTSUM_HALT991_960_OFFSET)
 #define DMI_HALTSUM_HALT959_928_OFFSET      29
 #define DMI_HALTSUM_HALT959_928_LENGTH      1
-#define DMI_HALTSUM_HALT959_928             (0x1 << DMI_HALTSUM_HALT959_928_OFFSET)
+#define DMI_HALTSUM_HALT959_928             (0x1U << DMI_HALTSUM_HALT959_928_OFFSET)
 #define DMI_HALTSUM_HALT927_896_OFFSET      28
 #define DMI_HALTSUM_HALT927_896_LENGTH      1
-#define DMI_HALTSUM_HALT927_896             (0x1 << DMI_HALTSUM_HALT927_896_OFFSET)
+#define DMI_HALTSUM_HALT927_896             (0x1U << DMI_HALTSUM_HALT927_896_OFFSET)
 #define DMI_HALTSUM_HALT895_864_OFFSET      27
 #define DMI_HALTSUM_HALT895_864_LENGTH      1
-#define DMI_HALTSUM_HALT895_864             (0x1 << DMI_HALTSUM_HALT895_864_OFFSET)
+#define DMI_HALTSUM_HALT895_864             (0x1U << DMI_HALTSUM_HALT895_864_OFFSET)
 #define DMI_HALTSUM_HALT863_832_OFFSET      26
 #define DMI_HALTSUM_HALT863_832_LENGTH      1
-#define DMI_HALTSUM_HALT863_832             (0x1 << DMI_HALTSUM_HALT863_832_OFFSET)
+#define DMI_HALTSUM_HALT863_832             (0x1U << DMI_HALTSUM_HALT863_832_OFFSET)
 #define DMI_HALTSUM_HALT831_800_OFFSET      25
 #define DMI_HALTSUM_HALT831_800_LENGTH      1
-#define DMI_HALTSUM_HALT831_800             (0x1 << DMI_HALTSUM_HALT831_800_OFFSET)
+#define DMI_HALTSUM_HALT831_800             (0x1U << DMI_HALTSUM_HALT831_800_OFFSET)
 #define DMI_HALTSUM_HALT799_768_OFFSET      24
 #define DMI_HALTSUM_HALT799_768_LENGTH      1
-#define DMI_HALTSUM_HALT799_768             (0x1 << DMI_HALTSUM_HALT799_768_OFFSET)
+#define DMI_HALTSUM_HALT799_768             (0x1U << DMI_HALTSUM_HALT799_768_OFFSET)
 #define DMI_HALTSUM_HALT767_736_OFFSET      23
 #define DMI_HALTSUM_HALT767_736_LENGTH      1
-#define DMI_HALTSUM_HALT767_736             (0x1 << DMI_HALTSUM_HALT767_736_OFFSET)
+#define DMI_HALTSUM_HALT767_736             (0x1U << DMI_HALTSUM_HALT767_736_OFFSET)
 #define DMI_HALTSUM_HALT735_704_OFFSET      22
 #define DMI_HALTSUM_HALT735_704_LENGTH      1
-#define DMI_HALTSUM_HALT735_704             (0x1 << DMI_HALTSUM_HALT735_704_OFFSET)
+#define DMI_HALTSUM_HALT735_704             (0x1U << DMI_HALTSUM_HALT735_704_OFFSET)
 #define DMI_HALTSUM_HALT703_672_OFFSET      21
 #define DMI_HALTSUM_HALT703_672_LENGTH      1
-#define DMI_HALTSUM_HALT703_672             (0x1 << DMI_HALTSUM_HALT703_672_OFFSET)
+#define DMI_HALTSUM_HALT703_672             (0x1U << DMI_HALTSUM_HALT703_672_OFFSET)
 #define DMI_HALTSUM_HALT671_640_OFFSET      20
 #define DMI_HALTSUM_HALT671_640_LENGTH      1
-#define DMI_HALTSUM_HALT671_640             (0x1 << DMI_HALTSUM_HALT671_640_OFFSET)
+#define DMI_HALTSUM_HALT671_640             (0x1U << DMI_HALTSUM_HALT671_640_OFFSET)
 #define DMI_HALTSUM_HALT639_608_OFFSET      19
 #define DMI_HALTSUM_HALT639_608_LENGTH      1
-#define DMI_HALTSUM_HALT639_608             (0x1 << DMI_HALTSUM_HALT639_608_OFFSET)
+#define DMI_HALTSUM_HALT639_608             (0x1U << DMI_HALTSUM_HALT639_608_OFFSET)
 #define DMI_HALTSUM_HALT607_576_OFFSET      18
 #define DMI_HALTSUM_HALT607_576_LENGTH      1
-#define DMI_HALTSUM_HALT607_576             (0x1 << DMI_HALTSUM_HALT607_576_OFFSET)
+#define DMI_HALTSUM_HALT607_576             (0x1U << DMI_HALTSUM_HALT607_576_OFFSET)
 #define DMI_HALTSUM_HALT575_544_OFFSET      17
 #define DMI_HALTSUM_HALT575_544_LENGTH      1
-#define DMI_HALTSUM_HALT575_544             (0x1 << DMI_HALTSUM_HALT575_544_OFFSET)
+#define DMI_HALTSUM_HALT575_544             (0x1U << DMI_HALTSUM_HALT575_544_OFFSET)
 #define DMI_HALTSUM_HALT543_512_OFFSET      16
 #define DMI_HALTSUM_HALT543_512_LENGTH      1
-#define DMI_HALTSUM_HALT543_512             (0x1 << DMI_HALTSUM_HALT543_512_OFFSET)
+#define DMI_HALTSUM_HALT543_512             (0x1U << DMI_HALTSUM_HALT543_512_OFFSET)
 #define DMI_HALTSUM_HALT511_480_OFFSET      15
 #define DMI_HALTSUM_HALT511_480_LENGTH      1
-#define DMI_HALTSUM_HALT511_480             (0x1 << DMI_HALTSUM_HALT511_480_OFFSET)
+#define DMI_HALTSUM_HALT511_480             (0x1U << DMI_HALTSUM_HALT511_480_OFFSET)
 #define DMI_HALTSUM_HALT479_448_OFFSET      14
 #define DMI_HALTSUM_HALT479_448_LENGTH      1
-#define DMI_HALTSUM_HALT479_448             (0x1 << DMI_HALTSUM_HALT479_448_OFFSET)
+#define DMI_HALTSUM_HALT479_448             (0x1U << DMI_HALTSUM_HALT479_448_OFFSET)
 #define DMI_HALTSUM_HALT447_416_OFFSET      13
 #define DMI_HALTSUM_HALT447_416_LENGTH      1
-#define DMI_HALTSUM_HALT447_416             (0x1 << DMI_HALTSUM_HALT447_416_OFFSET)
+#define DMI_HALTSUM_HALT447_416             (0x1U << DMI_HALTSUM_HALT447_416_OFFSET)
 #define DMI_HALTSUM_HALT415_384_OFFSET      12
 #define DMI_HALTSUM_HALT415_384_LENGTH      1
-#define DMI_HALTSUM_HALT415_384             (0x1 << DMI_HALTSUM_HALT415_384_OFFSET)
+#define DMI_HALTSUM_HALT415_384             (0x1U << DMI_HALTSUM_HALT415_384_OFFSET)
 #define DMI_HALTSUM_HALT383_352_OFFSET      11
 #define DMI_HALTSUM_HALT383_352_LENGTH      1
-#define DMI_HALTSUM_HALT383_352             (0x1 << DMI_HALTSUM_HALT383_352_OFFSET)
+#define DMI_HALTSUM_HALT383_352             (0x1U << DMI_HALTSUM_HALT383_352_OFFSET)
 #define DMI_HALTSUM_HALT351_320_OFFSET      10
 #define DMI_HALTSUM_HALT351_320_LENGTH      1
-#define DMI_HALTSUM_HALT351_320             (0x1 << DMI_HALTSUM_HALT351_320_OFFSET)
+#define DMI_HALTSUM_HALT351_320             (0x1U << DMI_HALTSUM_HALT351_320_OFFSET)
 #define DMI_HALTSUM_HALT319_288_OFFSET      9
 #define DMI_HALTSUM_HALT319_288_LENGTH      1
-#define DMI_HALTSUM_HALT319_288             (0x1 << DMI_HALTSUM_HALT319_288_OFFSET)
+#define DMI_HALTSUM_HALT319_288             (0x1U << DMI_HALTSUM_HALT319_288_OFFSET)
 #define DMI_HALTSUM_HALT287_256_OFFSET      8
 #define DMI_HALTSUM_HALT287_256_LENGTH      1
-#define DMI_HALTSUM_HALT287_256             (0x1 << DMI_HALTSUM_HALT287_256_OFFSET)
+#define DMI_HALTSUM_HALT287_256             (0x1U << DMI_HALTSUM_HALT287_256_OFFSET)
 #define DMI_HALTSUM_HALT255_224_OFFSET      7
 #define DMI_HALTSUM_HALT255_224_LENGTH      1
-#define DMI_HALTSUM_HALT255_224             (0x1 << DMI_HALTSUM_HALT255_224_OFFSET)
+#define DMI_HALTSUM_HALT255_224             (0x1U << DMI_HALTSUM_HALT255_224_OFFSET)
 #define DMI_HALTSUM_HALT223_192_OFFSET      6
 #define DMI_HALTSUM_HALT223_192_LENGTH      1
-#define DMI_HALTSUM_HALT223_192             (0x1 << DMI_HALTSUM_HALT223_192_OFFSET)
+#define DMI_HALTSUM_HALT223_192             (0x1U << DMI_HALTSUM_HALT223_192_OFFSET)
 #define DMI_HALTSUM_HALT191_160_OFFSET      5
 #define DMI_HALTSUM_HALT191_160_LENGTH      1
-#define DMI_HALTSUM_HALT191_160             (0x1 << DMI_HALTSUM_HALT191_160_OFFSET)
+#define DMI_HALTSUM_HALT191_160             (0x1U << DMI_HALTSUM_HALT191_160_OFFSET)
 #define DMI_HALTSUM_HALT159_128_OFFSET      4
 #define DMI_HALTSUM_HALT159_128_LENGTH      1
-#define DMI_HALTSUM_HALT159_128             (0x1 << DMI_HALTSUM_HALT159_128_OFFSET)
+#define DMI_HALTSUM_HALT159_128             (0x1U << DMI_HALTSUM_HALT159_128_OFFSET)
 #define DMI_HALTSUM_HALT127_96_OFFSET       3
 #define DMI_HALTSUM_HALT127_96_LENGTH       1
-#define DMI_HALTSUM_HALT127_96              (0x1 << DMI_HALTSUM_HALT127_96_OFFSET)
+#define DMI_HALTSUM_HALT127_96              (0x1U << DMI_HALTSUM_HALT127_96_OFFSET)
 #define DMI_HALTSUM_HALT95_64_OFFSET        2
 #define DMI_HALTSUM_HALT95_64_LENGTH        1
-#define DMI_HALTSUM_HALT95_64               (0x1 << DMI_HALTSUM_HALT95_64_OFFSET)
+#define DMI_HALTSUM_HALT95_64               (0x1U << DMI_HALTSUM_HALT95_64_OFFSET)
 #define DMI_HALTSUM_HALT63_32_OFFSET        1
 #define DMI_HALTSUM_HALT63_32_LENGTH        1
-#define DMI_HALTSUM_HALT63_32               (0x1 << DMI_HALTSUM_HALT63_32_OFFSET)
+#define DMI_HALTSUM_HALT63_32               (0x1U << DMI_HALTSUM_HALT63_32_OFFSET)
 #define DMI_HALTSUM_HALT31_0_OFFSET         0
 #define DMI_HALTSUM_HALT31_0_LENGTH         1
-#define DMI_HALTSUM_HALT31_0                (0x1 << DMI_HALTSUM_HALT31_0_OFFSET)
+#define DMI_HALTSUM_HALT31_0                (0x1U << DMI_HALTSUM_HALT31_0_OFFSET)
 #define DMI_HAWINDOWSEL                     0x14
 #define DMI_HAWINDOWSEL_HAWINDOWSEL_OFFSET  0
 #define DMI_HAWINDOWSEL_HAWINDOWSEL_LENGTH  5
-#define DMI_HAWINDOWSEL_HAWINDOWSEL         (0x1f << DMI_HAWINDOWSEL_HAWINDOWSEL_OFFSET)
+#define DMI_HAWINDOWSEL_HAWINDOWSEL         (0x1fU << DMI_HAWINDOWSEL_HAWINDOWSEL_OFFSET)
 #define DMI_HAWINDOW                        0x15
 #define DMI_HAWINDOW_MASKDATA_OFFSET        0
 #define DMI_HAWINDOW_MASKDATA_LENGTH        32
-#define DMI_HAWINDOW_MASKDATA               (0xffffffff << DMI_HAWINDOW_MASKDATA_OFFSET)
+#define DMI_HAWINDOW_MASKDATA               (0xffffffffU << DMI_HAWINDOW_MASKDATA_OFFSET)
 #define DMI_ABSTRACTCS                      0x16
 /*
 * Size of the Program Buffer, in 32-bit words. Valid sizes are 0 - 16.
-*
-* TODO: Explain what can be done with each size of the buffer, to suggest
-* why you would want more or less words.
  */
-#define DMI_ABSTRACTCS_PROGSIZE_OFFSET      24
-#define DMI_ABSTRACTCS_PROGSIZE_LENGTH      5
-#define DMI_ABSTRACTCS_PROGSIZE             (0x1f << DMI_ABSTRACTCS_PROGSIZE_OFFSET)
+#define DMI_ABSTRACTCS_PROGBUFSIZE_OFFSET   24
+#define DMI_ABSTRACTCS_PROGBUFSIZE_LENGTH   5
+#define DMI_ABSTRACTCS_PROGBUFSIZE          (0x1fU << DMI_ABSTRACTCS_PROGBUFSIZE_OFFSET)
 /*
 * 1: An abstract command is currently being executed.
 *
@@ -894,7 +930,7 @@
  */
 #define DMI_ABSTRACTCS_BUSY_OFFSET          12
 #define DMI_ABSTRACTCS_BUSY_LENGTH          1
-#define DMI_ABSTRACTCS_BUSY                 (0x1 << DMI_ABSTRACTCS_BUSY_OFFSET)
+#define DMI_ABSTRACTCS_BUSY                 (0x1U << DMI_ABSTRACTCS_BUSY_OFFSET)
 /*
 * Gets set if an abstract command fails. The bits in this field remain set until
 * they are cleared by writing 1 to them. No abstract command is
@@ -902,8 +938,9 @@
 *
 * 0 (none): No error.
 *
-* 1 (busy): An abstract command was executing while \Rcommand or one
-* of the {\tt data} registers was accessed.
+* 1 (busy): An abstract command was executing while \Rcommand,
+* \Rabstractcs, \Rabstractauto was written, or when one
+* of the {\tt data} or {\tt progbuf} registers was read or written.
 *
 * 2 (not supported): The requested command is not supported. A
 * command that is not supported while the hart is running may be
@@ -919,14 +956,14 @@
  */
 #define DMI_ABSTRACTCS_CMDERR_OFFSET        8
 #define DMI_ABSTRACTCS_CMDERR_LENGTH        3
-#define DMI_ABSTRACTCS_CMDERR               (0x7 << DMI_ABSTRACTCS_CMDERR_OFFSET)
+#define DMI_ABSTRACTCS_CMDERR               (0x7U << DMI_ABSTRACTCS_CMDERR_OFFSET)
 /*
 * Number of {\tt data} registers that are implemented as part of the
-* abstract command interface. Valid sizes are 0 - 8.
+* abstract command interface. Valid sizes are 0 - 12.
  */
 #define DMI_ABSTRACTCS_DATACOUNT_OFFSET     0
 #define DMI_ABSTRACTCS_DATACOUNT_LENGTH     5
-#define DMI_ABSTRACTCS_DATACOUNT            (0x1f << DMI_ABSTRACTCS_DATACOUNT_OFFSET)
+#define DMI_ABSTRACTCS_DATACOUNT            (0x1fU << DMI_ABSTRACTCS_DATACOUNT_OFFSET)
 #define DMI_COMMAND                         0x17
 /*
 * The type determines the overall functionality of this
@@ -934,14 +971,14 @@
  */
 #define DMI_COMMAND_CMDTYPE_OFFSET          24
 #define DMI_COMMAND_CMDTYPE_LENGTH          8
-#define DMI_COMMAND_CMDTYPE                 (0xff << DMI_COMMAND_CMDTYPE_OFFSET)
+#define DMI_COMMAND_CMDTYPE                 (0xffU << DMI_COMMAND_CMDTYPE_OFFSET)
 /*
 * This field is interpreted in a command-specific manner,
 * described for each abstract command.
  */
 #define DMI_COMMAND_CONTROL_OFFSET          0
 #define DMI_COMMAND_CONTROL_LENGTH          24
-#define DMI_COMMAND_CONTROL                 (0xffffff << DMI_COMMAND_CONTROL_OFFSET)
+#define DMI_COMMAND_CONTROL                 (0xffffffU << DMI_COMMAND_CONTROL_OFFSET)
 #define DMI_ABSTRACTAUTO                    0x18
 /*
 * When a bit in this field is 1, read or write accesses the corresponding {\tt progbuf} word
@@ -949,139 +986,35 @@
  */
 #define DMI_ABSTRACTAUTO_AUTOEXECPROGBUF_OFFSET 16
 #define DMI_ABSTRACTAUTO_AUTOEXECPROGBUF_LENGTH 16
-#define DMI_ABSTRACTAUTO_AUTOEXECPROGBUF    (0xffff << DMI_ABSTRACTAUTO_AUTOEXECPROGBUF_OFFSET)
+#define DMI_ABSTRACTAUTO_AUTOEXECPROGBUF    (0xffffU << DMI_ABSTRACTAUTO_AUTOEXECPROGBUF_OFFSET)
 /*
 * When a bit in this field is 1, read or write accesses the corresponding {\tt data} word
 * cause the command in \Rcommand to be executed again.
  */
 #define DMI_ABSTRACTAUTO_AUTOEXECDATA_OFFSET 0
 #define DMI_ABSTRACTAUTO_AUTOEXECDATA_LENGTH 12
-#define DMI_ABSTRACTAUTO_AUTOEXECDATA       (0xfff << DMI_ABSTRACTAUTO_AUTOEXECDATA_OFFSET)
-#define DMI_CFGSTRADDR0                     0x19
-#define DMI_CFGSTRADDR0_ADDR_OFFSET         0
-#define DMI_CFGSTRADDR0_ADDR_LENGTH         32
-#define DMI_CFGSTRADDR0_ADDR                (0xffffffff << DMI_CFGSTRADDR0_ADDR_OFFSET)
-#define DMI_CFGSTRADDR1                     0x1a
-#define DMI_CFGSTRADDR2                     0x1b
-#define DMI_CFGSTRADDR3                     0x1c
+#define DMI_ABSTRACTAUTO_AUTOEXECDATA       (0xfffU << DMI_ABSTRACTAUTO_AUTOEXECDATA_OFFSET)
+#define DMI_DEVTREEADDR0                    0x19
+#define DMI_DEVTREEADDR0_ADDR_OFFSET        0
+#define DMI_DEVTREEADDR0_ADDR_LENGTH        32
+#define DMI_DEVTREEADDR0_ADDR               (0xffffffffU << DMI_DEVTREEADDR0_ADDR_OFFSET)
+#define DMI_DEVTREEADDR1                    0x1a
+#define DMI_DEVTREEADDR2                    0x1b
+#define DMI_DEVTREEADDR3                    0x1c
 #define DMI_DATA0                           0x04
 #define DMI_DATA0_DATA_OFFSET               0
 #define DMI_DATA0_DATA_LENGTH               32
-#define DMI_DATA0_DATA                      (0xffffffff << DMI_DATA0_DATA_OFFSET)
+#define DMI_DATA0_DATA                      (0xffffffffU << DMI_DATA0_DATA_OFFSET)
 #define DMI_DATA11                          0x0f
 #define DMI_PROGBUF0                        0x20
 #define DMI_PROGBUF0_DATA_OFFSET            0
 #define DMI_PROGBUF0_DATA_LENGTH            32
-#define DMI_PROGBUF0_DATA                   (0xffffffff << DMI_PROGBUF0_DATA_OFFSET)
+#define DMI_PROGBUF0_DATA                   (0xffffffffU << DMI_PROGBUF0_DATA_OFFSET)
 #define DMI_PROGBUF15                       0x2f
 #define DMI_AUTHDATA                        0x30
 #define DMI_AUTHDATA_DATA_OFFSET            0
 #define DMI_AUTHDATA_DATA_LENGTH            32
-#define DMI_AUTHDATA_DATA                   (0xffffffff << DMI_AUTHDATA_DATA_OFFSET)
-#define DMI_SERCS                           0x34
-/*
-* Number of supported serial ports.
- */
-#define DMI_SERCS_SERIALCOUNT_OFFSET        28
-#define DMI_SERCS_SERIALCOUNT_LENGTH        4
-#define DMI_SERCS_SERIALCOUNT               (0xf << DMI_SERCS_SERIALCOUNT_OFFSET)
-/*
-* Select which serial port is accessed by \Rserrx and \Rsertx.
- */
-#define DMI_SERCS_SERIAL_OFFSET             24
-#define DMI_SERCS_SERIAL_LENGTH             3
-#define DMI_SERCS_SERIAL                    (0x7 << DMI_SERCS_SERIAL_OFFSET)
-#define DMI_SERCS_ERROR7_OFFSET             23
-#define DMI_SERCS_ERROR7_LENGTH             1
-#define DMI_SERCS_ERROR7                    (0x1 << DMI_SERCS_ERROR7_OFFSET)
-#define DMI_SERCS_VALID7_OFFSET             22
-#define DMI_SERCS_VALID7_LENGTH             1
-#define DMI_SERCS_VALID7                    (0x1 << DMI_SERCS_VALID7_OFFSET)
-#define DMI_SERCS_FULL7_OFFSET              21
-#define DMI_SERCS_FULL7_LENGTH              1
-#define DMI_SERCS_FULL7                     (0x1 << DMI_SERCS_FULL7_OFFSET)
-#define DMI_SERCS_ERROR6_OFFSET             20
-#define DMI_SERCS_ERROR6_LENGTH             1
-#define DMI_SERCS_ERROR6                    (0x1 << DMI_SERCS_ERROR6_OFFSET)
-#define DMI_SERCS_VALID6_OFFSET             19
-#define DMI_SERCS_VALID6_LENGTH             1
-#define DMI_SERCS_VALID6                    (0x1 << DMI_SERCS_VALID6_OFFSET)
-#define DMI_SERCS_FULL6_OFFSET              18
-#define DMI_SERCS_FULL6_LENGTH              1
-#define DMI_SERCS_FULL6                     (0x1 << DMI_SERCS_FULL6_OFFSET)
-#define DMI_SERCS_ERROR5_OFFSET             17
-#define DMI_SERCS_ERROR5_LENGTH             1
-#define DMI_SERCS_ERROR5                    (0x1 << DMI_SERCS_ERROR5_OFFSET)
-#define DMI_SERCS_VALID5_OFFSET             16
-#define DMI_SERCS_VALID5_LENGTH             1
-#define DMI_SERCS_VALID5                    (0x1 << DMI_SERCS_VALID5_OFFSET)
-#define DMI_SERCS_FULL5_OFFSET              15
-#define DMI_SERCS_FULL5_LENGTH              1
-#define DMI_SERCS_FULL5                     (0x1 << DMI_SERCS_FULL5_OFFSET)
-#define DMI_SERCS_ERROR4_OFFSET             14
-#define DMI_SERCS_ERROR4_LENGTH             1
-#define DMI_SERCS_ERROR4                    (0x1 << DMI_SERCS_ERROR4_OFFSET)
-#define DMI_SERCS_VALID4_OFFSET             13
-#define DMI_SERCS_VALID4_LENGTH             1
-#define DMI_SERCS_VALID4                    (0x1 << DMI_SERCS_VALID4_OFFSET)
-#define DMI_SERCS_FULL4_OFFSET              12
-#define DMI_SERCS_FULL4_LENGTH              1
-#define DMI_SERCS_FULL4                     (0x1 << DMI_SERCS_FULL4_OFFSET)
-#define DMI_SERCS_ERROR3_OFFSET             11
-#define DMI_SERCS_ERROR3_LENGTH             1
-#define DMI_SERCS_ERROR3                    (0x1 << DMI_SERCS_ERROR3_OFFSET)
-#define DMI_SERCS_VALID3_OFFSET             10
-#define DMI_SERCS_VALID3_LENGTH             1
-#define DMI_SERCS_VALID3                    (0x1 << DMI_SERCS_VALID3_OFFSET)
-#define DMI_SERCS_FULL3_OFFSET              9
-#define DMI_SERCS_FULL3_LENGTH              1
-#define DMI_SERCS_FULL3                     (0x1 << DMI_SERCS_FULL3_OFFSET)
-#define DMI_SERCS_ERROR2_OFFSET             8
-#define DMI_SERCS_ERROR2_LENGTH             1
-#define DMI_SERCS_ERROR2                    (0x1 << DMI_SERCS_ERROR2_OFFSET)
-#define DMI_SERCS_VALID2_OFFSET             7
-#define DMI_SERCS_VALID2_LENGTH             1
-#define DMI_SERCS_VALID2                    (0x1 << DMI_SERCS_VALID2_OFFSET)
-#define DMI_SERCS_FULL2_OFFSET              6
-#define DMI_SERCS_FULL2_LENGTH              1
-#define DMI_SERCS_FULL2                     (0x1 << DMI_SERCS_FULL2_OFFSET)
-#define DMI_SERCS_ERROR1_OFFSET             5
-#define DMI_SERCS_ERROR1_LENGTH             1
-#define DMI_SERCS_ERROR1                    (0x1 << DMI_SERCS_ERROR1_OFFSET)
-#define DMI_SERCS_VALID1_OFFSET             4
-#define DMI_SERCS_VALID1_LENGTH             1
-#define DMI_SERCS_VALID1                    (0x1 << DMI_SERCS_VALID1_OFFSET)
-#define DMI_SERCS_FULL1_OFFSET              3
-#define DMI_SERCS_FULL1_LENGTH              1
-#define DMI_SERCS_FULL1                     (0x1 << DMI_SERCS_FULL1_OFFSET)
-/*
-* 1 when the debugger-to-core queue for serial port 0 has
-* over or underflowed. This bit will remain set until it is reset by
-* writing 1 to this bit.
- */
-#define DMI_SERCS_ERROR0_OFFSET             2
-#define DMI_SERCS_ERROR0_LENGTH             1
-#define DMI_SERCS_ERROR0                    (0x1 << DMI_SERCS_ERROR0_OFFSET)
-/*
-* 1 when the core-to-debugger queue for serial port 0 is not empty.
- */
-#define DMI_SERCS_VALID0_OFFSET             1
-#define DMI_SERCS_VALID0_LENGTH             1
-#define DMI_SERCS_VALID0                    (0x1 << DMI_SERCS_VALID0_OFFSET)
-/*
-* 1 when the debugger-to-core queue for serial port 0 is full.
- */
-#define DMI_SERCS_FULL0_OFFSET              0
-#define DMI_SERCS_FULL0_LENGTH              1
-#define DMI_SERCS_FULL0                     (0x1 << DMI_SERCS_FULL0_OFFSET)
-#define DMI_SERTX                           0x35
-#define DMI_SERTX_DATA_OFFSET               0
-#define DMI_SERTX_DATA_LENGTH               32
-#define DMI_SERTX_DATA                      (0xffffffff << DMI_SERTX_DATA_OFFSET)
-#define DMI_SERRX                           0x36
-#define DMI_SERRX_DATA_OFFSET               0
-#define DMI_SERRX_DATA_LENGTH               32
-#define DMI_SERRX_DATA                      (0xffffffff << DMI_SERRX_DATA_OFFSET)
+#define DMI_AUTHDATA_DATA                   (0xffffffffU << DMI_AUTHDATA_DATA_OFFSET)
 #define DMI_SBCS                            0x38
 /*
 * When a 1 is written here, triggers a read at the address in {\tt
@@ -1089,7 +1022,7 @@
  */
 #define DMI_SBCS_SBSINGLEREAD_OFFSET        20
 #define DMI_SBCS_SBSINGLEREAD_LENGTH        1
-#define DMI_SBCS_SBSINGLEREAD               (0x1 << DMI_SBCS_SBSINGLEREAD_OFFSET)
+#define DMI_SBCS_SBSINGLEREAD               (0x1U << DMI_SBCS_SBSINGLEREAD_OFFSET)
 /*
 * Select the access size to use for system bus accesses triggered by
 * writes to the {\tt sbaddress} registers or \Rsbdatazero.
@@ -1104,28 +1037,26 @@
 *
 * 4: 128-bit
 *
-* If an unsupported system bus access size is written here,
-* the DM may not perform the access, or may perform the access
-* with any access size.
+* If an unsupported system bus access size is written here, the DM
+* does not perform the access and sberror is set to 3.
  */
 #define DMI_SBCS_SBACCESS_OFFSET            17
 #define DMI_SBCS_SBACCESS_LENGTH            3
-#define DMI_SBCS_SBACCESS                   (0x7 << DMI_SBCS_SBACCESS_OFFSET)
+#define DMI_SBCS_SBACCESS                   (0x7U << DMI_SBCS_SBACCESS_OFFSET)
 /*
-* When 1, the internal address value (used by the system bus master)
-* is incremented by the access size (in bytes) selected in \Fsbaccess
-* after every system bus access.
+* When 1, {\tt sbaddress} is incremented by the access size (in
+* bytes) selected in \Fsbaccess after every system bus access.
  */
 #define DMI_SBCS_SBAUTOINCREMENT_OFFSET     16
 #define DMI_SBCS_SBAUTOINCREMENT_LENGTH     1
-#define DMI_SBCS_SBAUTOINCREMENT            (0x1 << DMI_SBCS_SBAUTOINCREMENT_OFFSET)
+#define DMI_SBCS_SBAUTOINCREMENT            (0x1U << DMI_SBCS_SBAUTOINCREMENT_OFFSET)
 /*
-* When 1, every read from \Rsbdatazero automatically triggers a system
-* bus read at the new address.
+* When 1, every read from \Rsbdatazero automatically triggers a
+* system bus read at the (possibly auto-incremented) address.
  */
 #define DMI_SBCS_SBAUTOREAD_OFFSET          15
 #define DMI_SBCS_SBAUTOREAD_LENGTH          1
-#define DMI_SBCS_SBAUTOREAD                 (0x1 << DMI_SBCS_SBAUTOREAD_OFFSET)
+#define DMI_SBCS_SBAUTOREAD                 (0x1U << DMI_SBCS_SBAUTOREAD_OFFSET)
 /*
 * When the debug module's system bus
 * master causes a bus error, this field gets set. The bits in this
@@ -1141,223 +1072,118 @@
 *
 * 3: There was some other error (eg. alignment).
 *
-* 4: The system bus master was busy when a one of the
+* 4: The system bus master was busy when one of the
 * {\tt sbaddress} or {\tt sbdata} registers was written,
-* or the {\tt sbdata} register was read when it had
-* stale data.
+* or \Rsbdatazero was read when it had stale data.
  */
 #define DMI_SBCS_SBERROR_OFFSET             12
 #define DMI_SBCS_SBERROR_LENGTH             3
-#define DMI_SBCS_SBERROR                    (0x7 << DMI_SBCS_SBERROR_OFFSET)
+#define DMI_SBCS_SBERROR                    (0x7U << DMI_SBCS_SBERROR_OFFSET)
 /*
 * Width of system bus addresses in bits. (0 indicates there is no bus
 * access support.)
  */
 #define DMI_SBCS_SBASIZE_OFFSET             5
 #define DMI_SBCS_SBASIZE_LENGTH             7
-#define DMI_SBCS_SBASIZE                    (0x7f << DMI_SBCS_SBASIZE_OFFSET)
+#define DMI_SBCS_SBASIZE                    (0x7fU << DMI_SBCS_SBASIZE_OFFSET)
 /*
 * 1 when 128-bit system bus accesses are supported.
  */
 #define DMI_SBCS_SBACCESS128_OFFSET         4
 #define DMI_SBCS_SBACCESS128_LENGTH         1
-#define DMI_SBCS_SBACCESS128                (0x1 << DMI_SBCS_SBACCESS128_OFFSET)
+#define DMI_SBCS_SBACCESS128                (0x1U << DMI_SBCS_SBACCESS128_OFFSET)
 /*
 * 1 when 64-bit system bus accesses are supported.
  */
 #define DMI_SBCS_SBACCESS64_OFFSET          3
 #define DMI_SBCS_SBACCESS64_LENGTH          1
-#define DMI_SBCS_SBACCESS64                 (0x1 << DMI_SBCS_SBACCESS64_OFFSET)
+#define DMI_SBCS_SBACCESS64                 (0x1U << DMI_SBCS_SBACCESS64_OFFSET)
 /*
 * 1 when 32-bit system bus accesses are supported.
  */
 #define DMI_SBCS_SBACCESS32_OFFSET          2
 #define DMI_SBCS_SBACCESS32_LENGTH          1
-#define DMI_SBCS_SBACCESS32                 (0x1 << DMI_SBCS_SBACCESS32_OFFSET)
+#define DMI_SBCS_SBACCESS32                 (0x1U << DMI_SBCS_SBACCESS32_OFFSET)
 /*
 * 1 when 16-bit system bus accesses are supported.
  */
 #define DMI_SBCS_SBACCESS16_OFFSET          1
 #define DMI_SBCS_SBACCESS16_LENGTH          1
-#define DMI_SBCS_SBACCESS16                 (0x1 << DMI_SBCS_SBACCESS16_OFFSET)
+#define DMI_SBCS_SBACCESS16                 (0x1U << DMI_SBCS_SBACCESS16_OFFSET)
 /*
 * 1 when 8-bit system bus accesses are supported.
  */
 #define DMI_SBCS_SBACCESS8_OFFSET           0
 #define DMI_SBCS_SBACCESS8_LENGTH           1
-#define DMI_SBCS_SBACCESS8                  (0x1 << DMI_SBCS_SBACCESS8_OFFSET)
+#define DMI_SBCS_SBACCESS8                  (0x1U << DMI_SBCS_SBACCESS8_OFFSET)
 #define DMI_SBADDRESS0                      0x39
 /*
-* Accesses bits 31:0 of the internal address.
+* Accesses bits 31:0 of the physical address in {\tt sbaddress}.
  */
 #define DMI_SBADDRESS0_ADDRESS_OFFSET       0
 #define DMI_SBADDRESS0_ADDRESS_LENGTH       32
-#define DMI_SBADDRESS0_ADDRESS              (0xffffffff << DMI_SBADDRESS0_ADDRESS_OFFSET)
+#define DMI_SBADDRESS0_ADDRESS              (0xffffffffU << DMI_SBADDRESS0_ADDRESS_OFFSET)
 #define DMI_SBADDRESS1                      0x3a
 /*
-* Accesses bits 63:32 of the internal address (if the system address
-* bus is that wide).
+* Accesses bits 63:32 of the physical address in {\tt sbaddress} (if
+* the system address bus is that wide).
  */
 #define DMI_SBADDRESS1_ADDRESS_OFFSET       0
 #define DMI_SBADDRESS1_ADDRESS_LENGTH       32
-#define DMI_SBADDRESS1_ADDRESS              (0xffffffff << DMI_SBADDRESS1_ADDRESS_OFFSET)
+#define DMI_SBADDRESS1_ADDRESS              (0xffffffffU << DMI_SBADDRESS1_ADDRESS_OFFSET)
 #define DMI_SBADDRESS2                      0x3b
 /*
-* Accesses bits 95:64 of the internal address (if the system address
-* bus is that wide).
+* Accesses bits 95:64 of the physical address in {\tt sbaddress} (if
+* the system address bus is that wide).
  */
 #define DMI_SBADDRESS2_ADDRESS_OFFSET       0
 #define DMI_SBADDRESS2_ADDRESS_LENGTH       32
-#define DMI_SBADDRESS2_ADDRESS              (0xffffffff << DMI_SBADDRESS2_ADDRESS_OFFSET)
+#define DMI_SBADDRESS2_ADDRESS              (0xffffffffU << DMI_SBADDRESS2_ADDRESS_OFFSET)
 #define DMI_SBDATA0                         0x3c
 /*
-* Accesses bits 31:0 of the internal data.
+* Accesses bits 31:0 of {\tt sbdata}.
  */
 #define DMI_SBDATA0_DATA_OFFSET             0
 #define DMI_SBDATA0_DATA_LENGTH             32
-#define DMI_SBDATA0_DATA                    (0xffffffff << DMI_SBDATA0_DATA_OFFSET)
+#define DMI_SBDATA0_DATA                    (0xffffffffU << DMI_SBDATA0_DATA_OFFSET)
 #define DMI_SBDATA1                         0x3d
 /*
-* Accesses bits 63:32 of the internal data (if the system bus is
-* that wide).
+* Accesses bits 63:32 of {\tt sbdata} (if the system bus is that
+* wide).
  */
 #define DMI_SBDATA1_DATA_OFFSET             0
 #define DMI_SBDATA1_DATA_LENGTH             32
-#define DMI_SBDATA1_DATA                    (0xffffffff << DMI_SBDATA1_DATA_OFFSET)
+#define DMI_SBDATA1_DATA                    (0xffffffffU << DMI_SBDATA1_DATA_OFFSET)
 #define DMI_SBDATA2                         0x3e
 /*
-* Accesses bits 95:64 of the internal data (if the system bus is
-* that wide).
+* Accesses bits 95:64 of {\tt sbdata} (if the system bus is that
+* wide).
  */
 #define DMI_SBDATA2_DATA_OFFSET             0
 #define DMI_SBDATA2_DATA_LENGTH             32
-#define DMI_SBDATA2_DATA                    (0xffffffff << DMI_SBDATA2_DATA_OFFSET)
+#define DMI_SBDATA2_DATA                    (0xffffffffU << DMI_SBDATA2_DATA_OFFSET)
 #define DMI_SBDATA3                         0x3f
 /*
-* Accesses bits 127:96 of the internal data (if the system bus is
-* that wide).
+* Accesses bits 127:96 of {\tt sbdata} (if the system bus is that
+* wide).
  */
 #define DMI_SBDATA3_DATA_OFFSET             0
 #define DMI_SBDATA3_DATA_LENGTH             32
-#define DMI_SBDATA3_DATA                    (0xffffffff << DMI_SBDATA3_DATA_OFFSET)
-#define TRACE                               0x728
-/*
-* 1 if the trace buffer has wrapped since the last time \Fdiscard was
-* written. 0 otherwise.
- */
-#define TRACE_WRAPPED_OFFSET                24
-#define TRACE_WRAPPED_LENGTH                1
-#define TRACE_WRAPPED                       (0x1 << TRACE_WRAPPED_OFFSET)
-/*
-* Emit Timestamp trace sequences.
- */
-#define TRACE_EMITTIMESTAMP_OFFSET          23
-#define TRACE_EMITTIMESTAMP_LENGTH          1
-#define TRACE_EMITTIMESTAMP                 (0x1 << TRACE_EMITTIMESTAMP_OFFSET)
-/*
-* Emit Store Data trace sequences.
- */
-#define TRACE_EMITSTOREDATA_OFFSET          22
-#define TRACE_EMITSTOREDATA_LENGTH          1
-#define TRACE_EMITSTOREDATA                 (0x1 << TRACE_EMITSTOREDATA_OFFSET)
-/*
-* Emit Load Data trace sequences.
- */
-#define TRACE_EMITLOADDATA_OFFSET           21
-#define TRACE_EMITLOADDATA_LENGTH           1
-#define TRACE_EMITLOADDATA                  (0x1 << TRACE_EMITLOADDATA_OFFSET)
-/*
-* Emit Store Address trace sequences.
- */
-#define TRACE_EMITSTOREADDR_OFFSET          20
-#define TRACE_EMITSTOREADDR_LENGTH          1
-#define TRACE_EMITSTOREADDR                 (0x1 << TRACE_EMITSTOREADDR_OFFSET)
-/*
-* Emit Load Address trace sequences.
- */
-#define TRACE_EMITLOADADDR_OFFSET           19
-#define TRACE_EMITLOADADDR_LENGTH           1
-#define TRACE_EMITLOADADDR                  (0x1 << TRACE_EMITLOADADDR_OFFSET)
-/*
-* Emit Privilege Level trace sequences.
- */
-#define TRACE_EMITPRIV_OFFSET               18
-#define TRACE_EMITPRIV_LENGTH               1
-#define TRACE_EMITPRIV                      (0x1 << TRACE_EMITPRIV_OFFSET)
-/*
-* Emit Branch Taken and Branch Not Taken trace sequences.
- */
-#define TRACE_EMITBRANCH_OFFSET             17
-#define TRACE_EMITBRANCH_LENGTH             1
-#define TRACE_EMITBRANCH                    (0x1 << TRACE_EMITBRANCH_OFFSET)
-/*
-* Emit PC trace sequences.
- */
-#define TRACE_EMITPC_OFFSET                 16
-#define TRACE_EMITPC_LENGTH                 1
-#define TRACE_EMITPC                        (0x1 << TRACE_EMITPC_OFFSET)
-/*
-* Determine what happens when the trace buffer is full.  0 means wrap
-* and overwrite. 1 means turn off trace until \Fdiscard is written as 1.
-* 2 means cause a trace full exception. 3 is reserved for future use.
- */
-#define TRACE_FULLACTION_OFFSET             8
-#define TRACE_FULLACTION_LENGTH             2
-#define TRACE_FULLACTION                    (0x3 << TRACE_FULLACTION_OFFSET)
-/*
-* 0: Trace to a dedicated on-core RAM (which is not further defined in
-* this spec).
-*
-* 1: Trace to RAM on the system bus.
-*
-* 2: Send trace data to a dedicated off-chip interface (which is not
-* defined in this spec). This does not affect execution speed.
-*
-* 3: Reserved for future use.
-*
-* Options 0 and 1 slow down execution (eg. because of system bus
-* contention).
- */
-#define TRACE_DESTINATION_OFFSET            4
-#define TRACE_DESTINATION_LENGTH            2
-#define TRACE_DESTINATION                   (0x3 << TRACE_DESTINATION_OFFSET)
-/*
-* When 1, the trace logic may stall processor execution to ensure it
-* can emit all the trace sequences required. When 0 individual trace
-* sequences may be dropped.
- */
-#define TRACE_STALL_OFFSET                  2
-#define TRACE_STALL_LENGTH                  1
-#define TRACE_STALL                         (0x1 << TRACE_STALL_OFFSET)
-/*
-* Writing 1 to this bit tells the trace logic that any trace
-* collected is no longer required. When tracing to RAM, it resets the
-* trace write pointer to the start of the memory, as well as
-* \Fwrapped.
- */
-#define TRACE_DISCARD_OFFSET                1
-#define TRACE_DISCARD_LENGTH                1
-#define TRACE_DISCARD                       (0x1 << TRACE_DISCARD_OFFSET)
-#define TRACE_SUPPORTED_OFFSET              0
-#define TRACE_SUPPORTED_LENGTH              1
-#define TRACE_SUPPORTED                     (0x1 << TRACE_SUPPORTED_OFFSET)
-#define TBUFSTART                           0x729
-#define TBUFEND                             0x72a
-#define TBUFWRITE                           0x72b
+#define DMI_SBDATA3_DATA                    (0xffffffffU << DMI_SBDATA3_DATA_OFFSET)
 #define SHORTNAME                           0x123
 /*
 * Description of what this field is used for.
  */
 #define SHORTNAME_FIELD_OFFSET              0
 #define SHORTNAME_FIELD_LENGTH              8
-#define SHORTNAME_FIELD                     (0xff << SHORTNAME_FIELD_OFFSET)
+#define SHORTNAME_FIELD                     (0xffU << SHORTNAME_FIELD_OFFSET)
 #define AC_ACCESS_REGISTER                  None
 /*
 * This is 0 to indicate Access Register Command.
  */
 #define AC_ACCESS_REGISTER_CMDTYPE_OFFSET   24
 #define AC_ACCESS_REGISTER_CMDTYPE_LENGTH   8
-#define AC_ACCESS_REGISTER_CMDTYPE          (0xff << AC_ACCESS_REGISTER_CMDTYPE_OFFSET)
+#define AC_ACCESS_REGISTER_CMDTYPE          (0xffU << AC_ACCESS_REGISTER_CMDTYPE_OFFSET)
 /*
 * 2: Access the lowest 32 bits of the register.
 *
@@ -1371,22 +1197,25 @@
  */
 #define AC_ACCESS_REGISTER_SIZE_OFFSET      20
 #define AC_ACCESS_REGISTER_SIZE_LENGTH      3
-#define AC_ACCESS_REGISTER_SIZE             (0x7 << AC_ACCESS_REGISTER_SIZE_OFFSET)
+#define AC_ACCESS_REGISTER_SIZE             (0x7U << AC_ACCESS_REGISTER_SIZE_OFFSET)
 /*
 * When 1, execute the program in the Program Buffer exactly once
 * after performing the transfer, if any.
  */
 #define AC_ACCESS_REGISTER_POSTEXEC_OFFSET  18
 #define AC_ACCESS_REGISTER_POSTEXEC_LENGTH  1
-#define AC_ACCESS_REGISTER_POSTEXEC         (0x1 << AC_ACCESS_REGISTER_POSTEXEC_OFFSET)
+#define AC_ACCESS_REGISTER_POSTEXEC         (0x1U << AC_ACCESS_REGISTER_POSTEXEC_OFFSET)
 /*
 * 0: Don't do the operation specified by \Fwrite.
 *
 * 1: Do the operation specified by \Fwrite.
+*
+* This bit can be used to just execute the Program Buffer without
+* having to worry about placing valid values into \Fsize or \Fregno.
  */
 #define AC_ACCESS_REGISTER_TRANSFER_OFFSET  17
 #define AC_ACCESS_REGISTER_TRANSFER_LENGTH  1
-#define AC_ACCESS_REGISTER_TRANSFER         (0x1 << AC_ACCESS_REGISTER_TRANSFER_OFFSET)
+#define AC_ACCESS_REGISTER_TRANSFER         (0x1U << AC_ACCESS_REGISTER_TRANSFER_OFFSET)
 /*
 * When \Ftransfer is set:
 * 0: Copy data from the specified register into {\tt arg0} portion
@@ -1397,17 +1226,135 @@
  */
 #define AC_ACCESS_REGISTER_WRITE_OFFSET     16
 #define AC_ACCESS_REGISTER_WRITE_LENGTH     1
-#define AC_ACCESS_REGISTER_WRITE            (0x1 << AC_ACCESS_REGISTER_WRITE_OFFSET)
+#define AC_ACCESS_REGISTER_WRITE            (0x1U << AC_ACCESS_REGISTER_WRITE_OFFSET)
 /*
-* Number of the register to access, as described in Table~\ref{tab:regno}.
+* Number of the register to access, as described in
+* Table~\ref{tab:regno}.
+* \Rdpc may be used as an alias for PC if this command is
+* supported on a non-halted hart.
  */
 #define AC_ACCESS_REGISTER_REGNO_OFFSET     0
 #define AC_ACCESS_REGISTER_REGNO_LENGTH     16
-#define AC_ACCESS_REGISTER_REGNO            (0xffff << AC_ACCESS_REGISTER_REGNO_OFFSET)
+#define AC_ACCESS_REGISTER_REGNO            (0xffffU << AC_ACCESS_REGISTER_REGNO_OFFSET)
 #define AC_QUICK_ACCESS                     None
 /*
 * This is 1 to indicate Quick Access command.
  */
 #define AC_QUICK_ACCESS_CMDTYPE_OFFSET      24
 #define AC_QUICK_ACCESS_CMDTYPE_LENGTH      8
-#define AC_QUICK_ACCESS_CMDTYPE             (0xff << AC_QUICK_ACCESS_CMDTYPE_OFFSET)
+#define AC_QUICK_ACCESS_CMDTYPE             (0xffU << AC_QUICK_ACCESS_CMDTYPE_OFFSET)
+#define VIRT_PRIV                           virtual
+/*
+* Contains the privilege level the hart was operating in when Debug
+* Mode was entered. The encoding is described in Table
+* \ref{tab:privlevel}, and matches the privilege level encoding from
+* the RISC-V Privileged ISA Specification. A user can write this
+* value to change the hart's privilege level when exiting Debug Mode.
+ */
+#define VIRT_PRIV_PRV_OFFSET                0
+#define VIRT_PRIV_PRV_LENGTH                2
+#define VIRT_PRIV_PRV                       (0x3U << VIRT_PRIV_PRV_OFFSET)
+#define DMI_SERCS                           0x34
+/*
+* Number of supported serial ports.
+ */
+#define DMI_SERCS_SERIALCOUNT_OFFSET        28
+#define DMI_SERCS_SERIALCOUNT_LENGTH        4
+#define DMI_SERCS_SERIALCOUNT               (0xfU << DMI_SERCS_SERIALCOUNT_OFFSET)
+/*
+* Select which serial port is accessed by \Rserrx and \Rsertx.
+ */
+#define DMI_SERCS_SERIAL_OFFSET             24
+#define DMI_SERCS_SERIAL_LENGTH             3
+#define DMI_SERCS_SERIAL                    (0x7U << DMI_SERCS_SERIAL_OFFSET)
+#define DMI_SERCS_ERROR7_OFFSET             23
+#define DMI_SERCS_ERROR7_LENGTH             1
+#define DMI_SERCS_ERROR7                    (0x1U << DMI_SERCS_ERROR7_OFFSET)
+#define DMI_SERCS_VALID7_OFFSET             22
+#define DMI_SERCS_VALID7_LENGTH             1
+#define DMI_SERCS_VALID7                    (0x1U << DMI_SERCS_VALID7_OFFSET)
+#define DMI_SERCS_FULL7_OFFSET              21
+#define DMI_SERCS_FULL7_LENGTH              1
+#define DMI_SERCS_FULL7                     (0x1U << DMI_SERCS_FULL7_OFFSET)
+#define DMI_SERCS_ERROR6_OFFSET             20
+#define DMI_SERCS_ERROR6_LENGTH             1
+#define DMI_SERCS_ERROR6                    (0x1U << DMI_SERCS_ERROR6_OFFSET)
+#define DMI_SERCS_VALID6_OFFSET             19
+#define DMI_SERCS_VALID6_LENGTH             1
+#define DMI_SERCS_VALID6                    (0x1U << DMI_SERCS_VALID6_OFFSET)
+#define DMI_SERCS_FULL6_OFFSET              18
+#define DMI_SERCS_FULL6_LENGTH              1
+#define DMI_SERCS_FULL6                     (0x1U << DMI_SERCS_FULL6_OFFSET)
+#define DMI_SERCS_ERROR5_OFFSET             17
+#define DMI_SERCS_ERROR5_LENGTH             1
+#define DMI_SERCS_ERROR5                    (0x1U << DMI_SERCS_ERROR5_OFFSET)
+#define DMI_SERCS_VALID5_OFFSET             16
+#define DMI_SERCS_VALID5_LENGTH             1
+#define DMI_SERCS_VALID5                    (0x1U << DMI_SERCS_VALID5_OFFSET)
+#define DMI_SERCS_FULL5_OFFSET              15
+#define DMI_SERCS_FULL5_LENGTH              1
+#define DMI_SERCS_FULL5                     (0x1U << DMI_SERCS_FULL5_OFFSET)
+#define DMI_SERCS_ERROR4_OFFSET             14
+#define DMI_SERCS_ERROR4_LENGTH             1
+#define DMI_SERCS_ERROR4                    (0x1U << DMI_SERCS_ERROR4_OFFSET)
+#define DMI_SERCS_VALID4_OFFSET             13
+#define DMI_SERCS_VALID4_LENGTH             1
+#define DMI_SERCS_VALID4                    (0x1U << DMI_SERCS_VALID4_OFFSET)
+#define DMI_SERCS_FULL4_OFFSET              12
+#define DMI_SERCS_FULL4_LENGTH              1
+#define DMI_SERCS_FULL4                     (0x1U << DMI_SERCS_FULL4_OFFSET)
+#define DMI_SERCS_ERROR3_OFFSET             11
+#define DMI_SERCS_ERROR3_LENGTH             1
+#define DMI_SERCS_ERROR3                    (0x1U << DMI_SERCS_ERROR3_OFFSET)
+#define DMI_SERCS_VALID3_OFFSET             10
+#define DMI_SERCS_VALID3_LENGTH             1
+#define DMI_SERCS_VALID3                    (0x1U << DMI_SERCS_VALID3_OFFSET)
+#define DMI_SERCS_FULL3_OFFSET              9
+#define DMI_SERCS_FULL3_LENGTH              1
+#define DMI_SERCS_FULL3                     (0x1U << DMI_SERCS_FULL3_OFFSET)
+#define DMI_SERCS_ERROR2_OFFSET             8
+#define DMI_SERCS_ERROR2_LENGTH             1
+#define DMI_SERCS_ERROR2                    (0x1U << DMI_SERCS_ERROR2_OFFSET)
+#define DMI_SERCS_VALID2_OFFSET             7
+#define DMI_SERCS_VALID2_LENGTH             1
+#define DMI_SERCS_VALID2                    (0x1U << DMI_SERCS_VALID2_OFFSET)
+#define DMI_SERCS_FULL2_OFFSET              6
+#define DMI_SERCS_FULL2_LENGTH              1
+#define DMI_SERCS_FULL2                     (0x1U << DMI_SERCS_FULL2_OFFSET)
+#define DMI_SERCS_ERROR1_OFFSET             5
+#define DMI_SERCS_ERROR1_LENGTH             1
+#define DMI_SERCS_ERROR1                    (0x1U << DMI_SERCS_ERROR1_OFFSET)
+#define DMI_SERCS_VALID1_OFFSET             4
+#define DMI_SERCS_VALID1_LENGTH             1
+#define DMI_SERCS_VALID1                    (0x1U << DMI_SERCS_VALID1_OFFSET)
+#define DMI_SERCS_FULL1_OFFSET              3
+#define DMI_SERCS_FULL1_LENGTH              1
+#define DMI_SERCS_FULL1                     (0x1U << DMI_SERCS_FULL1_OFFSET)
+/*
+* 1 when the debugger-to-core queue for serial port 0 has
+* over or underflowed. This bit will remain set until it is reset by
+* writing 1 to this bit.
+ */
+#define DMI_SERCS_ERROR0_OFFSET             2
+#define DMI_SERCS_ERROR0_LENGTH             1
+#define DMI_SERCS_ERROR0                    (0x1U << DMI_SERCS_ERROR0_OFFSET)
+/*
+* 1 when the core-to-debugger queue for serial port 0 is not empty.
+ */
+#define DMI_SERCS_VALID0_OFFSET             1
+#define DMI_SERCS_VALID0_LENGTH             1
+#define DMI_SERCS_VALID0                    (0x1U << DMI_SERCS_VALID0_OFFSET)
+/*
+* 1 when the debugger-to-core queue for serial port 0 is full.
+ */
+#define DMI_SERCS_FULL0_OFFSET              0
+#define DMI_SERCS_FULL0_LENGTH              1
+#define DMI_SERCS_FULL0                     (0x1U << DMI_SERCS_FULL0_OFFSET)
+#define DMI_SERTX                           0x35
+#define DMI_SERTX_DATA_OFFSET               0
+#define DMI_SERTX_DATA_LENGTH               32
+#define DMI_SERTX_DATA                      (0xffffffffU << DMI_SERTX_DATA_OFFSET)
+#define DMI_SERRX                           0x36
+#define DMI_SERRX_DATA_OFFSET               0
+#define DMI_SERRX_DATA_LENGTH               32
+#define DMI_SERRX_DATA                      (0xffffffffU << DMI_SERRX_DATA_OFFSET)

--- a/riscv/debug_module.cc
+++ b/riscv/debug_module.cc
@@ -26,6 +26,7 @@ debug_module_t::debug_module_t(sim_t *sim, unsigned progbufsize) :
   dmcontrol = {0};
 
   dmstatus = {0};
+  dmstatus.impebreak = true;
   dmstatus.authenticated = 1;
   dmstatus.version = 2;
 
@@ -40,7 +41,10 @@ debug_module_t::debug_module_t(sim_t *sim, unsigned progbufsize) :
   memset(debug_rom_flags, 0, sizeof(debug_rom_flags));
   memset(resumeack, 0, sizeof(resumeack));
   memset(program_buffer, 0, program_buffer_bytes);
-  program_buffer[progbufsize] = ebreak();
+  program_buffer[4*progbufsize] = ebreak();
+  program_buffer[4*progbufsize+1] = ebreak() >> 8;
+  program_buffer[4*progbufsize+2] = ebreak() >> 16;
+  program_buffer[4*progbufsize+3] = ebreak() >> 24;
   memset(dmdata, 0, sizeof(dmdata));
 
   write32(debug_rom_whereto, 0,
@@ -65,6 +69,7 @@ void debug_module_t::reset()
   dmcontrol = {0};
 
   dmstatus = {0};
+  dmstatus.impebreak = true;
   dmstatus.authenticated = 1;
   dmstatus.version = 2;
 
@@ -301,6 +306,8 @@ bool debug_module_t::dmi_read(unsigned address, uint32_t *value)
             dmstatus.allresumeack = false;
           }
 
+          result = set_field(result, DMI_DMSTATUS_IMPEBREAK,
+              dmstatus.impebreak);
 	  result = set_field(result, DMI_DMSTATUS_ALLNONEXISTENT, dmstatus.allnonexistant);
 	  result = set_field(result, DMI_DMSTATUS_ALLUNAVAIL, dmstatus.allunavail);
 	  result = set_field(result, DMI_DMSTATUS_ALLRUNNING, dmstatus.allrunning);

--- a/riscv/debug_module.h
+++ b/riscv/debug_module.h
@@ -18,6 +18,7 @@ typedef struct {
 } dmcontrol_t;
 
 typedef struct {
+  bool impebreak;
   bool allnonexistant;
   bool anynonexistant;
   bool allunavail;

--- a/riscv/debug_module.h
+++ b/riscv/debug_module.h
@@ -31,8 +31,7 @@ typedef struct {
   bool authenticated;
   bool authbusy;
   bool cfgstrvalid;
-  unsigned versionhi;
-  unsigned versionlo;
+  unsigned version;
 } dmstatus_t;
 
 typedef enum cmderr {
@@ -47,7 +46,7 @@ typedef enum cmderr {
 typedef struct {
   bool busy;
   unsigned datacount;
-  unsigned progsize;
+  unsigned progbufsize;
   cmderr_t cmderr;
 } abstractcs_t;
 
@@ -59,7 +58,7 @@ typedef struct {
 class debug_module_t : public abstract_device_t
 {
   public:
-    debug_module_t(sim_t *sim, unsigned progsize);
+    debug_module_t(sim_t *sim, unsigned progbufsize);
     ~debug_module_t();
 
     void add_device(bus_t *bus);
@@ -77,7 +76,7 @@ class debug_module_t : public abstract_device_t
     static const unsigned datasize = 2;
     // Size of program_buffer in 32-bit words, as exposed to the rest of the
     // world.
-    unsigned progsize;
+    unsigned progbufsize;
     // Actual size of the program buffer, which is 1 word bigger than we let on
     // to implement the implicit ebreak at the end.
     unsigned program_buffer_bytes;

--- a/riscv/debug_module.h
+++ b/riscv/debug_module.h
@@ -59,7 +59,8 @@ typedef struct {
 class debug_module_t : public abstract_device_t
 {
   public:
-    debug_module_t(sim_t *sim);
+    debug_module_t(sim_t *sim, unsigned progsize);
+    ~debug_module_t();
 
     void add_device(bus_t *bus);
 
@@ -74,18 +75,23 @@ class debug_module_t : public abstract_device_t
 
   private:
     static const unsigned datasize = 2;
-    static const unsigned progsize = 16;
+    // Size of program_buffer in 32-bit words, as exposed to the rest of the
+    // world.
+    unsigned progsize;
+    // Actual size of the program buffer, which is 1 word bigger than we let on
+    // to implement the implicit ebreak at the end.
+    unsigned program_buffer_bytes;
     static const unsigned debug_data_start = 0x380;
-    static const unsigned debug_progbuf_start = debug_data_start - progsize*4;
+    unsigned debug_progbuf_start;
 
     static const unsigned debug_abstract_size = 2;
-    static const unsigned debug_abstract_start = debug_progbuf_start - debug_abstract_size*4;
-        
+    unsigned debug_abstract_start;
+
     sim_t *sim;
 
     uint8_t debug_rom_whereto[4];
     uint8_t debug_abstract[debug_abstract_size * 4];
-    uint8_t program_buffer[progsize * 4];
+    uint8_t *program_buffer;
     uint8_t dmdata[datasize * 4];
     
     bool halted[1024];

--- a/riscv/execute.cc
+++ b/riscv/execute.cc
@@ -147,14 +147,12 @@ void processor_t::step(size_t n)
             break;
           }
 
-          if (unlikely(state.pc >= DEBUG_START &&
+          if (unlikely(state.pc >= DEBUG_ROM_ENTRY &&
                        state.pc < DEBUG_END)) {
             // We're waiting for the debugger to tell us something.
             return;
           }
 
-          
-          
         }
       }
       else while (instret < n)

--- a/riscv/sim.cc
+++ b/riscv/sim.cc
@@ -25,8 +25,10 @@ static void handle_signal(int sig)
 
 sim_t::sim_t(const char* isa, size_t nprocs, bool halted, reg_t start_pc,
              std::vector<std::pair<reg_t, mem_t*>> mems,
-             const std::vector<std::string>& args, std::vector<int> const hartids)
-  : htif_t(args), debug_module(this), mems(mems), procs(std::max(nprocs, size_t(1))),
+             const std::vector<std::string>& args,
+             std::vector<int> const hartids, unsigned progsize)
+  : htif_t(args), debug_module(this, progsize), mems(mems),
+      procs(std::max(nprocs, size_t(1))),
     start_pc(start_pc),
     current_step(0), current_proc(0), debug(false), remote_bitbang(NULL)
 {

--- a/riscv/sim.h
+++ b/riscv/sim.h
@@ -21,7 +21,8 @@ class sim_t : public htif_t
 public:
   sim_t(const char* isa, size_t _nprocs,  bool halted, reg_t start_pc,
         std::vector<std::pair<reg_t, mem_t*>> mems,
-        const std::vector<std::string>& args, const std::vector<int> hartids);
+        const std::vector<std::string>& args, const std::vector<int> hartids,
+        unsigned progsize);
   ~sim_t();
 
   // run the simulation to completion

--- a/spike_main/spike.cc
+++ b/spike_main/spike.cc
@@ -25,7 +25,7 @@ static void help()
   fprintf(stderr, "  -g                    Track histogram of PCs\n");
   fprintf(stderr, "  -l                    Generate a log of execution\n");
   fprintf(stderr, "  -h                    Print this help message\n");
-  fprintf(stderr, "  -H                 Start halted, allowing a debugger to connect\n");
+  fprintf(stderr, "  -H                    Start halted, allowing a debugger to connect\n");
   fprintf(stderr, "  --isa=<name>          RISC-V ISA string [default %s]\n", DEFAULT_ISA);
   fprintf(stderr, "  --pc=<address>        Override ELF entry point\n");
   fprintf(stderr, "  --hartids=<a,b,...>   Explicitly specify hartids, default is 0,1,...\n");
@@ -35,7 +35,8 @@ static void help()
   fprintf(stderr, "  --extension=<name>    Specify RoCC Extension\n");
   fprintf(stderr, "  --extlib=<name>       Shared library to load\n");
   fprintf(stderr, "  --rbb-port=<port>     Listen on <port> for remote bitbang connection\n");
-  fprintf(stderr, "  --dump-dts  Print device tree string and exit\n");
+  fprintf(stderr, "  --dump-dts            Print device tree string and exit\n");
+  fprintf(stderr, "  --progsize=<words>    progsize for the debug module [default 2]\n");
   exit(1);
 }
 
@@ -85,6 +86,7 @@ int main(int argc, char** argv)
   const char* isa = DEFAULT_ISA;
   uint16_t rbb_port = 0;
   bool use_rbb = false;
+  unsigned progsize = 2;
   std::vector<int> hartids;
 
   auto const hartids_parser = [&](const char *s) {
@@ -125,13 +127,15 @@ int main(int argc, char** argv)
       exit(-1);
     }
   });
+  parser.option(0, "progsize", 1, [&](const char* s){progsize = atoi(s);});
 
   auto argv1 = parser.parse(argv);
   std::vector<std::string> htif_args(argv1, (const char*const*)argv + argc);
   if (mems.empty())
     mems = make_mems("2048");
 
-  sim_t s(isa, nprocs, halted, start_pc, mems, htif_args, std::move(hartids));
+  sim_t s(isa, nprocs, halted, start_pc, mems, htif_args, std::move(hartids),
+      progsize);
   std::unique_ptr<remote_bitbang_t> remote_bitbang((remote_bitbang_t *) NULL);
   std::unique_ptr<jtag_dtm_t> jtag_dtm(new jtag_dtm_t(&s.debug_module));
   if (use_rbb) {


### PR DESCRIPTION
This allows us to test that OpenOCD can work with that limitation.

The default program buffer size is now 2, but a command line option allows it to be set to any size.