### PR TITLE
Fix #607: Add a core parameter to the interactive str command

### DIFF
--- a/riscv/interactive.cc
+++ b/riscv/interactive.cc
@@ -125,7 +125,7 @@ void sim_t::interactive_help(const std::string& cmd, const std::vector<std::stri
     "vreg <core> [reg]               # Display vector [reg] (all if omitted) in <core>\n"
     "pc <core>                       # Show current PC in <core>\n"
     "mem <hex addr>                  # Show contents of physical memory\n"
-    "str <hex addr>                  # Show NUL-terminated C string\n"
+    "str <core> <hex addr>           # Show NUL-terminated C string at <hex addr> in core <core>\n"
     "until reg <core> <reg> <val>    # Stop when <reg> in <core> hits <val>\n"
     "until pc <core> <val>           # Stop when PC in <core> hits <val>\n"
     "untiln pc <core> <val>          # Run noisy and stop when PC in <core> hits <val>\n"
@@ -363,13 +363,22 @@ void sim_t::interactive_mem(const std::string& cmd, const std::vector<std::strin
 
 void sim_t::interactive_str(const std::string& cmd, const std::vector<std::string>& args)
 {
-  if(args.size() != 1)
+  if(args.size() != 1 && args.size() != 2)
     throw trap_interactive();
 
-  reg_t addr = strtol(args[0].c_str(),NULL,16);
+  std::string addr_str = args[0];
+  mmu_t* mmu = debug_mmu;
+  if(args.size() == 2)
+  {
+    processor_t *p = get_core(args[0]);
+    mmu = p->get_mmu();
+    addr_str = args[1];
+  }
+
+  reg_t addr = strtol(addr_str.c_str(),NULL,16);
 
   char ch;
-  while((ch = debug_mmu->load_uint8(addr++)))
+  while((ch = mmu->load_uint8(addr++)))
     putchar(ch);
 
   putchar('\n');

--- a/riscv/sim.cc
+++ b/riscv/sim.cc
@@ -351,9 +351,13 @@ char* sim_t::addr_to_mem(reg_t addr) {
   if (!paddr_ok(addr))
     return NULL;
   auto desc = bus.find_device(addr);
-  if (auto mem = dynamic_cast<mem_t*>(desc.second))
+  if (auto mem = dynamic_cast<mem_t*>(desc.second)) {
     if (addr - desc.first < mem->size())
       return mem->contents() + (addr - desc.first);
+  } else if (auto mem = dynamic_cast<clint_t*>(desc.second)) {
+    fprintf(stdout, "clint_t\n");
+    return NULL;
+  }
   return NULL;
 }
 


### PR DESCRIPTION
Add a core parameter to the interactive str command. This makes it
possible for the spike user to specify the device whose memory contains
the NUL-terminated string to be printed.