### PR TITLE
fix clang compile error within FDT parsing

### DIFF
--- a/riscv/dts.cc
+++ b/riscv/dts.cc
@@ -170,7 +170,7 @@ std::string dts_compile(const std::string& dts)
 }
 
 
-static int fdt_get_node_addr_size(void *fdt, int node, unsigned long *addr,
+static int fdt_get_node_addr_size(void *fdt, int node, reg_t *addr,
                                   unsigned long *size, const char *field)
 {
   int parent, len, i;
@@ -214,7 +214,7 @@ static int fdt_get_node_addr_size(void *fdt, int node, unsigned long *addr,
   return 0;
 }
 
-int fdt_parse_clint(void *fdt, unsigned long *clint_addr,
+int fdt_parse_clint(void *fdt, reg_t *clint_addr,
                     const char *compatible)
 {
   int nodeoffset, rc;
@@ -230,7 +230,7 @@ int fdt_parse_clint(void *fdt, unsigned long *clint_addr,
   return 0;
 }
 
-int fdt_parse_pmp_num(void *fdt, unsigned long *pmp_num, const char *compatible)
+int fdt_parse_pmp_num(void *fdt, reg_t *pmp_num, const char *compatible)
 {
   int nodeoffset, rc;
 
@@ -246,7 +246,7 @@ int fdt_parse_pmp_num(void *fdt, unsigned long *pmp_num, const char *compatible)
   return 0;
 }
 
-int fdt_parse_pmp_alignment(void *fdt, unsigned long *pmp_align,
+int fdt_parse_pmp_alignment(void *fdt, reg_t *pmp_align,
                             const char *compatible)
 {
   int nodeoffset, rc;

--- a/riscv/dts.h
+++ b/riscv/dts.h
@@ -13,10 +13,10 @@ std::string make_dts(size_t insns_per_rtc_tick, size_t cpu_hz,
 
 std::string dts_compile(const std::string& dts);
 
-int fdt_parse_clint(void *fdt, unsigned long *clint_addr,
+int fdt_parse_clint(void *fdt, reg_t *clint_addr,
                     const char *compatible);
-int fdt_parse_pmp_num(void *fdt, unsigned long *pmp_num,
+int fdt_parse_pmp_num(void *fdt, reg_t *pmp_num,
                       const char *compatible);
-int fdt_parse_pmp_alignment(void *fdt, unsigned long *pmp_align,
+int fdt_parse_pmp_alignment(void *fdt, reg_t *pmp_align,
                             const char *compatible);
 #endif


### PR DESCRIPTION
Clang is more finicky about types (even though they are pointers) and runs into the following compile errors when building. This fix changes some arguments from unsigned long to reg_t to be consistent with where they are used.

g++ -MMD -MP  -DPREFIX=\"/usr/local/riscv\" -Wall -Wno-unused -g -O2 -std=c++11 -g -O2   -I. -I.. -I../fesvr -I../riscv -I../dummy_rocc -I../fdt -I../softfloat -I../spike_main  -c ../riscv/sim.cc
../riscv/sim.cc:87:7: error: no matching function for call to 'fdt_parse_clint'
  if (fdt_parse_clint((void *)dtb.c_str(), &clint_base, "riscv,clint0")) {
      ^~~~~~~~~~~~~~~
../riscv/dts.h:16:5: note: candidate function not viable: no known conversion
      from 'reg_t *' (aka 'unsigned long long *') to 'unsigned long *' for 2nd
      argument
int fdt_parse_clint(void *fdt, unsigned long *clint_addr,
    ^
../riscv/sim.cc:95:5: error: no matching function for call to
      'fdt_parse_pmp_num'
    fdt_parse_pmp_num((void *)dtb.c_str(), &pmp_num, "riscv");
    ^~~~~~~~~~~~~~~~~
../riscv/dts.h:18:5: note: candidate function not viable: no known conversion
      from 'reg_t *' (aka 'unsigned long long *') to 'unsigned long *' for 2nd
      argument
int fdt_parse_pmp_num(void *fdt, unsigned long *pmp_num,
    ^
../riscv/sim.cc:96:5: error: no matching function for call to
      'fdt_parse_pmp_alignment'
    fdt_parse_pmp_alignment((void *)dtb.c_str(), &pmp_granularity, "riscv");
    ^~~~~~~~~~~~~~~~~~~~~~~
../riscv/dts.h:20:5: note: candidate function not viable: no known conversion
      from 'reg_t *' (aka 'unsigned long long *') to 'unsigned long *' for 2nd
      argument
int fdt_parse_pmp_alignment(void *fdt, unsigned long *pmp_align,
    ^
3 errors generated.
