### PR TITLE
Reset an extension when it is registered

### DIFF
--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -152,9 +152,6 @@ void processor_t::reset()
   halt_on_reset = false;
   set_csr(CSR_MSTATUS, state.mstatus);
 
-  if (ext)
-    ext->reset(); // reset the extension
-
   if (sim)
     sim->proc_reset(id);
 }
@@ -744,6 +741,9 @@ void processor_t::register_extension(extension_t* x)
     throw std::logic_error("only one extension may be registered");
   ext = x;
   x->set_processor(this);
+
+  /* Reset the extension */
+  x->reset();
 }
 
 void processor_t::register_base_instructions()


### PR DESCRIPTION
Right now processor_t::reset is being called when sim_t is created. That's before spike_main is able to register an extension.

This doesn't reset the extension (ext->reset()) as ext is still null at the time of resetting the processor.

This commit resets the extension when it is registered, and not when processor_t::reset is called
