### PR TITLE
Add core id to lines generated by --log-commits

### DIFF
--- a/riscv/execute.cc
+++ b/riscv/execute.cc
@@ -72,7 +72,7 @@ static void commit_log_print_insn(processor_t *p, reg_t pc, insn_t insn)
 
   // print core id on all lines so it is easy to grep
   uint64_t id = p->get_csr(CSR_MHARTID);
-  fprintf(log_file, "core%4ld: ", id);
+  fprintf(log_file, "core%4" PRId64 ": ", id);
 
   fprintf(log_file, "%1d ", priv);
   commit_log_print_value(log_file, xlen, pc);

--- a/riscv/execute.cc
+++ b/riscv/execute.cc
@@ -70,6 +70,10 @@ static void commit_log_print_insn(processor_t *p, reg_t pc, insn_t insn)
   int xlen = p->get_state()->last_inst_xlen;
   int flen = p->get_state()->last_inst_flen;
 
+  // print core id on all lines so it is easy to grep
+  uint64_t id = p->get_csr(CSR_MHARTID);
+  fprintf(log_file, "core%4ld: ", id);
+
   fprintf(log_file, "%1d ", priv);
   commit_log_print_value(log_file, xlen, pc);
   fprintf(log_file, " (");


### PR DESCRIPTION
Add core id lines generated by --log-commit.
This lets us separate log lines based on cpu_id 