### PR TITLE
Adding symbol lookup when --enable-commitlog is enabled

### DIFF
--- a/fesvr/htif.cc
+++ b/fesvr/htif.cc
@@ -142,6 +142,25 @@ void htif_t::load_program()
     reg_t dummy_entry;
     load_payload(payload, &dummy_entry);
   }
+
+   for (auto i : symbols)
+   {
+     auto it = addr2symbol.find(i.second);
+     if ( it == addr2symbol.end())
+       addr2symbol[i.second] = i.first;
+   }
+
+   return;
+}
+
+const char* htif_t::get_symbol(uint64_t addr)
+{
+  auto it = addr2symbol.find(addr);
+
+  if(it == addr2symbol.end())
+      return nullptr;
+
+  return it->second.c_str();
 }
 
 void htif_t::stop()

--- a/fesvr/htif.h
+++ b/fesvr/htif.h
@@ -49,6 +49,9 @@ class htif_t : public chunked_memif_t
   // range to memory, because it has already been loaded through a sideband
   virtual bool is_address_preloaded(addr_t taddr, size_t len) { return false; }
 
+  // Given an address, return symbol from addr2symbol map
+  const char* get_symbol(uint64_t addr);
+
  private:
   void parse_arguments(int argc, char ** argv);
   void register_devices();
@@ -74,6 +77,8 @@ class htif_t : public chunked_memif_t
   std::vector<std::string> payloads;
 
   const std::vector<std::string>& target_args() { return targs; }
+
+  std::map<uint64_t, std::string> addr2symbol;
 
   friend class memif_t;
   friend class syscall_t;

--- a/riscv/execute.cc
+++ b/riscv/execute.cc
@@ -59,6 +59,11 @@ static void commit_log_print_value(FILE *log_file, int width, uint64_t val)
   commit_log_print_value(log_file, width, &val);
 }
 
+const char* processor_t::get_symbol(uint64_t addr)
+{
+  return sim->get_symbol(addr);
+}
+
 static void commit_log_print_insn(processor_t *p, reg_t pc, insn_t insn)
 {
   FILE *log_file = p->get_log_file();

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -743,6 +743,15 @@ void processor_t::disasm(insn_t insn)
 {
   uint64_t bits = insn.bits() & ((1ULL << (8 * insn_length(insn.bits()))) - 1);
   if (last_pc != state.pc || last_bits != bits) {
+
+#ifdef RISCV_ENABLE_COMMITLOG
+    const char* sym = get_symbol(state.pc);
+    if (sym != nullptr)
+    {
+      fprintf(log_file, "core %3d: >>>>  %s\n", id, sym);
+    }
+#endif
+
     if (executions != 1) {
       fprintf(log_file, "core %3d: Executed %" PRIx64 " times\n", id, executions);
     }

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -409,6 +409,10 @@ public:
   void set_pmp_num(reg_t pmp_num);
   void set_pmp_granularity(reg_t pmp_granularity);
 
+#ifdef RISCV_ENABLE_COMMITLOG
+  const char* get_symbol(uint64_t addr);
+#endif
+
 private:
   simif_t* sim;
   mmu_t* mmu; // main memory is always accessed via the mmu

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -409,9 +409,7 @@ public:
   void set_pmp_num(reg_t pmp_num);
   void set_pmp_granularity(reg_t pmp_granularity);
 
-#ifdef RISCV_ENABLE_COMMITLOG
   const char* get_symbol(uint64_t addr);
-#endif
 
 private:
   simif_t* sim;

--- a/riscv/sim.cc
+++ b/riscv/sim.cc
@@ -294,12 +294,10 @@ char* sim_t::addr_to_mem(reg_t addr) {
   return NULL;
 }
 
-#ifdef RISCV_ENABLE_COMMITLOG
 const char* sim_t::get_symbol(uint64_t addr)
 {
   return htif_t::get_symbol(addr);
 }
-#endif
 
 // htif
 

--- a/riscv/sim.cc
+++ b/riscv/sim.cc
@@ -294,6 +294,13 @@ char* sim_t::addr_to_mem(reg_t addr) {
   return NULL;
 }
 
+#ifdef RISCV_ENABLE_COMMITLOG
+const char* sim_t::get_symbol(uint64_t addr)
+{
+  return htif_t::get_symbol(addr);
+}
+#endif
+
 // htif
 
 void sim_t::reset()

--- a/riscv/sim.h
+++ b/riscv/sim.h
@@ -94,9 +94,7 @@ private:
   void make_dtb();
   void set_rom();
 
-#ifdef RISCV_ENABLE_COMMITLOG
   const char* get_symbol(uint64_t addr);
-#endif
 
   // presents a prompt for introspection into the simulation
   void interactive();

--- a/riscv/sim.h
+++ b/riscv/sim.h
@@ -94,6 +94,10 @@ private:
   void make_dtb();
   void set_rom();
 
+#ifdef RISCV_ENABLE_COMMITLOG
+  const char* get_symbol(uint64_t addr);
+#endif
+
   // presents a prompt for introspection into the simulation
   void interactive();
 

--- a/riscv/simif.h
+++ b/riscv/simif.h
@@ -16,6 +16,10 @@ public:
   virtual bool mmio_store(reg_t addr, size_t len, const uint8_t* bytes) = 0;
   // Callback for processors to let the simulation know they were reset.
   virtual void proc_reset(unsigned id) = 0;
+
+#ifdef RISCV_ENABLE_COMMITLOG
+  virtual const char* get_symbol(uint64_t addr) = 0;
+#endif
 };
 
 #endif

--- a/riscv/simif.h
+++ b/riscv/simif.h
@@ -17,9 +17,8 @@ public:
   // Callback for processors to let the simulation know they were reset.
   virtual void proc_reset(unsigned id) = 0;
 
-#ifdef RISCV_ENABLE_COMMITLOG
   virtual const char* get_symbol(uint64_t addr) = 0;
-#endif
+
 };
 
 #endif


### PR DESCRIPTION
The PR add symbol lookup when --enable-commitlog is enabled.
This makes debug easier.

The output looks like this:
core   0: >>>>  at_zero_end
core   0: 0x000000008000000c (0x000060b3) or      ra, zero, zero
3 0x000000008000000c (0x000060b3) x 1 0x0000000000000000
core   0: 0x0000000080000010 (0x00006133) or      sp, zero, zero
3 0x0000000080000010 (0x00006133) x 2 0x0000000000000000


An earlier PR adds core id to all log-commits line