### PR TITLE
rvv: vstart register needs only lg2(VLEN) bits

### DIFF
--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -925,7 +925,7 @@ void processor_t::set_csr(int which, reg_t val)
       break;
     case CSR_VSTART:
       dirty_vs_state;
-      VU.vstart = val;
+      VU.vstart = val & (VU.get_vlen() - 1);
       break;
     case CSR_VXSAT:
       dirty_vs_state;


### PR DESCRIPTION
As section 3.6 says:
  The vstart CSR is defined to have only enough writable bits to hold
  the largest element index (one less than the maximum VLMAX) or lg2(VLEN) bits.

Signed-off-by: Chih-Min Chao <chihmin.chao@sifive.com>