### PR TITLE
Fix spike-dasm.

### DIFF
--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -155,7 +155,8 @@ void processor_t::reset()
   if (ext)
     ext->reset(); // reset the extension
 
-  sim->proc_reset(id);
+  if (sim)
+    sim->proc_reset(id);
 }
 
 // Count number of contiguous 0 bits starting from the LSB.


### PR DESCRIPTION
It had been broken by 90bafe660b323250338fd564bb9ab4316576d59b.

If somebody wants to flip the travis switch on this repo, I will write the .travis.yml file that does a build and ensures that spike-dasm doesn't segfault on startup.