### PR TITLE
Make spike capable of booting Linux

### DIFF
--- a/riscv/dts.cc
+++ b/riscv/dts.cc
@@ -9,6 +9,7 @@
 #include <sys/types.h>
 
 std::string make_dts(size_t insns_per_rtc_tick, size_t cpu_hz,
+                     reg_t initrd_start, reg_t initrd_end,
                      std::vector<processor_t*> procs,
                      std::vector<std::pair<reg_t, mem_t*>> mems)
 {
@@ -21,6 +22,15 @@ std::string make_dts(size_t insns_per_rtc_tick, size_t cpu_hz,
          "  #size-cells = <2>;\n"
          "  compatible = \"ucbbar,spike-bare-dev\";\n"
          "  model = \"ucbbar,spike-bare\";\n"
+         "  chosen {\n";
+  if (initrd_start < initrd_end) {
+    s << "    bootargs = \"root=/dev/ram console=hvc0 earlycon=sbi\";\n"
+         "    linux,initrd-start = <" << (size_t)initrd_start << ">;\n"
+         "    linux,initrd-end = <" << (size_t)initrd_end << ">;\n";
+  } else {
+    s << "    bootargs = \"console=hvc0 earlycon=sbi\";\n";
+  }
+    s << "  };\n"
          "  cpus {\n"
          "    #address-cells = <1>;\n"
          "    #size-cells = <0>;\n"

--- a/riscv/dts.h
+++ b/riscv/dts.h
@@ -7,6 +7,7 @@
 #include <string>
 
 std::string make_dts(size_t insns_per_rtc_tick, size_t cpu_hz,
+                     reg_t initrd_start, reg_t initrd_end,
                      std::vector<processor_t*> procs,
                      std::vector<std::pair<reg_t, mem_t*>> mems);
 

--- a/riscv/sim.cc
+++ b/riscv/sim.cc
@@ -26,14 +26,14 @@ static void handle_signal(int sig)
 }
 
 sim_t::sim_t(const char* isa, const char* priv, const char* varch,
-             size_t nprocs, bool halted,
+             size_t nprocs, bool halted, reg_t initrd_start, reg_t initrd_end,
              reg_t start_pc, std::vector<std::pair<reg_t, mem_t*>> mems,
              std::vector<std::pair<reg_t, abstract_device_t*>> plugin_devices,
              const std::vector<std::string>& args,
              std::vector<int> const hartids,
              const debug_module_config_t &dm_config)
   : htif_t(args), mems(mems), plugin_devices(plugin_devices),
-    procs(std::max(nprocs, size_t(1))), start_pc(start_pc), current_step(0),
+    procs(std::max(nprocs, size_t(1))), initrd_start(initrd_start), initrd_end(initrd_end), start_pc(start_pc), current_step(0),
     current_proc(0), debug(false), histogram_enabled(false),
     log_commits_enabled(false), dtb_enabled(true),
     remote_bitbang(NULL), debug_module(this, dm_config)
@@ -201,7 +201,7 @@ void sim_t::make_dtb()
 
   std::vector<char> rom((char*)reset_vec, (char*)reset_vec + sizeof(reset_vec));
 
-  dts = make_dts(INSNS_PER_RTC_TICK, CPU_HZ, procs, mems);
+  dts = make_dts(INSNS_PER_RTC_TICK, CPU_HZ, initrd_start, initrd_end, procs, mems);
   std::string dtb = dts_compile(dts);
 
   rom.insert(rom.end(), dtb.begin(), dtb.end());

--- a/riscv/sim.h
+++ b/riscv/sim.h
@@ -22,7 +22,7 @@ class sim_t : public htif_t, public simif_t
 {
 public:
   sim_t(const char* isa, const char* priv, const char* varch, size_t _nprocs,
-        bool halted,
+        bool halted, reg_t initrd_start, reg_t initrd_end,
         reg_t start_pc, std::vector<std::pair<reg_t, mem_t*>> mems,
         std::vector<std::pair<reg_t, abstract_device_t*>> plugin_devices,
         const std::vector<std::string>& args, const std::vector<int> hartids,
@@ -54,6 +54,8 @@ private:
   std::vector<std::pair<reg_t, abstract_device_t*>> plugin_devices;
   mmu_t* debug_mmu;  // debug port into main memory
   std::vector<processor_t*> procs;
+  reg_t initrd_start;
+  reg_t initrd_end;
   reg_t start_pc;
   std::string dts;
   std::unique_ptr<rom_device_t> boot_rom;


### PR DESCRIPTION
Latest Linux does not boot Spike mainly because:
1. Spike does not set bootargs in DTS
2. Spike does not provide mechanism to load initrd for Linux

This patch addresses both above issues and we can now
get latest Linux to prompt on Spike.

Signed-off-by: Anup Patel <anup.patel@wdc.com>