### PR TITLE
Return non-zero trap value for illegal CSR accessing instructions

### DIFF
--- a/riscv/decode.h
+++ b/riscv/decode.h
@@ -353,7 +353,10 @@ inline freg_t f128_negate(freg_t a)
   bool mode_unsupported = csr_priv == PRV_S && !P.supports_extension('S'); \
   unsigned csr_read_only = get_field((which), 0xC00) == 3; \
   if (((write) && csr_read_only) || STATE.prv < csr_priv || mode_unsupported) \
-    throw trap_illegal_instruction((uint32_t)insn_bits); \
+    if (p->get_tval_nz_csr_enabled()) \
+      throw trap_illegal_instruction((uint32_t)insn_bits); \
+    else \
+      throw trap_illegal_instruction(0); \
   (which); })
 
 /* For debug only. This will fail if the native machine's float types are not IEEE */

--- a/riscv/decode.h
+++ b/riscv/decode.h
@@ -346,14 +346,14 @@ inline freg_t f128_negate(freg_t a)
   return a;
 }
 
-#define validate_csr(which, write) ({ \
+#define validate_csr(which, write, insn_bits) ({ \
   if (!STATE.serialized) return PC_SERIALIZE_BEFORE; \
   STATE.serialized = false; \
   unsigned csr_priv = get_field((which), 0x300); \
   bool mode_unsupported = csr_priv == PRV_S && !P.supports_extension('S'); \
   unsigned csr_read_only = get_field((which), 0xC00) == 3; \
   if (((write) && csr_read_only) || STATE.prv < csr_priv || mode_unsupported) \
-    throw trap_illegal_instruction(0); \
+    throw trap_illegal_instruction((uint32_t)insn_bits); \
   (which); })
 
 /* For debug only. This will fail if the native machine's float types are not IEEE */

--- a/riscv/insns/csrrc.h
+++ b/riscv/insns/csrrc.h
@@ -1,5 +1,5 @@
 bool write = insn.rs1() != 0;
-int csr = validate_csr(insn.csr(), write);
+int csr = validate_csr(insn.csr(), write, insn.bits());
 reg_t old = p->get_csr(csr);
 if (write) {
   p->set_csr(csr, old & ~RS1);

--- a/riscv/insns/csrrci.h
+++ b/riscv/insns/csrrci.h
@@ -1,5 +1,5 @@
 bool write = insn.rs1() != 0;
-int csr = validate_csr(insn.csr(), write);
+int csr = validate_csr(insn.csr(), write, insn.csr());
 reg_t old = p->get_csr(csr);
 if (write) {
   p->set_csr(csr, old & ~(reg_t)insn.rs1());

--- a/riscv/insns/csrrs.h
+++ b/riscv/insns/csrrs.h
@@ -1,5 +1,5 @@
 bool write = insn.rs1() != 0;
-int csr = validate_csr(insn.csr(), write);
+int csr = validate_csr(insn.csr(), write, insn.bits());
 reg_t old = p->get_csr(csr);
 if (write) {
   p->set_csr(csr, old | RS1);

--- a/riscv/insns/csrrsi.h
+++ b/riscv/insns/csrrsi.h
@@ -1,5 +1,5 @@
 bool write = insn.rs1() != 0;
-int csr = validate_csr(insn.csr(), write);
+int csr = validate_csr(insn.csr(), write, insn.bits());
 reg_t old = p->get_csr(csr);
 if (write) {
   p->set_csr(csr, old | insn.rs1());

--- a/riscv/insns/csrrw.h
+++ b/riscv/insns/csrrw.h
@@ -1,4 +1,4 @@
-int csr = validate_csr(insn.csr(), true);
+int csr = validate_csr(insn.csr(), true, insn.bits());
 reg_t old = p->get_csr(csr);
 p->set_csr(csr, RS1);
 WRITE_RD(sext_xlen(old));

--- a/riscv/insns/csrrwi.h
+++ b/riscv/insns/csrrwi.h
@@ -1,4 +1,4 @@
-int csr = validate_csr(insn.csr(), true);
+int csr = validate_csr(insn.csr(), true, insn.bits());
 reg_t old = p->get_csr(csr);
 p->set_csr(csr, insn.rs1());
 WRITE_RD(sext_xlen(old));

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -437,6 +437,11 @@ void processor_t::set_histogram(bool value)
 #endif
 }
 
+void processor_t::enable_tval_nz_csr()
+{
+  tval_nz_csr_enabled = true;
+}
+
 #ifdef RISCV_ENABLE_COMMITLOG
 void processor_t::enable_log_commits()
 {

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -254,6 +254,8 @@ public:
 
   void set_debug(bool value);
   void set_histogram(bool value);
+  void enable_tval_nz_csr();
+  bool get_tval_nz_csr_enabled() const { return tval_nz_csr_enabled; }
 #ifdef RISCV_ENABLE_COMMITLOG
   void enable_log_commits();
   bool get_log_commits_enabled() const { return log_commits_enabled; }
@@ -407,6 +409,7 @@ private:
   unsigned xlen;
   reg_t max_isa;
   std::string isa_string;
+  bool tval_nz_csr_enabled;
   bool histogram_enabled;
   bool log_commits_enabled;
   FILE *log_file;

--- a/spike_main/spike.cc
+++ b/spike_main/spike.cc
@@ -219,6 +219,7 @@ int main(int argc, char** argv)
     .support_haltgroups = true
   };
   std::vector<int> hartids;
+  bool tval_nz_csr = false;
 
   auto const hartids_parser = [&](const char *s) {
     std::string const str(s);
@@ -329,6 +330,8 @@ int main(int argc, char** argv)
                 [&](const char* s){log_commits = true;});
   parser.option(0, "log", 1,
                 [&](const char* s){log_path = s;});
+  parser.option(0, "tval-nz-csr", 0,
+                [&](const char* s){tval_nz_csr = true;});
 
   auto argv1 = parser.parse(argv);
   std::vector<std::string> htif_args(argv1, (const char*const*)argv + argc);
@@ -375,6 +378,7 @@ int main(int argc, char** argv)
     if (ic) s.get_core(i)->get_mmu()->register_memtracer(&*ic);
     if (dc) s.get_core(i)->get_mmu()->register_memtracer(&*dc);
     if (extension) s.get_core(i)->register_extension(extension());
+	if (tval_nz_csr) s.get_core(i)->enable_tval_nz_csr();
   }
 
   s.set_debug(debug);


### PR DESCRIPTION
The original Spike always returns zero in mtval/stval for illegal instruction traps that accessing CSR.
Here another choice is provided that returns instruction bits rather zero.
A command line parameter --tval-nz-csr is also added to turn this function on.