### PR TITLE
Ensure mstatus.FS is hardwired to zero in absence of floating-point.

### DIFF
--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -380,10 +380,13 @@ void processor_t::set_csr(int which, reg_t val)
         mmu->flush_tlb();
 
       reg_t mask = MSTATUS_SIE | MSTATUS_SPIE | MSTATUS_MIE | MSTATUS_MPIE
-                 | MSTATUS_FS | MSTATUS_MPRV | MSTATUS_SUM
+                 | MSTATUS_MPRV | MSTATUS_SUM
                  | MSTATUS_MXR | MSTATUS_TW | MSTATUS_TVM
                  | MSTATUS_TSR | MSTATUS_UXL | MSTATUS_SXL |
                  (ext ? MSTATUS_XS : 0);
+
+      if (supports_extension('F'))
+	mask |= MSTATUS_FS;
 
       reg_t requested_mpp = legalize_privilege(get_field(val, MSTATUS_MPP));
       state.mstatus = set_field(state.mstatus, MSTATUS_MPP, requested_mpp);


### PR DESCRIPTION
mstatus.FS was getting set even when --isa disabled F/D.  The spec says it should be hardwired to zero.