### PR TITLE
Add --debug-no-abstract-csr

### DIFF
--- a/riscv/debug_module.h
+++ b/riscv/debug_module.h
@@ -95,7 +95,8 @@ class debug_module_t : public abstract_device_t
      */
     debug_module_t(sim_t *sim, unsigned progbufsize,
         unsigned max_bus_master_bits, bool require_authentication,
-        unsigned abstract_rti, bool support_hasel);
+        unsigned abstract_rti, bool support_hasel,
+        bool support_abstract_csr_access);
     ~debug_module_t();
 
     void add_device(bus_t *bus);
@@ -127,6 +128,7 @@ class debug_module_t : public abstract_device_t
     unsigned max_bus_master_bits;
     bool require_authentication;
     unsigned abstract_rti;
+    bool support_abstract_csr_access;
     static const unsigned debug_data_start = 0x380;
     unsigned debug_progbuf_start;
 

--- a/riscv/sim.cc
+++ b/riscv/sim.cc
@@ -29,12 +29,14 @@ sim_t::sim_t(const char* isa, size_t nprocs, bool halted, reg_t start_pc,
              const std::vector<std::string>& args,
              std::vector<int> const hartids, unsigned progsize,
              unsigned max_bus_master_bits, bool require_authentication,
-             suseconds_t abstract_delay_usec, bool support_hasel)
+             suseconds_t abstract_delay_usec, bool support_hasel,
+             bool support_abstract_csr_access)
   : htif_t(args), mems(mems), procs(std::max(nprocs, size_t(1))),
     start_pc(start_pc), current_step(0), current_proc(0), debug(false),
     histogram_enabled(false), dtb_enabled(true), remote_bitbang(NULL),
     debug_module(this, progsize, max_bus_master_bits, require_authentication,
-        abstract_delay_usec, support_hasel)
+        abstract_delay_usec, support_hasel,
+        support_abstract_csr_access)
 {
   signal(SIGINT, &handle_signal);
 

--- a/riscv/sim.h
+++ b/riscv/sim.h
@@ -26,7 +26,7 @@ public:
         const std::vector<std::string>& args, const std::vector<int> hartids,
         unsigned progsize, unsigned max_bus_master_bits,
         bool require_authentication, suseconds_t abstract_delay_usec,
-        bool support_hasel);
+        bool support_hasel, bool support_abstract_csr_access);
   ~sim_t();
 
   // run the simulation to completion

--- a/spike_main/spike.cc
+++ b/spike_main/spike.cc
@@ -49,6 +49,7 @@ static void help(int exit_code = 1)
   fprintf(stderr, "  --abstract-rti=<n>    Number of Run-Test/Idle cycles "
       "required for an abstract command to execute [default 0]\n");
   fprintf(stderr, "  --without-hasel       Debug module supports hasel\n");
+  fprintf(stderr, "  --debug-no-abstract-csr  Debug module won't support abstract to authenticate\n");
 
   exit(exit_code);
 }
@@ -115,6 +116,7 @@ int main(int argc, char** argv)
   unsigned dmi_rti = 0;
   unsigned abstract_rti = 0;
   bool support_hasel = true;
+  bool support_abstract_csr_access = true;
   std::vector<int> hartids;
 
   auto const hartids_parser = [&](const char *s) {
@@ -168,6 +170,8 @@ int main(int argc, char** argv)
       [&](const char* s){abstract_rti = atoi(s);});
   parser.option(0, "without-hasel", 0,
       [&](const char* s){support_hasel = false;});
+  parser.option(0, "debug-no-abstract-csr", 0,
+      [&](const char* s){support_abstract_csr_access = false;});
 
   auto argv1 = parser.parse(argv);
   std::vector<std::string> htif_args(argv1, (const char*const*)argv + argc);
@@ -179,7 +183,7 @@ int main(int argc, char** argv)
 
   sim_t s(isa, nprocs, halted, start_pc, mems, htif_args, std::move(hartids),
       progsize, max_bus_master_bits, require_authentication,
-      abstract_rti, support_hasel);
+      abstract_rti, support_hasel, support_abstract_csr_access);
   std::unique_ptr<remote_bitbang_t> remote_bitbang((remote_bitbang_t *) NULL);
   std::unique_ptr<jtag_dtm_t> jtag_dtm(
       new jtag_dtm_t(&s.debug_module, dmi_rti));


### PR DESCRIPTION
This is used to make sure that OpenOCD can work on targets that don't
support abstract access to CSR registers. It replaces a simpler hack,
which caused #266.