### PR TITLE
Pmp per core

### DIFF
--- a/riscv/dts.cc
+++ b/riscv/dts.cc
@@ -225,6 +225,24 @@ static int fdt_get_node_addr_size(void *fdt, int node, reg_t *addr,
   return 0;
 }
 
+static int check_cpu_node(void *fdt, int cpu_offset)
+{
+  int len;
+  const void *prop;
+
+  if (!fdt || cpu_offset < 0)
+    return -EINVAL;
+
+  prop = fdt_getprop(fdt, cpu_offset, "device_type", &len);
+  if (!prop || !len)
+    return -EINVAL;
+  if (strncmp ((char *)prop, "cpu", strlen ("cpu")))
+    return -EINVAL;
+
+  return 0;
+}
+
+
 int fdt_get_offset(void *fdt, const char *field)
 {
   return fdt_path_offset(fdt, field);
@@ -291,17 +309,11 @@ int fdt_parse_pmp_alignment(void *fdt, reg_t *pmp_align,
 
 int fdt_parse_mmu_type(void *fdt, int cpu_offset, char *mmu_type)
 {
-  int len;
+  int len, rc;
   const void *prop;
 
-  if (!fdt || cpu_offset < 0)
-    return -EINVAL;
-
-  prop = fdt_getprop(fdt, cpu_offset, "device_type", &len);
-  if (!prop || !len)
-    return -EINVAL;
-  if (strncmp ((char *)prop, "cpu", strlen ("cpu")))
-    return -EINVAL;
+  if ((rc = check_cpu_node(fdt, cpu_offset)) < 0)
+    return rc;
 
   prop = fdt_getprop(fdt, cpu_offset, "mmu-type", &len);
   if (!prop || !len)

--- a/riscv/dts.cc
+++ b/riscv/dts.cc
@@ -274,15 +274,14 @@ int fdt_parse_clint(void *fdt, reg_t *clint_addr,
   return 0;
 }
 
-int fdt_parse_pmp_num(void *fdt, reg_t *pmp_num, const char *compatible)
+int fdt_parse_pmp_num(void *fdt, int cpu_offset, reg_t *pmp_num)
 {
-  int nodeoffset, rc;
+  int rc;
 
-  nodeoffset = fdt_node_offset_by_compatible(fdt, -1, compatible);
-  if (nodeoffset < 0)
-    return nodeoffset;
+  if ((rc = check_cpu_node(fdt, cpu_offset)) < 0)
+    return rc;
 
-  rc = fdt_get_node_addr_size(fdt, nodeoffset, pmp_num, NULL,
+  rc = fdt_get_node_addr_size(fdt, cpu_offset, pmp_num, NULL,
                               "riscv,pmpregions");
   if (rc < 0 || !pmp_num)
     return -ENODEV;
@@ -290,16 +289,14 @@ int fdt_parse_pmp_num(void *fdt, reg_t *pmp_num, const char *compatible)
   return 0;
 }
 
-int fdt_parse_pmp_alignment(void *fdt, reg_t *pmp_align,
-                            const char *compatible)
+int fdt_parse_pmp_alignment(void *fdt, int cpu_offset, reg_t *pmp_align)
 {
-  int nodeoffset, rc;
+  int rc;
 
-  nodeoffset = fdt_node_offset_by_compatible(fdt, -1, compatible);
-  if (nodeoffset < 0)
-    return nodeoffset;
+  if ((rc = check_cpu_node(fdt, cpu_offset)) < 0)
+    return rc;
 
-  rc = fdt_get_node_addr_size(fdt, nodeoffset, pmp_align, NULL,
+  rc = fdt_get_node_addr_size(fdt, cpu_offset, pmp_align, NULL,
                               "riscv,pmpgranularity");
   if (rc < 0 || !pmp_align)
     return -ENODEV;

--- a/riscv/dts.h
+++ b/riscv/dts.h
@@ -20,9 +20,7 @@ int fdt_get_next_subnode(void *fdt, int node);
 
 int fdt_parse_clint(void *fdt, reg_t *clint_addr,
                     const char *compatible);
-int fdt_parse_pmp_num(void *fdt, reg_t *pmp_num,
-                      const char *compatible);
-int fdt_parse_pmp_alignment(void *fdt, reg_t *pmp_align,
-                            const char *compatible);
+int fdt_parse_pmp_num(void *fdt, int cpu_offset, reg_t *pmp_num);
+int fdt_parse_pmp_alignment(void *fdt, int cpu_offset, reg_t *pmp_align);
 int fdt_parse_mmu_type(void *fdt, int cpu_offset, char *mmu_type);
 #endif


### PR DESCRIPTION
The original implementation uses the value in the first core to configure all cores. The patch makes pmp configured by each core's setting in DTS