### PR TITLE
Improve --varch error checking.

### DIFF
--- a/configure
+++ b/configure
@@ -1362,7 +1362,7 @@ Optional Packages:
   --without-PACKAGE       do not use PACKAGE (same as --with-PACKAGE=no)
   --with-isa=RV64IMAFDC   Sets the default RISC-V ISA
   --with-priv=MSU         Sets the default RISC-V privilege modes supported
-  --with-varch=v128:e32:s128
+  --with-varch=v128:e64:s128
                           Sets the default vector config
 
 Some influential environment variables:
@@ -4649,7 +4649,7 @@ _ACEOF
 else
 
 cat >>confdefs.h <<_ACEOF
-#define DEFAULT_VARCH "v128:e32:s128"
+#define DEFAULT_VARCH "v128:e64:s128"
 _ACEOF
 
 fi

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -126,10 +126,8 @@ void processor_t::parse_varch_string(const char* s)
     bad_varch_string(s, "vlen must be >= slen");
   if (slen < 32)
     bad_varch_string(s, "slen must be >= 32");
-  if ((unsigned) elen < std::max(max_xlen, get_flen())) {
-    fprintf(stderr, "elen=%d, xlen=%d, flen=%d\n", elen, max_xlen, get_flen());
+  if ((unsigned) elen < std::max(max_xlen, get_flen()))
     bad_varch_string(s, "elen must be >= max(xlen, flen)");
-  }
 
   /* spike requirements. */
   if (vlen > 4096)

--- a/riscv/riscv.ac
+++ b/riscv/riscv.ac
@@ -13,10 +13,10 @@ AC_ARG_WITH(priv,
   AC_DEFINE_UNQUOTED([DEFAULT_PRIV], "MSU", [Default value for --priv switch]))
 
 AC_ARG_WITH(varch,
-	[AS_HELP_STRING([--with-varch=v128:e32:s128],
+	[AS_HELP_STRING([--with-varch=v128:e64:s128],
 		[Sets the default vector config])],
   AC_DEFINE_UNQUOTED([DEFAULT_VARCH], "$withval", [Default value for --varch switch]),
-  AC_DEFINE_UNQUOTED([DEFAULT_VARCH], "v128:e32:s128", [Default value for --varch switch]))
+  AC_DEFINE_UNQUOTED([DEFAULT_VARCH], "v128:e64:s128", [Default value for --varch switch]))
 
 
 AC_SEARCH_LIBS([dlopen], [dl dld], [], [


### PR DESCRIPTION
Print out why an option has problems.
Add check that elen must be >= xlen, flen, per the spec.
Since RV32G includes D by default, bump default elen to 64.