### PR TITLE
Memory size not limited by the multiply of page size

### DIFF
--- a/spike_main/spike.cc
+++ b/spike_main/spike.cc
@@ -113,7 +113,7 @@ static std::vector<std::pair<reg_t, mem_t*>> make_mems(const char* arg)
       help();
     auto size = strtoull(p + 1, &p, 0);
     if ((size | base) % PGSIZE != 0)
-      help();
+      fprintf(stderr, "Warning: the memory size %llu at 0x%llX is not align to the page size (%ld)\n", size, base, PGSIZE);
     res.push_back(std::make_pair(reg_t(base), new mem_t(size)));
     if (!*p)
       break;


### PR DESCRIPTION
we're going to release the memory size limitation of multiply of PGSIZE to any size when the user specifies the memory base address and size by the option "-m".