### PR TITLE
Fix for issue #183: No illegal instruction exception for c.sxxi instructions encoded with zero shift amount

### DIFF
--- a/riscv/insns/c_slli.h
+++ b/riscv/insns/c_slli.h
@@ -1,3 +1,4 @@
 require_extension('C');
 require(insn.rvc_zimm() < xlen);
+require((xlen < 128) ? (insn.rvc_zimm() > 0) : 1);
 WRITE_RD(sext_xlen(RVC_RS1 << insn.rvc_zimm()));

--- a/riscv/insns/c_srai.h
+++ b/riscv/insns/c_srai.h
@@ -1,3 +1,4 @@
 require_extension('C');
 require(insn.rvc_zimm() < xlen);
+require((xlen < 128) ? (insn.rvc_zimm() > 0) : 1);
 WRITE_RVC_RS1S(sext_xlen(sext_xlen(RVC_RS1S) >> insn.rvc_zimm()));

--- a/riscv/insns/c_srli.h
+++ b/riscv/insns/c_srli.h
@@ -1,3 +1,4 @@
 require_extension('C');
 require(insn.rvc_zimm() < xlen);
+require((xlen < 128) ? (insn.rvc_zimm() > 0) : 1);
 WRITE_RVC_RS1S(sext_xlen(zext_xlen(RVC_RS1S) >> insn.rvc_zimm()));


### PR DESCRIPTION
RISC-V spec says that the shift amount must be non-zero for c.slli, c.srli and c.srai instructions in RV32C and RV64C. SPIKE was not reporting illegal instruction exception in case a zero shift amount was encoded. The diff being submitted below will fix that.
