### PR TITLE
Improved log

### DIFF
--- a/fesvr/htif.h
+++ b/fesvr/htif.h
@@ -49,6 +49,9 @@ class htif_t : public chunked_memif_t
   // range to memory, because it has already been loaded through a sideband
   virtual bool is_address_preloaded(addr_t taddr, size_t len) { return false; }
 
+  // Given an address, return symbol from addr2symbol map
+  const char* get_symbol(uint64_t addr);
+
  private:
   void parse_arguments(int argc, char ** argv);
   void register_devices();
@@ -74,6 +77,9 @@ class htif_t : public chunked_memif_t
   std::vector<std::string> payloads;
 
   const std::vector<std::string>& target_args() { return targs; }
+
+  std::map<std::string, uint64_t> symbols;
+  std::map<uint64_t, std::string> addr2symbol;
 
   friend class memif_t;
   friend class syscall_t;

--- a/riscv/execute.cc
+++ b/riscv/execute.cc
@@ -59,6 +59,11 @@ static void commit_log_print_value(FILE *log_file, int width, uint64_t val)
   commit_log_print_value(log_file, width, &val);
 }
 
+const char* processor_t::get_symbol(uint64_t addr)
+{
+  return sim->get_symbol(addr);
+}
+
 static void commit_log_print_insn(processor_t *p, reg_t pc, insn_t insn)
 {
   FILE *log_file = p->get_log_file();
@@ -70,6 +75,9 @@ static void commit_log_print_insn(processor_t *p, reg_t pc, insn_t insn)
   int xlen = p->get_state()->last_inst_xlen;
   int flen = p->get_state()->last_inst_flen;
 
+  // print core id on all lines so it is easy to grep
+  uint64_t id = p->get_csr(CSR_MHARTID);
+  fprintf(log_file, "core%4ld: ", id);
   fprintf(log_file, "%1d ", priv);
   commit_log_print_value(log_file, xlen, pc);
   fprintf(log_file, " (");

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -743,6 +743,13 @@ void processor_t::disasm(insn_t insn)
 {
   uint64_t bits = insn.bits() & ((1ULL << (8 * insn_length(insn.bits()))) - 1);
   if (last_pc != state.pc || last_bits != bits) {
+
+    const char* sym = get_symbol(state.pc);
+    if (sym != nullptr)
+    {
+      fprintf(log_file, "core %3d: >>>>  %s\n", id, sym);
+    }
+
     if (executions != 1) {
       fprintf(log_file, "core %3d: Executed %" PRIx64 " times\n", id, executions);
     }

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -409,6 +409,8 @@ public:
   void set_pmp_num(reg_t pmp_num);
   void set_pmp_granularity(reg_t pmp_granularity);
 
+  const char* get_symbol(uint64_t addr);
+
 private:
   simif_t* sim;
   mmu_t* mmu; // main memory is always accessed via the mmu

--- a/riscv/sim.cc
+++ b/riscv/sim.cc
@@ -294,6 +294,11 @@ char* sim_t::addr_to_mem(reg_t addr) {
   return NULL;
 }
 
+const char* sim_t::get_symbol(uint64_t addr)
+{
+  return htif_t::get_symbol(addr);
+}
+
 // htif
 
 void sim_t::reset()

--- a/riscv/sim.h
+++ b/riscv/sim.h
@@ -94,6 +94,8 @@ private:
   void make_dtb();
   void set_rom();
 
+  const char* get_symbol(uint64_t addr);
+
   // presents a prompt for introspection into the simulation
   void interactive();
 

--- a/riscv/simif.h
+++ b/riscv/simif.h
@@ -16,6 +16,8 @@ public:
   virtual bool mmio_store(reg_t addr, size_t len, const uint8_t* bytes) = 0;
   // Callback for processors to let the simulation know they were reset.
   virtual void proc_reset(unsigned id) = 0;
+
+  virtual const char* get_symbol(uint64_t addr) = 0;
 };
 
 #endif


### PR DESCRIPTION
Hi,
This pull request adds the following features to improves the trace:

1. Ability to  load multiple elfs. The symbols of all the elfs are collected but only the last elf load takes effect.
2. All trace lines prepended with "core   x: ". This makes it easier to "grep" out per core activity.
3. PC is looked up in the symbol table to indicate the start of a function or any other label making it easier to figure out what a given cpu is upto without a look up in the disassembly file.

I have attached part of a trace file.

[sample_trace.txt](https://github.com/riscv/riscv-isa-sim/files/5254751/sample_trace.txt)

