### PR TITLE
Assert that debug_module is initialized correctly.

### DIFF
--- a/riscv/debug_module.cc
+++ b/riscv/debug_module.cc
@@ -77,6 +77,7 @@ debug_module_t::~debug_module_t()
 
 void debug_module_t::reset()
 {
+  assert(sim->nprocs() > 0);
   for (unsigned i = 0; i < sim->nprocs(); i++) {
     processor_t *proc = sim->get_core(i);
     if (proc)


### PR DESCRIPTION
This would have prevented the regression in #409.