### PR TITLE
Extends the commit log feature with memory writes.

### DIFF
--- a/riscv/execute.cc
+++ b/riscv/execute.cc
@@ -18,6 +18,9 @@ static void commit_log_stash_privilege(processor_t* p)
 static void commit_log_print_value(int width, uint64_t hi, uint64_t lo)
 {
   switch (width) {
+    case 8:
+      fprintf(stderr, "0x%01" PRIx8, (uint8_t)lo);
+      break;
     case 16:
       fprintf(stderr, "0x%04" PRIx16, (uint16_t)lo);
       break;
@@ -39,6 +42,7 @@ static void commit_log_print_insn(state_t* state, reg_t pc, insn_t insn)
 {
 #ifdef RISCV_ENABLE_COMMITLOG
   auto& reg = state->log_reg_write;
+  auto& mem = state->log_mem_write;
   int priv = state->last_inst_priv;
   int xlen = state->last_inst_xlen;
   int flen = state->last_inst_flen;
@@ -55,10 +59,17 @@ static void commit_log_print_insn(state_t* state, reg_t pc, insn_t insn)
     fprintf(stderr, ") %c%2d ", fp ? 'f' : 'x', rd);
     commit_log_print_value(size, reg.data.v[1], reg.data.v[0]);
     fprintf(stderr, "\n");
+  } else if (mem.size) {
+    fprintf(stderr, ") mem ");
+    commit_log_print_value(xlen, 0, mem.addr);
+    fprintf(stderr, " ");
+    commit_log_print_value(mem.size << 3, 0, mem.value);
+    fprintf(stderr, "\n");
   } else {
     fprintf(stderr, ")\n");
   }
   reg.addr = 0;
+  mem.size = 0;
 #endif
 }
 

--- a/riscv/execute.cc
+++ b/riscv/execute.cc
@@ -51,23 +51,21 @@ static void commit_log_print_insn(state_t* state, reg_t pc, insn_t insn)
   commit_log_print_value(xlen, 0, pc);
   fprintf(stderr, " (");
   commit_log_print_value(insn.length() * 8, 0, insn.bits());
-
+  fprintf(stderr, ")");
   if (reg.addr) {
     bool fp = reg.addr & 1;
     int rd = reg.addr >> 1;
     int size = fp ? flen : xlen;
-    fprintf(stderr, ") %c%2d ", fp ? 'f' : 'x', rd);
+    fprintf(stderr, " %c%2d ", fp ? 'f' : 'x', rd);
     commit_log_print_value(size, reg.data.v[1], reg.data.v[0]);
-    fprintf(stderr, "\n");
-  } else if (mem.size) {
-    fprintf(stderr, ") mem ");
+  }
+  if (mem.size) {
+    fprintf(stderr, " mem ");
     commit_log_print_value(xlen, 0, mem.addr);
     fprintf(stderr, " ");
     commit_log_print_value(mem.size << 3, 0, mem.value);
-    fprintf(stderr, "\n");
-  } else {
-    fprintf(stderr, ")\n");
   }
+  fprintf(stderr, "\n");
   reg.addr = 0;
   mem.size = 0;
 #endif

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -34,6 +34,13 @@ struct commit_log_reg_t
   freg_t data;
 };
 
+struct commit_log_mem_t
+{
+  reg_t addr;
+  uint64_t value;
+  uint8_t size; // bytes: 1, 2, 4, or 8
+};
+
 typedef struct
 {
   uint8_t prv;
@@ -259,6 +266,7 @@ struct state_t
 
 #ifdef RISCV_ENABLE_COMMITLOG
   commit_log_reg_t log_reg_write;
+  commit_log_mem_t log_mem_write;
   reg_t last_inst_priv;
   int last_inst_xlen;
   int last_inst_flen;


### PR DESCRIPTION
This provides a little more information for debugging instruction
traces, allowing you to maintain the state of memory as the trace
is processed.

The following sample trace output illustrates the formatting of
the new memory writes. Each line contains the address and the
instruction bytes. If there is a register commited, then it is shown
with the register number and the value. If there is memory written
then it appears after 'mem' with the address and the value.

    0 0x80000130 (0x03d79863)
    0 0x80000134 (0x800005b7) x11 0x80000000
    0 0x8000010c (0x00a6a023) mem 0x80002000 0x80000000
    0 0x80000138 (0x00b6a72f) x14 0x7ffff800 mem 0x80002000 0xfffff800