### PR TITLE
Fix Issue #609

### DIFF
--- a/riscv/sim.cc
+++ b/riscv/sim.cc
@@ -351,13 +351,9 @@ char* sim_t::addr_to_mem(reg_t addr) {
   if (!paddr_ok(addr))
     return NULL;
   auto desc = bus.find_device(addr);
-  if (auto mem = dynamic_cast<mem_t*>(desc.second)) {
+  if (auto mem = dynamic_cast<mem_t*>(desc.second))
     if (addr - desc.first < mem->size())
       return mem->contents() + (addr - desc.first);
-  } else if (auto mem = dynamic_cast<clint_t*>(desc.second)) {
-    fprintf(stdout, "clint_t\n");
-    return NULL;
-  }
   return NULL;
 }
 


### PR DESCRIPTION
Fix Issue #609 where extraneous debugging output was added when the user
invoked any simulation operation that involved `addr_to_mem`.