### PR TITLE
Update Makefile.in to install correct pc target

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -339,7 +339,7 @@ install_hdrs += $$(addprefix $(src_dir)/$(1)/, $$($(2)_install_hdrs))
 install_libs += $$(if $$($(2)_install_lib),lib$(1).a,)
 install_libs += $$(if $$($(2)_install_shared_lib),lib$(1).so,)
 install_exes += $$($(2)_install_prog_exes)
-install_pcs  += $$(if $$($(2)_install_lib),riscv-$(1).pc,)
+install_pcs  += $$(if $$($(2)_install_lib),riscv-fesvr.pc,)
 
 endef
 

--- a/disasm/disasm.mk.in
+++ b/disasm/disasm.mk.in
@@ -3,3 +3,5 @@ disasm_CFLAGS = -fPIC
 disasm_srcs = \
   disasm.cc \
 	regnames.cc \
+
+disasm_install_lib = yes


### PR DESCRIPTION
The `install_pcs` target was failing because it was trying to install all pc files which is not present anymore.