### PR TITLE
Fixed match trigger MATCH_NAPOT case.

### DIFF
--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -388,7 +388,7 @@ public:
           break;
         case MATCH_NAPOT:
           {
-            reg_t mask = ~((1 << cto(state.tdata2[i])) - 1);
+            reg_t mask = ~((1 << (cto(state.tdata2[i])+1)) - 1);
             if ((value & mask) != (state.tdata2[i] & mask))
               continue;
           }


### PR DESCRIPTION
Mask calculation was not in consistency with debug spec.
Watch debug spec. 5.2.7 match field overview and
debug spec. B.9 fourth example.
Mask should not cover LSB zero bit.

Also there is a way to make it simplier:
reg_t mask = ~(((~state.tdata2[i]) - 1) ^ ~state.tdata2[i]);