### PR TITLE
Fix using the uninitialized disassemble object.

### DIFF
--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -24,11 +24,11 @@ processor_t::processor_t(const char* isa, simif_t* sim, uint32_t id,
   : debug(false), halt_request(false), sim(sim), ext(NULL), id(id),
   halt_on_reset(halt_on_reset), last_pc(1), executions(1)
 {
+  disassembler = new disassembler_t(max_xlen);
   parse_isa_string(isa);
   register_base_instructions();
 
   mmu = new mmu_t(sim, this);
-  disassembler = new disassembler_t(max_xlen);
 
   reset();
 }


### PR DESCRIPTION
This fixes runtime crash when custom extension registers its
disassembly.

Before this commit, disassembler_t is instantiated after parsing the ISA string.
So, if custom extension adds disasm_insn_t, at that time, disassembler_t object is not exist.
disassembler_t can be instantiated before parsing ISA string.