### PR TITLE
processor_t cleanups

### DIFF
--- a/riscv/decode.h
+++ b/riscv/decode.h
@@ -152,7 +152,7 @@ private:
 };
 
 // helpful macros, etc
-#define MMU (*p->get_mmu())
+#define MMU (p->get_mmu())
 #define STATE (*p->get_state())
 #define P (*p)
 #define FLEN (p->get_flen())

--- a/riscv/execute.cc
+++ b/riscv/execute.cc
@@ -170,10 +170,11 @@ void processor_t::step(size_t n)
     }
   }
 
+  mmu_t &_mmu = * mmu;
+
   while (n > 0) {
     size_t instret = 0;
     reg_t pc = state.pc;
-    mmu_t* _mmu = mmu;
 
     #define advance_pc() \
      if (unlikely(invalid_pc(pc))) { \
@@ -236,13 +237,13 @@ void processor_t::step(size_t n)
         // resulted in approximately a 2x performance increase.
 
         // This figures out where to jump to in the switch statement
-        size_t idx = _mmu->icache_index(pc);
+        size_t idx = _mmu.icache_index(pc);
 
         // This gets the cached decoded instruction from the MMU. If the MMU
         // does not have the current pc cached, it will refill the MMU and
         // return the correct entry. ic_entry->data.func is the C++ function
         // corresponding to the instruction.
-        auto ic_entry = _mmu->access_icache(pc);
+        auto ic_entry = _mmu.access_icache(pc);
 
         // This macro is included in "icache.h" included within the switch
         // statement below. The indirect jump corresponding to the instruction

--- a/riscv/execute.cc
+++ b/riscv/execute.cc
@@ -15,42 +15,48 @@ static void commit_log_stash_privilege(processor_t* p)
 #endif
 }
 
-static void commit_log_print_value(int width, const void *data)
+#ifdef RISCV_ENABLE_COMMITLOG
+static void commit_log_print_value(FILE *log_file, int width, const void *data)
 {
+  assert(log_file);
   const uint64_t *arr = (const uint64_t *)data;
 
-  fprintf(stderr, "0x");
+  fprintf(log_file, "0x");
   for (int idx = width / 64 - 1; idx >= 0; --idx) {
-    fprintf(stderr, "%016" PRIx64, arr[idx]);
+    fprintf(log_file, "%016" PRIx64, arr[idx]);
   }
 }
 
-static void commit_log_print_value(int width, uint64_t hi, uint64_t lo)
+static void commit_log_print_value(FILE *log_file,
+                                   int width, uint64_t hi, uint64_t lo)
 {
+  assert(log_file);
+
   switch (width) {
     case 8:
-      fprintf(stderr, "0x%01" PRIx8, (uint8_t)lo);
+      fprintf(log_file, "0x%01" PRIx8, (uint8_t)lo);
       break;
     case 16:
-      fprintf(stderr, "0x%04" PRIx16, (uint16_t)lo);
+      fprintf(log_file, "0x%04" PRIx16, (uint16_t)lo);
       break;
     case 32:
-      fprintf(stderr, "0x%08" PRIx32, (uint32_t)lo);
+      fprintf(log_file, "0x%08" PRIx32, (uint32_t)lo);
       break;
     case 64:
-      fprintf(stderr, "0x%016" PRIx64, lo);
+      fprintf(log_file, "0x%016" PRIx64, lo);
       break;
     case 128:
-      fprintf(stderr, "0x%016" PRIx64 "%016" PRIx64, hi, lo);
+      fprintf(log_file, "0x%016" PRIx64 "%016" PRIx64, hi, lo);
       break;
     default:
       abort();
   }
 }
 
-static void commit_log_print_insn(processor_t* p, reg_t pc, insn_t insn)
+static void commit_log_print_insn(processor_t *p, reg_t pc, insn_t insn)
 {
-#ifdef RISCV_ENABLE_COMMITLOG
+  FILE *log_file = p->get_log_file();
+
   auto& reg = p->get_state()->log_reg_write;
   auto& load = p->get_state()->log_mem_read;
   auto& store = p->get_state()->log_mem_write;
@@ -58,11 +64,11 @@ static void commit_log_print_insn(processor_t* p, reg_t pc, insn_t insn)
   int xlen = p->get_state()->last_inst_xlen;
   int flen = p->get_state()->last_inst_flen;
 
-  fprintf(stderr, "%1d ", priv);
-  commit_log_print_value(xlen, 0, pc);
-  fprintf(stderr, " (");
-  commit_log_print_value(insn.length() * 8, 0, insn.bits());
-  fprintf(stderr, ")");
+  fprintf(log_file, "%1d ", priv);
+  commit_log_print_value(log_file, xlen, 0, pc);
+  fprintf(log_file, " (");
+  commit_log_print_value(log_file, insn.length() * 8, 0, insn.bits());
+  fprintf(log_file, ")");
 
   for (auto item : reg) {
     if (item.first == 0)
@@ -92,32 +98,33 @@ static void commit_log_print_insn(processor_t* p, reg_t pc, insn_t insn)
     }
 
     if (is_vec)
-        fprintf(stderr, " e%ld m%ld", p->VU.vsew, p->VU.vlmul);
+      fprintf(log_file, " e%ld m%ld", p->VU.vsew, p->VU.vlmul);
 
-    fprintf(stderr, " %c%2d ", prefix, rd);
+    fprintf(log_file, " %c%2d ", prefix, rd);
+
     if (is_vec)
-        commit_log_print_value(size, &p->VU.elt<uint8_t>(rd, 0));
+      commit_log_print_value(log_file, size, &p->VU.elt<uint8_t>(rd, 0));
     else
-        commit_log_print_value(size, item.second.v[1], item.second.v[0]);
+      commit_log_print_value(log_file, size, item.second.v[1], item.second.v[0]);
   }
 
   for (auto item : load) {
-    fprintf(stderr, " mem ");
-    commit_log_print_value(xlen, 0, std::get<0>(item));
+    fprintf(log_file, " mem ");
+    commit_log_print_value(log_file, xlen, 0, std::get<0>(item));
   }
 
   for (auto item : store) {
-    fprintf(stderr, " mem ");
-    commit_log_print_value(xlen, 0, std::get<0>(item));
-    fprintf(stderr, " ");
-    commit_log_print_value(std::get<2>(item) << 3, 0, std::get<1>(item));
+    fprintf(log_file, " mem ");
+    commit_log_print_value(log_file, xlen, 0, std::get<0>(item));
+    fprintf(log_file, " ");
+    commit_log_print_value(log_file, std::get<2>(item) << 3, 0, std::get<1>(item));
   }
-  fprintf(stderr, "\n");
+  fprintf(log_file, "\n");
   reg.clear();
   load.clear();
   store.clear();
-#endif
 }
+#endif
 
 inline void processor_t::update_histogram(reg_t pc)
 {
@@ -134,9 +141,13 @@ static reg_t execute_insn(processor_t* p, reg_t pc, insn_fetch_t fetch)
   commit_log_stash_privilege(p);
   reg_t npc = fetch.func(p, fetch.insn, pc);
   if (npc != PC_SERIALIZE_BEFORE) {
-    if (p->get_log_commits()) {
+
+#ifdef RISCV_ENABLE_COMMITLOG
+    if (p->get_log_commits_enabled()) {
       commit_log_print_insn(p, pc, fetch.insn);
     }
+#endif
+
     p->update_histogram(pc);
   }
   return npc;

--- a/riscv/interactive.cc
+++ b/riscv/interactive.cc
@@ -320,7 +320,7 @@ reg_t sim_t::get_mem(const std::vector<std::string>& args)
   if(args.size() == 2)
   {
     processor_t *p = get_core(args[0]);
-    mmu = p->get_mmu();
+    mmu = &p->get_mmu();
     addr_str = args[1];
   }
 

--- a/riscv/log_file.h
+++ b/riscv/log_file.h
@@ -1,0 +1,37 @@
+// See LICENSE for license details.
+#ifndef _RISCV_LOGFILE_H
+#define _RISCV_LOGFILE_H
+
+#include <stdio.h>
+#include <memory>
+#include <sstream>
+#include <stdexcept>
+
+// Header-only class wrapping a log file. When constructed with an
+// actual path, it opens the named file for writing. When constructed
+// with the null path, it wraps stderr.
+class log_file_t
+{
+public:
+  log_file_t(const char *path)
+    : wrapped_file (nullptr, &fclose)
+  {
+    if (!path)
+      return;
+
+    wrapped_file.reset(fopen(path, "w"));
+    if (! wrapped_file) {
+      std::ostringstream oss;
+      oss << "Failed to open log file at `" << path << "': "
+          << strerror (errno);
+      throw std::runtime_error(oss.str());
+    }
+  }
+
+  FILE *get() { return wrapped_file ? wrapped_file.get() : stderr; }
+
+private:
+  std::unique_ptr<FILE, decltype(&fclose)> wrapped_file;
+};
+
+#endif

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -239,13 +239,16 @@ class processor_t : public abstract_device_t
 {
 public:
   processor_t(const char* isa, const char* priv, const char* varch,
-              simif_t* sim, uint32_t id, bool halt_on_reset=false);
+              simif_t* sim, uint32_t id, bool halt_on_reset,
+              FILE *log_file);
   ~processor_t();
 
   void set_debug(bool value);
   void set_histogram(bool value);
-  void set_log_commits(bool value);
-  bool get_log_commits() { return log_commits_enabled; }
+#ifdef RISCV_ENABLE_COMMITLOG
+  void enable_log_commits();
+  bool get_log_commits_enabled() const { return log_commits_enabled; }
+#endif
   void reset();
   void step(size_t n); // run for n cycles
   void set_csr(int which, reg_t val);
@@ -276,6 +279,8 @@ public:
   void set_privilege(reg_t);
   void update_histogram(reg_t pc);
   const disassembler_t* get_disassembler() { return disassembler; }
+
+  FILE *get_log_file() { return log_file; }
 
   void register_insn(insn_desc_t);
   void register_extension(extension_t*);
@@ -386,6 +391,7 @@ private:
   std::string isa_string;
   bool histogram_enabled;
   bool log_commits_enabled;
+  FILE *log_file;
   bool halt_on_reset;
 
   std::vector<insn_desc_t> instructions;

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -256,7 +256,7 @@ public:
   void step(size_t n); // run for n cycles
   void set_csr(int which, reg_t val);
   reg_t get_csr(int which);
-  mmu_t* get_mmu() { return mmu.get(); }
+  mmu_t &get_mmu() { return *mmu; }
   state_t* get_state() { return &state; }
   unsigned get_xlen() { return xlen; }
   unsigned get_max_xlen() { return max_xlen; }
@@ -281,7 +281,7 @@ public:
   reg_t legalize_privilege(reg_t);
   void set_privilege(reg_t);
   void update_histogram(reg_t pc);
-  const disassembler_t* get_disassembler() const { return disassembler.get(); }
+  const disassembler_t &get_disassembler() const { return *disassembler; }
 
   FILE *get_log_file() { return log_file; }
 

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -6,11 +6,14 @@
 #include "config.h"
 #include "devices.h"
 #include "trap.h"
-#include <string>
-#include <vector>
-#include <unordered_map>
+
 #include <map>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
 #include <cassert>
+
 #include "debug_rom_defines.h"
 
 class processor_t;
@@ -253,7 +256,7 @@ public:
   void step(size_t n); // run for n cycles
   void set_csr(int which, reg_t val);
   reg_t get_csr(int which);
-  mmu_t* get_mmu() { return mmu; }
+  mmu_t* get_mmu() { return mmu.get(); }
   state_t* get_state() { return &state; }
   unsigned get_xlen() { return xlen; }
   unsigned get_max_xlen() { return max_xlen; }
@@ -278,7 +281,7 @@ public:
   reg_t legalize_privilege(reg_t);
   void set_privilege(reg_t);
   void update_histogram(reg_t pc);
-  const disassembler_t* get_disassembler() { return disassembler; }
+  const disassembler_t* get_disassembler() const { return disassembler.get(); }
 
   FILE *get_log_file() { return log_file; }
 
@@ -380,9 +383,9 @@ public:
 
 private:
   simif_t* sim;
-  mmu_t* mmu; // main memory is always accessed via the mmu
+  std::unique_ptr<mmu_t> mmu; // main memory is always accessed via the mmu
   extension_t* ext;
-  disassembler_t* disassembler;
+  std::unique_ptr<disassembler_t> disassembler;
   state_t state;
   uint32_t id;
   unsigned max_xlen;

--- a/riscv/sim.cc
+++ b/riscv/sim.cc
@@ -118,7 +118,7 @@ void sim_t::step(size_t n)
     if (current_step == INTERLEAVE)
     {
       current_step = 0;
-      procs[current_proc]->get_mmu()->yield_load_reservation();
+      procs[current_proc]->get_mmu().yield_load_reservation();
       if (++current_proc == procs.size()) {
         current_proc = 0;
         clint->increment(INTERLEAVE / INSNS_PER_RTC_TICK);

--- a/riscv/sim.h
+++ b/riscv/sim.h
@@ -3,10 +3,12 @@
 #ifndef _RISCV_SIM_H
 #define _RISCV_SIM_H
 
-#include "processor.h"
-#include "devices.h"
 #include "debug_module.h"
+#include "devices.h"
+#include "log_file.h"
+#include "processor.h"
 #include "simif.h"
+
 #include <fesvr/htif.h>
 #include <fesvr/context.h>
 #include <vector>
@@ -27,15 +29,22 @@ public:
         reg_t start_pc, std::vector<std::pair<reg_t, mem_t*>> mems,
         std::vector<std::pair<reg_t, abstract_device_t*>> plugin_devices,
         const std::vector<std::string>& args, const std::vector<int> hartids,
-        const debug_module_config_t &dm_config);
+        const debug_module_config_t &dm_config, const char *log_path);
   ~sim_t();
 
   // run the simulation to completion
   int run();
   void set_debug(bool value);
-  void set_log(bool value);
   void set_histogram(bool value);
-  void set_log_commits(bool value);
+
+  // Configure logging
+  //
+  // If enable_log is true, an instruction trace will be generated. If
+  // enable_commitlog is true, so will the commit results (if this
+  // build was configured without support for commit logging, the
+  // function will print an error message and abort).
+  void configure_log(bool enable_log, bool enable_commitlog);
+
   void set_procs_debug(bool value);
   void set_dtb_enabled(bool value) {
     this->dtb_enabled = value;
@@ -62,6 +71,7 @@ private:
   std::unique_ptr<rom_device_t> boot_rom;
   std::unique_ptr<clint_t> clint;
   bus_t bus;
+  log_file_t log_file;
 
   processor_t* get_core(const std::string& i);
   void step(size_t n); // step through simulation
@@ -71,9 +81,8 @@ private:
   size_t current_step;
   size_t current_proc;
   bool debug;
-  bool log;
   bool histogram_enabled; // provide a histogram of PCs
-  bool log_commits_enabled;
+  bool log;
   bool dtb_enabled;
   remote_bitbang_t* remote_bitbang;
 

--- a/spike_main/spike-log-parser.cc
+++ b/spike_main/spike-log-parser.cc
@@ -27,7 +27,7 @@ int main(int argc, char** argv)
   parser.option(0, "isa", 1, [&](const char* s){isa = s;});
   parser.parse(argv);
 
-  processor_t p(isa, DEFAULT_PRIV, DEFAULT_VARCH, 0, 0);
+  processor_t p(isa, DEFAULT_PRIV, DEFAULT_VARCH, 0, 0, false, nullptr);
   if (extension) {
     p.register_extension(extension());
   }

--- a/spike_main/spike-log-parser.cc
+++ b/spike_main/spike-log-parser.cc
@@ -47,7 +47,7 @@ int main(int argc, char** argv)
           opcode = opcode << (64-bit_num) >> (64-bit_num);
       }
 
-      const disasm_insn_t* disasm = p.get_disassembler()->lookup(opcode);
+      const disasm_insn_t* disasm = p.get_disassembler().lookup(opcode);
       if (disasm) {
           cout << disasm->get_name() << '\n';
       } else {

--- a/spike_main/spike.cc
+++ b/spike_main/spike.cc
@@ -316,8 +316,8 @@ int main(int argc, char** argv)
   if (dc) dc->set_log(log_cache);
   for (size_t i = 0; i < nprocs; i++)
   {
-    if (ic) s.get_core(i)->get_mmu()->register_memtracer(&*ic);
-    if (dc) s.get_core(i)->get_mmu()->register_memtracer(&*dc);
+    if (ic) s.get_core(i)->get_mmu().register_memtracer(&*ic);
+    if (dc) s.get_core(i)->get_mmu().register_memtracer(&*dc);
     if (extension) s.get_core(i)->register_extension(extension());
   }
 


### PR DESCRIPTION
Here are a couple of small cleanups in processor_t that I made when working on PR #409. At one point, I thought I needed to throw in the processor_t constructor, so had to replace the raw mmu and disassembler pointers with smart pointers. As it turns out, there was a cleaner way to do things, so this doesn't really matter, but I thought I may as well push this up in case it's useful.

The first patch here is the patch of PR #409, so this PR will need rebasing before it can be applied.