### PR TITLE
Fix single stepping csrrw instructions

### DIFF
--- a/riscv/execute.cc
+++ b/riscv/execute.cc
@@ -128,6 +128,13 @@ void processor_t::step(size_t n)
       {
         while (instret < n)
         {
+          if (unlikely(!state.serialized && state.single_step == state.STEP_STEPPED)) {
+            state.single_step = state.STEP_NONE;
+            enter_debug_mode(DCSR_CAUSE_STEP);
+            // enter_debug_mode changed state.pc, so we can't just continue.
+            break;
+          }
+
           if (unlikely(state.single_step == state.STEP_STEPPING)) {
             state.single_step = state.STEP_STEPPED;
           }
@@ -136,16 +143,8 @@ void processor_t::step(size_t n)
           if (debug && !state.serialized)
             disasm(fetch.insn);
           pc = execute_insn(this, pc, fetch);
-          bool serialize_before = (pc == PC_SERIALIZE_BEFORE);
 
           advance_pc();
-
-          if (unlikely(state.single_step == state.STEP_STEPPED) && !serialize_before) {
-            state.single_step = state.STEP_NONE;
-            enter_debug_mode(DCSR_CAUSE_STEP);
-            // enter_debug_mode changed state.pc, so we can't just continue.
-            break;
-          }
 
           if (unlikely(state.pc >= DEBUG_ROM_ENTRY &&
                        state.pc < DEBUG_END)) {


### PR DESCRIPTION
This code is still a bit voodoo to me, but now we pass all the tests
again. (Stepping was broken by
4299874ad4b07ef457776513a64e5b2397a6a75e.)