### PR TITLE
Don't increment instret immediately after it is written

### DIFF
--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -403,10 +403,16 @@ void processor_t::set_csr(int which, reg_t val)
         state.minstret = (state.minstret >> 32 << 32) | (val & 0xffffffffU);
       else
         state.minstret = val;
+      // The ISA mandates that if an instruction writes instret, the write
+      // takes precedence over the increment to instret.  However, Spike
+      // unconditionally increments instret after executing an instruction.
+      // Correct for this artifact by decrementing instret here.
+      state.minstret--;
       break;
     case CSR_MINSTRETH:
     case CSR_MCYCLEH:
       state.minstret = (val << 32) | (state.minstret << 32 >> 32);
+      state.minstret--; // See comment above.
       break;
     case CSR_SCOUNTEREN:
       state.scounteren = val;


### PR DESCRIPTION
This brings Spike into compliance with this clause in the spec:
https://github.com/riscv/riscv-isa-manual/blob/master/src/csr.tex#L96