### PR TITLE
Implement MMIO device plugins.

### DIFF
--- a/configure
+++ b/configure
@@ -4364,6 +4364,8 @@ CFLAGS="-Wall -Wno-unused -g -O2"
 
 CXXFLAGS="-Wall -Wno-unused -g -O2 -std=c++11"
 
+LDFLAGS="-Wl,--export-dynamic"
+
 
 #-------------------------------------------------------------------------
 # MCPPBS subproject list

--- a/configure.ac
+++ b/configure.ac
@@ -84,6 +84,7 @@ AC_CHECK_TYPE([__int128_t], AC_SUBST([HAVE_INT128],[yes]))
 
 AC_SUBST([CFLAGS],  ["-Wall -Wno-unused -g -O2"])
 AC_SUBST([CXXFLAGS],["-Wall -Wno-unused -g -O2 -std=c++11"])
+AC_SUBST([LDFLAGS], ["-Wl,--export-dynamic"])
 
 #-------------------------------------------------------------------------
 # MCPPBS subproject list

--- a/riscv/devices.h
+++ b/riscv/devices.h
@@ -2,6 +2,7 @@
 #define _RISCV_DEVICES_H
 
 #include "decode.h"
+#include "mmio_plugin.h"
 #include <cstdlib>
 #include <string>
 #include <map>
@@ -74,6 +75,19 @@ class clint_t : public abstract_device_t {
   std::vector<processor_t*>& procs;
   mtime_t mtime;
   std::vector<mtimecmp_t> mtimecmp;
+};
+
+class mmio_plugin_device_t : public abstract_device_t {
+ public:
+  mmio_plugin_device_t(const std::string& name, const std::string& args);
+  virtual ~mmio_plugin_device_t() override;
+
+  virtual bool load(reg_t addr, size_t len, uint8_t* bytes) override;
+  virtual bool store(reg_t addr, size_t len, const uint8_t* bytes) override;
+
+ private:
+  mmio_plugin_t plugin;
+  void* user_data;
 };
 
 #endif

--- a/riscv/mmio_plugin.h
+++ b/riscv/mmio_plugin.h
@@ -1,0 +1,91 @@
+#ifndef _RISCV_MMIO_PLUGIN_H
+#define _RISCV_MMIO_PLUGIN_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+typedef uint64_t reg_t;
+
+typedef struct {
+  // Allocate user data for an instance of the plugin. The parameter is a simple
+  // c-string containing arguments used to construct the plugin. It returns a
+  // void* to the allocated data.
+  void* (*alloc)(const char*);
+
+  // Load a memory address of the MMIO plugin. The parameters are the user_data
+  // (void*), memory offset (reg_t), number of bytes to load (size_t), and the
+  // buffer into which the loaded data should be written (uint8_t*). Return true
+  // if the load is successful and false otherwise.
+  bool (*load)(void*, reg_t, size_t, uint8_t*);
+
+  // Store some bytes to a memory address of the MMIO plugin. The parameters are
+  // the user_data (void*), memory offset (reg_t), number of bytes to store
+  // (size_t), and the buffer containing the data to be stored (const uint8_t*).
+  // Return true if the store is successful and false otherwise.
+  bool (*store)(void*, reg_t, size_t, const uint8_t*);
+
+  // Deallocate the data allocated during the call to alloc. The parameter is a
+  // pointer to the user data allocated during the call to alloc.
+  void (*dealloc)(void*);
+} mmio_plugin_t;
+
+// Register an mmio plugin with the application. This should be called by
+// plugins as part of their loading process.
+extern void register_mmio_plugin(const char* name_cstr,
+                                 const mmio_plugin_t* mmio_plugin);
+
+#ifdef __cplusplus
+}
+
+#include <string>
+
+// Wrapper around the C plugin API that makes registering a C++ class with
+// correctly formed constructor, load, and store functions easier. The template
+// type should be the type that implements the MMIO plugin interface. Simply
+// make a global mmio_plugin_registration_t and your plugin should register
+// itself with the application when it is loaded because the
+// mmio_plugin_registration_t constructor will be called.
+template <typename T>
+struct mmio_plugin_registration_t
+{
+  static void* alloc(const char* args)
+  {
+    return reinterpret_cast<void*>(new T(std::string(args)));
+  }
+
+  static bool load(void* self, reg_t addr, size_t len, uint8_t* bytes)
+  {
+    return reinterpret_cast<T*>(self)->load(addr, len, bytes);
+  }
+
+  static bool store(void* self, reg_t addr, size_t len, const uint8_t* bytes)
+  {
+    return reinterpret_cast<T*>(self)->store(addr, len, bytes);
+  }
+
+  static void dealloc(void* self)
+  {
+    delete reinterpret_cast<T*>(self);
+  }
+
+  mmio_plugin_registration_t(const std::string& name)
+  {
+    mmio_plugin_t plugin = {
+      mmio_plugin_registration_t<T>::alloc,
+      mmio_plugin_registration_t<T>::load,
+      mmio_plugin_registration_t<T>::store,
+      mmio_plugin_registration_t<T>::dealloc,
+    };
+
+    register_mmio_plugin(name.c_str(), &plugin);
+  }
+};
+#endif // __cplusplus
+
+#endif

--- a/riscv/riscv.mk.in
+++ b/riscv/riscv.mk.in
@@ -20,6 +20,7 @@ riscv_hdrs = \
 	encoding.h \
 	cachesim.h \
 	memtracer.h \
+	mmio_plugin.h \
 	tracer.h \
 	extension.h \
 	rocc.h \
@@ -28,6 +29,8 @@ riscv_hdrs = \
 	debug_rom_defines.h \
 	remote_bitbang.h \
 	jtag_dtm.h \
+
+riscv_install_hdrs = mmio_plugin.h
 
 riscv_precompiled_hdrs = \
 	insn_template.h \

--- a/riscv/sim.cc
+++ b/riscv/sim.cc
@@ -26,17 +26,21 @@ static void handle_signal(int sig)
 
 sim_t::sim_t(const char* isa, const char* varch, size_t nprocs, bool halted,
              reg_t start_pc, std::vector<std::pair<reg_t, mem_t*>> mems,
+             std::vector<std::pair<reg_t, abstract_device_t*>> plugin_devices,
              const std::vector<std::string>& args,
              std::vector<int> const hartids,
              const debug_module_config_t &dm_config)
-  : htif_t(args), mems(mems), procs(std::max(nprocs, size_t(1))),
-    start_pc(start_pc), current_step(0), current_proc(0), debug(false),
-    histogram_enabled(false), dtb_enabled(true), remote_bitbang(NULL),
-    debug_module(this, dm_config)
+  : htif_t(args), mems(mems), plugin_devices(plugin_devices),
+    procs(std::max(nprocs, size_t(1))), start_pc(start_pc), current_step(0),
+    current_proc(0), debug(false), histogram_enabled(false), dtb_enabled(true),
+    remote_bitbang(NULL), debug_module(this, dm_config)
 {
   signal(SIGINT, &handle_signal);
 
   for (auto& x : mems)
+    bus.add_device(x.first, x.second);
+
+  for (auto& x : plugin_devices)
     bus.add_device(x.first, x.second);
 
   debug_module.add_device(&bus);

--- a/riscv/sim.h
+++ b/riscv/sim.h
@@ -23,6 +23,7 @@ class sim_t : public htif_t, public simif_t
 public:
   sim_t(const char* isa, const char* varch, size_t _nprocs, bool halted,
         reg_t start_pc, std::vector<std::pair<reg_t, mem_t*>> mems,
+        std::vector<std::pair<reg_t, abstract_device_t*>> plugin_devices,
         const std::vector<std::string>& args, const std::vector<int> hartids,
         const debug_module_config_t &dm_config);
   ~sim_t();
@@ -48,6 +49,7 @@ public:
 
 private:
   std::vector<std::pair<reg_t, mem_t*>> mems;
+  std::vector<std::pair<reg_t, abstract_device_t*>> plugin_devices;
   mmu_t* debug_mmu;  // debug port into main memory
   std::vector<processor_t*> procs;
   reg_t start_pc;


### PR DESCRIPTION
This is a second attempt at implementing plugin devices, #186 was the first, but there was no movement on it for a year so I have changed the implementation around to hopefully make it simpler, more flexible, and easier to accept.

This allows devices implemented as shared objects separate from spike to be attached to the bus at a specified base address. This way, MMIO functionality can be added to spike without having to have that functionality checked in to the main codebase.

Adds a public interface at `riscv/mmio_plugin.h` that is used by both the primary application and plugins. This is a C interface, but a C++ wrapper around the C interface is provided to make implementing C++ plugins more straightforward. Starting with a C interface allows plugins to be developed in more languages, and provides a more stable interface than using C++ would. The interface is simply a set of four function pointers that provide the allocate/load/store/deallocate interface of `abstract_device_t`. Plugins register themselves via a public interface `register_mmio_plugin` when they are loaded via the `--extlib` flag. Once a plugin is loaded with `--extlib` an instance of the plugin can be defined using the new `--device` flag which takes the plugin name, a base address, and a string of arguments to pass to the plugin. Plugin devices are represented by a new `mmio_plugin_device_t` type which is derived from `abstract_device_t` and these are the devices that are attached to the bus. Since the plugins need to call methods in the main application when they were loaded, the `configure.ac` file was updated to add a `-Wl,--export-dynamic` flag to the linker options to enable this. The `configure` script was regenerated with `autoconf`.

An [example repository](https://github.com/vexingcodes/spike-plugin) exists with plugin examples in C, C++, and Rust. A Dockerfile in that repository should build this code, the example plugins, and test them. The example code is provided here also for completeness:

# C Plugin

```c
#include <riscv/mmio_plugin.h>
#include <stdio.h>

void* test_mmio_plugin_alloc(const char* args)
{
    printf("ALLOC -- ARGS=%s\n", args);
    return (void*)0x0123456789abcdef;
}

bool test_mmio_plugin_load(void* self, reg_t addr, size_t len, uint8_t* bytes)
{
    printf("LOAD -- SELF=%p ADDR=0x%lx LEN=%lu BYTES=%p\n", self, addr, len, (void*)bytes);
    return true;
}

bool test_mmio_plugin_store(void* self, reg_t addr, size_t len, const uint8_t* bytes)
{
    printf("STORE -- SELF=%p ADDR=0x%lx LEN=%lu BYTES=%p\n", self, addr, len, (const void*)bytes);
    return true;
}

void test_mmio_plugin_dealloc(void* self)
{
    printf("DEALLOC -- SELF=%p\n", self);
}

__attribute__((constructor)) static void on_load()
{
  static mmio_plugin_t test_mmio_plugin = {
      test_mmio_plugin_alloc,
      test_mmio_plugin_load,
      test_mmio_plugin_store,
      test_mmio_plugin_dealloc
  };

  register_mmio_plugin("test_mmio_plugin", &test_mmio_plugin);
}
```

Compile with:

    gcc -shared -o plugin.so -Wall -Werror -fPIC plugin.c

# C++ Plugin

```cpp
#include <riscv/mmio_plugin.h>
#include <cstdio>

struct test_mmio_plugin
{
  test_mmio_plugin(const std::string& args)
  {
    printf("ALLOC -- ARGS=%s\n", args.c_str());
  }

  ~test_mmio_plugin()
  {
    printf("DEALLOC -- SELF=%p\n", this);
  }

  bool load(reg_t addr, size_t len, uint8_t* bytes)
  {
    printf("LOAD -- SELF=%p ADDR=0x%lx LEN=%lu BYTES=%p\n", this, addr, len, (void*)bytes);
    return true;
  }

  bool store(reg_t addr, size_t len, const uint8_t* bytes)
  {
    printf("STORE -- SELF=%p ADDR=0x%lx LEN=%lu BYTES=%p\n", this, addr, len, (const void*)bytes);
    return true;
  }
};

static mmio_plugin_registration_t<test_mmio_plugin> test_mmio_plugin_registration("test_mmio_plugin");
```

Compile with

    g++ -shared -o plugin.so -Wall -Werror -fPIC plugin.cpp

# Rust Plugin

This is a C-style plugin written in Rust. A more Rust-native approach is probably possible, but I haven't tried that out yet.

```rust
#[repr(C)]
struct CMmioPlugin {
    alloc: extern fn(*const libc::c_char) -> *mut libc::c_void,
    load: extern fn(*mut libc::c_void, u64, libc::size_t, *mut libc::c_uchar) -> bool,
    store: extern fn(*mut libc::c_void, u64, libc::size_t, *const libc::c_uchar) -> bool,
    dealloc: extern fn(*mut libc::c_void)
}

extern "C" {
    fn register_mmio_plugin(name_cstr: *const libc::c_char, mmio_plugin: *const CMmioPlugin);
}

extern "C" fn alloc(args: *const libc::c_char) -> *mut libc::c_void {
  unsafe {
      println!("ALLOC -- ARGS={}", std::ffi::CStr::from_ptr(args).to_string_lossy().into_owned());
  }

  return 0x123456789abcdef as *mut libc::c_void;
}

extern "C" fn load(c_self: *mut libc::c_void, addr: u64, len: libc::size_t, bytes: *mut libc::c_uchar) -> bool {
  println!("LOAD -- SELF={:p} ADDR={:#x} LEN={} BYTES={:p}", c_self, addr, len, bytes);
  return true
}

extern "C" fn store(c_self: *mut libc::c_void, addr: u64, len: libc::size_t, bytes: *const libc::c_uchar) -> bool {
  println!("STORE -- SELF={:p} ADDR={:#x} LEN={} BYTES={:p}", c_self, addr, len, bytes);
  return true
}

extern "C" fn dealloc(c_self: *mut libc::c_void) {
  println!("DEALLOC -- SELF={:p}", c_self);
}

#[ctor::ctor]
fn on_load() {
    let test_mmio_plugin = CMmioPlugin {
        alloc: alloc,
        load: load,
        store: store,
        dealloc: dealloc
    };

    unsafe {
        register_mmio_plugin(std::ffi::CString::new("test_mmio_plugin").unwrap().as_ptr(), &test_mmio_plugin);
    }
}
```

Compile with

    cargo build

Requires dependencies `ctor = "0.1.9"` and `libc = "0.2.60"`.

# Test Driver

This is a tiny RISC-V assembly program that will exercise the plugin by performing a load and store operation at address `0x10000000` where the plugin is loaded.

```
# Test program for the minimal Spike MMIO plugin.
.text
.global _start
_start:

# Do a load and a store of address 0x10000000 to exercise the MMIO plugin.
li t0, 0x10000000
lw t1, 0(t0)
sw t1, 0(t0)

# Write the value 1 to tohost, telling Spike to quit with an exit code of 0.
li t0, 1
la t1, tohost
sw t0, 0(t1)

# Spin until Spike terminates the run.
1: j 1b

# Expose tohost and fromhost to Spike so we can communicate with it.
.data

.align 3
.global tohost
tohost:
.dword 0

.align 3
.global fromhost
fromhost:
.dword 0
```

Compile with

    riscv64-linux-gnu-gcc -nostdlib -static -Wl,-Ttext-segment,0x80000000 plugin_test.S -o plugin_test

# Test Output

## C Plugin

Command

    spike -m1 --extlib=/tmp/example_c/plugin.so --device=test_mmio_plugin,0x10000000,argument /tmp/plugin_test/plugin_test

Output

```
ALLOC -- ARGS=argument
LOAD -- SELF=0x123456789abcdef ADDR=0x0 LEN=4 BYTES=0x562c3bec1cbc
STORE -- SELF=0x123456789abcdef ADDR=0x0 LEN=4 BYTES=0x562c3bec1cbc
DEALLOC -- SELF=0x123456789abcdef
```

## C++ Plugin

Command

    spike -m1 --extlib=/tmp/example_cpp/plugin.so --device=test_mmio_plugin,0x10000000,argument /tmp/plugin_test/plugin_test

Output

```
ALLOC -- ARGS=argument
LOAD -- SELF=0x5577e9c42b80 ADDR=0x0 LEN=4 BYTES=0x5577e9cb9d8c
STORE -- SELF=0x5577e9c42b80 ADDR=0x0 LEN=4 BYTES=0x5577e9cb9d8c
DEALLOC -- SELF=0x5577e9c42b80
```

## Rust Plugin

Command

    spike -m1 --extlib=/tmp/example_rust/target/debug/libplugin.so --device=test_mmio_plugin,0x10000000,argument /tmp/plugin_test/plugin_test

Output

```
ALLOC -- ARGS=argument
LOAD -- SELF=0x123456789abcdef ADDR=0x0 LEN=4 BYTES=0x558d3c66ea9c
STORE -- SELF=0x123456789abcdef ADDR=0x0 LEN=4 BYTES=0x558d3c66ea9c
DEALLOC -- SELF=0x123456789abcdef
```