### PR TITLE
restore macOS support (BSD ar)

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -211,7 +211,7 @@ $(2)_lib_libnames   := $$(patsubst %, lib%.a, $$($(2)_lib_libs))
 $(2)_lib_libarg     := $$(patsubst %, -l%, $$($(2)_lib_libs))
 
 lib$(1).a : $$($(2)_objs) $$($(2)_c_objs) $$($(2)_lib_libnames)
-	$(AR) rcs -o $$@ $$^
+	$(AR) rcs $$@ $$^
 
 $(2)_junk += lib$(1).a
 


### PR DESCRIPTION
The current set of flags to ar (`rcs -o`), triggers the following error on when building on macOS: `ar: illegal option combination for -r`

The conflicting flag appears to be `-o`. After reading the man pages for both the GNU and BSD versions of ar, they agree that it should preserve the original times when extracting files, but it isn't clear what effect that flag should have when making an archive. Perhaps the GNU version is more tolerant of spurious flags.

Simply removing `-o` seems to fix the problem, and it builds correctly on both macOS (10.14) and linux (Ubuntu 18.04). If there is a need for the `-o`, I can look for another solution.