### PR TITLE
Add debug module authentication.

### DIFF
--- a/riscv/debug_module.cc
+++ b/riscv/debug_module.cc
@@ -16,10 +16,12 @@
 
 ///////////////////////// debug_module_t
 
-debug_module_t::debug_module_t(sim_t *sim, unsigned progbufsize, unsigned max_bus_master_bits) :
+debug_module_t::debug_module_t(sim_t *sim, unsigned progbufsize, unsigned max_bus_master_bits,
+    bool require_authentication) :
   progbufsize(progbufsize),
   program_buffer_bytes(4 + 4*progbufsize),
   max_bus_master_bits(max_bus_master_bits),
+  require_authentication(require_authentication),
   debug_progbuf_start(debug_data_start - program_buffer_bytes),
   debug_abstract_start(debug_progbuf_start - debug_abstract_size*4),
   sim(sim)
@@ -61,7 +63,7 @@ void debug_module_t::reset()
 
   dmstatus = {0};
   dmstatus.impebreak = true;
-  dmstatus.authenticated = 1;
+  dmstatus.authenticated = !require_authentication;
   dmstatus.version = 2;
 
   abstractcs = {0};
@@ -83,6 +85,8 @@ void debug_module_t::reset()
     sbcs.access16 = true;
   if (max_bus_master_bits >= 8)
     sbcs.access8 = true;
+
+  challenge = random();
 }
 
 void debug_module_t::add_device(bus_t *bus) {
@@ -458,6 +462,9 @@ bool debug_module_t::dmi_read(unsigned address, uint32_t *value)
       case DMI_SBDATA3:
         result = sbdata[3];
         break;
+      case DMI_AUTHDATA:
+        result = challenge;
+        break;
       default:
         result = 0;
         D(fprintf(stderr, "Unexpected. Returning Error."));
@@ -548,6 +555,11 @@ bool debug_module_t::perform_abstract_command()
 bool debug_module_t::dmi_write(unsigned address, uint32_t value)
 {
   D(fprintf(stderr, "dmi_write(0x%x, 0x%x)\n", address, value));
+
+  if (!dmstatus.authenticated && address != DMI_AUTHDATA &&
+      address != DMI_DMCONTROL)
+    return false;
+
   if (address >= DMI_DATA0 && address < DMI_DATA0 + abstractcs.datacount) {
     unsigned i = address - DMI_DATA0;
     if (!abstractcs.busy)
@@ -580,6 +592,8 @@ bool debug_module_t::dmi_write(unsigned address, uint32_t value)
           if (!dmcontrol.dmactive && get_field(value, DMI_DMCONTROL_DMACTIVE))
             reset();
           dmcontrol.dmactive = get_field(value, DMI_DMCONTROL_DMACTIVE);
+          if (!dmstatus.authenticated)
+            return true;
           if (dmcontrol.dmactive) {
             dmcontrol.haltreq = get_field(value, DMI_DMCONTROL_HALTREQ);
             dmcontrol.resumereq = get_field(value, DMI_DMCONTROL_RESUMEREQ);
@@ -661,6 +675,18 @@ bool debug_module_t::dmi_write(unsigned address, uint32_t value)
         return true;
       case DMI_SBDATA3:
         sbdata[3] = value;
+        return true;
+      case DMI_AUTHDATA:
+        D(fprintf(stderr, "debug authentication: got 0x%x; 0x%x unlocks\n", value,
+            challenge + secret));
+        if (require_authentication) {
+          if (value == challenge + secret) {
+            dmstatus.authenticated = true;
+          } else {
+            dmstatus.authenticated = false;
+            challenge = random();
+          }
+        }
         return true;
     }
   }

--- a/riscv/debug_module.h
+++ b/riscv/debug_module.h
@@ -74,7 +74,14 @@ typedef struct {
 class debug_module_t : public abstract_device_t
 {
   public:
-    debug_module_t(sim_t *sim, unsigned progbufsize, unsigned max_bus_master_bits);
+    /*
+     * If require_authentication is true, then a debugger must authenticate as
+     * follows:
+     * 1. Read a 32-bit value from authdata:
+     * 2. Write the value that was read back, plus one, to authdata.
+     */
+    debug_module_t(sim_t *sim, unsigned progbufsize, unsigned max_bus_master_bits,
+        bool require_authentication);
     ~debug_module_t();
 
     void add_device(bus_t *bus);
@@ -96,7 +103,8 @@ class debug_module_t : public abstract_device_t
     // Actual size of the program buffer, which is 1 word bigger than we let on
     // to implement the implicit ebreak at the end.
     unsigned program_buffer_bytes;
-    unsigned max_bus_master_bits ;
+    unsigned max_bus_master_bits;
+    bool require_authentication;
     static const unsigned debug_data_start = 0x380;
     unsigned debug_progbuf_start;
 
@@ -133,6 +141,9 @@ class debug_module_t : public abstract_device_t
     sbcs_t sbcs;
     uint32_t sbaddress[4];
     uint32_t sbdata[4];
+
+    uint32_t challenge;
+    const uint32_t secret = 1;
 
     processor_t *current_proc() const;
     void reset();

--- a/riscv/jtag_dtm.cc
+++ b/riscv/jtag_dtm.cc
@@ -14,7 +14,8 @@
 enum {
   IR_IDCODE=1,
   IR_DTMCONTROL=0x10,
-  IR_DBUS=0x11
+  IR_DBUS=0x11,
+  IR_RESET=0x1c
 };
 
 #define DTMCONTROL_VERSION      0xf
@@ -104,8 +105,11 @@ void jtag_dtm_t::set_pins(bool tck, bool tms, bool tdi) {
       case SHIFT_IR:
         _tdo = ir & 1;
         break;
-      case UPDATE_IR:
-        break;
+      //case UPDATE_IR:
+        //if (ir == IR_RESET) {
+          // Make a reset happen
+        //}
+        //break;
       default:
         break;
     }

--- a/riscv/sim.cc
+++ b/riscv/sim.cc
@@ -27,10 +27,11 @@ sim_t::sim_t(const char* isa, size_t nprocs, bool halted, reg_t start_pc,
              std::vector<std::pair<reg_t, mem_t*>> mems,
              const std::vector<std::string>& args,
              std::vector<int> const hartids, unsigned progsize,
-             unsigned max_bus_master_bits)
+             unsigned max_bus_master_bits, bool require_authentication)
   : htif_t(args), mems(mems), procs(std::max(nprocs, size_t(1))),
     start_pc(start_pc), current_step(0), current_proc(0), debug(false),
-    remote_bitbang(NULL), debug_module(this, progsize, max_bus_master_bits)
+    remote_bitbang(NULL),
+    debug_module(this, progsize, max_bus_master_bits, require_authentication)
 {
   signal(SIGINT, &handle_signal);
 

--- a/riscv/sim.h
+++ b/riscv/sim.h
@@ -22,7 +22,7 @@ public:
   sim_t(const char* isa, size_t _nprocs,  bool halted, reg_t start_pc,
         std::vector<std::pair<reg_t, mem_t*>> mems,
         const std::vector<std::string>& args, const std::vector<int> hartids,
-        unsigned progsize, unsigned max_bus_master_bits);
+        unsigned progsize, unsigned max_bus_master_bits, bool require_authentication);
   ~sim_t();
 
   // run the simulation to completion


### PR DESCRIPTION
Off by default, enabled with --debug-auth.
The protocol is very simple (definitely not secure) to allow debuggers
to test their authentication feature. To authenticate a debugger must:
1. Read authdata
2. Write to authdata the value that it just read, plus 1