### PR TITLE
reduce sig_len constraint to 4 bytes

### DIFF
--- a/fesvr/htif.cc
+++ b/fesvr/htif.cc
@@ -174,7 +174,7 @@ void htif_t::stop()
     assert(sigs && "can't open signature file!");
     sigs << std::setfill('0') << std::hex;
 
-    const addr_t incr = 16;
+    const addr_t incr = 4;
     assert(sig_len % incr == 0);
     for (addr_t i = 0; i < sig_len; i += incr)
     {

--- a/fesvr/htif.cc
+++ b/fesvr/htif.cc
@@ -316,9 +316,9 @@ void htif_t::parse_arguments(int argc, char ** argv)
           c = HTIF_LONG_OPTIONS_OPTIND + 4;
           optarg = optarg + 9;
         }
-        else if(arg.find("+size=")==0){
+        else if(arg.find("+granularity=")==0){
             c = HTIF_LONG_OPTIONS_OPTIND + 5;
-            optarg = optarg + 6;
+            optarg = optarg + 13;
         }
         else if (arg.find("+permissive-off") == 0) {
           if (opterr)

--- a/fesvr/htif.cc
+++ b/fesvr/htif.cc
@@ -316,9 +316,9 @@ void htif_t::parse_arguments(int argc, char ** argv)
           c = HTIF_LONG_OPTIONS_OPTIND + 4;
           optarg = optarg + 9;
         }
-        else if(arg.find("+granularity=")==0){
+        else if(arg.find("+signature-granularity=")==0){
             c = HTIF_LONG_OPTIONS_OPTIND + 5;
-            optarg = optarg + 13;
+            optarg = optarg + 23;
         }
         else if (arg.find("+permissive-off") == 0) {
           if (opterr)

--- a/fesvr/htif.h
+++ b/fesvr/htif.h
@@ -101,8 +101,8 @@ class htif_t : public chunked_memif_t
        +rfb=DISPLAY          to be accessible on 5900 + DISPLAY (default = 0)\n\
       --signature=FILE     Write torture test signature to FILE\n\
        +signature=FILE\n\
-      --granularity=VAL           Size of each line in signature.\n\
-       +granularity=VAL\n\
+      --signature-granularity=VAL           Size of each line in signature.\n\
+       +signature-granularity=VAL\n\
       --chroot=PATH        Use PATH as location of syscall-servicing binaries\n\
        +chroot=PATH\n\
       --payload=PATH       Load PATH memory as an additional ELF payload\n\
@@ -124,7 +124,7 @@ TARGET (RISC-V BINARY) OPTIONS\n\
 {"signature", required_argument, 0, HTIF_LONG_OPTIONS_OPTIND + 2 },     \
 {"chroot",    required_argument, 0, HTIF_LONG_OPTIONS_OPTIND + 3 },     \
 {"payload",   required_argument, 0, HTIF_LONG_OPTIONS_OPTIND + 4 },     \
-{"granularity",    optional_argument, 0, HTIF_LONG_OPTIONS_OPTIND + 5 },     \
+{"signature-granularity",    optional_argument, 0, HTIF_LONG_OPTIONS_OPTIND + 5 },     \
 {0, 0, 0, 0}
 
 #endif // __HTIF_H

--- a/fesvr/htif.h
+++ b/fesvr/htif.h
@@ -63,7 +63,7 @@ class htif_t : public chunked_memif_t
   std::vector<std::string> hargs;
   std::vector<std::string> targs;
   std::string sig_file;
-  int line_size;
+  unsigned int line_size;
   addr_t sig_addr; // torture
   addr_t sig_len; // torture
   addr_t tohost_addr;

--- a/fesvr/htif.h
+++ b/fesvr/htif.h
@@ -101,8 +101,8 @@ class htif_t : public chunked_memif_t
        +rfb=DISPLAY          to be accessible on 5900 + DISPLAY (default = 0)\n\
       --signature=FILE     Write torture test signature to FILE\n\
        +signature=FILE\n\
-      --size=VAL           Size of each line in signature.\n\
-       +size=VAL\n\
+      --granularity=VAL           Size of each line in signature.\n\
+       +granularity=VAL\n\
       --chroot=PATH        Use PATH as location of syscall-servicing binaries\n\
        +chroot=PATH\n\
       --payload=PATH       Load PATH memory as an additional ELF payload\n\
@@ -124,7 +124,7 @@ TARGET (RISC-V BINARY) OPTIONS\n\
 {"signature", required_argument, 0, HTIF_LONG_OPTIONS_OPTIND + 2 },     \
 {"chroot",    required_argument, 0, HTIF_LONG_OPTIONS_OPTIND + 3 },     \
 {"payload",   required_argument, 0, HTIF_LONG_OPTIONS_OPTIND + 4 },     \
-{"size",    optional_argument, 0, HTIF_LONG_OPTIONS_OPTIND + 5 },     \
+{"granularity",    optional_argument, 0, HTIF_LONG_OPTIONS_OPTIND + 5 },     \
 {0, 0, 0, 0}
 
 #endif // __HTIF_H

--- a/fesvr/htif.h
+++ b/fesvr/htif.h
@@ -63,6 +63,7 @@ class htif_t : public chunked_memif_t
   std::vector<std::string> hargs;
   std::vector<std::string> targs;
   std::string sig_file;
+  int line_size;
   addr_t sig_addr; // torture
   addr_t sig_len; // torture
   addr_t tohost_addr;
@@ -100,6 +101,8 @@ class htif_t : public chunked_memif_t
        +rfb=DISPLAY          to be accessible on 5900 + DISPLAY (default = 0)\n\
       --signature=FILE     Write torture test signature to FILE\n\
        +signature=FILE\n\
+      --size=VAL           Size of each line in signature.\n\
+       +size=VAL\n\
       --chroot=PATH        Use PATH as location of syscall-servicing binaries\n\
        +chroot=PATH\n\
       --payload=PATH       Load PATH memory as an additional ELF payload\n\
@@ -121,6 +124,7 @@ TARGET (RISC-V BINARY) OPTIONS\n\
 {"signature", required_argument, 0, HTIF_LONG_OPTIONS_OPTIND + 2 },     \
 {"chroot",    required_argument, 0, HTIF_LONG_OPTIONS_OPTIND + 3 },     \
 {"payload",   required_argument, 0, HTIF_LONG_OPTIONS_OPTIND + 4 },     \
+{"size",    optional_argument, 0, HTIF_LONG_OPTIONS_OPTIND + 5 },     \
 {0, 0, 0, 0}
 
 #endif // __HTIF_H


### PR DESCRIPTION
Spike currently asserts that the signature length should always be a multiple of 16-bytes. However, the compliance suite has agreed to upon the signature being a multiple ot 4-bytes. This prevents some of the tests to run on spike since it fails the assertion.

The proposed change fixes this issue and reduces the assertion to 4 bytes.