### PR TITLE
Add interactive command to show/clear stats

### DIFF
--- a/riscv/mmu.cc
+++ b/riscv/mmu.cc
@@ -13,6 +13,7 @@ mmu_t::mmu_t(simif_t* sim, processor_t* proc)
 {
   flush_tlb();
   yield_load_reservation();
+  clear_stats();
 }
 
 mmu_t::~mmu_t()
@@ -27,6 +28,7 @@ void mmu_t::flush_icache()
 
 void mmu_t::flush_tlb()
 {
+  stats_tlb_flush_all++;
   memset(tlb_insn_tag, -1, sizeof(tlb_insn_tag));
   memset(tlb_load_tag, -1, sizeof(tlb_load_tag));
   memset(tlb_store_tag, -1, sizeof(tlb_store_tag));

--- a/riscv/sim.h
+++ b/riscv/sim.h
@@ -99,6 +99,7 @@ private:
   void interactive_fregd(const std::string& cmd, const std::vector<std::string>& args);
   void interactive_pc(const std::string& cmd, const std::vector<std::string>& args);
   void interactive_mem(const std::string& cmd, const std::vector<std::string>& args);
+  void interactive_stats(const std::string& cmd, const std::vector<std::string>& args);
   void interactive_str(const std::string& cmd, const std::vector<std::string>& args);
   void interactive_until(const std::string& cmd, const std::vector<std::string>& args, bool noisy);
   void interactive_until_silent(const std::string& cmd, const std::vector<std::string>& args);


### PR DESCRIPTION
We add an interactive "stats" command to show/clear
stats from different parts of each CPU/HART. As an example,
the patch also implements TLB related stats.
