### PR TITLE
Check and use proc variable in MMU emulation

### DIFF
--- a/riscv/mmu.cc
+++ b/riscv/mmu.cc
@@ -54,7 +54,7 @@ reg_t mmu_t::translate(reg_t addr, reg_t len, access_type type, uint32_t xlate_f
     return addr;
 
   bool mxr = get_field(proc->state.mstatus, MSTATUS_MXR);
-  bool virt = proc->state.v;
+  bool virt = (proc) ? proc->state.v : false;
   reg_t mode = proc->state.prv;
   if (type != FETCH) {
     if (!proc->state.debug_mode && get_field(proc->state.mstatus, MSTATUS_MPRV)) {
@@ -153,7 +153,7 @@ void mmu_t::load_slow_path(reg_t addr, reg_t len, uint8_t* bytes, uint32_t xlate
     else
       refill_tlb(addr, paddr, host_addr, LOAD);
   } else if (!mmio_load(paddr, len, bytes)) {
-    throw trap_load_access_fault(proc->state.v, addr, 0, 0);
+    throw trap_load_access_fault((proc) ? proc->state.v : false, addr, 0, 0);
   }
 
   if (!matched_trigger) {
@@ -182,7 +182,7 @@ void mmu_t::store_slow_path(reg_t addr, reg_t len, const uint8_t* bytes, uint32_
     else
       refill_tlb(addr, paddr, host_addr, STORE);
   } else if (!mmio_store(paddr, len, bytes)) {
-    throw trap_store_access_fault(proc->state.v, addr, 0, 0);
+    throw trap_store_access_fault((proc) ? proc->state.v : false, addr, 0, 0);
   }
 }
 

--- a/riscv/mmu.h
+++ b/riscv/mmu.h
@@ -253,7 +253,7 @@ public:
     if (auto host_addr = sim->addr_to_mem(paddr))
       load_reservation_address = refill_tlb(vaddr, paddr, host_addr, LOAD).target_offset + vaddr;
     else
-      throw trap_load_access_fault(proc->state.v, vaddr, 0, 0); // disallow LR to I/O space
+      throw trap_load_access_fault((proc) ? proc->state.v : false, vaddr, 0, 0); // disallow LR to I/O space
   }
 
   inline bool check_load_reservation(reg_t vaddr, size_t size)
@@ -265,7 +265,7 @@ public:
     if (auto host_addr = sim->addr_to_mem(paddr))
       return load_reservation_address == refill_tlb(vaddr, paddr, host_addr, STORE).target_offset + vaddr;
     else
-      throw trap_store_access_fault(proc->state.v, vaddr, 0, 0); // disallow SC to I/O space
+      throw trap_store_access_fault((proc) ? proc->state.v : false, vaddr, 0, 0); // disallow SC to I/O space
   }
 
   static const reg_t ICACHE_ENTRIES = 1024;

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -539,7 +539,7 @@ void processor_t::take_interrupt(reg_t pending_interrupts)
   enabled_interrupts = pending_interrupts & ~state.mideleg & -m_enabled;
   if (enabled_interrupts == 0) {
     // HS-ints have higher priority over VS-ints
-    deleg = state.mideleg & ~MIP_VS_MASK;
+    deleg = state.mideleg & ~state.hideleg;
     status = (state.v) ? state.vsstatus : state.mstatus;
     hsie = get_field(status, MSTATUS_SIE);
     hs_enabled = state.prv < PRV_S || (state.prv == PRV_S && hsie);


### PR DESCRIPTION
Don't blindly use proc variable in MMU emulation