### PR TITLE
Fix DRET in M-mode, and change how D-mode is represented

### DIFF
--- a/riscv/execute.cc
+++ b/riscv/execute.cc
@@ -85,13 +85,13 @@ static reg_t execute_insn(processor_t* p, reg_t pc, insn_fetch_t fetch)
 
 bool processor_t::slow_path()
 {
-  return debug || state.single_step != state.STEP_NONE || state.dcsr.cause;
+  return debug || state.single_step != state.STEP_NONE || state.debug_mode;
 }
 
 // fetch/decode/execute loop
 void processor_t::step(size_t n)
 {
-  if (state.dcsr.cause == DCSR_CAUSE_NONE) {
+  if (!state.debug_mode) {
     if (halt_request) {
       enter_debug_mode(DCSR_CAUSE_DEBUGINT);
     } // !!!The halt bit in DCSR is deprecated.
@@ -130,7 +130,7 @@ void processor_t::step(size_t n)
         {
           if (unlikely(!state.serialized && state.single_step == state.STEP_STEPPED)) {
             state.single_step = state.STEP_NONE;
-            if (state.dcsr.cause == DCSR_CAUSE_NONE) {
+            if (!state.debug_mode) {
               enter_debug_mode(DCSR_CAUSE_STEP);
               // enter_debug_mode changed state.pc, so we can't just continue.
               break;

--- a/riscv/insns/dret.h
+++ b/riscv/insns/dret.h
@@ -1,4 +1,4 @@
-require_privilege(PRV_M);
+require(STATE.debug_mode);
 set_pc_and_serialize(STATE.dpc);
 p->set_privilege(STATE.dcsr.prv);
 

--- a/riscv/insns/dret.h
+++ b/riscv/insns/dret.h
@@ -3,7 +3,7 @@ set_pc_and_serialize(STATE.dpc);
 p->set_privilege(STATE.dcsr.prv);
 
 /* We're not in Debug Mode anymore. */
-STATE.dcsr.cause = 0;
+STATE.debug_mode = false;
 
 if (STATE.dcsr.step)
   STATE.single_step = STATE.STEP_STEPPING;

--- a/riscv/mmu.cc
+++ b/riscv/mmu.cc
@@ -51,7 +51,7 @@ reg_t mmu_t::translate(reg_t addr, reg_t len, access_type type)
 
   reg_t mode = proc->state.prv;
   if (type != FETCH) {
-    if (!proc->state.dcsr.cause && get_field(proc->state.mstatus, MSTATUS_MPRV))
+    if (!proc->state.debug_mode && get_field(proc->state.mstatus, MSTATUS_MPRV))
       mode = get_field(proc->state.mstatus, MSTATUS_MPP);
   }
 

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -232,12 +232,14 @@ struct state_t
   reg_t stvec;
   reg_t satp;
   reg_t scause;
+
   reg_t dpc;
   reg_t dscratch;
   dcsr_t dcsr;
   reg_t tselect;
   mcontrol_t mcontrol[num_triggers];
   reg_t tdata2[num_triggers];
+  bool debug_mode;
 
   static const int n_pmp = 16;
   uint8_t pmpcfg[n_pmp];
@@ -330,13 +332,13 @@ public:
   bool debug;
   // When true, take the slow simulation path.
   bool slow_path();
-  bool halted() { return state.dcsr.cause ? true : false; }
+  bool halted() { return state.debug_mode; }
   bool halt_request;
 
   // Return the index of a trigger that matched, or -1.
   inline int trigger_match(trigger_operation_t operation, reg_t address, reg_t data)
   {
-    if (state.dcsr.cause)
+    if (state.debug_mode)
       return -1;
 
     bool chain_ok = true;


### PR DESCRIPTION
This PR adds a debug_mode state bit, rather than overloading dcsr.cause for that purpose  In the previous scheme, debug-mode software could exit debug mode by zeroing the dcsr.cause field.  While benign, that behavior is out of spec.

Use the new debug_mode state bit to guard execution of DRET.

cc @ernie-sifive

