### PR TITLE
Refactor and fix LR/SC implementation

### DIFF
--- a/riscv/insns/lr_d.h
+++ b/riscv/insns/lr_d.h
@@ -1,4 +1,4 @@
 require_extension('A');
 require_rv64;
-p->get_state()->load_reservation = RS1;
+MMU.acquire_load_reservation(RS1);
 WRITE_RD(MMU.load_int64(RS1));

--- a/riscv/insns/lr_w.h
+++ b/riscv/insns/lr_w.h
@@ -1,3 +1,3 @@
 require_extension('A');
-p->get_state()->load_reservation = RS1;
+MMU.acquire_load_reservation(RS1);
 WRITE_RD(MMU.load_int32(RS1));

--- a/riscv/insns/sc_d.h
+++ b/riscv/insns/sc_d.h
@@ -1,9 +1,11 @@
 require_extension('A');
 require_rv64;
-if (RS1 == p->get_state()->load_reservation)
+if (MMU.check_load_reservation(RS1))
 {
   MMU.store_uint64(RS1, RS2);
   WRITE_RD(0);
 }
 else
   WRITE_RD(1);
+
+MMU.yield_load_reservation();

--- a/riscv/insns/sc_w.h
+++ b/riscv/insns/sc_w.h
@@ -1,8 +1,10 @@
 require_extension('A');
-if (RS1 == p->get_state()->load_reservation)
+if (MMU.check_load_reservation(RS1))
 {
   MMU.store_uint32(RS1, RS2);
   WRITE_RD(0);
 }
 else
   WRITE_RD(1);
+
+MMU.yield_load_reservation();

--- a/riscv/mmu.cc
+++ b/riscv/mmu.cc
@@ -12,6 +12,7 @@ mmu_t::mmu_t(simif_t* sim, processor_t* proc)
   matched_trigger(NULL)
 {
   flush_tlb();
+  yield_load_reservation();
 }
 
 mmu_t::~mmu_t()

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -121,7 +121,6 @@ void state_t::reset(reg_t max_isa)
   misa = max_isa;
   prv = PRV_M;
   pc = DEFAULT_RSTVEC;
-  load_reservation = -1;
   tselect = 0;
   for (unsigned int i = 0; i < num_triggers; i++)
     mcontrol[i].type = 2;
@@ -298,8 +297,6 @@ void processor_t::take_trap(trap_t& t, reg_t epc)
     set_csr(CSR_MSTATUS, s);
     set_privilege(PRV_M);
   }
-
-  yield_load_reservation();
 }
 
 void processor_t::disasm(insn_t insn)

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -135,8 +135,6 @@ struct state_t
       STEP_STEPPED
   } single_step;
 
-  reg_t load_reservation;
-
 #ifdef RISCV_ENABLE_COMMITLOG
   commit_log_reg_t log_reg_write;
   reg_t last_inst_priv;
@@ -197,7 +195,6 @@ public:
   }
   reg_t legalize_privilege(reg_t);
   void set_privilege(reg_t);
-  void yield_load_reservation() { state.load_reservation = (reg_t)-1; }
   void update_histogram(reg_t pc);
   const disassembler_t* get_disassembler() { return disassembler; }
 

--- a/riscv/sim.cc
+++ b/riscv/sim.cc
@@ -109,7 +109,7 @@ void sim_t::step(size_t n)
     if (current_step == INTERLEAVE)
     {
       current_step = 0;
-      procs[current_proc]->yield_load_reservation();
+      procs[current_proc]->get_mmu()->yield_load_reservation();
       if (++current_proc == procs.size()) {
         current_proc = 0;
         clint->increment(INTERLEAVE / INSNS_PER_RTC_TICK);


### PR DESCRIPTION
- Use physical addresses to avoid homonym ambiguity (closes #215)

- Disallow LR/SC to non-memory-like regions

- Yield reservation on store-conditional (https://github.com/riscv/riscv-isa-manual/commit/03a5e722fc0fe7b94dd0a49f550ff7b41a63f612)

- Don't yield reservation on exceptions (it's no longer required).