### PR TITLE
Hardwire mstatus.[sie,spie] to zero if 'S' mode absent

### DIFF
--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -697,9 +697,8 @@ void processor_t::set_csr(int which, reg_t val)
                   || supports_extension('V');
       bool has_vs = supports_extension('V');
 
-      reg_t mask = MSTATUS_SIE | MSTATUS_SPIE | MSTATUS_MIE | MSTATUS_MPIE
-                 | MSTATUS_MPRV
-                 | (supports_extension('S') ? MSTATUS_SUM : 0)
+      reg_t mask = MSTATUS_MIE | MSTATUS_MPIE | MSTATUS_MPRV
+                 | (supports_extension('S') ? (MSTATUS_SUM | MSTATUS_SIE | MSTATUS_SPIE) : 0)
                  | MSTATUS_MXR | MSTATUS_TW | MSTATUS_TVM | MSTATUS_TSR
                  | (has_fs ? MSTATUS_FS : 0)
                  | (has_vs ? MSTATUS_VS : 0)


### PR DESCRIPTION
UIE and UPIE fields of mstatus are explicitly marked as 'WPRI' in Privileged ISA 1.12-draft, which implies they are hardwired to zero when N extension is absent. By the same logic, hardwire SIE and SPIE to zero (although this is not explicitly mentioned in the spec).