### PR TITLE
Add option to dissable implicit ebreak in program buffer

### DIFF
--- a/riscv/debug_module.cc
+++ b/riscv/debug_module.cc
@@ -34,7 +34,7 @@ static unsigned field_width(unsigned n)
 debug_module_t::debug_module_t(sim_t *sim, const debug_module_config_t &config) :
   nprocs(sim->nprocs()),
   config(config),
-  program_buffer_bytes(4 + 4*config.progbufsize),
+  program_buffer_bytes(config.support_impebreak ? 4 : 0 + 4*config.progbufsize),
   debug_progbuf_start(debug_data_start - program_buffer_bytes),
   debug_abstract_start(debug_progbuf_start - debug_abstract_size*4),
   custom_base(0),
@@ -56,11 +56,14 @@ debug_module_t::debug_module_t(sim_t *sim, const debug_module_config_t &config) 
 
   memset(debug_rom_flags, 0, sizeof(debug_rom_flags));
   memset(program_buffer, 0, program_buffer_bytes);
-  program_buffer[4*config.progbufsize] = ebreak();
-  program_buffer[4*config.progbufsize+1] = ebreak() >> 8;
-  program_buffer[4*config.progbufsize+2] = ebreak() >> 16;
-  program_buffer[4*config.progbufsize+3] = ebreak() >> 24;
   memset(dmdata, 0, sizeof(dmdata));
+
+  if (config.support_impebreak) {
+    program_buffer[4*config.progbufsize] = ebreak();
+    program_buffer[4*config.progbufsize+1] = ebreak() >> 8;
+    program_buffer[4*config.progbufsize+2] = ebreak() >> 16;
+    program_buffer[4*config.progbufsize+3] = ebreak() >> 24;
+  }
 
   write32(debug_rom_whereto, 0,
           jal(ZERO, debug_abstract_start - DEBUG_ROM_WHERETO));
@@ -87,7 +90,7 @@ void debug_module_t::reset()
   dmcontrol = {0};
 
   dmstatus = {0};
-  dmstatus.impebreak = true;
+  dmstatus.impebreak = config.support_impebreak;
   dmstatus.authenticated = !config.require_authentication;
   dmstatus.version = 2;
 

--- a/riscv/debug_module.h
+++ b/riscv/debug_module.h
@@ -18,6 +18,7 @@ typedef struct {
     bool support_hasel;
     bool support_abstract_csr_access;
     bool support_haltgroups;
+    bool support_impebreak;
 } debug_module_config_t;
 
 typedef struct {

--- a/spike_main/spike.cc
+++ b/spike_main/spike.cc
@@ -65,6 +65,7 @@ static void help(int exit_code = 1)
   fprintf(stderr, "  --dm-no-hasel         Debug module supports hasel\n");
   fprintf(stderr, "  --dm-no-abstract-csr  Debug module won't support abstract to authenticate\n");
   fprintf(stderr, "  --dm-no-halt-groups   Debug module won't support halt groups\n");
+  fprintf(stderr, "  --dm-no-impebreak     Debug module won't support implicit ebreak in program buffer\n");
 
   exit(exit_code);
 }
@@ -221,7 +222,8 @@ int main(int argc, char** argv)
     .abstract_rti = 0,
     .support_hasel = true,
     .support_abstract_csr_access = true,
-    .support_haltgroups = true
+    .support_haltgroups = true,
+    .support_impebreak = true
   };
   std::vector<int> hartids;
 
@@ -318,6 +320,8 @@ int main(int argc, char** argv)
   });
   parser.option(0, "dm-progsize", 1,
       [&](const char* s){dm_config.progbufsize = atoi(s);});
+  parser.option(0, "dm-no-impebreak", 0,
+      [&](const char* s){dm_config.support_impebreak = false;});
   parser.option(0, "dm-sba", 1,
       [&](const char* s){dm_config.max_bus_master_bits = atoi(s);});
   parser.option(0, "dm-auth", 0,


### PR DESCRIPTION
This can be useful e.g. when testing OpenOCD