### PR TITLE
allow prefix to be overriden

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -50,7 +50,7 @@ endif
 
 # Installation directories
 
-prefix       := @prefix@
+prefix       ?= @prefix@
 
 INSTALLDIR ?= $(DESTDIR)$(prefix)
 


### PR DESCRIPTION
This was part of https://github.com/riscv/riscv-fesvr/commit/10d669d04c5fc7941c7ee619bdabe7e50c283438, and it allowed spike to easily find pk when things are moved post install.