### PR TITLE
Read interactive debug commands from standard input

### DIFF
--- a/riscv/interactive.cc
+++ b/riscv/interactive.cc
@@ -85,7 +85,7 @@ void sim_t::interactive()
   while (!done())
   {
     std::cerr << ": " << std::flush;
-    std::string s = readline(2);
+    std::string s = readline(0);
 
     std::stringstream ss(s);
     std::string cmd, tmp;


### PR DESCRIPTION
I recently wrote a cosimulator for [my own RISC-V emulator](https://github.com/michaelmelanson/riscy), intending to drive Spike by starting it as a child process and interacting with it over standard input and standard error. But I ran into a problem because apparently Spike was, in fact, reading its commands from standard _error_ instead of standard input.

I've always assumed that you could not read from standard output/error so that was a weird discovery. 🤯

This change fixes the interactive debug loop so it reads from file descriptor 0 (standard input) instead of 2 (standard error). It should work as before when used interactively from the terminal, but it should now accept piped commands or (as was my use case) from a parent process.