### PR TITLE
Add missing stdexcept imports (for GCC 10)

### DIFF
--- a/fesvr/dtm.cc
+++ b/fesvr/dtm.cc
@@ -6,6 +6,7 @@
 #include <string.h>
 #include <assert.h>
 #include <pthread.h>
+#include <stdexcept>
 
 #define RV_X(x, s, n) \
   (((x) >> (s)) & ((1 << (n)) - 1))

--- a/riscv/devices.h
+++ b/riscv/devices.h
@@ -7,6 +7,7 @@
 #include <string>
 #include <map>
 #include <vector>
+#include <stdexcept>
 
 class processor_t;
 


### PR DESCRIPTION
[GCC 10 changed some C++ standard library headers to not import `stdexcept`](https://gcc.gnu.org/gcc-10/porting_to.html). This adds those back in so that spike will build on distros with GCC 10 as the default, e.g., Fedora 32.

This should be backwards compatible. 