### PR TITLE
extend the memory writes log feature with memory reads

### DIFF
--- a/riscv/execute.cc
+++ b/riscv/execute.cc
@@ -42,7 +42,8 @@ static void commit_log_print_insn(state_t* state, reg_t pc, insn_t insn)
 {
 #ifdef RISCV_ENABLE_COMMITLOG
   auto& reg = state->log_reg_write;
-  auto& mem = state->log_mem_write;
+  auto& load = state->log_mem_read;
+  auto& store = state->log_mem_write;
   int priv = state->last_inst_priv;
   int xlen = state->last_inst_xlen;
   int flen = state->last_inst_flen;
@@ -59,15 +60,20 @@ static void commit_log_print_insn(state_t* state, reg_t pc, insn_t insn)
     fprintf(stderr, " %c%2d ", fp ? 'f' : 'x', rd);
     commit_log_print_value(size, reg.data.v[1], reg.data.v[0]);
   }
-  if (mem.size) {
+  if (load.size) {
     fprintf(stderr, " mem ");
-    commit_log_print_value(xlen, 0, mem.addr);
+    commit_log_print_value(xlen, 0, load.addr);
+  }
+  if (store.size) {
+    fprintf(stderr, " mem ");
+    commit_log_print_value(xlen, 0, store.addr);
     fprintf(stderr, " ");
-    commit_log_print_value(mem.size << 3, 0, mem.value);
+    commit_log_print_value(store.size << 3, 0, store.value);
   }
   fprintf(stderr, "\n");
   reg.addr = 0;
-  mem.size = 0;
+  load.size = 0;
+  store.size = 0;
 #endif
 }
 

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -271,6 +271,7 @@ struct state_t
 
 #ifdef RISCV_ENABLE_COMMITLOG
   commit_log_reg_t log_reg_write;
+  commit_log_mem_t log_mem_read;
   commit_log_mem_t log_mem_write;
   reg_t last_inst_priv;
   int last_inst_xlen;


### PR DESCRIPTION
Follow-up to #324:
This provides a little more information for debugging instruction traces, allowing you to check the memory addresses accessed as the trace is processed.

The following sample trace output illustrates the formatting of the new memory reads.  Memory reads appear very similarly to memory writes, but only print the address, not the value, because the value is already shown in the register write data value.

```
# jump
0 0xPC (0xINSTR)
# arithmetic
0 0xPC (0xINSTR) xRD 0xVAL
# store
0 0xPC (0xINSTR) mem 0xADDR 0xVAL
# load
0 0xPC (0xINSTR) xRD 0xVAL mem 0xADDR
# amo
0 0xPC (0xINSTR) xRD 0xVAL mem 0xADDR mem 0xADDR 0xVAL
```

@dave-estes-syzexion I moved the `WRITE_MEM` call upwards in the `store_##type` function to only print twice for misaligned stores (once for each naturally aligned piece) instead of three times (once for each naturally aligned piece and once for the whole).
@ccelio can you please review this similarly to #324?
