### PR TITLE
Preserve abstract s0 write if progbuf excepts.

### DIFF
--- a/riscv/debug_module.cc
+++ b/riscv/debug_module.cc
@@ -661,6 +661,17 @@ bool debug_module_t::perform_abstract_command()
             return true;
         }
 
+        if (regno == 0x1000 + S0 && write) {
+          /*
+           * The exception handler starts out be restoring dscratch to s0,
+           * which was saved before executing the abstract memory region. Since
+           * we just wrote s0, also make sure to write that same value to
+           * dscratch in case an exception occurs in a program buffer that
+           * might be executed later.
+           */
+          write32(debug_abstract, i++, csrw(S0, CSR_DSCRATCH0));
+        }
+
       } else if (regno >= 0x1020 && regno < 0x1040) {
         unsigned fprnum = regno - 0x1020;
 


### PR DESCRIPTION
When a single abstract command writes s0 and executes a program buffer
that leads to an exception, the value of s0 should still persist. The
fact that it did not masked the following bug in OpenOCD:
https://github.com/riscv/riscv-openocd/issues/559