### PR TITLE
Put simif_t declaration in its own file.

### DIFF
--- a/riscv/debug_module.cc
+++ b/riscv/debug_module.cc
@@ -4,6 +4,7 @@
 #include "debug_defines.h"
 #include "opcodes.h"
 #include "mmu.h"
+#include "sim.h"
 
 #include "debug_rom/debug_rom.h"
 #include "debug_rom_defines.h"

--- a/riscv/mmu.cc
+++ b/riscv/mmu.cc
@@ -1,7 +1,7 @@
 // See LICENSE for license details.
 
 #include "mmu.h"
-#include "sim.h"
+#include "simif.h"
 #include "processor.h"
 
 mmu_t::mmu_t(simif_t* sim, processor_t* proc)

--- a/riscv/mmu.h
+++ b/riscv/mmu.h
@@ -7,7 +7,7 @@
 #include "trap.h"
 #include "common.h"
 #include "config.h"
-#include "sim.h"
+#include "simif.h"
 #include "processor.h"
 #include "memtracer.h"
 #include <stdlib.h>

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -4,7 +4,7 @@
 #include "extension.h"
 #include "common.h"
 #include "config.h"
-#include "sim.h"
+#include "simif.h"
 #include "mmu.h"
 #include "disasm.h"
 #include <cinttypes>

--- a/riscv/riscv.mk.in
+++ b/riscv/riscv.mk.in
@@ -15,6 +15,7 @@ riscv_hdrs = \
 	mmu.h \
 	processor.h \
 	sim.h \
+	simif.h \
 	trap.h \
 	encoding.h \
 	cachesim.h \

--- a/riscv/sim.h
+++ b/riscv/sim.h
@@ -6,6 +6,7 @@
 #include "processor.h"
 #include "devices.h"
 #include "debug_module.h"
+#include "simif.h"
 #include <fesvr/htif.h>
 #include <fesvr/context.h>
 #include <vector>
@@ -14,19 +15,6 @@
 
 class mmu_t;
 class remote_bitbang_t;
-
-// this is the interface to the simulator used by the processors and memory
-class simif_t
-{
-public:
-  // should return NULL for MMIO addresses
-  virtual char* addr_to_mem(reg_t addr) = 0;
-  // used for MMIO addresses
-  virtual bool mmio_load(reg_t addr, size_t len, uint8_t* bytes) = 0;
-  virtual bool mmio_store(reg_t addr, size_t len, const uint8_t* bytes) = 0;
-  // Callback for processors to let the simulation know they were reset.
-  virtual void proc_reset(unsigned id) = 0;
-};
 
 // this class encapsulates the processors and memory in a RISC-V machine.
 class sim_t : public htif_t, public simif_t

--- a/riscv/simif.h
+++ b/riscv/simif.h
@@ -1,0 +1,21 @@
+// See LICENSE for license details.
+
+#ifndef _RISCV_SIMIF_H
+#define _RISCV_SIMIF_H
+
+#include "decode.h"
+
+// this is the interface to the simulator used by the processors and memory
+class simif_t
+{
+public:
+  // should return NULL for MMIO addresses
+  virtual char* addr_to_mem(reg_t addr) = 0;
+  // used for MMIO addresses
+  virtual bool mmio_load(reg_t addr, size_t len, uint8_t* bytes) = 0;
+  virtual bool mmio_store(reg_t addr, size_t len, const uint8_t* bytes) = 0;
+  // Callback for processors to let the simulation know they were reset.
+  virtual void proc_reset(unsigned id) = 0;
+};
+
+#endif


### PR DESCRIPTION
By separating the simif_t declaration from the sim_t declaration, the
simif_t declaration no longer depends on fesvr header files. This
simplifies compilation of custom sim class implementations that don't
depend on fesvr.