### PR TITLE
FESVR: Can't read a DM register when DMACTIVE=0

### DIFF
--- a/fesvr/dtm.cc
+++ b/fesvr/dtm.cc
@@ -137,7 +137,7 @@ void dtm_t::resume(int hartsel)
   current_hart = hartsel;
 
   if (running) {
-    write(DMI_DMCONTROL, 0);
+    write(DMI_DMCONTROL, DMI_DMCONTROL_DMACTIVE);
     // Read dmstatus to avoid back-to-back writes to dmcontrol.
     read(DMI_DMSTATUS);
   }


### PR DESCRIPTION
As noted in discussion in https://github.com/chipsalliance/rocket-chip/pull/2205, its not really allowed by the debug spec to read Debug Module DMI registers when DMACTIVE is 0. OpenOCD was fixed a while ago (https://github.com/riscv/riscv-openocd/commit/906635c) to not do this. FESVR has never been fixed.

This PR does not set DMACTIVE to 0 even when resuming a hart. This shouldn't have any actual impact on the performance since having DMACTIVE=1 doesn't necessarily do anything to the hart's execution (though it may prevent clock gating or other low-power mechanisms).

