### PR TITLE
include sys/types.h for suseconds_t

### DIFF
--- a/riscv/sim.h
+++ b/riscv/sim.h
@@ -12,6 +12,7 @@
 #include <vector>
 #include <string>
 #include <memory>
+#include <sys/types.h>
 
 class mmu_t;
 class remote_bitbang_t;


### PR DESCRIPTION
This fixes the build on [Alpine Linux](https://alpinelinux.org/) (which uses [musl libc](https://www.musl-libc.org/)).

---

Without this patch you get the following compilation error on Alpine otherwise:

```
In file included from ../riscv/sim.cc:3:                                                                                                                                  
../riscv/sim.h:27:38: error: 'suseconds_t' has not been declared                                                                                                          
         bool require_authentication, suseconds_t abstract_delay_usec);                                                                                                   
                                      ^~~~~~~~~~~                                                                                                                        
```