### PR TITLE
Require VM enabled for SFENCE.VMA and S-mode for mstatus.SUM

### DIFF
--- a/riscv/insns/sfence_vma.h
+++ b/riscv/insns/sfence_vma.h
@@ -1,2 +1,3 @@
+require_extension('S');
 require_privilege(get_field(STATE.mstatus, MSTATUS_TVM) ? PRV_M : PRV_S);
 MMU.flush_tlb();

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -541,7 +541,8 @@ void processor_t::set_csr(int which, reg_t val)
                   || supports_extension('V');
 
       reg_t mask = MSTATUS_SIE | MSTATUS_SPIE | MSTATUS_MIE | MSTATUS_MPIE
-                 | MSTATUS_MPRV | MSTATUS_SUM
+                 | MSTATUS_MPRV
+                 | (supports_extension('S') ? MSTATUS_SUM : 0)
                  | MSTATUS_MXR | MSTATUS_TW | MSTATUS_TVM
                  | MSTATUS_TSR | MSTATUS_UXL | MSTATUS_SXL |
                  (has_fs ? MSTATUS_FS : 0) |


### PR DESCRIPTION
Make SFENCE.VMA raise an exception if Virtual Memory is not implemented (i.e. no supervisor mode or `satp.mode == 0`).

Hardwire mstatus.SUM to 0 if no supervisor mode.

Tested by observing illegal instruction exception being raised on `sfence.vma` with `--priv=mu` and successful TLB flush with `--priv=msu`