### PR TITLE
Rvv commitlog

### DIFF
--- a/riscv/decode.h
+++ b/riscv/decode.h
@@ -538,7 +538,7 @@ static inline bool is_overlapped(const int astart, const int asize,
   for (reg_t i=P.VU.vstart; i<vl; ++i){ \
     VI_LOOP_ELEMENT_SKIP(); \
     uint64_t mmask = (UINT64_MAX << (64 - mlen)) >> (64 - mlen - mpos); \
-    uint64_t &vdi = P.VU.elt<uint64_t>(insn.rd(), midx); \
+    uint64_t &vdi = P.VU.elt<uint64_t>(insn.rd(), midx, true); \
     uint64_t res = 0;
 
 #define VI_LOOP_CMP_END \
@@ -595,68 +595,68 @@ static inline bool is_overlapped(const int astart, const int asize,
 // vector: integer and masking operand access helper
 //
 #define VXI_PARAMS(x) \
-  type_sew_t<x>::type &vd = P.VU.elt<type_sew_t<x>::type>(rd_num, i); \
+  type_sew_t<x>::type &vd = P.VU.elt<type_sew_t<x>::type>(rd_num, i, true); \
   type_sew_t<x>::type vs1 = P.VU.elt<type_sew_t<x>::type>(rs1_num, i); \
   type_sew_t<x>::type vs2 = P.VU.elt<type_sew_t<x>::type>(rs2_num, i); \
   type_sew_t<x>::type rs1 = (type_sew_t<x>::type)RS1; \
   type_sew_t<x>::type simm5 = (type_sew_t<x>::type)insn.v_simm5();
 
 #define VV_U_PARAMS(x) \
-  type_usew_t<x>::type &vd = P.VU.elt<type_usew_t<x>::type>(rd_num, i); \
+  type_usew_t<x>::type &vd = P.VU.elt<type_usew_t<x>::type>(rd_num, i, true); \
   type_usew_t<x>::type vs1 = P.VU.elt<type_usew_t<x>::type>(rs1_num, i); \
   type_usew_t<x>::type vs2 = P.VU.elt<type_usew_t<x>::type>(rs2_num, i);
 
 #define VX_U_PARAMS(x) \
-  type_usew_t<x>::type &vd = P.VU.elt<type_usew_t<x>::type>(rd_num, i); \
+  type_usew_t<x>::type &vd = P.VU.elt<type_usew_t<x>::type>(rd_num, i, true); \
   type_usew_t<x>::type rs1 = (type_usew_t<x>::type)RS1; \
   type_usew_t<x>::type vs2 = P.VU.elt<type_usew_t<x>::type>(rs2_num, i);
 
 #define VI_U_PARAMS(x) \
-  type_usew_t<x>::type &vd = P.VU.elt<type_usew_t<x>::type>(rd_num, i); \
+  type_usew_t<x>::type &vd = P.VU.elt<type_usew_t<x>::type>(rd_num, i, true); \
   type_usew_t<x>::type simm5 = (type_usew_t<x>::type)insn.v_zimm5(); \
   type_usew_t<x>::type vs2 = P.VU.elt<type_usew_t<x>::type>(rs2_num, i);
 
 #define VV_PARAMS(x) \
-  type_sew_t<x>::type &vd = P.VU.elt<type_sew_t<x>::type>(rd_num, i); \
+  type_sew_t<x>::type &vd = P.VU.elt<type_sew_t<x>::type>(rd_num, i, true); \
   type_sew_t<x>::type vs1 = P.VU.elt<type_sew_t<x>::type>(rs1_num, i); \
   type_sew_t<x>::type vs2 = P.VU.elt<type_sew_t<x>::type>(rs2_num, i);
 
 #define VX_PARAMS(x) \
-  type_sew_t<x>::type &vd = P.VU.elt<type_sew_t<x>::type>(rd_num, i); \
+  type_sew_t<x>::type &vd = P.VU.elt<type_sew_t<x>::type>(rd_num, i, true); \
   type_sew_t<x>::type rs1 = (type_sew_t<x>::type)RS1; \
   type_sew_t<x>::type vs2 = P.VU.elt<type_sew_t<x>::type>(rs2_num, i);
 
 #define VI_PARAMS(x) \
-  type_sew_t<x>::type &vd = P.VU.elt<type_sew_t<x>::type>(rd_num, i); \
+  type_sew_t<x>::type &vd = P.VU.elt<type_sew_t<x>::type>(rd_num, i, true); \
   type_sew_t<x>::type simm5 = (type_sew_t<x>::type)insn.v_simm5(); \
   type_sew_t<x>::type vs2 = P.VU.elt<type_sew_t<x>::type>(rs2_num, i);
 
 #define XV_PARAMS(x) \
-  type_sew_t<x>::type &vd = P.VU.elt<type_sew_t<x>::type>(rd_num, i); \
+  type_sew_t<x>::type &vd = P.VU.elt<type_sew_t<x>::type>(rd_num, i, true); \
   type_usew_t<x>::type vs2 = P.VU.elt<type_usew_t<x>::type>(rs2_num, RS1);
 
 #define VI_XI_SLIDEDOWN_PARAMS(x, off) \
-  auto &vd = P.VU.elt<type_sew_t<x>::type>(rd_num, i); \
+  auto &vd = P.VU.elt<type_sew_t<x>::type>(rd_num, i, true); \
   auto vs2 = P.VU.elt<type_sew_t<x>::type>(rs2_num, i + off);
 
 #define VI_XI_SLIDEUP_PARAMS(x, offset) \
-  auto &vd = P.VU.elt<type_sew_t<x>::type>(rd_num, i); \
+  auto &vd = P.VU.elt<type_sew_t<x>::type>(rd_num, i, true); \
   auto vs2 = P.VU.elt<type_sew_t<x>::type>(rs2_num, i - offset);
 
 #define VI_NSHIFT_PARAMS(sew1, sew2) \
-  auto &vd = P.VU.elt<type_usew_t<sew1>::type>(rd_num, i); \
+  auto &vd = P.VU.elt<type_usew_t<sew1>::type>(rd_num, i, true); \
   auto vs2_u = P.VU.elt<type_usew_t<sew2>::type>(rs2_num, i); \
   auto vs2 = P.VU.elt<type_sew_t<sew2>::type>(rs2_num, i); \
   auto zimm5 = (type_usew_t<sew1>::type)insn.v_zimm5();
 
 #define VX_NSHIFT_PARAMS(sew1, sew2) \
-  auto &vd = P.VU.elt<type_usew_t<sew1>::type>(rd_num, i); \
+  auto &vd = P.VU.elt<type_usew_t<sew1>::type>(rd_num, i, true); \
   auto vs2_u = P.VU.elt<type_usew_t<sew2>::type>(rs2_num, i); \
   auto vs2 = P.VU.elt<type_sew_t<sew2>::type>(rs2_num, i); \
   auto rs1 = (type_sew_t<sew1>::type)RS1;
 
 #define VV_NSHIFT_PARAMS(sew1, sew2) \
-  auto &vd = P.VU.elt<type_usew_t<sew1>::type>(rd_num, i); \
+  auto &vd = P.VU.elt<type_usew_t<sew1>::type>(rd_num, i, true); \
   auto vs2_u = P.VU.elt<type_usew_t<sew2>::type>(rs2_num, i); \
   auto vs2 = P.VU.elt<type_sew_t<sew2>::type>(rs2_num, i); \
   auto vs1 = P.VU.elt<type_sew_t<sew1>::type>(rs1_num, i);
@@ -665,23 +665,23 @@ static inline bool is_overlapped(const int astart, const int asize,
   auto vs2 = P.VU.elt<type_sew_t<x>::type>(rs2_num, i); \
   auto rs1 = (type_sew_t<x>::type)RS1; \
   auto simm5 = (type_sew_t<x>::type)insn.v_simm5(); \
-  auto &vd = P.VU.elt<uint64_t>(rd_num, midx);
+  auto &vd = P.VU.elt<uint64_t>(rd_num, midx, true);
 
 #define VV_CARRY_PARAMS(x) \
   auto vs2 = P.VU.elt<type_sew_t<x>::type>(rs2_num, i); \
   auto vs1 = P.VU.elt<type_sew_t<x>::type>(rs1_num, i); \
-  auto &vd = P.VU.elt<uint64_t>(rd_num, midx);
+  auto &vd = P.VU.elt<uint64_t>(rd_num, midx, true);
 
 #define XI_WITH_CARRY_PARAMS(x) \
   auto vs2 = P.VU.elt<type_sew_t<x>::type>(rs2_num, i); \
   auto rs1 = (type_sew_t<x>::type)RS1; \
   auto simm5 = (type_sew_t<x>::type)insn.v_simm5(); \
-  auto &vd = P.VU.elt<type_sew_t<x>::type>(rd_num, i);
+  auto &vd = P.VU.elt<type_sew_t<x>::type>(rd_num, i, true);
 
 #define VV_WITH_CARRY_PARAMS(x) \
   auto vs2 = P.VU.elt<type_sew_t<x>::type>(rs2_num, i); \
   auto vs1 = P.VU.elt<type_sew_t<x>::type>(rs1_num, i); \
-  auto &vd = P.VU.elt<type_sew_t<x>::type>(rd_num, i);
+  auto &vd = P.VU.elt<type_sew_t<x>::type>(rd_num, i, true);
 
 //
 // vector: integer and masking operation loop
@@ -822,7 +822,7 @@ static inline bool is_overlapped(const int astart, const int asize,
   reg_t rd_num = insn.rd(); \
   reg_t rs1_num = insn.rs1(); \
   reg_t rs2_num = insn.rs2(); \
-  auto &vd_0_des = P.VU.elt<type_sew_t<x>::type>(rd_num, 0); \
+  auto &vd_0_des = P.VU.elt<type_sew_t<x>::type>(rd_num, 0, true); \
   auto vd_0_res = P.VU.elt<type_sew_t<x>::type>(rs1_num, 0); \
   for (reg_t i=P.VU.vstart; i<vl; ++i){ \
     VI_LOOP_ELEMENT_SKIP(); \
@@ -853,7 +853,7 @@ static inline bool is_overlapped(const int astart, const int asize,
   reg_t rd_num = insn.rd(); \
   reg_t rs1_num = insn.rs1(); \
   reg_t rs2_num = insn.rs2(); \
-  auto &vd_0_des = P.VU.elt<type_usew_t<x>::type>(rd_num, 0); \
+  auto &vd_0_des = P.VU.elt<type_usew_t<x>::type>(rd_num, 0, true); \
   auto vd_0_res = P.VU.elt<type_usew_t<x>::type>(rs1_num, 0); \
   for (reg_t i=P.VU.vstart; i<vl; ++i){ \
     VI_LOOP_ELEMENT_SKIP(); \
@@ -1003,7 +1003,7 @@ if (sew == e8){ \
 VI_LOOP_END 
 
 #define VI_NARROW_SHIFT(sew1, sew2) \
-  type_usew_t<sew1>::type &vd = P.VU.elt<type_usew_t<sew1>::type>(rd_num, i); \
+  type_usew_t<sew1>::type &vd = P.VU.elt<type_usew_t<sew1>::type>(rd_num, i, true); \
   type_usew_t<sew2>::type vs2_u = P.VU.elt<type_usew_t<sew2>::type>(rs2_num, i); \
   type_usew_t<sew1>::type zimm5 = (type_usew_t<sew1>::type)insn.v_zimm5(); \
   type_sew_t<sew2>::type vs2 = P.VU.elt<type_sew_t<sew2>::type>(rs2_num, i); \
@@ -1103,19 +1103,19 @@ VI_LOOP_END
   switch(P.VU.vsew) { \
   case e8: { \
     sign##16_t vd_w = P.VU.elt<sign##16_t>(rd_num, i); \
-    P.VU.elt<uint16_t>(rd_num, i) = \
+    P.VU.elt<uint16_t>(rd_num, i, true) = \
       op1((sign##16_t)(sign##8_t)var0 op0 (sign##16_t)(sign##8_t)var1) + var2; \
     } \
     break; \
   case e16: { \
     sign##32_t vd_w = P.VU.elt<sign##32_t>(rd_num, i); \
-    P.VU.elt<uint32_t>(rd_num, i) = \
+    P.VU.elt<uint32_t>(rd_num, i, true) = \
       op1((sign##32_t)(sign##16_t)var0 op0 (sign##32_t)(sign##16_t)var1) + var2; \
     } \
     break; \
   default: { \
     sign##64_t vd_w = P.VU.elt<sign##64_t>(rd_num, i); \
-    P.VU.elt<uint64_t>(rd_num, i) = \
+    P.VU.elt<uint64_t>(rd_num, i, true) = \
       op1((sign##64_t)(sign##32_t)var0 op0 (sign##64_t)(sign##32_t)var1) + var2; \
     } \
     break; \
@@ -1146,19 +1146,19 @@ VI_LOOP_END
 #define VI_WIDE_WVX_OP(var0, op0, sign) \
   switch(P.VU.vsew) { \
   case e8: { \
-    sign##16_t &vd_w = P.VU.elt<sign##16_t>(rd_num, i); \
+    sign##16_t &vd_w = P.VU.elt<sign##16_t>(rd_num, i, true); \
     sign##16_t vs2_w = P.VU.elt<sign##16_t>(rs2_num, i); \
     vd_w = vs2_w op0 (sign##16_t)(sign##8_t)var0; \
     } \
     break; \
   case e16: { \
-    sign##32_t &vd_w = P.VU.elt<sign##32_t>(rd_num, i); \
+    sign##32_t &vd_w = P.VU.elt<sign##32_t>(rd_num, i, true); \
     sign##32_t vs2_w = P.VU.elt<sign##32_t>(rs2_num, i); \
     vd_w = vs2_w op0 (sign##32_t)(sign##16_t)var0; \
     } \
     break; \
   default: { \
-    sign##64_t &vd_w = P.VU.elt<sign##64_t>(rd_num, i); \
+    sign##64_t &vd_w = P.VU.elt<sign##64_t>(rd_num, i, true); \
     sign##64_t vs2_w = P.VU.elt<sign##64_t>(rs2_num, i); \
     vd_w = vs2_w op0 (sign##64_t)(sign##32_t)var0; \
     } \
@@ -1194,13 +1194,13 @@ VI_LOOP_END
   switch(P.VU.vsew) { \
   case e8: { \
     sign##32_t vd_w = P.VU.elt<sign##32_t>(rd_num, i); \
-    P.VU.elt<uint32_t>(rd_num, i) = \
+    P.VU.elt<uint32_t>(rd_num, i, true) = \
       op1((sign##32_t)(sign##8_t)var0 op0 (sign##32_t)(sign##8_t)var1) + var2; \
     } \
     break; \
   default: { \
     sign##64_t vd_w = P.VU.elt<sign##64_t>(rd_num, i); \
-    P.VU.elt<uint64_t>(rd_num, i) = \
+    P.VU.elt<uint64_t>(rd_num, i, true) = \
       op1((sign##64_t)(sign##16_t)var0 op0 (sign##64_t)(sign##16_t)var1) + var2; \
     } \
     break; \
@@ -1210,13 +1210,13 @@ VI_LOOP_END
   switch(P.VU.vsew) { \
   case e8: { \
     sign_d##32_t vd_w = P.VU.elt<sign_d##32_t>(rd_num, i); \
-    P.VU.elt<uint32_t>(rd_num, i) = \
+    P.VU.elt<uint32_t>(rd_num, i, true) = \
       op1((sign_1##32_t)(sign_1##8_t)var0 op0 (sign_2##32_t)(sign_2##8_t)var1) + var2; \
     } \
     break; \
   default: { \
     sign_d##64_t vd_w = P.VU.elt<sign_d##64_t>(rd_num, i); \
-    P.VU.elt<uint64_t>(rd_num, i) = \
+    P.VU.elt<uint64_t>(rd_num, i, true) = \
       op1((sign_1##64_t)(sign_1##16_t)var0 op0 (sign_2##64_t)(sign_2##16_t)var1) + var2; \
     } \
     break; \
@@ -1228,7 +1228,7 @@ VI_LOOP_END
   reg_t rd_num = insn.rd(); \
   reg_t rs1_num = insn.rs1(); \
   reg_t rs2_num = insn.rs2(); \
-  auto &vd_0_des = P.VU.elt<type_sew_t<sew2>::type>(rd_num, 0); \
+  auto &vd_0_des = P.VU.elt<type_sew_t<sew2>::type>(rd_num, 0, true); \
   auto vd_0_res = P.VU.elt<type_sew_t<sew2>::type>(rs1_num, 0); \
   for (reg_t i=P.VU.vstart; i<vl; ++i){ \
     VI_LOOP_ELEMENT_SKIP(); \
@@ -1256,7 +1256,7 @@ VI_LOOP_END
   reg_t rd_num = insn.rd(); \
   reg_t rs1_num = insn.rs1(); \
   reg_t rs2_num = insn.rs2(); \
-  auto &vd_0_des = P.VU.elt<type_usew_t<sew2>::type>(rd_num, 0); \
+  auto &vd_0_des = P.VU.elt<type_usew_t<sew2>::type>(rd_num, 0, true); \
   auto vd_0_res = P.VU.elt<type_usew_t<sew2>::type>(rs1_num, 0); \
   for (reg_t i=P.VU.vstart; i<vl; ++i) { \
     VI_LOOP_ELEMENT_SKIP(); \

--- a/riscv/decode.h
+++ b/riscv/decode.h
@@ -139,6 +139,14 @@ public:
   {
     return data[i];
   }
+  regfile_t()
+  {
+    reset();
+  }
+  void reset()
+  {
+    memset(data, 0, sizeof(data));
+  }
 private:
   T data[N];
 };

--- a/riscv/decode.h
+++ b/riscv/decode.h
@@ -170,12 +170,12 @@ private:
 #else
 # define WRITE_REG(reg, value) ({ \
     reg_t wdata = (value); /* value may have side effects */ \
-    STATE.log_reg_write = (commit_log_reg_t){(reg) << 1, {wdata, 0}}; \
+    STATE.log_reg_write[(reg) << 2] = {wdata, 0}; \
     STATE.XPR.write(reg, wdata); \
   })
 # define WRITE_FREG(reg, value) ({ \
     freg_t wdata = freg(value); /* value may have side effects */ \
-    STATE.log_reg_write = (commit_log_reg_t){((reg) << 1) | 1, wdata}; \
+    STATE.log_reg_write[((reg) << 2) | 1] = wdata; \
     DO_WRITE_FREG(reg, wdata); \
   })
 #endif

--- a/riscv/decode.h
+++ b/riscv/decode.h
@@ -1630,7 +1630,7 @@ for (reg_t i = 0; i < vlmax; ++i) { \
     float32_t rs1 = f32(READ_FREG(rs1_num)); \
     VI_LOOP_ELEMENT_SKIP(); \
     uint64_t mmask = (UINT64_MAX << (64 - mlen)) >> (64 - mlen - mpos); \
-    uint64_t &vdi = P.VU.elt<uint64_t>(rd_num, midx); \
+    uint64_t &vdi = P.VU.elt<uint64_t>(rd_num, midx, true); \
     uint64_t res = 0;
 
 #define VI_VFP_LOOP_REDUCTION_BASE(width) \
@@ -1639,7 +1639,7 @@ for (reg_t i = 0; i < vlmax; ++i) { \
   vd_0 = vs1_0;\
   for (reg_t i=P.VU.vstart; i<vl; ++i){ \
     VI_LOOP_ELEMENT_SKIP(); \
-    int##width##_t &vd = P.VU.elt<int##width##_t>(rd_num, i); \
+    int##width##_t &vd = P.VU.elt<int##width##_t>(rd_num, i, true); \
     float##width##_t vs2 = P.VU.elt<float##width##_t>(rs2_num, i); \
 
 #define VI_VFP_LOOP_WIDE_REDUCTION_BASE \
@@ -1661,7 +1661,7 @@ for (reg_t i = 0; i < vlmax; ++i) { \
   } \
   P.VU.vstart = 0; \
   if (vl > 0) { \
-    P.VU.elt<type_sew_t<x>::type>(rd_num, 0) = vd_0.v; \
+    P.VU.elt<type_sew_t<x>::type>(rd_num, 0, true) = vd_0.v; \
   }
 
 #define VI_VFP_LOOP_CMP_END \
@@ -1685,7 +1685,7 @@ for (reg_t i = 0; i < vlmax; ++i) { \
   VI_VFP_LOOP_BASE \
   switch(P.VU.vsew) { \
     case e32: {\
-      float32_t &vd = P.VU.elt<float32_t>(rd_num, i); \
+      float32_t &vd = P.VU.elt<float32_t>(rd_num, i, true); \
       float32_t vs1 = P.VU.elt<float32_t>(rs1_num, i); \
       float32_t vs2 = P.VU.elt<float32_t>(rs2_num, i); \
       BODY32; \
@@ -1693,7 +1693,7 @@ for (reg_t i = 0; i < vlmax; ++i) { \
       break; \
     }\
     case e64: {\
-      float64_t &vd = P.VU.elt<float64_t>(rd_num, i); \
+      float64_t &vd = P.VU.elt<float64_t>(rd_num, i, true); \
       float64_t vs1 = P.VU.elt<float64_t>(rs1_num, i); \
       float64_t vs2 = P.VU.elt<float64_t>(rs2_num, i); \
       BODY64; \
@@ -1745,7 +1745,7 @@ for (reg_t i = 0; i < vlmax; ++i) { \
   VI_VFP_LOOP_BASE \
   switch(P.VU.vsew) { \
     case e32: {\
-      float32_t &vd = P.VU.elt<float32_t>(rd_num, i); \
+      float32_t &vd = P.VU.elt<float32_t>(rd_num, i, true); \
       float32_t rs1 = f32(READ_FREG(rs1_num)); \
       float32_t vs2 = P.VU.elt<float32_t>(rs2_num, i); \
       BODY32; \
@@ -1753,7 +1753,7 @@ for (reg_t i = 0; i < vlmax; ++i) { \
       break; \
     }\
     case e64: {\
-      float64_t &vd = P.VU.elt<float64_t>(rd_num, i); \
+      float64_t &vd = P.VU.elt<float64_t>(rd_num, i, true); \
       float64_t rs1 = f64(READ_FREG(rs1_num)); \
       float64_t vs2 = P.VU.elt<float64_t>(rs2_num, i); \
       BODY64; \
@@ -1801,7 +1801,7 @@ for (reg_t i = 0; i < vlmax; ++i) { \
   VI_VFP_LOOP_BASE \
   switch(P.VU.vsew) { \
     case e32: {\
-      float64_t &vd = P.VU.elt<float64_t>(rd_num, i); \
+      float64_t &vd = P.VU.elt<float64_t>(rd_num, i, true); \
       float64_t vs2 = f32_to_f64(P.VU.elt<float32_t>(rs2_num, i)); \
       float64_t rs1 = f32_to_f64(f32(READ_FREG(rs1_num))); \
       BODY; \
@@ -1823,7 +1823,7 @@ for (reg_t i = 0; i < vlmax; ++i) { \
   VI_VFP_LOOP_BASE \
   switch(P.VU.vsew) { \
     case e32: {\
-      float64_t &vd = P.VU.elt<float64_t>(rd_num, i); \
+      float64_t &vd = P.VU.elt<float64_t>(rd_num, i, true); \
       float64_t vs2 = f32_to_f64(P.VU.elt<float32_t>(rs2_num, i)); \
       float64_t vs1 = f32_to_f64(P.VU.elt<float32_t>(rs1_num, i)); \
       BODY; \
@@ -1844,7 +1844,7 @@ for (reg_t i = 0; i < vlmax; ++i) { \
   VI_VFP_LOOP_BASE \
   switch(P.VU.vsew) { \
     case e32: {\
-      float64_t &vd = P.VU.elt<float64_t>(rd_num, i); \
+      float64_t &vd = P.VU.elt<float64_t>(rd_num, i, true); \
       float64_t vs2 = P.VU.elt<float64_t>(rs2_num, i); \
       float64_t rs1 = f32_to_f64(f32(READ_FREG(rs1_num))); \
       BODY; \
@@ -1864,7 +1864,7 @@ for (reg_t i = 0; i < vlmax; ++i) { \
   VI_VFP_LOOP_BASE \
   switch(P.VU.vsew) { \
     case e32: {\
-      float64_t &vd = P.VU.elt<float64_t>(rd_num, i); \
+      float64_t &vd = P.VU.elt<float64_t>(rd_num, i, true); \
       float64_t vs2 = P.VU.elt<float64_t>(rs2_num, i); \
       float64_t vs1 = f32_to_f64(P.VU.elt<float32_t>(rs1_num, i)); \
       BODY; \

--- a/riscv/decode.h
+++ b/riscv/decode.h
@@ -168,6 +168,10 @@ private:
 # define WRITE_REG(reg, value) STATE.XPR.write(reg, value)
 # define WRITE_FREG(reg, value) DO_WRITE_FREG(reg, freg(value))
 #else
+   /* 0 : int
+    * 1 : floating
+    * 2 : vector
+    */
 # define WRITE_REG(reg, value) ({ \
     reg_t wdata = (value); /* value may have side effects */ \
     STATE.log_reg_write[(reg) << 2] = {wdata, 0}; \

--- a/riscv/decode.h
+++ b/riscv/decode.h
@@ -1519,16 +1519,17 @@ for (reg_t i = 0; i < vlmax; ++i) { \
       ld_width##_t val = MMU.load_##ld_width(baseAddr + (stride) + (offset) * elt_byte); \
       switch(P.VU.vsew){ \
         case e8: \
-          P.VU.elt<uint8_t>(vd + fn * vlmul, vreg_inx) = val; \
+          P.VU.elt<uint8_t>(vd + fn * vlmul, vreg_inx, true) = val; \
           break; \
         case e16: \
-          P.VU.elt<uint16_t>(vd + fn * vlmul, vreg_inx) = val; \
+          P.VU.elt<uint16_t>(vd + fn * vlmul, vreg_inx, true) = val; \
           break; \
         case e32: \
-          P.VU.elt<uint32_t>(vd + fn * vlmul, vreg_inx) = val; \
+          P.VU.elt<uint32_t>(vd + fn * vlmul, vreg_inx, true) = val; \
           break; \
         default: \
-          P.VU.elt<uint64_t>(vd + fn * vlmul, vreg_inx) = val; \
+          P.VU.elt<uint64_t>(vd + fn * vlmul, vreg_inx, true) = val; \
+          break; \
       } \
     } \
   } \
@@ -1582,16 +1583,16 @@ for (reg_t i = 0; i < vlmax; ++i) { \
       \
       switch (sew) { \
       case e8: \
-        p->VU.elt<uint8_t>(rd_num + fn * vlmul, vreg_inx) = val; \
+        p->VU.elt<uint8_t>(rd_num + fn * vlmul, vreg_inx, true) = val; \
         break; \
       case e16: \
-        p->VU.elt<uint16_t>(rd_num + fn * vlmul, vreg_inx) = val; \
+        p->VU.elt<uint16_t>(rd_num + fn * vlmul, vreg_inx, true) = val; \
         break; \
       case e32: \
-        p->VU.elt<uint32_t>(rd_num + fn * vlmul, vreg_inx) = val; \
+        p->VU.elt<uint32_t>(rd_num + fn * vlmul, vreg_inx, true) = val; \
         break; \
       case e64: \
-        p->VU.elt<uint64_t>(rd_num + fn * vlmul, vreg_inx) = val; \
+        p->VU.elt<uint64_t>(rd_num + fn * vlmul, vreg_inx, true) = val; \
         break; \
       } \
     } \

--- a/riscv/execute.cc
+++ b/riscv/execute.cc
@@ -60,20 +60,22 @@ static void commit_log_print_insn(state_t* state, reg_t pc, insn_t insn)
     fprintf(stderr, " %c%2d ", fp ? 'f' : 'x', rd);
     commit_log_print_value(size, reg.data.v[1], reg.data.v[0]);
   }
-  if (load.size) {
+
+  for (auto item : load) {
     fprintf(stderr, " mem ");
-    commit_log_print_value(xlen, 0, load.addr);
+    commit_log_print_value(xlen, 0, std::get<0>(item));
   }
-  if (store.size) {
+
+  for (auto item : store) {
     fprintf(stderr, " mem ");
-    commit_log_print_value(xlen, 0, store.addr);
+    commit_log_print_value(xlen, 0, std::get<0>(item));
     fprintf(stderr, " ");
-    commit_log_print_value(store.size << 3, 0, store.value);
+    commit_log_print_value(std::get<2>(item) << 3, 0, std::get<1>(item));
   }
   fprintf(stderr, "\n");
   reg.addr = 0;
-  load.size = 0;
-  store.size = 0;
+  load.clear();
+  store.clear();
 #endif
 }
 

--- a/riscv/insns/vcompress_vm.h
+++ b/riscv/insns/vcompress_vm.h
@@ -16,16 +16,16 @@ VI_GENERAL_LOOP_BASE
   if (do_mask) {
     switch (sew) {
     case e8:
-      P.VU.elt<uint8_t>(rd_num, pos) = P.VU.elt<uint8_t>(rs2_num, i);
+      P.VU.elt<uint8_t>(rd_num, pos, true) = P.VU.elt<uint8_t>(rs2_num, i);
       break;
     case e16:
-      P.VU.elt<uint16_t>(rd_num, pos) = P.VU.elt<uint16_t>(rs2_num, i);
+      P.VU.elt<uint16_t>(rd_num, pos, true) = P.VU.elt<uint16_t>(rs2_num, i);
       break;
     case e32:
-      P.VU.elt<uint32_t>(rd_num, pos) = P.VU.elt<uint32_t>(rs2_num, i);
+      P.VU.elt<uint32_t>(rd_num, pos, true) = P.VU.elt<uint32_t>(rs2_num, i);
       break;
     default:
-      P.VU.elt<uint64_t>(rd_num, pos) = P.VU.elt<uint64_t>(rs2_num, i);
+      P.VU.elt<uint64_t>(rd_num, pos, true) = P.VU.elt<uint64_t>(rs2_num, i);
       break;
     }
 

--- a/riscv/insns/vfmerge_vfm.h
+++ b/riscv/insns/vfmerge_vfm.h
@@ -2,12 +2,11 @@
 require(insn.rd() != 0);
 VI_CHECK_SSS(false);
 VI_VFP_COMMON;
-reg_t sew = P.VU.vsew;
 
 switch(P.VU.vsew) {
   case 32:
     for (reg_t i=P.VU.vstart; i<vl; ++i) {
-      auto &vd = P.VU.elt<float32_t>(rd_num, i);
+      auto &vd = P.VU.elt<float32_t>(rd_num, i, true);
       auto rs1 = f32(READ_FREG(rs1_num));
       auto vs2 = P.VU.elt<float32_t>(rs2_num, i);
 
@@ -20,7 +19,7 @@ switch(P.VU.vsew) {
     break;
   case 64:
     for (reg_t i=P.VU.vstart; i<vl; ++i) {
-      auto &vd = P.VU.elt<float64_t>(rd_num, i);
+      auto &vd = P.VU.elt<float64_t>(rd_num, i, true);
       auto rs1 = f64(READ_FREG(rs1_num));
       auto vs2 = P.VU.elt<float64_t>(rs2_num, i);
 

--- a/riscv/insns/vfmv_s_f.h
+++ b/riscv/insns/vfmv_s_f.h
@@ -11,15 +11,15 @@ if (vl > 0) {
   switch(P.VU.vsew) {
     case 32:
       if (FLEN == 64)
-        P.VU.elt<uint32_t>(rd_num, 0) = f64(FRS1).v;
+        P.VU.elt<uint32_t>(rd_num, 0, true) = f64(FRS1).v;
       else
-        P.VU.elt<uint32_t>(rd_num, 0) = f32(FRS1).v;
+        P.VU.elt<uint32_t>(rd_num, 0, true) = f32(FRS1).v;
       break;
     case 64:
       if (FLEN == 64)
-        P.VU.elt<uint64_t>(rd_num, 0) = f64(FRS1).v;
+        P.VU.elt<uint64_t>(rd_num, 0, true) = f64(FRS1).v;
       else
-        P.VU.elt<uint64_t>(rd_num, 0) = f32(FRS1).v;
+        P.VU.elt<uint64_t>(rd_num, 0, true) = f32(FRS1).v;
       break;
   }
 }

--- a/riscv/insns/vfmv_v_f.h
+++ b/riscv/insns/vfmv_v_f.h
@@ -4,7 +4,7 @@ VI_VFP_COMMON
 switch(P.VU.vsew) {
   case e32:
     for (reg_t i=P.VU.vstart; i<vl; ++i) {
-      auto &vd = P.VU.elt<float32_t>(rd_num, i);
+      auto &vd = P.VU.elt<float32_t>(rd_num, i, true);
       auto rs1 = f32(READ_FREG(rs1_num));
 
       vd = rs1;
@@ -12,7 +12,7 @@ switch(P.VU.vsew) {
     break;
   case e64:
     for (reg_t i=P.VU.vstart; i<vl; ++i) {
-      auto &vd = P.VU.elt<float64_t>(rd_num, i);
+      auto &vd = P.VU.elt<float64_t>(rd_num, i, true);
       auto rs1 = f64(READ_FREG(rs1_num));
 
       vd = rs1;

--- a/riscv/insns/vfncvt_f_f_w.h
+++ b/riscv/insns/vfncvt_f_f_w.h
@@ -5,6 +5,6 @@ if (P.VU.vsew == e32)
 
 VI_VFP_LOOP_BASE
   auto vs2 = P.VU.elt<float64_t>(rs2_num, i);
-  P.VU.elt<float32_t>(rd_num, i) = f64_to_f32(vs2);
+  P.VU.elt<float32_t>(rd_num, i, true) = f64_to_f32(vs2);
   set_fp_exceptions;
 VI_VFP_LOOP_END

--- a/riscv/insns/vfncvt_f_x_w.h
+++ b/riscv/insns/vfncvt_f_x_w.h
@@ -5,6 +5,6 @@ if (P.VU.vsew == e32)
 
 VI_VFP_LOOP_BASE
   auto vs2 = P.VU.elt<int64_t>(rs2_num, i);
-  P.VU.elt<float32_t>(rd_num, i) = i64_to_f32(vs2);
+  P.VU.elt<float32_t>(rd_num, i, true) = i64_to_f32(vs2);
   set_fp_exceptions;
 VI_VFP_LOOP_END

--- a/riscv/insns/vfncvt_f_xu_w.h
+++ b/riscv/insns/vfncvt_f_xu_w.h
@@ -5,6 +5,6 @@ if (P.VU.vsew == e32)
 
 VI_VFP_LOOP_BASE
   auto vs2 = P.VU.elt<uint64_t>(rs2_num, i);
-  P.VU.elt<float32_t>(rd_num, i) = ui64_to_f32(vs2);
+  P.VU.elt<float32_t>(rd_num, i, true) = ui64_to_f32(vs2);
   set_fp_exceptions;
 VI_VFP_LOOP_END

--- a/riscv/insns/vfncvt_rod_f_f_w.h
+++ b/riscv/insns/vfncvt_rod_f_f_w.h
@@ -6,6 +6,6 @@ if (P.VU.vsew == e32)
 VI_VFP_LOOP_BASE
   softfloat_roundingMode = softfloat_round_odd;
   auto vs2 = P.VU.elt<float64_t>(rs2_num, i);
-  P.VU.elt<float32_t>(rd_num, i) = f64_to_f32(vs2);
+  P.VU.elt<float32_t>(rd_num, i, true) = f64_to_f32(vs2);
   set_fp_exceptions;
 VI_VFP_LOOP_END

--- a/riscv/insns/vfncvt_x_f_w.h
+++ b/riscv/insns/vfncvt_x_f_w.h
@@ -5,6 +5,6 @@ if (P.VU.vsew == e32)
 
 VI_VFP_LOOP_BASE
   auto vs2 = P.VU.elt<float64_t>(rs2_num, i);
-  P.VU.elt<int32_t>(rd_num, i) = f64_to_i32(vs2, STATE.frm, true);
+  P.VU.elt<int32_t>(rd_num, i, true) = f64_to_i32(vs2, STATE.frm, true);
   set_fp_exceptions;
 VI_VFP_LOOP_END

--- a/riscv/insns/vfncvt_xu_f_w.h
+++ b/riscv/insns/vfncvt_xu_f_w.h
@@ -5,6 +5,6 @@ if (P.VU.vsew == e32)
 
 VI_VFP_LOOP_BASE
   auto vs2 = P.VU.elt<float64_t>(rs2_num, i);
-  P.VU.elt<uint32_t>(rd_num, i) = f64_to_ui32(vs2, STATE.frm, true);
+  P.VU.elt<uint32_t>(rd_num, i, true) = f64_to_ui32(vs2, STATE.frm, true);
   set_fp_exceptions;
 VI_VFP_LOOP_END

--- a/riscv/insns/vfwcvt_f_f_v.h
+++ b/riscv/insns/vfwcvt_f_f_v.h
@@ -5,6 +5,6 @@ if (P.VU.vsew == e32)
 
 VI_VFP_LOOP_BASE
   auto vs2 = P.VU.elt<float32_t>(rs2_num, i);
-  P.VU.elt<float64_t>(rd_num, i) = f32_to_f64(vs2);
+  P.VU.elt<float64_t>(rd_num, i, true) = f32_to_f64(vs2);
   set_fp_exceptions;
 VI_VFP_LOOP_WIDE_END

--- a/riscv/insns/vfwcvt_f_x_v.h
+++ b/riscv/insns/vfwcvt_f_x_v.h
@@ -5,6 +5,6 @@ if (P.VU.vsew == e32)
 
 VI_VFP_LOOP_BASE
   auto vs2 = P.VU.elt<int32_t>(rs2_num, i);
-  P.VU.elt<float64_t>(rd_num, i) = i32_to_f64(vs2);
+  P.VU.elt<float64_t>(rd_num, i, true) = i32_to_f64(vs2);
   set_fp_exceptions;
 VI_VFP_LOOP_WIDE_END

--- a/riscv/insns/vfwcvt_f_xu_v.h
+++ b/riscv/insns/vfwcvt_f_xu_v.h
@@ -5,6 +5,6 @@ if (P.VU.vsew == e32)
 
 VI_VFP_LOOP_BASE
   auto vs2 = P.VU.elt<uint32_t>(rs2_num, i);
-  P.VU.elt<float64_t>(rd_num, i) = ui32_to_f64(vs2);
+  P.VU.elt<float64_t>(rd_num, i, true) = ui32_to_f64(vs2);
   set_fp_exceptions;
 VI_VFP_LOOP_WIDE_END

--- a/riscv/insns/vfwcvt_x_f_v.h
+++ b/riscv/insns/vfwcvt_x_f_v.h
@@ -5,6 +5,6 @@ if (P.VU.vsew == e32)
 
 VI_VFP_LOOP_BASE
   auto vs2 = P.VU.elt<float32_t>(rs2_num, i);
-  P.VU.elt<int64_t>(rd_num, i) = f32_to_i64(vs2, STATE.frm, true);
+  P.VU.elt<int64_t>(rd_num, i, true) = f32_to_i64(vs2, STATE.frm, true);
   set_fp_exceptions;
 VI_VFP_LOOP_WIDE_END

--- a/riscv/insns/vfwcvt_xu_f_v.h
+++ b/riscv/insns/vfwcvt_xu_f_v.h
@@ -5,6 +5,6 @@ if (P.VU.vsew == e32)
 
 VI_VFP_LOOP_BASE
   auto vs2 = P.VU.elt<float32_t>(rs2_num, i);
-  P.VU.elt<uint64_t>(rd_num, i) = f32_to_ui64(vs2, STATE.frm, true);
+  P.VU.elt<uint64_t>(rd_num, i, true) = f32_to_ui64(vs2, STATE.frm, true);
   set_fp_exceptions;
 VI_VFP_LOOP_WIDE_END

--- a/riscv/insns/vid_v.h
+++ b/riscv/insns/vid_v.h
@@ -15,16 +15,16 @@ for (reg_t i = P.VU.vstart ; i < P.VU.vl; ++i) {
 
   switch (sew) {
   case e8:
-    P.VU.elt<uint8_t>(rd_num, i) = i;
+    P.VU.elt<uint8_t>(rd_num, i, true) = i;
     break;
   case e16:
-    P.VU.elt<uint16_t>(rd_num, i) = i;
+    P.VU.elt<uint16_t>(rd_num, i, true) = i;
     break;
   case e32:
-    P.VU.elt<uint32_t>(rd_num, i) = i;
+    P.VU.elt<uint32_t>(rd_num, i, true) = i;
     break;
   default:
-    P.VU.elt<uint64_t>(rd_num, i) = i;
+    P.VU.elt<uint64_t>(rd_num, i, true) = i;
     break;
   }
 }

--- a/riscv/insns/viota_m.h
+++ b/riscv/insns/viota_m.h
@@ -31,19 +31,19 @@ for (reg_t i = 0; i < vl; ++i) {
   bool use_ori = (insn.v_vm() == 0) && !do_mask;
   switch (sew) {
   case e8:
-    P.VU.elt<uint8_t>(rd_num, i) = use_ori ?
+    P.VU.elt<uint8_t>(rd_num, i, true) = use_ori ?
                                    P.VU.elt<uint8_t>(rd_num, i) : cnt;
     break;
   case e16:
-    P.VU.elt<uint16_t>(rd_num, i) = use_ori ?
+    P.VU.elt<uint16_t>(rd_num, i, true) = use_ori ?
                                     P.VU.elt<uint16_t>(rd_num, i) : cnt;
     break;
   case e32:
-    P.VU.elt<uint32_t>(rd_num, i) = use_ori ?
+    P.VU.elt<uint32_t>(rd_num, i, true) = use_ori ?
                                     P.VU.elt<uint32_t>(rd_num, i) : cnt;
     break;
   default:
-    P.VU.elt<uint64_t>(rd_num, i) = use_ori ?
+    P.VU.elt<uint64_t>(rd_num, i, true) = use_ori ?
                                     P.VU.elt<uint64_t>(rd_num, i) : cnt;
     break;
   }

--- a/riscv/insns/vl1r_v.h
+++ b/riscv/insns/vl1r_v.h
@@ -4,6 +4,6 @@ const reg_t baseAddr = RS1;
 const reg_t vd = insn.rd();
 for (reg_t i = 0; i < P.VU.vlenb; ++i) {
   auto val = MMU.load_uint8(baseAddr + i);
-  P.VU.elt<uint8_t>(vd, i) = val;
+  P.VU.elt<uint8_t>(vd, i, true) = val;
 }
 P.VU.vstart = 0;

--- a/riscv/insns/vmsbf_m.h
+++ b/riscv/insns/vmsbf_m.h
@@ -16,10 +16,10 @@ for (reg_t i = P.VU.vstart; i < vl; ++i) {
 
   bool vs2_lsb = ((P.VU.elt<uint64_t>(rs2_num, midx) >> mpos) & 0x1) == 1;
   bool do_mask = (P.VU.elt<uint64_t>(0, midx) >> mpos) & 0x1;
-  auto &vd = P.VU.elt<uint64_t>(rd_num, midx);
 
 
   if (insn.v_vm() == 1 || (insn.v_vm() == 0 && do_mask)) {
+    auto &vd = P.VU.elt<uint64_t>(rd_num, midx, true);
     uint64_t res = 0;
     if (!has_one && !vs2_lsb) {
       res = 1;

--- a/riscv/insns/vmsif_m.h
+++ b/riscv/insns/vmsif_m.h
@@ -16,9 +16,9 @@ for (reg_t i = P.VU.vstart ; i < vl; ++i) {
 
   bool vs2_lsb = ((P.VU.elt<uint64_t>(rs2_num, midx ) >> mpos) & 0x1) == 1;
   bool do_mask = (P.VU.elt<uint64_t>(0, midx) >> mpos) & 0x1;
-  auto &vd = P.VU.elt<uint64_t>(rd_num, midx);
 
   if (insn.v_vm() == 1 || (insn.v_vm() == 0 && do_mask)) {
+    auto &vd = P.VU.elt<uint64_t>(rd_num, midx, true);
     uint64_t res = 0;
     if (!has_one && !vs2_lsb) {
       res = 1;

--- a/riscv/insns/vmsof_m.h
+++ b/riscv/insns/vmsof_m.h
@@ -16,9 +16,9 @@ for (reg_t i = P.VU.vstart ; i < vl; ++i) {
 
   bool vs2_lsb = ((P.VU.elt<uint64_t>(rs2_num, midx ) >> mpos) & 0x1) == 1;
   bool do_mask = (P.VU.elt<uint64_t>(0, midx) >> mpos) & 0x1;
-  uint64_t &vd = P.VU.elt<uint64_t>(rd_num, midx);
 
   if (insn.v_vm() == 1 || (insn.v_vm() == 0 && do_mask)) {
+    uint64_t &vd = P.VU.elt<uint64_t>(rd_num, midx, true);
     uint64_t res = 0;
     if(!has_one && vs2_lsb) {
       has_one = true;

--- a/riscv/insns/vmulhsu_vv.h
+++ b/riscv/insns/vmulhsu_vv.h
@@ -3,7 +3,7 @@ VI_CHECK_SSS(true);
 VI_LOOP_BASE
 switch(sew) {
 case e8: {
-  auto &vd = P.VU.elt<int8_t>(rd_num, i);
+  auto &vd = P.VU.elt<int8_t>(rd_num, i, true);
   auto vs2 = P.VU.elt<int8_t>(rs2_num, i);
   auto vs1 = P.VU.elt<uint8_t>(rs1_num, i);
 
@@ -11,7 +11,7 @@ case e8: {
   break;
 }
 case e16: {
-  auto &vd = P.VU.elt<int16_t>(rd_num, i);
+  auto &vd = P.VU.elt<int16_t>(rd_num, i, true);
   auto vs2 = P.VU.elt<int16_t>(rs2_num, i);
   auto vs1 = P.VU.elt<uint16_t>(rs1_num, i);
 
@@ -19,7 +19,7 @@ case e16: {
   break;
 }
 case e32: {
-  auto &vd = P.VU.elt<int32_t>(rd_num, i);
+  auto &vd = P.VU.elt<int32_t>(rd_num, i, true);
   auto vs2 = P.VU.elt<int32_t>(rs2_num, i);
   auto vs1 = P.VU.elt<uint32_t>(rs1_num, i);
 
@@ -27,7 +27,7 @@ case e32: {
   break;
 }
 default: {
-  auto &vd = P.VU.elt<int64_t>(rd_num, i);
+  auto &vd = P.VU.elt<int64_t>(rd_num, i, true);
   auto vs2 = P.VU.elt<int64_t>(rs2_num, i);
   auto vs1 = P.VU.elt<uint64_t>(rs1_num, i);
 

--- a/riscv/mmu.h
+++ b/riscv/mmu.h
@@ -83,10 +83,8 @@ public:
 #ifndef RISCV_ENABLE_COMMITLOG
 # define READ_MEM(addr, size) ({})
 #else
-# define READ_MEM(addr, size) ({ \
-    proc->state.log_mem_read.addr = addr; \
-    proc->state.log_mem_read.size = size; \
-  })
+# define READ_MEM(addr, size) \
+  proc->state.log_mem_read.push_back(std::make_tuple(addr, 0, size));
 #endif
 
   // template for functions that load an aligned value from memory
@@ -131,11 +129,8 @@ public:
 #ifndef RISCV_ENABLE_COMMITLOG
 # define WRITE_MEM(addr, value, size) ({})
 #else
-# define WRITE_MEM(addr, val, size) ({ \
-    proc->state.log_mem_write.addr = addr; \
-    proc->state.log_mem_write.value = val; \
-    proc->state.log_mem_write.size = size; \
-  })
+# define WRITE_MEM(addr, val, size) \
+  proc->state.log_mem_write.push_back(std::make_tuple(addr, val, size));
 #endif
 
   // template for functions that store an aligned value to memory

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -273,7 +273,7 @@ void state_t::reset(reg_t max_isa)
 #endif
 }
 
-void vectorUnit_t::reset(){
+void processor_t::vectorUnit_t::reset(){
   free(reg_file);
   VLEN = get_vlen();
   ELEN = get_elen();
@@ -284,7 +284,7 @@ void vectorUnit_t::reset(){
   set_vl(0, 0, 0, -1); // default to illegal configuration
 }
 
-reg_t vectorUnit_t::set_vl(int rd, int rs1, reg_t reqVL, reg_t newType){
+reg_t processor_t::vectorUnit_t::set_vl(int rd, int rs1, reg_t reqVL, reg_t newType){
   if (vtype != newType){
     vtype = newType;
     vsew = 1 << (BITS(newType, 4, 2) + 3);

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -215,16 +215,62 @@ void processor_t::parse_isa_string(const char* str)
 
 void state_t::reset(reg_t max_isa)
 {
-  memset(this, 0, sizeof(*this));
-  misa = max_isa;
-  prv = PRV_M;
   pc = DEFAULT_RSTVEC;
-  tselect = 0;
-  for (unsigned int i = 0; i < num_triggers; i++)
-    mcontrol[i].type = 2;
+  XPR.reset();
+  FPR.reset();
 
+  prv = PRV_M;
+  misa = max_isa;
+  mstatus = 0;
+  mepc = 0;
+  mtval = 0;
+  mscratch = 0;
+  mtvec = 0;
+  mcause = 0;
+  minstret = 0;
+  mie = 0;
+  mip = 0;
+  medeleg = 0;
+  mideleg = 0;
+  mcounteren = 0;
+  scounteren = 0;
+  sepc = 0;
+  stval = 0;
+  sscratch = 0;
+  stvec = 0;
+  satp = 0;
+  scause = 0;
+
+  dpc = 0;
+  dscratch0 = 0;
+  dscratch1 = 0;
+  memset(&this->dcsr, 0, sizeof(this->dcsr));
+
+  tselect = 0;
+  for (auto &item : mcontrol)
+    item.type = 2;
+
+  memset(this->tdata2, 0, sizeof(this->tdata2));
+  debug_mode = false;
+
+  memset(this->pmpcfg, 0, sizeof(this->pmpcfg));
   pmpcfg[0] = PMP_R | PMP_W | PMP_X | PMP_NAPOT;
+
+  memset(this->pmpaddr, 0, sizeof(this->pmpaddr));
   pmpaddr[0] = ~reg_t(0);
+
+  fflags = 0;
+  frm = 0;
+  serialized = false;
+
+#ifdef RISCV_ENABLE_COMMITLOG
+  log_reg_write.addr = 0;
+  log_mem_read.size = 0;
+  log_mem_write.size = 0;
+  last_inst_priv = 0;
+  last_inst_xlen = 0;
+  last_inst_flen = 0;
+#endif
 }
 
 void vectorUnit_t::reset(){

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -264,7 +264,7 @@ void state_t::reset(reg_t max_isa)
   serialized = false;
 
 #ifdef RISCV_ENABLE_COMMITLOG
-  log_reg_write.addr = 0;
+  log_reg_write.clear();
   log_mem_read.clear();
   log_mem_write.clear();
   last_inst_priv = 0;

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -265,8 +265,8 @@ void state_t::reset(reg_t max_isa)
 
 #ifdef RISCV_ENABLE_COMMITLOG
   log_reg_write.addr = 0;
-  log_mem_read.size = 0;
-  log_mem_write.size = 0;
+  log_mem_read.clear();
+  log_mem_write.clear();
   last_inst_priv = 0;
   last_inst_xlen = 0;
   last_inst_flen = 0;

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -470,6 +470,65 @@ private:
   // Track repeated executions for processor_t::disasm()
   uint64_t last_pc, last_bits, executions;
 public:
+  class vectorUnit_t {
+    public:
+      processor_t* p;
+      void *reg_file;
+      char reg_referenced[NVPR];
+      int setvl_count;
+      reg_t reg_mask, vlmax, vmlen;
+      reg_t vstart, vxrm, vxsat, vl, vtype, vlenb;
+      reg_t vediv, vsew, vlmul;
+      reg_t ELEN, VLEN, SLEN;
+      bool vill;
+
+      // vector element for varies SEW
+      template<class T>
+        T& elt(reg_t vReg, reg_t n, bool is_write = false){
+          assert(vsew != 0);
+          assert((VLEN >> 3)/sizeof(T) > 0);
+          reg_t elts_per_reg = (VLEN >> 3) / (sizeof(T));
+          vReg += n / elts_per_reg;
+          n = n % elts_per_reg;
+#ifdef WORDS_BIGENDIAN
+          // "V" spec 0.7.1 requires lower indices to map to lower significant
+          // bits when changing SEW, thus we need to index from the end on BE.
+  	  n ^= elts_per_reg - 1;
+#endif
+          reg_referenced[vReg] = 1;
+
+#ifdef RISCV_ENABLE_COMMITLOG
+          if (is_write)
+            p->get_state()->log_reg_write[((vReg) << 2) | 2] = {0, 0};
+#endif
+
+          T *regStart = (T*)((char*)reg_file + vReg * (VLEN >> 3));
+          return regStart[n];
+        }
+    public:
+
+      void reset();
+
+      vectorUnit_t(){
+        reg_file = 0;
+      }
+
+      ~vectorUnit_t(){
+        free(reg_file);
+        reg_file = 0;
+      }
+
+      reg_t set_vl(int rd, int rs1, reg_t reqVL, reg_t newType);
+
+      reg_t get_vlen() { return VLEN; }
+      reg_t get_elen() { return ELEN; }
+      reg_t get_slen() { return SLEN; }
+
+      VRM get_vround_mode() {
+        return (VRM)vxrm;
+      }
+  };
+
   vectorUnit_t VU;
 };
 

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -34,12 +34,8 @@ struct commit_log_reg_t
   freg_t data;
 };
 
-struct commit_log_mem_t
-{
-  reg_t addr;
-  uint64_t value;
-  uint8_t size; // bytes: 1, 2, 4, or 8
-};
+// addr, value, size
+typedef std::vector<std::tuple<reg_t, uint64_t, uint8_t>> commit_log_mem_t;
 
 typedef struct
 {

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -8,6 +8,7 @@
 #include "trap.h"
 #include <string>
 #include <vector>
+#include <unordered_map>
 #include <map>
 #include <cassert>
 #include "debug_rom_defines.h"
@@ -28,11 +29,8 @@ struct insn_desc_t
   insn_func_t rv64;
 };
 
-struct commit_log_reg_t
-{
-  reg_t addr;
-  freg_t data;
-};
+// regnum, data
+typedef std::unordered_map<reg_t, freg_t> commit_log_reg_t;
 
 // addr, value, size
 typedef std::vector<std::tuple<reg_t, uint64_t, uint8_t>> commit_log_mem_t;


### PR DESCRIPTION
Add commit log to all rvv instruction.  Since vector instructions may have multiple register and memory accesses, the patch sets use containter to keep access record. The format of register and memory record are still the same but may appeal many times in line for multiple access

ex:  vlb.v  instruction log is
v27 0xbe311649e962244962fe457d119bc150b219104d234fc9708d9cc6b2752288ae404f273b8dfd69d2b5a4a75217485349b59de08f775aabbc43b700127b14c17f mem 0x00000000800072db mem 0x00000000800072dc mem 0x00000000800072e1 mem 0x00000000800072e5 mem 0x00000000800072e9