### PR TITLE
rvv: sstatus.SD needs to include vs dirty state

### DIFF
--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -1420,7 +1420,8 @@ reg_t processor_t::get_csr(int which, insn_t insn, bool write, bool peek)
                  | SSTATUS_XS | SSTATUS_SUM | SSTATUS_MXR | SSTATUS_UXL;
       reg_t sstatus = state.mstatus & mask;
       if ((sstatus & SSTATUS_FS) == SSTATUS_FS ||
-          (sstatus & SSTATUS_XS) == SSTATUS_XS)
+          (sstatus & SSTATUS_XS) == SSTATUS_XS ||
+          (sstatus & SSTATUS_VS) == SSTATUS_VS)
         sstatus |= (xlen == 32 ? SSTATUS32_SD : SSTATUS64_SD);
       ret(sstatus);
     }


### PR DESCRIPTION
Signed-off-by: Chih-Min Chao <chihmin.chao@sifive.com>