### PR TITLE
Fix VSSTATUS bits updation

### DIFF
--- a/riscv/encoding.h
+++ b/riscv/encoding.h
@@ -44,7 +44,7 @@
 #define SSTATUS64_SD        0x8000000000000000
 
 #define SSTATUS_VS_MASK     (SSTATUS_SIE | SSTATUS_SPIE | \
-                             SSTATUS_SPP | SSTATUS_SUM | \
+                             SSTATUS_SPP | SSTATUS_FS | SSTATUS_SUM | \
                              SSTATUS_MXR | SSTATUS_UXL)
 
 #define HSTATUS_VSXL        0x300000000


### PR DESCRIPTION
This patch fixes VSSTATUS bits updations as follows:
1. set_csr() should not allow writs to VSSTATUS.SD bit instead
   VSSTATUS.SD bit should be derived again after VSSTATUS is updated
2. set_virt() should copy FS, VS and XS bits when transitioning
   from virt=on (VS/VU-mode) to virt=off (HS/M-mode)

Signed-off-by: Anup Patel <anup.patel@wdc.com>