### PR TITLE
Add --dmi-rti and --abstract-rti to test OpenOCD.

### DIFF
--- a/riscv/debug_module.cc
+++ b/riscv/debug_module.cc
@@ -18,11 +18,12 @@
 ///////////////////////// debug_module_t
 
 debug_module_t::debug_module_t(sim_t *sim, unsigned progbufsize, unsigned max_bus_master_bits,
-    bool require_authentication) :
+    bool require_authentication, unsigned abstract_rti) :
   progbufsize(progbufsize),
   program_buffer_bytes(4 + 4*progbufsize),
   max_bus_master_bits(max_bus_master_bits),
   require_authentication(require_authentication),
+  abstract_rti(abstract_rti),
   debug_progbuf_start(debug_data_start - program_buffer_bytes),
   debug_abstract_start(debug_progbuf_start - debug_abstract_size*4),
   custom_base(0),
@@ -183,7 +184,7 @@ bool debug_module_t::store(reg_t addr, size_t len, const uint8_t* bytes)
     if (dmcontrol.hartsel == id) {
         if (0 == (debug_rom_flags[id] & (1 << DEBUG_ROM_FLAG_GO))){
           if (dmcontrol.hartsel == id) {
-              abstractcs.busy = false;
+              abstract_command_completed = true;
           }
         }
     }
@@ -488,6 +489,16 @@ bool debug_module_t::dmi_read(unsigned address, uint32_t *value)
   return true;
 }
 
+void debug_module_t::run_test_idle()
+{
+  if (rti_remaining > 0) {
+    rti_remaining--;
+  }
+  if (rti_remaining == 0 && abstractcs.busy && abstract_command_completed) {
+    abstractcs.busy = false;
+  }
+}
+
 bool debug_module_t::perform_abstract_command()
 {
   if (abstractcs.cmderr != CMDERR_NONE)
@@ -629,6 +640,8 @@ bool debug_module_t::perform_abstract_command()
     }
 
     debug_rom_flags[dmcontrol.hartsel] |= 1 << DEBUG_ROM_FLAG_GO;
+    rti_remaining = abstract_rti;
+    abstract_command_completed = false;
 
     abstractcs.busy = true;
   } else {

--- a/riscv/debug_module.h
+++ b/riscv/debug_module.h
@@ -81,9 +81,13 @@ class debug_module_t : public abstract_device_t
      * follows:
      * 1. Read a 32-bit value from authdata:
      * 2. Write the value that was read back, plus one, to authdata.
+     *
+     * abstract_rti is extra run-test/idle cycles that each abstract command
+     * takes to execute. Useful for testing OpenOCD.
      */
-    debug_module_t(sim_t *sim, unsigned progbufsize, unsigned max_bus_master_bits,
-        bool require_authentication);
+    debug_module_t(sim_t *sim, unsigned progbufsize,
+        unsigned max_bus_master_bits, bool require_authentication,
+        unsigned abstract_rti);
     ~debug_module_t();
 
     void add_device(bus_t *bus);
@@ -96,6 +100,9 @@ class debug_module_t : public abstract_device_t
     // Return true for success, false for failure.
     bool dmi_read(unsigned address, uint32_t *value);
     bool dmi_write(unsigned address, uint32_t value);
+
+    // Called for every cycle the JTAG TAP spends in Run-Test/Idle.
+    void run_test_idle();
 
     // Called when one of the attached harts was reset.
     void proc_reset(unsigned id);
@@ -110,6 +117,7 @@ class debug_module_t : public abstract_device_t
     unsigned program_buffer_bytes;
     unsigned max_bus_master_bits;
     bool require_authentication;
+    unsigned abstract_rti;
     static const unsigned debug_data_start = 0x380;
     unsigned debug_progbuf_start;
 
@@ -159,6 +167,9 @@ class debug_module_t : public abstract_device_t
     processor_t *current_proc() const;
     void reset();
     bool perform_abstract_command();
+
+    bool abstract_command_completed;
+    unsigned rti_remaining;
 };
 
 #endif

--- a/riscv/jtag_dtm.h
+++ b/riscv/jtag_dtm.h
@@ -29,7 +29,7 @@ class jtag_dtm_t
   static const unsigned idcode = 0xdeadbeef;
 
   public:
-    jtag_dtm_t(debug_module_t *dm);
+    jtag_dtm_t(debug_module_t *dm, unsigned required_rti_cycles);
     void reset();
 
     void set_pins(bool tck, bool tms, bool tdi);
@@ -40,6 +40,9 @@ class jtag_dtm_t
 
   private:
     debug_module_t *dm;
+    // The number of Run-Test/Idle cycles required before a DMI access is
+    // complete.
+    unsigned required_rti_cycles;
     bool _tck, _tms, _tdi, _tdo;
     uint32_t ir;
     const unsigned ir_length = 5;
@@ -51,6 +54,10 @@ class jtag_dtm_t
     const unsigned abits = 6;
     uint32_t dtmcontrol;
     uint64_t dmi;
+    // Number of Run-Test/Idle cycles needed before we call this access
+    // complete.
+    unsigned rti_remaining;
+    bool busy_stuck;
 
     jtag_state_t _state;
 

--- a/riscv/sim.cc
+++ b/riscv/sim.cc
@@ -28,11 +28,13 @@ sim_t::sim_t(const char* isa, size_t nprocs, bool halted, reg_t start_pc,
              std::vector<std::pair<reg_t, mem_t*>> mems,
              const std::vector<std::string>& args,
              std::vector<int> const hartids, unsigned progsize,
-             unsigned max_bus_master_bits, bool require_authentication)
+             unsigned max_bus_master_bits, bool require_authentication,
+             suseconds_t abstract_delay_usec)
   : htif_t(args), mems(mems), procs(std::max(nprocs, size_t(1))),
     start_pc(start_pc), current_step(0), current_proc(0), debug(false),
     histogram_enabled(false), dtb_enabled(true), remote_bitbang(NULL),
-    debug_module(this, progsize, max_bus_master_bits, require_authentication)
+    debug_module(this, progsize, max_bus_master_bits, require_authentication,
+        abstract_delay_usec)
 {
   signal(SIGINT, &handle_signal);
 

--- a/riscv/sim.h
+++ b/riscv/sim.h
@@ -23,7 +23,8 @@ public:
   sim_t(const char* isa, size_t _nprocs,  bool halted, reg_t start_pc,
         std::vector<std::pair<reg_t, mem_t*>> mems,
         const std::vector<std::string>& args, const std::vector<int> hartids,
-        unsigned progsize, unsigned max_bus_master_bits, bool require_authentication);
+        unsigned progsize, unsigned max_bus_master_bits,
+        bool require_authentication, suseconds_t abstract_delay_usec);
   ~sim_t();
 
   // run the simulation to completion


### PR DESCRIPTION
Optionally make spike behave more like real hardware, to automatically
test OpenOCD's handling of such hardware.