### PR TITLE
Allow overriding CFLAGS and similar when building

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -77,25 +77,52 @@ VPATH := $(addprefix $(src_dir)/, $(sprojs_enabled))
 # C++ compiler
 #  - CPPFLAGS : flags for the preprocessor (eg. -I,-D)
 #  - CXXFLAGS : flags for C++ compiler (eg. -Wall,-g,-O3)
+#
+# To allow a user to specify CFLAGS or similar as part of the Make
+# command, we also have mcpps-CFLAGS etc. with stuff that shouldn't be
+# lost in such a case.
+#
+# The order of precedence (highest to lowest) is then:
+#
+#    - Specified as part of Make command line
+#    - Specified as part of running configure
+#    - Specified here (default-CFLAGS)
+#
+# These all appear on the command line, from lowest precedence to
+# highest.
+
+default-CFLAGS   := -DPREFIX=\"$(prefix)\" -Wall -Wno-unused -g -O2
+default-CXXFLAGS := $(default-CFLAGS) -std=c++11
+
+mcppbs-CPPFLAGS := @CPPFLAGS@
+mcppbs-CFLAGS   := $(default-CFLAGS) @CFLAGS@
+mcppbs-CXXFLAGS := $(default-CXXFLAGS) @CXXFLAGS@
 
 CC            := @CC@
 CXX           := @CXX@
-CFLAGS        += @CFLAGS@ -DPREFIX=\"$(prefix)\"
-CPPFLAGS      += @CPPFLAGS@
-CXXFLAGS      += @CXXFLAGS@ -DPREFIX=\"$(prefix)\"
-COMPILE       := $(CXX) -MMD -MP $(CPPFLAGS) $(CXXFLAGS) \
-                 $(sprojs_include)
-COMPILE_C     := $(CC) -MMD -MP $(CPPFLAGS) $(CFLAGS) \
-                 $(sprojs_include)
+
+# These are the flags actually used for a C++ compile or a C compile.
+# The language-specific flags come after the preprocessor flags, but
+# user-supplied flags always take precedence.
+all-cxx-flags := \
+  $(mcppbs-CPPFLAGS) $(mcppbs-CXXFLAGS) $(CPPFLAGS) $(CXXFLAGS)
+all-c-flags := \
+  $(mcppbs-CPPFLAGS) $(mcppbs-CFLAGS) $(CPPFLAGS) $(CFLAGS)
+
+COMPILE       := $(CXX) -MMD -MP $(all-cxx-flags) $(sprojs_include)
+COMPILE_C     := $(CC) -MMD -MP $(all-c-flags) $(sprojs_include)
+
 # Linker
 #  - LDFLAGS : Flags for the linker (eg. -L)
 #  - LIBS    : Library flags (eg. -l)
 
+mcppbs-LDFLAGS := @LDFLAGS@
+all-link-flags := $(mcppbs-LDFLAGS) $(LDFLAGS)
+
 comma := ,
 LD            := $(CXX)
-LDFLAGS       := @LDFLAGS@
 LIBS          := @LIBS@
-LINK          := $(LD) -L. $(LDFLAGS) -Wl,-rpath,$(install_libs_dir) $(patsubst -L%,-Wl$(comma)-rpath$(comma)%,$(filter -L%,$(LDFLAGS)))
+LINK          := $(LD) -L. $(all-link-flags) -Wl,-rpath,$(install_libs_dir) $(patsubst -L%,-Wl$(comma)-rpath$(comma)%,$(filter -L%,$(LDFLAGS)))
 
 # Library creation
 

--- a/ax_append_flag.m4
+++ b/ax_append_flag.m4
@@ -1,0 +1,50 @@
+# ===========================================================================
+#      https://www.gnu.org/software/autoconf-archive/ax_append_flag.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_APPEND_FLAG(FLAG, [FLAGS-VARIABLE])
+#
+# DESCRIPTION
+#
+#   FLAG is appended to the FLAGS-VARIABLE shell variable, with a space
+#   added in between.
+#
+#   If FLAGS-VARIABLE is not specified, the current language's flags (e.g.
+#   CFLAGS) is used.  FLAGS-VARIABLE is not changed if it already contains
+#   FLAG.  If FLAGS-VARIABLE is unset in the shell, it is set to exactly
+#   FLAG.
+#
+#   NOTE: Implementation based on AX_CFLAGS_GCC_OPTION.
+#
+# LICENSE
+#
+#   Copyright (c) 2008 Guido U. Draheim <guidod@gmx.de>
+#   Copyright (c) 2011 Maarten Bosmans <mkbosmans@gmail.com>
+#
+#   Copying and distribution of this file, with or without modification, are
+#   permitted in any medium without royalty provided the copyright notice
+#   and this notice are preserved.  This file is offered as-is, without any
+#   warranty.
+
+#serial 8
+
+AC_DEFUN([AX_APPEND_FLAG],
+[dnl
+AC_PREREQ(2.64)dnl for _AC_LANG_PREFIX and AS_VAR_SET_IF
+AS_VAR_PUSHDEF([FLAGS], [m4_default($2,_AC_LANG_PREFIX[FLAGS])])
+AS_VAR_SET_IF(FLAGS,[
+  AS_CASE([" AS_VAR_GET(FLAGS) "],
+    [*" $1 "*], [AC_RUN_LOG([: FLAGS already contains $1])],
+    [
+     AS_VAR_APPEND(FLAGS,[" $1"])
+     AC_RUN_LOG([: FLAGS="$FLAGS"])
+    ])
+  ],
+  [
+  AS_VAR_SET(FLAGS,[$1])
+  AC_RUN_LOG([: FLAGS="$FLAGS"])
+  ])
+AS_VAR_POPDEF([FLAGS])dnl
+])dnl AX_APPEND_FLAG

--- a/ax_append_link_flags.m4
+++ b/ax_append_link_flags.m4
@@ -1,0 +1,44 @@
+# ===========================================================================
+#   https://www.gnu.org/software/autoconf-archive/ax_append_link_flags.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_APPEND_LINK_FLAGS([FLAG1 FLAG2 ...], [FLAGS-VARIABLE], [EXTRA-FLAGS], [INPUT])
+#
+# DESCRIPTION
+#
+#   For every FLAG1, FLAG2 it is checked whether the linker works with the
+#   flag.  If it does, the flag is added FLAGS-VARIABLE
+#
+#   If FLAGS-VARIABLE is not specified, the linker's flags (LDFLAGS) is
+#   used. During the check the flag is always added to the linker's flags.
+#
+#   If EXTRA-FLAGS is defined, it is added to the linker's default flags
+#   when the check is done.  The check is thus made with the flags: "LDFLAGS
+#   EXTRA-FLAGS FLAG".  This can for example be used to force the linker to
+#   issue an error when a bad flag is given.
+#
+#   INPUT gives an alternative input source to AC_COMPILE_IFELSE.
+#
+#   NOTE: This macro depends on the AX_APPEND_FLAG and AX_CHECK_LINK_FLAG.
+#   Please keep this macro in sync with AX_APPEND_COMPILE_FLAGS.
+#
+# LICENSE
+#
+#   Copyright (c) 2011 Maarten Bosmans <mkbosmans@gmail.com>
+#
+#   Copying and distribution of this file, with or without modification, are
+#   permitted in any medium without royalty provided the copyright notice
+#   and this notice are preserved.  This file is offered as-is, without any
+#   warranty.
+
+#serial 7
+
+AC_DEFUN([AX_APPEND_LINK_FLAGS],
+[AX_REQUIRE_DEFINED([AX_CHECK_LINK_FLAG])
+AX_REQUIRE_DEFINED([AX_APPEND_FLAG])
+for flag in $1; do
+  AX_CHECK_LINK_FLAG([$flag], [AX_APPEND_FLAG([$flag], [m4_default([$2], [LDFLAGS])])], [], [$3], [$4])
+done
+])dnl AX_APPEND_LINK_FLAGS

--- a/ax_require_defined.m4
+++ b/ax_require_defined.m4
@@ -1,0 +1,37 @@
+# ===========================================================================
+#    https://www.gnu.org/software/autoconf-archive/ax_require_defined.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_REQUIRE_DEFINED(MACRO)
+#
+# DESCRIPTION
+#
+#   AX_REQUIRE_DEFINED is a simple helper for making sure other macros have
+#   been defined and thus are available for use.  This avoids random issues
+#   where a macro isn't expanded.  Instead the configure script emits a
+#   non-fatal:
+#
+#     ./configure: line 1673: AX_CFLAGS_WARN_ALL: command not found
+#
+#   It's like AC_REQUIRE except it doesn't expand the required macro.
+#
+#   Here's an example:
+#
+#     AX_REQUIRE_DEFINED([AX_CHECK_LINK_FLAG])
+#
+# LICENSE
+#
+#   Copyright (c) 2014 Mike Frysinger <vapier@gentoo.org>
+#
+#   Copying and distribution of this file, with or without modification, are
+#   permitted in any medium without royalty provided the copyright notice
+#   and this notice are preserved. This file is offered as-is, without any
+#   warranty.
+
+#serial 2
+
+AC_DEFUN([AX_REQUIRE_DEFINED], [dnl
+  m4_ifndef([$1], [m4_fatal([macro ]$1[ is not defined; is a m4 file missing?])])
+])dnl AX_REQUIRE_DEFINED

--- a/configure
+++ b/configure
@@ -2205,6 +2205,74 @@ case $host_os in *\ *) host_os=`echo "$host_os" | sed 's/ /-/g'`;; esac
 
 
 # ===========================================================================
+#    https://www.gnu.org/software/autoconf-archive/ax_require_defined.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_REQUIRE_DEFINED(MACRO)
+#
+# DESCRIPTION
+#
+#   AX_REQUIRE_DEFINED is a simple helper for making sure other macros have
+#   been defined and thus are available for use.  This avoids random issues
+#   where a macro isn't expanded.  Instead the configure script emits a
+#   non-fatal:
+#
+#     ./configure: line 1673: AX_CFLAGS_WARN_ALL: command not found
+#
+#   It's like AC_REQUIRE except it doesn't expand the required macro.
+#
+#   Here's an example:
+#
+#     AX_REQUIRE_DEFINED([AX_CHECK_LINK_FLAG])
+#
+# LICENSE
+#
+#   Copyright (c) 2014 Mike Frysinger <vapier@gentoo.org>
+#
+#   Copying and distribution of this file, with or without modification, are
+#   permitted in any medium without royalty provided the copyright notice
+#   and this notice are preserved. This file is offered as-is, without any
+#   warranty.
+
+#serial 2
+
+
+# ===========================================================================
+#      https://www.gnu.org/software/autoconf-archive/ax_append_flag.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_APPEND_FLAG(FLAG, [FLAGS-VARIABLE])
+#
+# DESCRIPTION
+#
+#   FLAG is appended to the FLAGS-VARIABLE shell variable, with a space
+#   added in between.
+#
+#   If FLAGS-VARIABLE is not specified, the current language's flags (e.g.
+#   CFLAGS) is used.  FLAGS-VARIABLE is not changed if it already contains
+#   FLAG.  If FLAGS-VARIABLE is unset in the shell, it is set to exactly
+#   FLAG.
+#
+#   NOTE: Implementation based on AX_CFLAGS_GCC_OPTION.
+#
+# LICENSE
+#
+#   Copyright (c) 2008 Guido U. Draheim <guidod@gmx.de>
+#   Copyright (c) 2011 Maarten Bosmans <mkbosmans@gmail.com>
+#
+#   Copying and distribution of this file, with or without modification, are
+#   permitted in any medium without royalty provided the copyright notice
+#   and this notice are preserved.  This file is offered as-is, without any
+#   warranty.
+
+#serial 8
+
+
+# ===========================================================================
 #    https://www.gnu.org/software/autoconf-archive/ax_check_link_flag.html
 # ===========================================================================
 #
@@ -2241,6 +2309,44 @@ case $host_os in *\ *) host_os=`echo "$host_os" | sed 's/ /-/g'`;; esac
 #   warranty.
 
 #serial 6
+
+
+# ===========================================================================
+#   https://www.gnu.org/software/autoconf-archive/ax_append_link_flags.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_APPEND_LINK_FLAGS([FLAG1 FLAG2 ...], [FLAGS-VARIABLE], [EXTRA-FLAGS], [INPUT])
+#
+# DESCRIPTION
+#
+#   For every FLAG1, FLAG2 it is checked whether the linker works with the
+#   flag.  If it does, the flag is added FLAGS-VARIABLE
+#
+#   If FLAGS-VARIABLE is not specified, the linker's flags (LDFLAGS) is
+#   used. During the check the flag is always added to the linker's flags.
+#
+#   If EXTRA-FLAGS is defined, it is added to the linker's default flags
+#   when the check is done.  The check is thus made with the flags: "LDFLAGS
+#   EXTRA-FLAGS FLAG".  This can for example be used to force the linker to
+#   issue an error when a bad flag is given.
+#
+#   INPUT gives an alternative input source to AC_COMPILE_IFELSE.
+#
+#   NOTE: This macro depends on the AX_APPEND_FLAG and AX_CHECK_LINK_FLAG.
+#   Please keep this macro in sync with AX_APPEND_COMPILE_FLAGS.
+#
+# LICENSE
+#
+#   Copyright (c) 2011 Maarten Bosmans <mkbosmans@gmail.com>
+#
+#   Copying and distribution of this file, with or without modification, are
+#   permitted in any medium without royalty provided the copyright notice
+#   and this notice are preserved.  This file is offered as-is, without any
+#   warranty.
+
+#serial 7
 
 
 
@@ -4403,18 +4509,20 @@ fi
 # Default compiler flags
 #-------------------------------------------------------------------------
 
-CFLAGS="-Wall -Wno-unused -g -O2"
 
-CXXFLAGS="-Wall -Wno-unused -g -O2 -std=c++11"
 
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether the linker accepts -Wl,--export-dynamic" >&5
-$as_echo_n "checking whether the linker accepts -Wl,--export-dynamic... " >&6; }
-if ${ax_cv_check_ldflags___Wl___export_dynamic+:} false; then :
+
+
+for flag in -Wl,--export-dynamic; do
+  as_CACHEVAR=`$as_echo "ax_cv_check_ldflags__$flag" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether the linker accepts $flag" >&5
+$as_echo_n "checking whether the linker accepts $flag... " >&6; }
+if eval \${$as_CACHEVAR+:} false; then :
   $as_echo_n "(cached) " >&6
 else
 
   ax_check_save_flags=$LDFLAGS
-  LDFLAGS="$LDFLAGS  -Wl,--export-dynamic"
+  LDFLAGS="$LDFLAGS  $flag"
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
@@ -4427,21 +4535,55 @@ main ()
 }
 _ACEOF
 if ac_fn_cxx_try_link "$LINENO"; then :
-  ax_cv_check_ldflags___Wl___export_dynamic=yes
+  eval "$as_CACHEVAR=yes"
 else
-  ax_cv_check_ldflags___Wl___export_dynamic=no
+  eval "$as_CACHEVAR=no"
 fi
 rm -f core conftest.err conftest.$ac_objext \
     conftest$ac_exeext conftest.$ac_ext
   LDFLAGS=$ax_check_save_flags
 fi
-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ax_cv_check_ldflags___Wl___export_dynamic" >&5
-$as_echo "$ax_cv_check_ldflags___Wl___export_dynamic" >&6; }
-if test "x$ax_cv_check_ldflags___Wl___export_dynamic" = xyes; then :
-  LDFLAGS="-Wl,--export-dynamic"
+eval ac_res=\$$as_CACHEVAR
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_CACHEVAR"\" = x"yes"; then :
+
+if ${LDFLAGS+:} false; then :
+
+  case " $LDFLAGS " in #(
+  *" $flag "*) :
+    { { $as_echo "$as_me:${as_lineno-$LINENO}: : LDFLAGS already contains \$flag"; } >&5
+  (: LDFLAGS already contains $flag) 2>&5
+  ac_status=$?
+  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+  test $ac_status = 0; } ;; #(
+  *) :
+
+     as_fn_append LDFLAGS " $flag"
+     { { $as_echo "$as_me:${as_lineno-$LINENO}: : LDFLAGS=\"\$LDFLAGS\""; } >&5
+  (: LDFLAGS="$LDFLAGS") 2>&5
+  ac_status=$?
+  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+  test $ac_status = 0; }
+     ;;
+esac
+
+else
+
+  LDFLAGS=$flag
+  { { $as_echo "$as_me:${as_lineno-$LINENO}: : LDFLAGS=\"\$LDFLAGS\""; } >&5
+  (: LDFLAGS="$LDFLAGS") 2>&5
+  ac_status=$?
+  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+  test $ac_status = 0; }
+
+fi
+
 else
   :
 fi
+
+done
 
 
 #-------------------------------------------------------------------------

--- a/configure.ac
+++ b/configure.ac
@@ -43,7 +43,10 @@ AC_CONFIG_AUX_DIR([scripts])
 AC_CANONICAL_BUILD
 AC_CANONICAL_HOST
 
+m4_include(ax_require_defined.m4)
+m4_include(ax_append_flag.m4)
 m4_include(ax_check_link_flag.m4)
+m4_include(ax_append_link_flags.m4)
 
 #-------------------------------------------------------------------------
 # Checks for programs
@@ -84,9 +87,7 @@ AC_CHECK_TYPE([__int128_t], AC_SUBST([HAVE_INT128],[yes]))
 # Default compiler flags
 #-------------------------------------------------------------------------
 
-AC_SUBST([CFLAGS],  ["-Wall -Wno-unused -g -O2"])
-AC_SUBST([CXXFLAGS],["-Wall -Wno-unused -g -O2 -std=c++11"])
-AX_CHECK_LINK_FLAG([-Wl,--export-dynamic], [LDFLAGS="-Wl,--export-dynamic"])
+AX_APPEND_LINK_FLAGS([-Wl,--export-dynamic])
 
 #-------------------------------------------------------------------------
 # MCPPBS subproject list


### PR DESCRIPTION
Before this patch, I don't think it was possible to change (say)
CFLAGS as part of running the make command. Nor did setting them when
running configure do anything. Getting this right is a little fiddly:
for example, see Automake's approach at [1] ("AM_CFLAGS" and friends).

This patch adds an "mcppbs-" prefix, and sets things up properly for
CFLAGS, CPPFLAGS, CXXFLAGS and LDFLAGS. Note that the bulk of the
patch is either the auto-generated configure script or the ax_*.m4
files vendored in from the autoconf archive (needed to handle
--export-dynamic correctly without trashing settings from the user
running configure).

What's supposed to happen is as follows:

  - Base compilation flags that should apply to everything (standard
    optimisation flags, warning flags etc.) are defined in
	Makefile.in.

  - When the user runs configure, they can set compilation flags on
    the command line. These end up as environment variables in the
	shell script.

  - Compilation flags that can only be decided when we run
    configure (this is currently just whether we support
    -Wl,--export-dynamic) are appended to the configure-time LDFLAGS
    environment variable.

  - At the end of the configure script, these environment variables
    are spliced into Makefile.in to fill out the corresponding
	@<varname>@ entries.

  - When running make, the user might again override compilation
    flags. These will get appended to the flags found so far.

As a concrete example:

  mkdir build
  cd build
  ../configure CXXFLAGS='-O3'
  make CXXFLAGS='-O0'

will result in c++ compile commands that look like this:

  g++ -MMD -MP \
      -DPREFIX=\"/usr/local\" -Wall -Wno-unused -g -O2 -std=c++11 \
      -O3 \
      -O0 \
      -I. -I.. -I../fesvr -I../riscv -I../dummy_rocc -I../softfloat \
      -I../spike_main -fPIC -c ../fesvr/elfloader.cc

(I've added some newlines to wrap the long line).

Note that we have the base flags from Makefile.in (called
$(default-CXXFLAGS) there) first. Then we have the -O3 from the
configure command. Finally we have the -O0 from the Make command line.

And I can finally run "make CXXFLAGS='-O0 -g3'". Phew!

[1] https://www.gnu.org/software/automake/manual/html_node/Flag-Variables-Ordering.html