### PR TITLE
Add "--log-cache-miss" option to generate a log of cache miss.

### DIFF
--- a/riscv/cachesim.cc
+++ b/riscv/cachesim.cc
@@ -7,7 +7,7 @@
 #include <iomanip>
 
 cache_sim_t::cache_sim_t(size_t _sets, size_t _ways, size_t _linesz, const char* _name)
- : sets(_sets), ways(_ways), linesz(_linesz), name(_name)
+: sets(_sets), ways(_ways), linesz(_linesz), name(_name), log(false)
 {
   init();
 }
@@ -62,7 +62,7 @@ void cache_sim_t::init()
 
 cache_sim_t::cache_sim_t(const cache_sim_t& rhs)
  : sets(rhs.sets), ways(rhs.ways), linesz(rhs.linesz),
-   idx_shift(rhs.idx_shift), name(rhs.name)
+   idx_shift(rhs.idx_shift), name(rhs.name), log(false)
 {
   tags = new uint64_t[sets*ways];
   memcpy(tags, rhs.tags, sets*ways*sizeof(uint64_t));
@@ -135,6 +135,13 @@ void cache_sim_t::access(uint64_t addr, size_t bytes, bool store)
   }
 
   store ? write_misses++ : read_misses++;
+  if (log)
+  {
+    std::cerr << name << " "
+              << (store ? "write" : "read") << " miss 0x"
+              << std::hex << addr << " ("
+              << std::hex << bytes << " bytes)" << std::endl;
+  }
 
   uint64_t victim = victimize(addr);
 

--- a/riscv/cachesim.cc
+++ b/riscv/cachesim.cc
@@ -139,8 +139,7 @@ void cache_sim_t::access(uint64_t addr, size_t bytes, bool store)
   {
     std::cerr << name << " "
               << (store ? "write" : "read") << " miss 0x"
-              << std::hex << addr << " ("
-              << std::hex << bytes << " bytes)" << std::endl;
+              << std::hex << addr << std::endl;
   }
 
   uint64_t victim = victimize(addr);

--- a/riscv/cachesim.h
+++ b/riscv/cachesim.h
@@ -29,6 +29,7 @@ class cache_sim_t
   void access(uint64_t addr, size_t bytes, bool store);
   void print_stats();
   void set_miss_handler(cache_sim_t* mh) { miss_handler = mh; }
+  void set_log(bool _log) { log = _log; }
 
   static cache_sim_t* construct(const char* config, const char* name);
 
@@ -58,6 +59,7 @@ class cache_sim_t
   uint64_t writebacks;
 
   std::string name;
+  bool log;
 
   void init();
 };
@@ -87,6 +89,10 @@ class cache_memtracer_t : public memtracer_t
   void set_miss_handler(cache_sim_t* mh)
   {
     cache->set_miss_handler(mh);
+  }
+  void set_log(bool log)
+  {
+    cache->set_log(log);
   }
 
  protected:


### PR DESCRIPTION
Thank you for your attention.
I'd like to add "--log-cache-miss" option to understand which instruction has caused the cache miss.

- When this option is true, spike outputs a log of cache miss (default: OFF).
- This option must be used with "--ic" and/or "--dc" options to enable cache simulation.
- This option is useful with "-l" option to understand  which instruction has caused the cache miss.


## Sample to use

```
$ spike --ic=64:4:64 --dc=64:4:64 --log-cache-miss -l pk sample
I$ read miss 0x1000 (4 bytes)
core   0: 0x0000000000001000 (0x00000297) auipc   t0, 0x0
core   0: 0x0000000000001004 (0x02028593) addi    a1, t0, 32
core   0: 0x0000000000001008 (0xf1402573) csrr    a0, mhartid
core   0: 0x000000000000100c (0x0182b283) ld      t0, 24(t0)
core   0: 0x0000000000001010 (0x00028067) jr      t0
I$ read miss 0x80000000 (4 bytes)
core   0: 0x0000000080000000 (0x1e80006f) j       pc + 0x1e8
I$ read miss 0x800001e8 (4 bytes)
core   0: 0x00000000800001e8 (0x00000093) li      ra, 0
core   0: 0x00000000800001ec (0x00000113) li      sp, 0
core   0: 0x00000000800001f0 (0x00000193) li      gp, 0
core   0: 0x00000000800001f4 (0x00000213) li      tp, 0
core   0: 0x00000000800001f8 (0x00000293) li      t0, 0
core   0: 0x00000000800001fc (0x00000313) li      t1, 0
I$ read miss 0x80000200 (4 bytes)
...
```
