### PR TITLE
Fix some uninitialized variables in state_t caught by Valgrind

### DIFF
--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -247,6 +247,7 @@ void state_t::reset(reg_t max_isa)
   memset(&this->dcsr, 0, sizeof(this->dcsr));
 
   tselect = 0;
+  memset(&this->mcontrol, 0, sizeof(this->mcontrol));
   for (auto &item : mcontrol)
     item.type = 2;
 
@@ -259,6 +260,7 @@ void state_t::reset(reg_t max_isa)
   fflags = 0;
   frm = 0;
   serialized = false;
+  single_step = STEP_NONE;
 
 #ifdef RISCV_ENABLE_COMMITLOG
   log_reg_write.clear();


### PR DESCRIPTION
Please review carefully as I'm not sure my fix here is really the best way to do it.

Valgrind reported usage of uninitialized variables on `single_step` and `mcontrol` in `execute.cc`.

I'm not sure why I didn't see these previously when I used Valgrind and got clean results.