### PR TITLE
Allow delegation of all interrupts

### DIFF
--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -333,9 +333,10 @@ int processor_t::paddr_bits()
 void processor_t::set_csr(int which, reg_t val)
 {
   val = zext_xlen(val);
-  reg_t delegable_ints = MIP_SSIP | MIP_STIP | MIP_SEIP
+  reg_t all_ints = MIP_SSIP | MIP_STIP | MIP_SEIP
+                       | MIP_MSIP | MIP_MTIP
                        | ((ext != NULL) << IRQ_COP);
-  reg_t all_ints = delegable_ints | MIP_MSIP | MIP_MTIP;
+  reg_t delegable_ints = all_ints;
 
   if (which >= CSR_PMPADDR0 && which < CSR_PMPADDR0 + state.n_pmp) {
     size_t i = which - CSR_PMPADDR0;

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -166,7 +166,8 @@ static int cto(reg_t val)
 class processor_t : public abstract_device_t
 {
 public:
-  processor_t(const char* isa, simif_t* sim, uint32_t id, bool halt_on_reset=false);
+  processor_t(const char* isa, simif_t* sim, uint32_t id,
+			  bool halt_on_reset=false, bool mideleg_all=false);
   ~processor_t();
 
   void set_debug(bool value);
@@ -311,6 +312,7 @@ private:
   std::string isa_string;
   bool histogram_enabled;
   bool halt_on_reset;
+  bool mideleg_all; // whether all interrupts can be delegated
 
   std::vector<insn_desc_t> instructions;
   std::map<reg_t,uint64_t> pc_histogram;

--- a/riscv/sim.cc
+++ b/riscv/sim.cc
@@ -29,7 +29,7 @@ sim_t::sim_t(const char* isa, size_t nprocs, bool halted, reg_t start_pc,
              const std::vector<std::string>& args,
              std::vector<int> const hartids, unsigned progsize,
              unsigned max_bus_master_bits, bool require_authentication,
-             suseconds_t abstract_delay_usec)
+             suseconds_t abstract_delay_usec, bool mideleg_all)
   : htif_t(args), mems(mems), procs(std::max(nprocs, size_t(1))),
     start_pc(start_pc), current_step(0), current_proc(0), debug(false),
     histogram_enabled(false), dtb_enabled(true), remote_bitbang(NULL),

--- a/riscv/sim.h
+++ b/riscv/sim.h
@@ -24,7 +24,8 @@ public:
         std::vector<std::pair<reg_t, mem_t*>> mems,
         const std::vector<std::string>& args, const std::vector<int> hartids,
         unsigned progsize, unsigned max_bus_master_bits,
-        bool require_authentication, suseconds_t abstract_delay_usec);
+        bool require_authentication, suseconds_t abstract_delay_usec,
+		bool mideleg_all);
   ~sim_t();
 
   // run the simulation to completion

--- a/spike_main/spike.cc
+++ b/spike_main/spike.cc
@@ -46,6 +46,7 @@ static void help()
       "required for a DMI access [default 0]\n");
   fprintf(stderr, "  --abstract-rti=<n>    Number of Run-Test/Idle cycles "
       "required for an abstract command to execute [default 0]\n");
+  fprintf(stderr, "  --mideleg-all         Allow delegation of M-mode interrupts\n");
   exit(1);
 }
 
@@ -104,6 +105,7 @@ int main(int argc, char** argv)
   bool require_authentication = false;
   unsigned dmi_rti = 0;
   unsigned abstract_rti = 0;
+  bool mideleg_all = false;
   std::vector<int> hartids;
 
   auto const hartids_parser = [&](const char *s) {
@@ -155,6 +157,7 @@ int main(int argc, char** argv)
       [&](const char* s){dmi_rti = atoi(s);});
   parser.option(0, "abstract-rti", 1,
       [&](const char* s){abstract_rti = atoi(s);});
+  parser.option(0, "mideleg-all", 0, [&](const char* s){mideleg_all=true;});
 
   auto argv1 = parser.parse(argv);
   std::vector<std::string> htif_args(argv1, (const char*const*)argv + argc);
@@ -166,7 +169,7 @@ int main(int argc, char** argv)
 
   sim_t s(isa, nprocs, halted, start_pc, mems, htif_args, std::move(hartids),
       progsize, max_bus_master_bits, require_authentication,
-      abstract_rti);
+      abstract_rti, mideleg_all);
   std::unique_ptr<remote_bitbang_t> remote_bitbang((remote_bitbang_t *) NULL);
   std::unique_ptr<jtag_dtm_t> jtag_dtm(
       new jtag_dtm_t(&s.debug_module, dmi_rti));


### PR DESCRIPTION
The RISC-V privileged spec places no restrictions on which interrupts implementations can allow to be delegated. Accordingly, this pull request allows delegation of all supported interrupt types, including MSIP and MTIP which were previously restricted.

It is unclear whether it is a good idea to delegate these interrupts. In particular, delegating these two machine mode interrupts could be better for performance and perhaps eliminate the need for any m-mode code at all. However, it involves m-mode code giving up substantial control of the runtime execution of the hart to s-mode code and the current SBI interface cannot be implemented with either of these delegated.

Regardless, I'd argue that this ISA simulator is the wrong place to make that decision and that this case should be supported to allow for experimentation.