### PR TITLE
mem_t: Throw an error if zero-sized memory is requested

### DIFF
--- a/riscv/devices.h
+++ b/riscv/devices.h
@@ -41,6 +41,8 @@ class rom_device_t : public abstract_device_t {
 class mem_t : public abstract_device_t {
  public:
   mem_t(size_t size) : len(size) {
+    if (!size)
+      throw std::runtime_error("zero bytes of target memory requested");
     data = (char*)calloc(1, size);
     if (!data)
       throw std::runtime_error("couldn't allocate " + std::to_string(size) + " bytes of target memory");

--- a/spike_main/spike.cc
+++ b/spike_main/spike.cc
@@ -47,6 +47,8 @@ static std::vector<std::pair<reg_t, mem_t*>> make_mems(const char* arg)
   auto mb = strtoull(arg, &p, 0);
   if (*p == 0) {
     reg_t size = reg_t(mb) << 20;
+    if (size != (size_t)size)
+      throw std::runtime_error("Size would overflow size_t");
     return std::vector<std::pair<reg_t, mem_t*>>(1, std::make_pair(reg_t(DRAM_BASE), new mem_t(size)));
   }
 


### PR DESCRIPTION
This improves usability in cases where the user accidentally specifies a
memory size that's big enough to overflow to 0.