### PR TITLE
rvv: fix int type is not enough to do shift

### DIFF
--- a/riscv/insns/vrem_vv.h
+++ b/riscv/insns/vrem_vv.h
@@ -3,7 +3,7 @@ VI_VV_LOOP
 ({
   if (vs1 == 0)
     vd = vs2;
-  else if(vs2 == -(1 << (sew - 1)) && vs1 == -1)
+  else if(vs2 == -(((intmax_t)1) << (sew - 1)) && vs1 == -1)
     vd = 0;
   else {
     vd = vs2 % vs1;

--- a/riscv/insns/vrem_vx.h
+++ b/riscv/insns/vrem_vx.h
@@ -3,7 +3,7 @@ VI_VX_LOOP
 ({
   if (rs1 == 0)
     vd = vs2;
-  else if (vs2 == -(1 << (sew - 1)) && rs1 == -1)
+  else if (vs2 == -(((intmax_t)1) << (sew - 1)) && rs1 == -1)
     vd = 0;
   else
     vd = vs2 % rs1;


### PR DESCRIPTION
int can only represent 32 bit in lp64 model

when sew is greater than 32, the behavior is undefined