### PR TITLE
[RFC] Implement snapshot feature for spike

### DIFF
--- a/configure
+++ b/configure
@@ -5126,7 +5126,24 @@ $as_echo "$as_me: configuring default subproject : spike_main" >&6;}
 
 $as_echo "#define SPIKE_MAIN_ENABLED /**/" >>confdefs.h
 
+    # Add subproject to our running list
 
+    subprojects="$subprojects snapshot"
+
+    # Process the subproject appropriately. If enabled add it to the
+    # $enabled_subprojects running shell variable, set a
+    # SUBPROJECT_ENABLED C define, and include the appropriate
+    # 'subproject.ac'.
+
+
+      { $as_echo "$as_me:${as_lineno-$LINENO}: configuring default subproject : snapshot" >&5
+$as_echo "$as_me: configuring default subproject : snapshot" >&6;}
+      ac_config_files="$ac_config_files snapshot.mk:snapshot/snapshot.mk.in"
+
+      enable_customext_sproj="yes"
+      subprojects_enabled="$subprojects_enabled snapshot"
+
+$as_echo "#define SNAPSHOT_ENABLED /**/" >>confdefs.h
 
 
 
@@ -5170,6 +5187,8 @@ ac_config_files="$ac_config_files riscv-customext.pc"
 ac_config_files="$ac_config_files riscv-fdt.pc"
 
 ac_config_files="$ac_config_files riscv-spike_main.pc"
+
+ac_config_files="$ac_config_files riscv-snapshot.pc"
 
 cat >confcache <<\_ACEOF
 # This file is a shell script that caches the results of configure
@@ -5877,6 +5896,7 @@ do
     "riscv-customext.pc") CONFIG_FILES="$CONFIG_FILES riscv-customext.pc" ;;
     "riscv-fdt.pc") CONFIG_FILES="$CONFIG_FILES riscv-fdt.pc" ;;
     "riscv-spike_main.pc") CONFIG_FILES="$CONFIG_FILES riscv-spike_main.pc" ;;
+    "riscv-snapshot.pc") CONFIG_FILES="$CONFIG_FILES riscv-snapshot.pc" ;;
 
   *) as_fn_error $? "invalid argument: \`$ac_config_target'" "$LINENO" 5;;
   esac

--- a/fesvr/elfloader.cc
+++ b/fesvr/elfloader.cc
@@ -15,7 +15,7 @@
 #include <vector>
 #include <map>
 
-std::map<std::string, uint64_t> load_elf(const char* fn, memif_t* memif, reg_t* entry,bool ramdump)
+std::map<std::string, uint64_t> load_elf(const char* fn, memif_t* memif, reg_t* entry, bool ramdump)
 {
   int fd = open(fn, O_RDONLY);
   struct stat s;

--- a/fesvr/elfloader.cc
+++ b/fesvr/elfloader.cc
@@ -15,7 +15,7 @@
 #include <vector>
 #include <map>
 
-std::map<std::string, uint64_t> load_elf(const char* fn, memif_t* memif, reg_t* entry)
+std::map<std::string, uint64_t> load_elf(const char* fn, memif_t* memif, reg_t* entry,bool ramdump)
 {
   int fd = open(fn, O_RDONLY);
   struct stat s;
@@ -82,11 +82,50 @@ std::map<std::string, uint64_t> load_elf(const char* fn, memif_t* memif, reg_t* 
       } \
     } \
   } while(0)
+  #define LOAD_ELF_NO_MEM(ehdr_t, phdr_t, shdr_t, sym_t, bswap) do { \
+    ehdr_t* eh = (ehdr_t*)buf; \
+    phdr_t* ph = (phdr_t*)(buf + bswap(eh->e_phoff)); \
+    *entry = bswap(eh->e_entry); \
+    assert(size >= bswap(eh->e_phoff) + bswap(eh->e_phnum)*sizeof(*ph)); \
+    shdr_t* sh = (shdr_t*)(buf + bswap(eh->e_shoff)); \
+    assert(size >= bswap(eh->e_shoff) + bswap(eh->e_shnum)*sizeof(*sh)); \
+    assert(bswap(eh->e_shstrndx) < bswap(eh->e_shnum)); \
+    assert(size >= bswap(sh[bswap(eh->e_shstrndx)].sh_offset) + bswap(sh[bswap(eh->e_shstrndx)].sh_size)); \
+    char *shstrtab = buf + bswap(sh[bswap(eh->e_shstrndx)].sh_offset);	\
+    unsigned strtabidx = 0, symtabidx = 0; \
+    for (unsigned i = 0; i < bswap(eh->e_shnum); i++) {		     \
+      unsigned max_len = bswap(sh[bswap(eh->e_shstrndx)].sh_size) - bswap(sh[i].sh_name); \
+      assert(bswap(sh[i].sh_name) < bswap(sh[bswap(eh->e_shstrndx)].sh_size));	\
+      assert(strnlen(shstrtab + bswap(sh[i].sh_name), max_len) < max_len); \
+      if (bswap(sh[i].sh_type) & SHT_NOBITS) continue; \
+      assert(size >= bswap(sh[i].sh_offset) + bswap(sh[i].sh_size)); \
+      if (strcmp(shstrtab + bswap(sh[i].sh_name), ".strtab") == 0) \
+        strtabidx = i; \
+      if (strcmp(shstrtab + bswap(sh[i].sh_name), ".symtab") == 0) \
+        symtabidx = i; \
+    } \
+    if (strtabidx && symtabidx) { \
+      char* strtab = buf + bswap(sh[strtabidx].sh_offset); \
+      sym_t* sym = (sym_t*)(buf + bswap(sh[symtabidx].sh_offset)); \
+      for (unsigned i = 0; i < bswap(sh[symtabidx].sh_size)/sizeof(sym_t); i++) { \
+        unsigned max_len = bswap(sh[strtabidx].sh_size) - bswap(sym[i].st_name); \
+        assert(bswap(sym[i].st_name) < bswap(sh[strtabidx].sh_size));	\
+        assert(strnlen(strtab + bswap(sym[i].st_name), max_len) < max_len); \
+        symbols[strtab + bswap(sym[i].st_name)] = bswap(sym[i].st_value); \
+      } \
+    } \
+  } while(0)
 
   if (IS_ELF32(*eh64))
-    LOAD_ELF(Elf32_Ehdr, Elf32_Phdr, Elf32_Shdr, Elf32_Sym, from_le);
+    if(!ramdump)
+      LOAD_ELF(Elf32_Ehdr, Elf32_Phdr, Elf32_Shdr, Elf32_Sym, from_le);
+    else
+      LOAD_ELF_NO_MEM(Elf32_Ehdr, Elf32_Phdr, Elf32_Shdr, Elf32_Sym, from_le);
   else
-    LOAD_ELF(Elf64_Ehdr, Elf64_Phdr, Elf64_Shdr, Elf64_Sym, from_le);
+    if(!ramdump)
+      LOAD_ELF(Elf64_Ehdr, Elf64_Phdr, Elf64_Shdr, Elf64_Sym, from_le);
+    else
+      LOAD_ELF_NO_MEM(Elf64_Ehdr, Elf64_Phdr, Elf64_Shdr, Elf64_Sym, from_le);
 
   munmap(buf, size);
 

--- a/fesvr/elfloader.h
+++ b/fesvr/elfloader.h
@@ -8,6 +8,6 @@
 #include <string>
 
 class memif_t;
-std::map<std::string, uint64_t> load_elf(const char* fn, memif_t* memif, reg_t* entry,bool ramdump=0);
+std::map<std::string, uint64_t> load_elf(const char* fn, memif_t* memif, reg_t* entry, bool ramdump = 0);
 
 #endif

--- a/fesvr/elfloader.h
+++ b/fesvr/elfloader.h
@@ -8,6 +8,6 @@
 #include <string>
 
 class memif_t;
-std::map<std::string, uint64_t> load_elf(const char* fn, memif_t* memif, reg_t* entry);
+std::map<std::string, uint64_t> load_elf(const char* fn, memif_t* memif, reg_t* entry,bool ramdump=0);
 
 #endif

--- a/fesvr/htif.cc
+++ b/fesvr/htif.cc
@@ -56,7 +56,7 @@ htif_t::htif_t(int argc, char** argv) : htif_t()
   register_devices();
 }
 
-htif_t::htif_t(const std::vector<std::string>& args) : htif_t()
+htif_t::htif_t(const std::vector<std::string>& args,bool dumped) : htif_t()
 {
   int argc = args.size() + 1;
   char * argv[argc];
@@ -65,6 +65,7 @@ htif_t::htif_t(const std::vector<std::string>& args) : htif_t()
     argv[i+1] = (char *) args[i].c_str();
   }
 
+  ramdump = dumped;
   parse_arguments(argc, argv);
   register_devices();
 }
@@ -78,12 +79,12 @@ htif_t::~htif_t()
 void htif_t::start()
 {
   if (!targs.empty() && targs[0] != "none")
-      load_program();
+      load_program(ramdump);
 
   reset();
 }
 
-std::map<std::string, uint64_t> htif_t::load_payload(const std::string& payload, reg_t* entry)
+std::map<std::string, uint64_t> htif_t::load_payload(const std::string& payload, reg_t* entry,bool ramdump)
 {
   std::string path;
   if (access(payload.c_str(), F_OK) == 0)
@@ -116,12 +117,12 @@ std::map<std::string, uint64_t> htif_t::load_payload(const std::string& payload,
     htif_t* htif;
   } preload_aware_memif(this);
 
-  return load_elf(path.c_str(), &preload_aware_memif, entry);
+  return load_elf(path.c_str(), &preload_aware_memif, entry,ramdump);
 }
 
-void htif_t::load_program()
+void htif_t::load_program(bool ramdump)
 {
-  std::map<std::string, uint64_t> symbols = load_payload(targs[0], &entry);
+  std::map<std::string, uint64_t> symbols = load_payload(targs[0], &entry,ramdump);
 
   if (symbols.count("tohost") && symbols.count("fromhost")) {
     tohost_addr = symbols["tohost"];
@@ -140,7 +141,7 @@ void htif_t::load_program()
   for (auto payload : payloads)
   {
     reg_t dummy_entry;
-    load_payload(payload, &dummy_entry);
+    load_payload(payload, &dummy_entry,ramdump);
   }
 }
 

--- a/fesvr/htif.cc
+++ b/fesvr/htif.cc
@@ -56,7 +56,7 @@ htif_t::htif_t(int argc, char** argv) : htif_t()
   register_devices();
 }
 
-htif_t::htif_t(const std::vector<std::string>& args,bool dumped) : htif_t()
+htif_t::htif_t(const std::vector<std::string>& args, bool dumped) : htif_t()
 {
   int argc = args.size() + 1;
   char * argv[argc];
@@ -84,7 +84,7 @@ void htif_t::start()
   reset();
 }
 
-std::map<std::string, uint64_t> htif_t::load_payload(const std::string& payload, reg_t* entry,bool ramdump)
+std::map<std::string, uint64_t> htif_t::load_payload(const std::string& payload, reg_t* entry, bool ramdump)
 {
   std::string path;
   if (access(payload.c_str(), F_OK) == 0)
@@ -117,12 +117,12 @@ std::map<std::string, uint64_t> htif_t::load_payload(const std::string& payload,
     htif_t* htif;
   } preload_aware_memif(this);
 
-  return load_elf(path.c_str(), &preload_aware_memif, entry,ramdump);
+  return load_elf(path.c_str(), &preload_aware_memif, entry, ramdump);
 }
 
 void htif_t::load_program(bool ramdump)
 {
-  std::map<std::string, uint64_t> symbols = load_payload(targs[0], &entry,ramdump);
+  std::map<std::string, uint64_t> symbols = load_payload(targs[0], &entry, ramdump);
 
   if (symbols.count("tohost") && symbols.count("fromhost")) {
     tohost_addr = symbols["tohost"];
@@ -141,7 +141,7 @@ void htif_t::load_program(bool ramdump)
   for (auto payload : payloads)
   {
     reg_t dummy_entry;
-    load_payload(payload, &dummy_entry,ramdump);
+    load_payload(payload, &dummy_entry, ramdump);
   }
 }
 

--- a/fesvr/htif.h
+++ b/fesvr/htif.h
@@ -15,7 +15,7 @@ class htif_t : public chunked_memif_t
  public:
   htif_t();
   htif_t(int argc, char** argv);
-  htif_t(const std::vector<std::string>& args);
+  htif_t(const std::vector<std::string>& args,bool ramdump = 0);
   virtual ~htif_t();
 
   virtual void start();
@@ -37,8 +37,8 @@ class htif_t : public chunked_memif_t
   virtual size_t chunk_align() = 0;
   virtual size_t chunk_max_size() = 0;
 
-  virtual std::map<std::string, uint64_t> load_payload(const std::string& payload, reg_t* entry);
-  virtual void load_program();
+  virtual std::map<std::string, uint64_t> load_payload(const std::string& payload, reg_t* entry,bool ramdump);
+  virtual void load_program(bool ramdump);
   virtual void idle() {}
 
   const std::vector<std::string>& host_args() { return hargs; }
@@ -66,6 +66,7 @@ class htif_t : public chunked_memif_t
   addr_t fromhost_addr;
   int exitcode;
   bool stopped;
+  bool ramdump;
 
   device_list_t device_list;
   syscall_t syscall_proxy;

--- a/fesvr/htif.h
+++ b/fesvr/htif.h
@@ -15,7 +15,7 @@ class htif_t : public chunked_memif_t
  public:
   htif_t();
   htif_t(int argc, char** argv);
-  htif_t(const std::vector<std::string>& args,bool ramdump = 0);
+  htif_t(const std::vector<std::string>& args, bool ramdump = 0);
   virtual ~htif_t();
 
   virtual void start();
@@ -37,7 +37,7 @@ class htif_t : public chunked_memif_t
   virtual size_t chunk_align() = 0;
   virtual size_t chunk_max_size() = 0;
 
-  virtual std::map<std::string, uint64_t> load_payload(const std::string& payload, reg_t* entry,bool ramdump);
+  virtual std::map<std::string, uint64_t> load_payload(const std::string& payload, reg_t* entry, bool ramdump);
   virtual void load_program(bool ramdump);
   virtual void idle() {}
 

--- a/riscv-snapshot.pc.in
+++ b/riscv-snapshot.pc.in
@@ -1,0 +1,10 @@
+prefix=@prefix@
+exec_prefix=@prefix@
+libdir=${prefix}/@libdir@
+includedir=${prefix}/@includedir@
+
+Name: riscv-snapshot
+Description: RISC-V Snapshot Plugin
+Version: git
+Libs: -Wl,-rpath,${libdir} -L${libdir} -lsnapshot
+Cflags: -I${includedir}

--- a/riscv/interactive.cc
+++ b/riscv/interactive.cc
@@ -139,7 +139,7 @@ void sim_t::interactive_help(const std::string& cmd, const std::vector<std::stri
     "r [count]                         Alias for run\n"
     "rs [count]                      # Resume silent execution (until CTRL+C, or [count] insns)\n"
     "quit                            # End the simulation\n"
-    "ramdump <path>                  # save ramdump file to <path>\n"
+    "snapshot <path>                 # save snapshot file to <path>\n"
     "q                                 Alias for quit\n"
     "help                            # This screen!\n"
     "h                                 Alias for help\n"
@@ -438,5 +438,5 @@ void sim_t::interactive_snapshot(const std::string& cmd, const std::vector<std::
 
   snapshot_t snapshot(this);
   snapshot.save(args[0].c_str());
-  fprintf(stderr, "ramdump file saved to %s\n",args[0].c_str());
+  fprintf(stderr, "snapshot file saved to %s\n",args[0].c_str());
 }

--- a/riscv/interactive.cc
+++ b/riscv/interactive.cc
@@ -18,6 +18,7 @@
 #include <vector>
 #include <algorithm>
 #include <math.h>
+#include "snapshot.h"
 
 DECLARE_TRAP(-1, interactive)
 
@@ -82,6 +83,7 @@ void sim_t::interactive()
   funcs["q"] = funcs["quit"];
   funcs["help"] = &sim_t::interactive_help;
   funcs["h"] = funcs["help"];
+  funcs["snapshot"] = &sim_t::interactive_snapshot;
 
   while (!done())
   {
@@ -137,6 +139,7 @@ void sim_t::interactive_help(const std::string& cmd, const std::vector<std::stri
     "r [count]                         Alias for run\n"
     "rs [count]                      # Resume silent execution (until CTRL+C, or [count] insns)\n"
     "quit                            # End the simulation\n"
+    "ramdump <path>                  # save ramdump file to <path>\n"
     "q                                 Alias for quit\n"
     "help                            # This screen!\n"
     "h                                 Alias for help\n"
@@ -425,4 +428,15 @@ void sim_t::interactive_until(const std::string& cmd, const std::vector<std::str
     set_procs_debug(noisy);
     step(1);
   }
+}
+void sim_t::interactive_snapshot(const std::string& cmd, const std::vector<std::string>& args)
+{
+  if(args.size() < 1)  {
+    fprintf(stderr, "illegal argument!\n" );
+    return;
+  }
+
+  snapshot_t snapshot(this);
+  snapshot.save(args[0].c_str());
+  fprintf(stderr, "ramdump file saved to %s\n",args[0].c_str());
 }

--- a/riscv/sim.cc
+++ b/riscv/sim.cc
@@ -35,8 +35,8 @@ sim_t::sim_t(const char* isa, const char* priv, const char* varch,
              std::vector<int> const hartids,
              const debug_module_config_t &dm_config,
              const char *log_path,
-             bool dtb_enabled, const char *dtb_file,bool ramdump)
-  : htif_t(args,ramdump),
+             bool dtb_enabled, const char *dtb_file, bool ramdump)
+  : htif_t(args, ramdump),
     mems(mems),
     plugin_devices(plugin_devices),
     procs(std::max(nprocs, size_t(1))),

--- a/riscv/sim.cc
+++ b/riscv/sim.cc
@@ -35,8 +35,8 @@ sim_t::sim_t(const char* isa, const char* priv, const char* varch,
              std::vector<int> const hartids,
              const debug_module_config_t &dm_config,
              const char *log_path,
-             bool dtb_enabled, const char *dtb_file)
-  : htif_t(args),
+             bool dtb_enabled, const char *dtb_file,bool ramdump)
+  : htif_t(args,ramdump),
     mems(mems),
     plugin_devices(plugin_devices),
     procs(std::max(nprocs, size_t(1))),
@@ -324,4 +324,13 @@ void sim_t::write_chunk(addr_t taddr, size_t len, const void* src)
 void sim_t::proc_reset(unsigned id)
 {
   debug_module.proc_reset(id);
+}
+
+reg_t sim_t::get_clint() {
+  reg_t clint_base;
+  if (fdt_parse_clint((void *)dtb.c_str(), &clint_base, "riscv,clint0")) {
+    return clint_base;
+  } else {
+    return CLINT_BASE;
+  }
 }

--- a/riscv/sim.h
+++ b/riscv/sim.h
@@ -30,7 +30,7 @@ public:
         std::vector<std::pair<reg_t, abstract_device_t*>> plugin_devices,
         const std::vector<std::string>& args, const std::vector<int> hartids,
         const debug_module_config_t &dm_config, const char *log_path,
-        bool dtb_enabled, const char *dtb_file,bool ramdump);
+        bool dtb_enabled, const char *dtb_file, bool ramdump);
   ~sim_t();
 
   // run the simulation to completion

--- a/riscv/sim.h
+++ b/riscv/sim.h
@@ -30,7 +30,7 @@ public:
         std::vector<std::pair<reg_t, abstract_device_t*>> plugin_devices,
         const std::vector<std::string>& args, const std::vector<int> hartids,
         const debug_module_config_t &dm_config, const char *log_path,
-        bool dtb_enabled, const char *dtb_file);
+        bool dtb_enabled, const char *dtb_file,bool ramdump);
   ~sim_t();
 
   // run the simulation to completion
@@ -53,6 +53,8 @@ public:
   const char* get_dts() { if (dts.empty()) reset(); return dts.c_str(); }
   processor_t* get_core(size_t i) { return procs.at(i); }
   unsigned nprocs() const { return procs.size(); }
+  std::vector<std::pair<reg_t, mem_t*>> get_mems() {return mems; }
+  reg_t get_clint();
 
   // Callback for processors to let the simulation know they were reset.
   void proc_reset(unsigned id);
@@ -114,6 +116,7 @@ private:
   void interactive_until(const std::string& cmd, const std::vector<std::string>& args, bool noisy);
   void interactive_until_silent(const std::string& cmd, const std::vector<std::string>& args);
   void interactive_until_noisy(const std::string& cmd, const std::vector<std::string>& args);
+  void interactive_snapshot(const std::string& cmd, const std::vector<std::string>& args);
   reg_t get_reg(const std::vector<std::string>& args);
   freg_t get_freg(const std::vector<std::string>& args);
   reg_t get_mem(const std::vector<std::string>& args);

--- a/snapshot/ramdump.cc
+++ b/snapshot/ramdump.cc
@@ -1,0 +1,37 @@
+#include "snapshot.h"
+#include <fstream>
+using namespace std;
+bool snapshot_t::ramdump(ofstream &out) 
+{
+  for (auto &mem : mems) {
+    out.write((char *)&mem.first, sizeof(mem.first)); // base address
+    size_t size = (*mem.second).size();
+    out.write((char *)&size, sizeof(size_t));
+    out.write((char *)mem.second->contents(), size);
+  }
+  return true;
+}
+std::vector<std::pair<reg_t, mem_t *>> getmem(const char *start,
+                                              const char *end) 
+{
+  std::vector<std::pair<reg_t, mem_t *>> res;
+  char *buf = (char *)start;
+  while (buf < end) {
+    reg_t base;
+    assert(buf + sizeof(reg_t) <= end);
+    memcpy((char *)&base, buf, sizeof(reg_t));
+    buf += sizeof(reg_t);
+    size_t size;
+    assert(buf + sizeof(size_t) <= end);
+    memcpy((char *)&size, buf, sizeof(size_t));
+    buf += sizeof(size_t);
+    mem_t *mem1 = new mem_t(size);
+    char *data = mem1->contents();
+    assert(buf + size <= end);
+    memcpy(data, buf, size);
+    buf += size;
+    res.push_back(std::make_pair(base, mem1));
+    assert(buf <= end);
+  }
+  return res;
+}

--- a/snapshot/snapshot.cc
+++ b/snapshot/snapshot.cc
@@ -1,0 +1,73 @@
+#include "snapshot.h"
+#include <fstream>
+#define MTIMECMP_BASE	0x4000
+#define MTIME_BASE	0xbff8
+using namespace std;
+std::vector<std::pair<reg_t, mem_t*>> snapshot_t::mem_restore() {return mems; }
+state_t * snapshot_t::get_state(int i) {return cpu_states[i]; }
+int snapshot_t::get_procs(){return procs;}
+snapshot_t::snapshot_t(const char * path) 
+{
+  int fd = open(path, O_RDONLY);
+  struct stat s;
+  assert(fd != -1);
+  if (fstat(fd, &s) < 0)
+    abort();
+  size_t size = s.st_size;
+  char* buf = (char*)mmap(NULL, size, PROT_READ, MAP_PRIVATE, fd, 0);
+  assert(buf != MAP_FAILED);
+  close(fd);
+  assert(size >= sizeof(Snapshot_Head));
+  const Snapshot_Head* sh = (const Snapshot_Head*)buf;
+  procs = sh->procs;
+  mems = getmem((const char *)(buf + sh->memoff),(const char *)(buf + sh->memend));
+  uint64_t offset = sh->cpuoff;
+  std::vector<state_t*> res;
+  for(int i = 0; i < procs; i++) {
+    char * tmp = (char *)calloc(1,sizeof(state_t));
+    memcpy(tmp,buf+offset,sizeof(state_t));
+    offset += sizeof(state_t);
+    res.push_back((state_t *)tmp);
+  }
+  cpu_states = res;
+  
+  memcpy(&mtime, buf + sh->cloff, sizeof(mtime_t));
+  mtimecmp_t tmp;
+  for(int i = 0; i < procs; i++) {
+    memcpy(&tmp, buf + sh->cloff + sizeof(mtime_t) + i * sizeof(mtimecmp_t),sizeof(mtimecmp_t));
+    mtimecmp.push_back(tmp);
+  }
+  close(fd);
+}
+snapshot_t::snapshot_t(sim_t * sim) 
+{
+  mems = sim->get_mems();
+  procs = sim->nprocs();
+  for(int i = 0; i < procs; i++) {
+    cpu_states.push_back(sim->get_core(i)->get_state());
+    mtimecmp.push_back(sim->get_core(0)->get_mmu()->load_uint64(sim->get_clint() + MTIMECMP_BASE + (uint64_t)sizeof(mtimecmp_t) * i));
+  }
+  mtime = sim->get_core(0)->get_mmu()->load_uint64(sim->get_clint() + MTIME_BASE);
+}
+void snapshot_t::save(const char * path) {
+  Snapshot_Head sh;
+  ofstream out;
+  out.open(path,ios::binary);
+  out.write((char *)&sh,sizeof(Snapshot_Head));
+  sh.memoff = out.tellp();
+  ramdump(out);
+  sh.memend = out.tellp();
+  sh.cpuoff=out.tellp();
+  sh.procs = procs;
+  for(int i = 0; i < procs; i++)
+    out.write((char *)cpu_states[i],sizeof(state_t));
+  sh.cloff=out.tellp();
+  //out.write((char *)&clint,sizeof(clint_t));
+  out.write((char *)&mtime,sizeof(mtime_t));
+  for(int i = 0; i < procs; i++) {
+    out.write((char *)&mtimecmp[i],sizeof(mtimecmp_t));
+  }
+  out.seekp(0, ios::beg);
+  out.write((char *)&sh,sizeof(Snapshot_Head));
+  out.close();
+}

--- a/snapshot/snapshot.h
+++ b/snapshot/snapshot.h
@@ -1,0 +1,46 @@
+#ifndef SNAP_H
+#define SNAP_H
+#include "device.h"
+#include "mmu.h"
+#include "sim.h"
+#include <assert.h>
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+typedef struct {
+  uint64_t memoff;
+  uint64_t memend;
+  uint64_t cpuoff;
+  uint64_t cloff;
+  int procs;
+} Snapshot_Head;
+
+std::vector<std::pair<reg_t, mem_t *>> getmem(const char *start,
+                                              const char *end);
+class snapshot_t 
+{
+public:
+  snapshot_t(const char *path);
+  snapshot_t(sim_t *sim);
+  snapshot_t() {}
+  void save(const char *path);
+  bool ramdump(std::ofstream &out);
+  std::vector<std::pair<reg_t, mem_t *>> mem_restore();
+  state_t *get_state(int i);
+  int get_procs();
+  typedef uint64_t mtime_t;
+  typedef uint64_t mtimecmp_t;
+  std::vector<mtimecmp_t> mtimecmp;
+  mtime_t mtime;
+
+private:
+  std::vector<std::pair<reg_t, mem_t *>> mems;
+  std::vector<state_t *> cpu_states;
+  // clint_t clint;
+
+  int procs;
+};
+
+#endif

--- a/snapshot/snapshot.mk.in
+++ b/snapshot/snapshot.mk.in
@@ -1,0 +1,12 @@
+snapshot_subproject_deps = \
+	riscv \
+
+snapshot_install_prog_srcs = \
+
+
+snapshot_hdrs = \
+    snapshot.h \
+
+snapshot_srcs = \
+	ramdump.cc \
+	snapshot.cc \

--- a/spike_main/spike.cc
+++ b/spike_main/spike.cc
@@ -54,6 +54,7 @@ static void help(int exit_code = 1)
   fprintf(stderr, "  --disable-dtb         Don't write the device tree blob into memory\n");
   fprintf(stderr, "  --initrd=<path>       Load kernel initrd into memory\n");
   fprintf(stderr, "  --real-time-clint     Increment clint time at real-time rate\n");
+  fprintf(stderr, "  --snapshot=<path>     Load a snapshot to start from the breakpoint\n");
   fprintf(stderr, "  --dm-progsize=<words> Progsize for the debug module [default 2]\n");
   fprintf(stderr, "  --dm-sba=<bits>       Debug bus master supports up to "
       "<bits> wide accesses [default 0]\n");

--- a/spike_main/spike_main.mk.in
+++ b/spike_main/spike_main.mk.in
@@ -3,6 +3,7 @@ spike_main_subproject_deps = \
 	fesvr \
 	softfloat \
 	riscv \
+	snapshot \
 
 spike_main_install_prog_srcs = \
 	spike.cc \


### PR DESCRIPTION
we implement snapshot feature which can save the runtime states of spike machine.

usage:

save snapshot: in interactive mode， use "snapshot " to save snapshot file to path, e.g. by inputing "snapshot a" will create a snapshot file ./a

load snapshot: use the optional "--snapshot=" command line option.

note: although loaded snapshot file, you still should specify which ELF file to load(to provide boot args, and some symbols in ELF, it won't be loaded actually)