### PR TITLE
decode: only return meaningful bits for insn_t

### DIFF
--- a/riscv/decode.h
+++ b/riscv/decode.h
@@ -77,7 +77,7 @@ class insn_t
 public:
   insn_t() = default;
   insn_t(insn_bits_t bits) : b(bits) {}
-  insn_bits_t bits() { return b; }
+  insn_bits_t bits() { return b & ~((UINT64_MAX) << (length() * 8)); }
   int length() { return insn_length(b); }
   int64_t i_imm() { return int64_t(b) >> 20; }
   int64_t shamt() { return x(20, 6); }


### PR DESCRIPTION
The original insn_t has the upper part with extended signed bit when the
instruction is fetched from mmu_t::refill_icache. It makes the tval of
illegal instruction exception wrong.

ref:
As the spec 3.1.17 says,

    after an illegal instruction trap, mtval will contain the shortest of:
     1. the actual faulting instruction
     2. the first ILEN bits of the faulting instruction
     3. the first XLEN bits of the faulting instruction
    The value loaded into mtval is right-justified and all unused upper bits
    are cleared to zero.

Signed-off-by: Chih-Min Chao <chihmin.chao@sifive.com>