### PR TITLE
Fix missing include in elfloader.cc

### DIFF
--- a/fesvr/elfloader.cc
+++ b/fesvr/elfloader.cc
@@ -10,6 +10,7 @@
 #include <sys/mman.h>
 #include <assert.h>
 #include <unistd.h>
+#include <stdexcept>
 #include <stdlib.h>
 #include <stdio.h>
 #include <vector>


### PR DESCRIPTION
Build wasn't working out-of-the-box for me on Ubuntu 20.10 with GCC 10.2.0. Including `stdexcept` fixed the issue.