### PR TITLE
bugfix for macOS/BSD

### DIFF
--- a/configure
+++ b/configure
@@ -4364,8 +4364,6 @@ CFLAGS="-Wall -Wno-unused -g -O2"
 
 CXXFLAGS="-Wall -Wno-unused -g -O2 -std=c++11"
 
-LDFLAGS="-Wl,--export-dynamic"
-
 
 #-------------------------------------------------------------------------
 # MCPPBS subproject list

--- a/configure.ac
+++ b/configure.ac
@@ -84,7 +84,6 @@ AC_CHECK_TYPE([__int128_t], AC_SUBST([HAVE_INT128],[yes]))
 
 AC_SUBST([CFLAGS],  ["-Wall -Wno-unused -g -O2"])
 AC_SUBST([CXXFLAGS],["-Wall -Wno-unused -g -O2 -std=c++11"])
-AC_SUBST([LDFLAGS], ["-Wl,--export-dynamic"])
 
 #-------------------------------------------------------------------------
 # MCPPBS subproject list


### PR DESCRIPTION
Recently (https://github.com/riscv/riscv-isa-sim/commit/d184cd4dbfb1c863ae9f1e7c4c263ac626706351), `--export-dynamic` was added to `LDFLAGS`, but it appears unnecessary on linux and build-breaking on macOS/BSD.

This PR was tested (and works) on Ubuntu 18.04.3 and macOS 10.14.6.