### PR TITLE
Fix a bug caused by moving misa into state_t.

### DIFF
--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -117,7 +117,9 @@ void processor_t::parse_isa_string(const char* str)
 
 void state_t::reset()
 {
+  reg_t misa = this->misa;
   memset(this, 0, sizeof(*this));
+  this->misa = misa;
   prv = PRV_M;
   pc = DEFAULT_RSTVEC;
   load_reservation = -1;

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -115,11 +115,10 @@ void processor_t::parse_isa_string(const char* str)
   max_isa = state.misa;
 }
 
-void state_t::reset()
+void state_t::reset(reg_t max_isa)
 {
-  reg_t misa = this->misa;
   memset(this, 0, sizeof(*this));
-  this->misa = misa;
+  this->misa = max_isa;
   prv = PRV_M;
   pc = DEFAULT_RSTVEC;
   load_reservation = -1;
@@ -148,7 +147,7 @@ void processor_t::set_histogram(bool value)
 
 void processor_t::reset()
 {
-  state.reset();
+  state.reset(max_isa);
   state.dcsr.halt = halt_on_reset;
   halt_on_reset = false;
   set_csr(CSR_MSTATUS, state.mstatus);

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -118,7 +118,7 @@ void processor_t::parse_isa_string(const char* str)
 void state_t::reset(reg_t max_isa)
 {
   memset(this, 0, sizeof(*this));
-  this->misa = max_isa;
+  misa = max_isa;
   prv = PRV_M;
   pc = DEFAULT_RSTVEC;
   load_reservation = -1;

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -86,7 +86,7 @@ typedef struct
 // architectural state of a RISC-V hart
 struct state_t
 {
-  void reset();
+  void reset(reg_t max_isa);
 
   static const int num_triggers = 4;
 


### PR DESCRIPTION
state->reset() clears misa, which causes it to lose its value assigned in the processor constructor.  One way to fix this by making state->reset() preserve misa.  A bit hacky; this might be the reason misa was outside state_t in the first place.