### PR TITLE
FESVR: ensure dmactive is 1 before reading debug module registers

### DIFF
--- a/fesvr/dtm.cc
+++ b/fesvr/dtm.cc
@@ -558,6 +558,9 @@ void dtm_t::producer_thread()
   // Learn about the Debug Module and assert things we
   // depend on in this code.
 
+  // Enable the debugger.
+  write(DMI_DMCONTROL, DMI_DMCONTROL_DMACTIVE);
+    
   // These are checked every time we run an abstract command.
   uint32_t abstractcs = read(DMI_ABSTRACTCS);
   ram_words = get_field(abstractcs, DMI_ABSTRACTCS_PROGSIZE);
@@ -571,9 +574,6 @@ void dtm_t::producer_thread()
   assert(get_field(hartinfo, DMI_HARTINFO_DATAACCESS));
 
   data_base = get_field(hartinfo, DMI_HARTINFO_DATAADDR);
-
-  // Enable the debugger.
-  write(DMI_DMCONTROL, DMI_DMCONTROL_DMACTIVE);
   
   num_harts = enumerate_harts();
   halt(0);


### PR DESCRIPTION
Similar to #392 , we need to set dmactive=1 before attempting to read any other debug module registers.

Otherwise, we fail an `assert` that we always get error response of 0 on reads and writes.