### PR TITLE
Fix the access exception during page-table walks to match the original access type, as specified in the manual.

### DIFF
--- a/riscv/mmu.cc
+++ b/riscv/mmu.cc
@@ -182,7 +182,7 @@ reg_t mmu_t::walk(reg_t addr, access_type type, reg_t mode)
     // check that physical address of PTE is legal
     auto ppte = sim->addr_to_mem(base + idx * vm.ptesize);
     if (!ppte)
-      throw trap_load_access_fault(addr);
+      goto fail_access;
 
     reg_t pte = vm.ptesize == 4 ? *(uint32_t*)ppte : *(uint64_t*)ppte;
     reg_t ppn = pte >> PTE_PPN_SHIFT;
@@ -221,6 +221,14 @@ fail:
     case FETCH: throw trap_instruction_page_fault(addr);
     case LOAD: throw trap_load_page_fault(addr);
     case STORE: throw trap_store_page_fault(addr);
+    default: abort();
+  }
+
+fail_access:
+  switch (type) {
+    case FETCH: throw trap_instruction_access_fault(addr);
+    case LOAD: throw trap_load_access_fault(addr);
+    case STORE: throw trap_store_access_fault(addr);
     default: abort();
   }
 }


### PR DESCRIPTION
This fix corresponds to my reading of the spec.  Is it correct?  Interestingly, all the rv64-v- tests pass with with and without this fix.  So they don't seem to be testing this detail.