### PR TITLE
Selective mmu mode

### DIFF
--- a/riscv/decode.h
+++ b/riscv/decode.h
@@ -236,6 +236,7 @@ private:
 #define require_rv64 require(xlen == 64)
 #define require_rv32 require(xlen == 32)
 #define require_extension(s) require(p->supports_extension(s))
+#define require_impl(s) require(p->supports_impl(s))
 #define require_fp require((STATE.mstatus & MSTATUS_FS) != 0)
 #define require_accelerator require((STATE.mstatus & MSTATUS_XS) != 0)
 

--- a/riscv/dts.cc
+++ b/riscv/dts.cc
@@ -225,6 +225,21 @@ static int fdt_get_node_addr_size(void *fdt, int node, reg_t *addr,
   return 0;
 }
 
+int fdt_get_offset(void *fdt, const char *field)
+{
+  return fdt_path_offset(fdt, field);
+}
+
+int fdt_get_first_subnode(void *fdt, int node)
+{
+  return fdt_first_subnode(fdt, node);
+}
+
+int fdt_get_next_subnode(void *fdt, int node)
+{
+  return fdt_next_subnode(fdt, node);
+}
+
 int fdt_parse_clint(void *fdt, reg_t *clint_addr,
                     const char *compatible)
 {
@@ -270,6 +285,29 @@ int fdt_parse_pmp_alignment(void *fdt, reg_t *pmp_align,
                               "riscv,pmpgranularity");
   if (rc < 0 || !pmp_align)
     return -ENODEV;
+
+  return 0;
+}
+
+int fdt_parse_mmu_type(void *fdt, int cpu_offset, char *mmu_type)
+{
+  int len;
+  const void *prop;
+
+  if (!fdt || cpu_offset < 0)
+    return -EINVAL;
+
+  prop = fdt_getprop(fdt, cpu_offset, "device_type", &len);
+  if (!prop || !len)
+    return -EINVAL;
+  if (strncmp ((char *)prop, "cpu", strlen ("cpu")))
+    return -EINVAL;
+
+  prop = fdt_getprop(fdt, cpu_offset, "mmu-type", &len);
+  if (!prop || !len)
+    return -EINVAL;
+
+  strcpy(mmu_type, (char *)prop);
 
   return 0;
 }

--- a/riscv/dts.h
+++ b/riscv/dts.h
@@ -14,10 +14,15 @@ std::string make_dts(size_t insns_per_rtc_tick, size_t cpu_hz,
 
 std::string dts_compile(const std::string& dts);
 
+int fdt_get_offset(void *fdt, const char *field);
+int fdt_get_first_subnode(void *fdt, int node);
+int fdt_get_next_subnode(void *fdt, int node);
+
 int fdt_parse_clint(void *fdt, reg_t *clint_addr,
                     const char *compatible);
 int fdt_parse_pmp_num(void *fdt, reg_t *pmp_num,
                       const char *compatible);
 int fdt_parse_pmp_alignment(void *fdt, reg_t *pmp_align,
                             const char *compatible);
+int fdt_parse_mmu_type(void *fdt, int cpu_offset, char *mmu_type);
 #endif

--- a/riscv/insns/sfence_vma.h
+++ b/riscv/insns/sfence_vma.h
@@ -1,4 +1,5 @@
 require_extension('S');
+require_impl(IMPL_MMU);
 if (STATE.v) {
   if (STATE.prv == PRV_U || get_field(STATE.hstatus, HSTATUS_VTVM))
     require_novirt();

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -805,6 +805,21 @@ int processor_t::paddr_bits()
   return max_xlen == 64 ? 50 : 34;
 }
 
+reg_t processor_t::cal_satp(reg_t val) const
+{
+  reg_t reg_val = 0;
+  reg_t rv64_ppn_mask = (reg_t(1) << (MAX_PADDR_BITS - PGSHIFT)) - 1;
+  mmu->flush_tlb();
+  if (max_xlen == 32)
+    reg_val = val & (SATP32_PPN | SATP32_MODE);
+
+  if (max_xlen == 64 && (get_field(val, SATP64_MODE) == SATP_MODE_OFF ||
+                         get_field(val, SATP64_MODE) == SATP_MODE_SV39 ||
+                         get_field(val, SATP64_MODE) == SATP_MODE_SV48))
+    reg_val = val & (SATP64_PPN | SATP64_MODE | rv64_ppn_mask);
+
+  return reg_val;
+}
 void processor_t::set_csr(int which, reg_t val)
 {
 #if defined(RISCV_ENABLE_COMMITLOG)
@@ -1001,22 +1016,12 @@ void processor_t::set_csr(int which, reg_t val)
       state.mie = (state.mie & ~mask) | (val & mask);
       break;
     }
-    case CSR_SATP: {
-      reg_t reg_val = 0;
-      reg_t rv64_ppn_mask = (reg_t(1) << (MAX_PADDR_BITS - PGSHIFT)) - 1;
-      mmu->flush_tlb();
-      if (max_xlen == 32)
-        reg_val = val & (SATP32_PPN | SATP32_MODE);
-      if (max_xlen == 64 && (get_field(val, SATP64_MODE) == SATP_MODE_OFF ||
-                             get_field(val, SATP64_MODE) == SATP_MODE_SV39 ||
-                             get_field(val, SATP64_MODE) == SATP_MODE_SV48))
-        reg_val = val & (SATP64_MODE | (SATP64_PPN & rv64_ppn_mask));
+    case CSR_SATP:
       if (state.v)
-        state.vsatp = reg_val;
+        state.vsatp = cal_satp(val);
       else
-        state.satp = reg_val;
+        state.satp = cal_satp(val);
       break;
-    }
     case CSR_SEPC:
       if (state.v)
         state.vsepc = val & ~(reg_t)1;
@@ -1171,19 +1176,9 @@ void processor_t::set_csr(int which, reg_t val)
       state.mip = (state.mip & ~mask) | ((val << 1) & mask);
       break;
     }
-    case CSR_VSATP: {
-      reg_t reg_val = 0;
-      reg_t rv64_ppn_mask = (reg_t(1) << (MAX_PADDR_BITS - PGSHIFT)) - 1;
-      mmu->flush_tlb();
-      if (max_xlen == 32)
-        reg_val = val & (SATP32_PPN | SATP32_MODE);
-      if (max_xlen == 64 && (get_field(val, SATP64_MODE) == SATP_MODE_OFF ||
-                             get_field(val, SATP64_MODE) == SATP_MODE_SV39 ||
-                             get_field(val, SATP64_MODE) == SATP_MODE_SV48))
-        reg_val = val & (SATP64_MODE | (SATP64_PPN & rv64_ppn_mask));
-      state.vsatp = reg_val;
+    case CSR_VSATP:
+      state.vsatp = cal_satp(val);
       break;
-    }
     case CSR_TSELECT:
       if (val < state.num_triggers) {
         state.tselect = val;

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -27,7 +27,7 @@ processor_t::processor_t(const char* isa, const char* priv, const char* varch,
   : debug(false), halt_request(HR_NONE), sim(sim), ext(NULL), id(id), xlen(0),
   histogram_enabled(false), log_commits_enabled(false),
   log_file(log_file), halt_on_reset(halt_on_reset),
-  extension_table(256, false), last_pc(1), executions(1)
+  extension_table(256, false), impl_table(256, false), last_pc(1), executions(1)
 {
   VU.p = this;
 
@@ -45,6 +45,12 @@ processor_t::processor_t(const char* isa, const char* priv, const char* varch,
 
   set_pmp_granularity(1 << PMP_SHIFT);
   set_pmp_num(state.max_pmp);
+
+  if (max_xlen == 32)
+    set_mmu_capability(IMPL_MMU_SV32);
+  else if (max_xlen == 64)
+    set_mmu_capability(IMPL_MMU_SV48);
+
   reset();
 }
 
@@ -500,6 +506,31 @@ void processor_t::set_pmp_granularity(reg_t gran) {
   }
 
   lg_pmp_granularity = ctz(gran);
+}
+
+void processor_t::set_mmu_capability(int cap)
+{
+  switch (cap) {
+    case IMPL_MMU_SV32:
+      set_impl(cap, true);
+      set_impl(IMPL_MMU, true);
+      break;
+    case IMPL_MMU_SV39:
+      set_impl(cap, true);
+      set_impl(IMPL_MMU, true);
+      break;
+    case IMPL_MMU_SV48:
+      set_impl(cap, true);
+      set_impl(IMPL_MMU_SV39, true);
+      set_impl(IMPL_MMU, true);
+      break;
+    default:
+      set_impl(IMPL_MMU_SV32, false);
+      set_impl(IMPL_MMU_SV39, false);
+      set_impl(IMPL_MMU_SV48, false);
+      set_impl(IMPL_MMU, false);
+      break;
+  }
 }
 
 void processor_t::take_interrupt(reg_t pending_interrupts)

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -470,6 +470,7 @@ private:
   void build_opcode_map();
   void register_base_instructions();
   insn_func_t decode_insn(insn_t insn);
+  reg_t cal_satp(reg_t val) const;
 
   // Track repeated executions for processor_t::disasm()
   uint64_t last_pc, last_bits, executions;

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -245,6 +245,14 @@ typedef enum {
   EXT_ZVEDIV,
 } isa_extension_t;
 
+typedef enum {
+  IMPL_MMU_SV32,
+  IMPL_MMU_SV39,
+  IMPL_MMU_SV48,
+  IMPL_MMU_BARE,
+  IMPL_MMU,
+} impl_extension_t;
+
 // Count number of contiguous 1 bits starting from the LSB.
 static int cto(reg_t val)
 {
@@ -291,6 +299,10 @@ public:
       return ((state.misa >> (ext - 'A')) & 1);
     else
       return extension_table[ext];
+  }
+  void set_impl(uint8_t impl, bool val) { impl_table[impl] = val; }
+  bool supports_impl(uint8_t impl) const {
+    return impl_table[impl];
   }
   reg_t pc_alignment_mask() {
     return ~(reg_t)(supports_extension('C') ? 0 : 2);
@@ -409,6 +421,7 @@ public:
 
   void set_pmp_num(reg_t pmp_num);
   void set_pmp_granularity(reg_t pmp_granularity);
+  void set_mmu_capability(int cap);
 
   const char* get_symbol(uint64_t addr);
 
@@ -428,6 +441,7 @@ private:
   FILE *log_file;
   bool halt_on_reset;
   std::vector<bool> extension_table;
+  std::vector<bool> impl_table;
   
 
   std::vector<insn_desc_t> instructions;


### PR DESCRIPTION
Use "mmu-type" in dts to specified implemented  mmu mode 

If there is no dts
   rv32 -> sv32 
   rv64 -> sv39,sv48
else if there is an dts having :mmu-type" field
   "riscv,bare" -> no mmu
   "riscv,sv32" -> sv32
   "riscv,sv39" -> sv39
   "riscv,sv48" -> sv39,sv48

    