### PR TITLE
Fix state.misa garbage initialization

### DIFF
--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -270,7 +270,7 @@ void processor_t::parse_isa_string(const char* str)
     }
   }
 
-  state.misa |= max_isa;
+  state.misa = max_isa;
 
   if (!supports_extension('I'))
     bad_isa_string(str, "'I' extension is required");


### PR DESCRIPTION
Original bug-report: Simulator is seeing an `flen` of 128 for a `--isa=rv64imafdc` argument

I found that [this](https://github.com/riscv/riscv-isa-sim/blob/2d8a94234ec1b1d57bb81bf5b826cb832cd8a2e1/riscv/processor.cc#L153) call to `get_flen` checks the state of `misa` [here](https://github.com/riscv/riscv-isa-sim/blob/2d8a94234ec1b1d57bb81bf5b826cb832cd8a2e1/riscv/processor.h#L278), and because `processor.reset()` hasn't been called until this point, `misa` is actually holding the value from [this](https://github.com/riscv/riscv-isa-sim/blob/a21011116cdaaa0eea2d4f16175cfc3f267d4765/riscv/processor.cc#L273) code. The initial `state.misa` value could be garbage, leading to this bug.

Since `misa` isn't being initialized anywhere before the line in question (is it?), it should be sufficient to set it directly to the parsed value of `max_isa`.

@aswaterman *please* give this a thorough review if you can, to make sure it doesn't break anything else. I tested it on the original bug report and a few other ISA strings.
