### PR TITLE
Make gen_icache script use only POSIX commands

### DIFF
--- a/riscv/gen_icache
+++ b/riscv/gen_icache
@@ -1,7 +1,8 @@
 #!/bin/sh
-n=$(($1-1))
-for i in `seq 0 $n`
+i=0
+while [ $i -lt $1 ]
 do
   echo case $i: ICACHE_ACCESS\($i\)\;
+  i=$((i+1))
 done
 echo


### PR DESCRIPTION
The `seq` utility is not available in OpenBSD.