### PR TITLE
fixed mtval update for breakpoint instructions

### DIFF
--- a/riscv/insns/c_ebreak.h
+++ b/riscv/insns/c_ebreak.h
@@ -1,2 +1,2 @@
 require_extension('C');
-throw trap_breakpoint(0);
+throw trap_breakpoint(pc);

--- a/riscv/insns/ebreak.h
+++ b/riscv/insns/ebreak.h
@@ -1,1 +1,1 @@
-throw trap_breakpoint(0);
+throw trap_breakpoint(pc);


### PR DESCRIPTION
This in regards to the recent clarity in spec regarding ebreaks and mtval : https://github.com/riscv/riscv-isa-manual/issues/600

Mtval is now updated with va of the ebreak instruction.