### PR TITLE
Adds --log-commits commandline option.

### DIFF
--- a/riscv/decode.h
+++ b/riscv/decode.h
@@ -166,12 +166,14 @@ private:
 #else
 # define WRITE_REG(reg, value) ({ \
     reg_t wdata = (value); /* value may have side effects */ \
-    STATE.log_reg_write = (commit_log_reg_t){(reg) << 1, {wdata, 0}}; \
+    if (p->get_log_commits()) \
+        STATE.log_reg_write = (commit_log_reg_t){(reg) << 1, {wdata, 0}}; \
     STATE.XPR.write(reg, wdata); \
   })
 # define WRITE_FREG(reg, value) ({ \
     freg_t wdata = freg(value); /* value may have side effects */ \
-    STATE.log_reg_write = (commit_log_reg_t){((reg) << 1) | 1, wdata}; \
+    if (p->get_log_commits()) \
+        STATE.log_reg_write = (commit_log_reg_t){((reg) << 1) | 1, wdata}; \
     DO_WRITE_FREG(reg, wdata); \
   })
 #endif

--- a/riscv/decode.h
+++ b/riscv/decode.h
@@ -166,14 +166,12 @@ private:
 #else
 # define WRITE_REG(reg, value) ({ \
     reg_t wdata = (value); /* value may have side effects */ \
-    if (p->get_log_commits()) \
-        STATE.log_reg_write = (commit_log_reg_t){(reg) << 1, {wdata, 0}}; \
+    STATE.log_reg_write = (commit_log_reg_t){(reg) << 1, {wdata, 0}}; \
     STATE.XPR.write(reg, wdata); \
   })
 # define WRITE_FREG(reg, value) ({ \
     freg_t wdata = freg(value); /* value may have side effects */ \
-    if (p->get_log_commits()) \
-        STATE.log_reg_write = (commit_log_reg_t){((reg) << 1) | 1, wdata}; \
+    STATE.log_reg_write = (commit_log_reg_t){((reg) << 1) | 1, wdata}; \
     DO_WRITE_FREG(reg, wdata); \
   })
 #endif

--- a/riscv/execute.cc
+++ b/riscv/execute.cc
@@ -77,7 +77,9 @@ static reg_t execute_insn(processor_t* p, reg_t pc, insn_fetch_t fetch)
   commit_log_stash_privilege(p);
   reg_t npc = fetch.func(p, fetch.insn, pc);
   if (npc != PC_SERIALIZE_BEFORE) {
-    commit_log_print_insn(p->get_state(), pc, fetch.insn);
+    if (p->get_log_commits()) {
+      commit_log_print_insn(p->get_state(), pc, fetch.insn);
+    }
     p->update_histogram(pc);
   }
   return npc;

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -241,6 +241,7 @@ void processor_t::set_histogram(bool value)
   if (value) {
     fprintf(stderr, "PC Histogram support has not been properly enabled;");
     fprintf(stderr, " please re-build the riscv-isa-sim project using \"configure --enable-histogram\".\n");
+    abort();
   }
 #endif
 }
@@ -252,6 +253,7 @@ void processor_t::set_log_commits(bool value)
   if (value) {
     fprintf(stderr, "Commit logging support has not been properly enabled;");
     fprintf(stderr, " please re-build the riscv-isa-sim project using \"configure --enable-commitlog\".\n");
+    abort();
   }
 #endif
 }

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -245,6 +245,17 @@ void processor_t::set_histogram(bool value)
 #endif
 }
 
+void processor_t::set_log_commits(bool value)
+{
+  log_commits_enabled = value;
+#ifndef RISCV_ENABLE_COMMITLOG
+  if (value) {
+    fprintf(stderr, "Commit logging support has not been properly enabled;");
+    fprintf(stderr, " please re-build the riscv-isa-sim project using \"configure --enable-commitlog\".\n");
+  }
+#endif
+}
+
 void processor_t::reset()
 {
   state.reset(max_isa);

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -290,6 +290,8 @@ public:
 
   void set_debug(bool value);
   void set_histogram(bool value);
+  void set_log_commits(bool value);
+  bool get_log_commits() { return log_commits_enabled; }
   void reset();
   void step(size_t n); // run for n cycles
   void set_csr(int which, reg_t val);
@@ -429,6 +431,7 @@ private:
   reg_t max_isa;
   std::string isa_string;
   bool histogram_enabled;
+  bool log_commits_enabled;
   bool halt_on_reset;
 
   std::vector<insn_desc_t> instructions;

--- a/riscv/sim.cc
+++ b/riscv/sim.cc
@@ -31,7 +31,8 @@ sim_t::sim_t(const char* isa, const char* varch, size_t nprocs, bool halted,
              const debug_module_config_t &dm_config)
   : htif_t(args), mems(mems), procs(std::max(nprocs, size_t(1))),
     start_pc(start_pc), current_step(0), current_proc(0), debug(false),
-    histogram_enabled(false), dtb_enabled(true), remote_bitbang(NULL),
+    histogram_enabled(false), log_commits_enabled(false),
+    dtb_enabled(true), remote_bitbang(NULL),
     debug_module(this, dm_config)
 {
   signal(SIGINT, &handle_signal);
@@ -135,6 +136,14 @@ void sim_t::set_histogram(bool value)
   histogram_enabled = value;
   for (size_t i = 0; i < procs.size(); i++) {
     procs[i]->set_histogram(histogram_enabled);
+  }
+}
+
+void sim_t::set_log_commits(bool value)
+{
+  log_commits_enabled = value;
+  for (size_t i = 0; i < procs.size(); i++) {
+    procs[i]->set_log_commits(log_commits_enabled);
   }
 }
 

--- a/riscv/sim.h
+++ b/riscv/sim.h
@@ -32,6 +32,7 @@ public:
   void set_debug(bool value);
   void set_log(bool value);
   void set_histogram(bool value);
+  void set_log_commits(bool value);
   void set_procs_debug(bool value);
   void set_dtb_enabled(bool value) {
     this->dtb_enabled = value;
@@ -66,6 +67,7 @@ private:
   bool debug;
   bool log;
   bool histogram_enabled; // provide a histogram of PCs
+  bool log_commits_enabled;
   bool dtb_enabled;
   remote_bitbang_t* remote_bitbang;
 

--- a/spike_main/spike.cc
+++ b/spike_main/spike.cc
@@ -108,6 +108,7 @@ int main(int argc, char** argv)
   std::unique_ptr<dcache_sim_t> dc;
   std::unique_ptr<cache_sim_t> l2;
   bool log_cache = false;
+  bool log_commits = false;
   std::function<extension_t*()> extension;
   const char* isa = DEFAULT_ISA;
   const char* varch = DEFAULT_VARCH;
@@ -182,6 +183,7 @@ int main(int argc, char** argv)
       [&](const char* s){dm_config.support_abstract_csr_access = false;});
   parser.option(0, "dm-no-halt-groups", 0,
       [&](const char* s){dm_config.support_haltgroups = false;});
+  parser.option(0, "log-commits", 0, [&](const char* s){log_commits = true;});
 
   auto argv1 = parser.parse(argv);
   std::vector<std::string> htif_args(argv1, (const char*const*)argv + argc);
@@ -221,5 +223,6 @@ int main(int argc, char** argv)
   s.set_debug(debug);
   s.set_log(log);
   s.set_histogram(histogram);
+  s.set_log_commits(log_commits);
   return s.run();
 }


### PR DESCRIPTION
Similar to histogram support, the commit logging feature must be
enabled with a configure option: --enable-commitlog. However, unlike
that feature, there was no way to turn off the logging with a
commandline option once the functionality was built in. This (git)
commit provides that abilty.