### PR TITLE
option: flag x extension without loading shared lib

### DIFF
--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -222,7 +222,11 @@ void processor_t::parse_isa_string(const char* str)
       const char* ext = p+1, *end = ext;
       while (islower(*end))
         end++;
-      register_extension(find_extension(std::string(ext, end - ext).c_str())());
+
+      auto ext_str = std::string(ext, end - ext);
+      if (ext_str != "dummy")
+        register_extension(find_extension(ext_str.c_str())());
+
       p = end;
     } else {
       bad_isa_string(str);


### PR DESCRIPTION
reserve the word 'dummy' to set the x-extension in misa but not to load
a related shared library.

ex:
   --isa=IMACXdummy

Signed-off-by: Chih-Min Chao <chihmin.chao@sifive.com>