### PR TITLE
Vector stores don't care if rd overlaps v0

### DIFF
--- a/riscv/insns/vsuxb_v.h
+++ b/riscv/insns/vsuxb_v.h
@@ -1,6 +1,6 @@
 // vsuxb.v and vsxseg[2-8]b.v
 require(P.VU.vsew >= e8);
-VI_CHECK_SXX;
+VI_CHECK_STORE_SXX;
 require((insn.rs2() & (P.VU.vlmul - 1)) == 0); \
 reg_t vl = P.VU.vl;
 reg_t baseAddr = RS1;

--- a/riscv/insns/vsuxe_v.h
+++ b/riscv/insns/vsuxe_v.h
@@ -2,7 +2,7 @@
 const reg_t sew = P.VU.vsew;
 const reg_t vl = P.VU.vl;
 require(sew >= e8 && sew <= e64);
-VI_CHECK_SXX;
+VI_CHECK_STORE_SXX;
 require((insn.rs2() & (P.VU.vlmul - 1)) == 0); \
 reg_t baseAddr = RS1;
 reg_t stride = insn.rs2();

--- a/riscv/insns/vsuxh_v.h
+++ b/riscv/insns/vsuxh_v.h
@@ -1,6 +1,6 @@
 // vsxh.v and vsxseg[2-8]h.v
 require(P.VU.vsew >= e16);
-VI_CHECK_SXX;
+VI_CHECK_STORE_SXX;
 require((insn.rs2() & (P.VU.vlmul - 1)) == 0); \
 reg_t vl = P.VU.vl;
 reg_t baseAddr = RS1;

--- a/riscv/insns/vsuxw_v.h
+++ b/riscv/insns/vsuxw_v.h
@@ -1,6 +1,6 @@
 // vsxw.v and vsxseg[2-8]w.v
 require(P.VU.vsew >= e32);
-VI_CHECK_SXX;
+VI_CHECK_STORE_SXX;
 require((insn.rs2() & (P.VU.vlmul - 1)) == 0); \
 reg_t vl = P.VU.vl;
 reg_t baseAddr = RS1;


### PR DESCRIPTION
Since vector stores read rd, rather than write rd, there is no overlap constraint.

@chihminchao 