### PR TITLE
Refuse to load non-EXEC/non-RISC-V/non-V1 ELFs

### DIFF
--- a/fesvr/elf.h
+++ b/fesvr/elf.h
@@ -5,6 +5,10 @@
 
 #include <stdint.h>
 
+#define ET_EXEC 2
+#define EM_RISCV 243
+#define EV_CURRENT 1
+
 #define IS_ELF(hdr) \
   ((hdr).e_ident[0] == 0x7f && (hdr).e_ident[1] == 'E' && \
    (hdr).e_ident[2] == 'L'  && (hdr).e_ident[3] == 'F')
@@ -13,6 +17,9 @@
 #define IS_ELF64(hdr) (IS_ELF(hdr) && (hdr).e_ident[4] == 2)
 #define IS_ELFLE(hdr) (IS_ELF(hdr) && (hdr).e_ident[5] == 1)
 #define IS_ELFBE(hdr) (IS_ELF(hdr) && (hdr).e_ident[5] == 2)
+#define IS_ELF_EXEC(hdr) (IS_ELF(hdr) && (hdr).e_type == ET_EXEC)
+#define IS_ELF_RISCV(hdr) (IS_ELF(hdr) && (hdr).e_machine == EM_RISCV)
+#define IS_ELF_VCURRENT(hdr) (IS_ELF(hdr) && (hdr).e_version == EV_CURRENT)
 
 #define PT_LOAD 1
 

--- a/fesvr/elfloader.cc
+++ b/fesvr/elfloader.cc
@@ -32,6 +32,9 @@ std::map<std::string, uint64_t> load_elf(const char* fn, memif_t* memif, reg_t* 
   const Elf64_Ehdr* eh64 = (const Elf64_Ehdr*)buf;
   assert(IS_ELF32(*eh64) || IS_ELF64(*eh64));
   assert(IS_ELFLE(*eh64));
+  assert(IS_ELF_EXEC(*eh64));
+  assert(IS_ELF_RISCV(*eh64));
+  assert(IS_ELF_VCURRENT(*eh64));
 
   std::vector<uint8_t> zeros;
   std::map<std::string, uint64_t> symbols;


### PR DESCRIPTION
As a beginner to bare-metal concepts, I've run into confusing behavior in spike when I loaded incorrect ELFs. I think that stricter ELF validation will limit user confusion by explicitly preventing certain kinds of user error while giving more informative error messages.

Unfortunately this does seem to be a breaking change, in that ELFs that don't conform to current RISC-V standards will be rejected, and that only ELF executable files will be loaded. I am concerned that this might break early RISC-V ELFs and toolchains if they didn't set magic numbers like modern toolchains do. Additionally, as a beginner, it seems like executable files are the only appropriate type to load into spike, but I may be incorrect, especially if other code uses fesvr/elfloader.

As an example without this patch: (with `X` masking irrelevant details)
```
$ spike `which ls`
ERROR: invalid load from debug module: 8 bytes at 0x0000000000XXXXXX
terminate called after throwing an instance of 'trap_load_access_fault'
```
With this patch:
```
$ ./spike `which ls`
spike: ./fesvr/elfloader.cc:35: std::map<std::__cxx11::basic_string<char>, long unsigned int> load_elf(const char*, memif_t*, reg_t*): Assertion `IS_ELF_EXEC(*eh64)' failed.
```
The check for EXEC happens before the check for RISC-V, which while in header order is potentially confusing. Would it make sense to move the larger problem (non-RISC-V binary) earlier in the validation? 

I look forward to receiving the community's feedback on this proposal.

(Commit message follows.)

---
Stricter validation of ELF binaries improves usability with informative
assertions. This prevents users from loading ELF relocatable files and
binaries compiled for their (non-RISC-V) workstations, for example.

Without this patch, spike would attempt to load nearly any ELF given,
but it would usually fail with an error about debug module accesses,
since the given ELF causes accesses in the debug module's memory space.
Even if spike successfully loaded the ELF file, it would still misbehave
during simulation, for example in the case of ELF relocatable files.

ELF magic numbers come from official ELF documents:
TIS ELF spec v1.2, via Linux Foundation Referenced Specifications
See: https://refspecs.linuxbase.org/

RISC-V magic number comes from official RISC-V ELF documents:
See: riscv/riscv-elf-psabi-doc@60c25981b62c0b43d16142f8a12c8b1e98e60d4d