### PR TITLE
Clean up debug module options.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,7 +1,13 @@
 Version 1.0.1-dev
 -----------------
 - Added `hasel` debug feature.
-- Added `--debug-no-abstract-csr` command-line option.
+- Added `--dm-no-abstract-csr` command-line option.
+- Renamed `--progsize` to `--dm-progsize`.
+- Renamed `--debug-sba` to `--dm-sba`.
+- Renamed `--debug-auth` to `--dm-auth`.
+- Renamed `--abstract-rti` to `--dm-abstract-rti`.
+- Renamed `--without-hasel` to `--dm-no-hasel`.
+- Added `--dm-no-halt-groups` command line option.
 
 Version 1.0.0 (2019-03-30)
 --------------------------

--- a/riscv/debug_module.h
+++ b/riscv/debug_module.h
@@ -9,6 +9,18 @@
 class sim_t;
 
 typedef struct {
+    // Size of program_buffer in 32-bit words, as exposed to the rest of the
+    // world.
+    unsigned progbufsize;
+    unsigned max_bus_master_bits;
+    bool require_authentication;
+    unsigned abstract_rti;
+    bool support_hasel;
+    bool support_abstract_csr_access;
+    bool support_haltgroups;
+} debug_module_config_t;
+
+typedef struct {
   bool haltreq;
   bool resumereq;
   bool hasel;
@@ -93,10 +105,7 @@ class debug_module_t : public abstract_device_t
      * abstract_rti is extra run-test/idle cycles that each abstract command
      * takes to execute. Useful for testing OpenOCD.
      */
-    debug_module_t(sim_t *sim, unsigned progbufsize,
-        unsigned max_bus_master_bits, bool require_authentication,
-        unsigned abstract_rti, bool support_hasel,
-        bool support_abstract_csr_access);
+    debug_module_t(sim_t *sim, const debug_module_config_t &config);
     ~debug_module_t();
 
     void add_device(bus_t *bus);
@@ -119,16 +128,10 @@ class debug_module_t : public abstract_device_t
   private:
     static const unsigned datasize = 2;
     unsigned nprocs;
-    // Size of program_buffer in 32-bit words, as exposed to the rest of the
-    // world.
-    unsigned progbufsize;
+    debug_module_config_t config;
     // Actual size of the program buffer, which is 1 word bigger than we let on
     // to implement the implicit ebreak at the end.
     unsigned program_buffer_bytes;
-    unsigned max_bus_master_bits;
-    bool require_authentication;
-    unsigned abstract_rti;
-    bool support_abstract_csr_access;
     static const unsigned debug_data_start = 0x380;
     unsigned debug_progbuf_start;
 
@@ -182,7 +185,6 @@ class debug_module_t : public abstract_device_t
 
     bool abstract_command_completed;
     unsigned rti_remaining;
-    bool support_hasel;
 };
 
 #endif

--- a/riscv/sim.cc
+++ b/riscv/sim.cc
@@ -27,16 +27,12 @@ static void handle_signal(int sig)
 sim_t::sim_t(const char* isa, size_t nprocs, bool halted, reg_t start_pc,
              std::vector<std::pair<reg_t, mem_t*>> mems,
              const std::vector<std::string>& args,
-             std::vector<int> const hartids, unsigned progsize,
-             unsigned max_bus_master_bits, bool require_authentication,
-             suseconds_t abstract_delay_usec, bool support_hasel,
-             bool support_abstract_csr_access)
+             std::vector<int> const hartids,
+             const debug_module_config_t &dm_config)
   : htif_t(args), mems(mems), procs(std::max(nprocs, size_t(1))),
     start_pc(start_pc), current_step(0), current_proc(0), debug(false),
     histogram_enabled(false), dtb_enabled(true), remote_bitbang(NULL),
-    debug_module(this, progsize, max_bus_master_bits, require_authentication,
-        abstract_delay_usec, support_hasel,
-        support_abstract_csr_access)
+    debug_module(this, dm_config)
 {
   signal(SIGINT, &handle_signal);
 

--- a/riscv/sim.h
+++ b/riscv/sim.h
@@ -24,9 +24,7 @@ public:
   sim_t(const char* isa, size_t _nprocs,  bool halted, reg_t start_pc,
         std::vector<std::pair<reg_t, mem_t*>> mems,
         const std::vector<std::string>& args, const std::vector<int> hartids,
-        unsigned progsize, unsigned max_bus_master_bits,
-        bool require_authentication, suseconds_t abstract_delay_usec,
-        bool support_hasel, bool support_abstract_csr_access);
+        const debug_module_config_t &dm_config);
   ~sim_t();
 
   // run the simulation to completion


### PR DESCRIPTION
1. Instead of passing each one a few levels deep, create
debug_module_config_t which contains them all.
2. Rename all those command line options so they start with --dm for
debug module.
3. Add --dm-no-halt-groups to disable halt group support.