### PR TITLE
Fix vnclip/vnclipu rounding

### DIFF
--- a/riscv/decode.h
+++ b/riscv/decode.h
@@ -541,30 +541,27 @@ static inline bool is_overlaped(const int astart, const int asize,
 
 
 #define INT_ROUNDING(result, xrm, gb) \
-  if (gb > 0) { \
-    switch(xrm) {\
+  do { \
+    const uint64_t lsb = 1UL << (gb); \
+    const uint64_t lsb_half = lsb >> 1; \
+    switch (xrm) {\
       case VRM::RNU:\
-        result += ((uint64_t)1 << ((gb) - 1));\
+        result += lsb_half; \
         break;\
       case VRM::RNE:\
-        if ((result & ((uint64_t)0x3 << ((gb) - 1))) == 0x1){\
-            result -= ((uint64_t)1 << ((gb) - 1));\
-            }else if ((result & ((uint64_t)0x3 << ((gb) - 1))) == 0x3){\
-            result += ((uint64_t)1 << ((gb) - 1));\
-        }\
+        if ((result & lsb_half) && ((result & (lsb_half - 1)) || (result & lsb))) \
+          result += lsb; \
         break;\
       case VRM::RDN:\
-        result = (result >> ((gb) - 1)) << ((gb) - 1);\
         break;\
       case VRM::ROD:\
-        result |= ((uint64_t)1ul << (gb)); \
+        if (result & (lsb - 1)) \
+          result |= lsb; \
         break;\
       case VRM::INVALID_RM:\
         assert(true);\
     } \
-  } else if (gb == 0 && xrm == VRM::ROD) { \
-    result |= 1ul; \
-  }
+  } while (0)
 
 
 //

--- a/riscv/insns/vnclip_vi.h
+++ b/riscv/insns/vnclip_vi.h
@@ -6,10 +6,13 @@ VI_VVXI_LOOP_NARROW
 ({
 
   int64_t result = vs2;
-// rounding
-  INT_ROUNDING(result, xrm, sew);
+  uint64_t shift = zimm5 & ((sew * 2) - 1);
 
-  result = vsext(result, sew * 2) >> (zimm5 & ((sew * 2) < 32? (sew * 2) - 1: 31));
+// rounding
+  INT_ROUNDING(result, xrm, shift);
+
+// signed right shift
+  result = vsext(result, sew * 2) >> shift;
 
 // saturation
   if (result < int_min) {

--- a/riscv/insns/vnclip_vv.h
+++ b/riscv/insns/vnclip_vv.h
@@ -6,16 +6,13 @@ VI_VVXI_LOOP_NARROW
 ({
 
   int64_t result = vs2;
+  uint64_t shift = vs1 & ((sew * 2) - 1);
+
 // rounding
-  INT_ROUNDING(result, xrm, sew);
+  INT_ROUNDING(result, xrm, shift);
 
-// unsigned shifting to rs1
-  uint64_t unsigned_shift_amount = (uint64_t)(vs1 & ((sew * 2) - 1));
-  if (unsigned_shift_amount >= (2 * sew)) {
-    unsigned_shift_amount = 2 * sew - 1;
-  }
-
-  result = (vsext(result, sew * 2)) >> unsigned_shift_amount;
+// signed right shift
+  result = (vsext(result, sew * 2)) >> shift;
 
 // saturation
   if (result < int_min) {

--- a/riscv/insns/vnclip_vx.h
+++ b/riscv/insns/vnclip_vx.h
@@ -6,15 +6,13 @@ VI_VVXI_LOOP_NARROW
 ({
 
   int64_t result = vs2;
-// rounding
-  INT_ROUNDING(result, xrm, sew);
+  uint64_t shift = rs1 & ((sew * 2) - 1);
 
-// unsigned shifting to rs1
-  uint64_t unsigned_shift_amount = (uint64_t)(rs1 & ((sew * 2) - 1));
-  if (unsigned_shift_amount >= (2 * sew)) {
-    unsigned_shift_amount = 2 * sew - 1;
-  }
-  result = vsext(result, sew * 2) >> unsigned_shift_amount;
+// rounding
+  INT_ROUNDING(result, xrm, shift);
+
+// signed right shift
+  result = vsext(result, sew * 2) >> shift;
 
 // saturation
   if (result < int_min) {

--- a/riscv/insns/vnclipu_vi.h
+++ b/riscv/insns/vnclipu_vi.h
@@ -4,11 +4,13 @@ uint64_t int_max = ~(-1ll << P.VU.vsew);
 VI_VVXI_LOOP_NARROW
 ({
   uint64_t result = vs2_u;
-  // rounding
-  INT_ROUNDING(result, xrm, sew);
+  uint64_t shift = zimm5 & ((sew * 2) - 1);
 
-  // unsigned shifting to rs1
-  result = vzext(result, sew * 2) >> (zimm5 & ((sew * 2) < 32? (sew * 2) - 1: 31));
+  // rounding
+  INT_ROUNDING(result, xrm, shift);
+
+  // unsigned right shift
+  result = vzext(result, sew * 2) >> shift;
 
   // saturation
   if (result & (uint64_t)(-1ll << sew)) {

--- a/riscv/insns/vnclipu_vv.h
+++ b/riscv/insns/vnclipu_vv.h
@@ -5,17 +5,14 @@ VI_VVXI_LOOP_NARROW
 ({
 
   uint64_t result = vs2_u;
+  uint64_t shift = vs1 & ((sew * 2) - 1);
 
 // rounding
-  INT_ROUNDING(result, xrm, sew);
+  INT_ROUNDING(result, xrm, shift);
 
-// unsigned shifting to rs1
-  uint64_t unsigned_shift_amount = (uint64_t)(vs1 & ((sew * 2) - 1));
-  if (unsigned_shift_amount >= (2 * sew)) {
-    result = 0;
-  } else {
-    result = vzext(result, sew * 2) >> unsigned_shift_amount;
-  }
+// unsigned right shift
+  result = vzext(result, sew * 2) >> shift;
+
 // saturation
   if (result & (uint64_t)(-1ll << sew)) {
     result = int_max;

--- a/riscv/insns/vnclipu_vx.h
+++ b/riscv/insns/vnclipu_vx.h
@@ -4,17 +4,13 @@ uint64_t int_max = ~(-1ll << P.VU.vsew);
 VI_VVXI_LOOP_NARROW
 ({
   uint64_t result = vs2;
+  uint64_t shift = rs1 & ((sew * 2) - 1);
 
 // rounding
-  INT_ROUNDING(result, xrm, sew);
+  INT_ROUNDING(result, xrm, shift);
 
-// unsigned shifting to rs1
-  uint64_t unsigned_shift_amount = (uint64_t)(rs1 & ((sew * 2) - 1));
-  if (unsigned_shift_amount >= (2 * sew)) {
-    result = 0;
-  } else {
-    result = vzext(result, sew * 2) >> unsigned_shift_amount;
-  }
+// unsigned right shift
+  result = vzext(result, sew * 2) >> shift;
 
 // saturation
   if (result & (uint64_t)(-1ll << sew)) {


### PR DESCRIPTION
The rounding increment should be derived from the shift amount, not `SEW`.

This also removes some redundant code for capping the shift amount to `(2 * sew) - 1`, which is already accomplished by taking the low `log2(2 * SEW)` bits.