### PR TITLE
Move `byteorder` to utils directory (fix #622)

### DIFF
--- a/config.h.in
+++ b/config.h.in
@@ -108,6 +108,9 @@
 /* Define to 1 if you have the ANSI C header files. */
 #undef STDC_HEADERS
 
+/* Define if subproject MCPPBS_SPROJ_NORM is enabled */
+#undef UTIL_ENABLED
+
 /* Define WORDS_BIGENDIAN to 1 if your processor stores words with the most
    significant byte first (like Motorola and SPARC, unlike Intel). */
 #if defined AC_APPLE_UNIVERSAL_BUILD

--- a/configure
+++ b/configure
@@ -4634,6 +4634,51 @@ fi
 
     # Add subproject to our running list
 
+    subprojects="$subprojects util"
+
+    # Process the subproject appropriately. If enabled add it to the
+    # $enabled_subprojects running shell variable, set a
+    # SUBPROJECT_ENABLED C define, and include the appropriate
+    # 'subproject.ac'.
+
+
+      { $as_echo "$as_me:${as_lineno-$LINENO}: configuring default subproject : util" >&5
+$as_echo "$as_me: configuring default subproject : util" >&6;}
+      ac_config_files="$ac_config_files util.mk:util/util.mk.in"
+
+      enable_util_sproj="yes"
+      subprojects_enabled="$subprojects_enabled util"
+
+$as_echo "#define UTIL_ENABLED /**/" >>confdefs.h
+
+
+
+
+
+
+    # Determine if this is a required or an optional subproject
+
+
+
+    # Determine if there is a group with the same name
+
+
+
+    # Create variations of the subproject name suitable for use as a CPP
+    # enabled define, a shell enabled variable, and a shell function
+
+
+
+
+
+
+
+
+
+
+
+    # Add subproject to our running list
+
     subprojects="$subprojects fesvr"
 
     # Process the subproject appropriately. If enabled add it to the
@@ -5973,6 +6018,7 @@ cat >>$CONFIG_STATUS <<\_ACEOF || ac_write_fail=1
 for ac_config_target in $ac_config_targets
 do
   case $ac_config_target in
+    "util.mk") CONFIG_FILES="$CONFIG_FILES util.mk:util/util.mk.in" ;;
     "fesvr.mk") CONFIG_FILES="$CONFIG_FILES fesvr.mk:fesvr/fesvr.mk.in" ;;
     "riscv.mk") CONFIG_FILES="$CONFIG_FILES riscv.mk:riscv/riscv.mk.in" ;;
     "disasm.mk") CONFIG_FILES="$CONFIG_FILES disasm.mk:disasm/disasm.mk.in" ;;

--- a/configure.ac
+++ b/configure.ac
@@ -96,7 +96,7 @@ AX_APPEND_LINK_FLAGS([-Wl,--export-dynamic])
 # The '*' suffix indicates an optional subproject. The '**' suffix
 # indicates an optional subproject which is also the name of a group.
 
-MCPPBS_SUBPROJECTS([ fesvr, riscv, disasm, customext, fdt, softfloat, spike_main, spike_dasm ])
+MCPPBS_SUBPROJECTS([ util, fesvr, riscv, disasm, customext, fdt, softfloat, spike_main, spike_dasm ])
 
 #-------------------------------------------------------------------------
 # MCPPBS subproject groups

--- a/fesvr/elfloader.cc
+++ b/fesvr/elfloader.cc
@@ -2,7 +2,7 @@
 
 #include "elf.h"
 #include "memif.h"
-#include "byteorder.h"
+#include <util/byteorder.h>
 #include <cstring>
 #include <string>
 #include <sys/stat.h>

--- a/fesvr/fesvr.mk.in
+++ b/fesvr/fesvr.mk.in
@@ -1,3 +1,6 @@
+fesvr_subproject_deps = \
+	util \
+
 fesvr_hdrs = \
   elf.h \
   elfloader.h \

--- a/fesvr/htif.cc
+++ b/fesvr/htif.cc
@@ -4,7 +4,7 @@
 #include "rfb.h"
 #include "elfloader.h"
 #include "encoding.h"
-#include "byteorder.h"
+#include <util/byteorder.h>
 #include <algorithm>
 #include <assert.h>
 #include <vector>

--- a/fesvr/htif.h
+++ b/fesvr/htif.h
@@ -6,7 +6,7 @@
 #include "memif.h"
 #include "syscall.h"
 #include "device.h"
-#include "byteorder.h"
+#include <util/byteorder.h>
 #include <string.h>
 #include <map>
 #include <vector>

--- a/fesvr/memif.h
+++ b/fesvr/memif.h
@@ -5,7 +5,7 @@
 
 #include <stdint.h>
 #include <stddef.h>
-#include "byteorder.h"
+#include <util/byteorder.h>
 
 typedef uint64_t reg_t;
 typedef int64_t sreg_t;

--- a/fesvr/syscall.cc
+++ b/fesvr/syscall.cc
@@ -2,7 +2,7 @@
 
 #include "syscall.h"
 #include "htif.h"
-#include "byteorder.h"
+#include <util/byteorder.h>
 #include <unistd.h>
 #include <fcntl.h>
 #include <sys/stat.h>

--- a/riscv/mmu.h
+++ b/riscv/mmu.h
@@ -10,7 +10,7 @@
 #include "simif.h"
 #include "processor.h"
 #include "memtracer.h"
-#include "byteorder.h"
+#include <util/byteorder.h>
 #include <stdlib.h>
 #include <vector>
 

--- a/riscv/riscv.mk.in
+++ b/riscv/riscv.mk.in
@@ -2,6 +2,7 @@ get_insn_list = $(shell grep ^DECLARE_INSN $(1) | sed 's/DECLARE_INSN(\(.*\),.*,
 get_opcode = $(shell grep ^DECLARE_INSN.*\\\<$(2)\\\> $(1) | sed 's/DECLARE_INSN(.*,\(.*\),.*)/\1/')
 
 riscv_subproject_deps = \
+	util \
 	fdt \
 	softfloat \
 

--- a/riscv/sim.cc
+++ b/riscv/sim.cc
@@ -4,7 +4,6 @@
 #include "mmu.h"
 #include "dts.h"
 #include "remote_bitbang.h"
-#include "byteorder.h"
 #include <fstream>
 #include <map>
 #include <iostream>

--- a/riscv/sim.h
+++ b/riscv/sim.h
@@ -9,6 +9,7 @@
 #include "processor.h"
 #include "simif.h"
 
+#include <util/byteorder.h>
 #include <fesvr/htif.h>
 #include <fesvr/context.h>
 #include <vector>

--- a/util/byteorder.cc
+++ b/util/byteorder.cc
@@ -1,0 +1,35 @@
+// See LICENSE for license details.
+
+#include "byteorder.h"
+#include "config.h"
+
+#ifdef WORDS_BIGENDIAN
+#define ENDIANESS_CONV(type)                 \
+    template <typename type>                 \
+    type from_be(type n) { return n; }       \
+    template <typename type>                 \
+    type to_be(type n) { return n; }         \
+    template <typename type>                 \
+    type from_le(type n) { return swap(n); } \
+    template <typename type>                 \
+    type to_le(type n) { return swap(n); }
+#else
+#define ENDIANESS_CONV(type)                 \
+    template <typename type>                 \
+    type from_be(type n) { return swap(n); } \
+    template <typename type>                 \
+    type to_be(type n) { return swap(n); }   \
+    template <typename type>                 \
+    type from_le(type n) { return n; }       \
+    template <typename type>                 \
+    type to_le(type n) { return n; }
+#endif
+
+ENDIANESS_CONV(uint8_t)
+ENDIANESS_CONV(uint16_t)
+ENDIANESS_CONV(uint32_t)
+ENDIANESS_CONV(uint64_t)
+ENDIANESS_CONV(int8_t)
+ENDIANESS_CONV(int16_t)
+ENDIANESS_CONV(int32_t)
+ENDIANESS_CONV(int64_t)

--- a/util/byteorder.h
+++ b/util/byteorder.h
@@ -3,7 +3,6 @@
 #ifndef _RISCV_BYTEORDER_H
 #define _RISCV_BYTEORDER_H
 
-#include "config.h"
 #include <stdint.h>
 
 static inline uint8_t swap(uint8_t n) { return n; }
@@ -15,46 +14,55 @@ static inline int16_t swap(int16_t n) { return int16_t(swap(uint16_t(n))); }
 static inline int32_t swap(int32_t n) { return int32_t(swap(uint32_t(n))); }
 static inline int64_t swap(int64_t n) { return int64_t(swap(uint64_t(n))); }
 
-#ifdef WORDS_BIGENDIAN
-template<typename T> static inline T from_be(T n) { return n; }
-template<typename T> static inline T to_be(T n) { return n; }
-template<typename T> static inline T from_le(T n) { return swap(n); }
-template<typename T> static inline T to_le(T n) { return swap(n); }
-#else
-template<typename T> static inline T from_le(T n) { return n; }
-template<typename T> static inline T to_le(T n) { return n; }
-template<typename T> static inline T from_be(T n) { return swap(n); }
-template<typename T> static inline T to_be(T n) { return swap(n); }
-#endif
+template <typename T> T from_le(T n);
+template <typename T> T to_le(T n);
+template <typename T> T from_be(T n);
+template <typename T> T to_be(T n);
 
 // Wrapper to mark a value as target endian, to guide conversion code
 
-template<typename T> class base_endian {
+template <typename T>
+class base_endian
+{
 
- protected:
+protected:
   T value;
 
   base_endian(T n) : value(n) {}
 
- public:
+public:
   // Setting to and testing against zero never needs swapping
   base_endian() : value(0) {}
   bool operator!() { return !value; }
 
   // Bitwise logic operations can be performed without swapping
-  base_endian& operator|=(const base_endian& rhs) { value |= rhs.value; return *this; }
-  base_endian& operator&=(const base_endian& rhs) { value &= rhs.value; return *this; }
-  base_endian& operator^=(const base_endian& rhs) { value ^= rhs.value; return *this; }
+  base_endian &operator|=(const base_endian &rhs)
+  {
+    value |= rhs.value;
+    return *this;
+  }
+  base_endian &operator&=(const base_endian &rhs)
+  {
+    value &= rhs.value;
+    return *this;
+  }
+  base_endian &operator^=(const base_endian &rhs)
+  {
+    value ^= rhs.value;
+    return *this;
+  }
 
   inline T from_be() { return ::from_be(value); }
   inline T from_le() { return ::from_le(value); }
 };
 
-template<typename T> class target_endian : public base_endian<T> {
- protected:
+template <typename T>
+class target_endian : public base_endian<T>
+{
+protected:
   target_endian(T n) : base_endian<T>(n) {}
 
- public:
+public:
   target_endian() {}
 
   static inline target_endian to_be(T n) { return target_endian(::to_be(n)); }
@@ -65,14 +73,17 @@ template<typename T> class target_endian : public base_endian<T> {
   static const target_endian all_ones;
 };
 
-template<typename T> const target_endian<T> target_endian<T>::zero = target_endian(T(0));
-template<typename T> const target_endian<T> target_endian<T>::all_ones = target_endian(~T(0));
-
+template <typename T>
+const target_endian<T> target_endian<T>::zero = target_endian(T(0));
+template <typename T>
+const target_endian<T> target_endian<T>::all_ones = target_endian(~T(0));
 
 // Specializations with implicit conversions (no swap information needed)
 
-template<> class target_endian<uint8_t> : public base_endian<uint8_t> {
- public:
+template <>
+class target_endian<uint8_t> : public base_endian<uint8_t>
+{
+public:
   target_endian() {}
   target_endian(uint8_t n) : base_endian<uint8_t>(n) {}
   operator uint8_t() { return value; }
@@ -81,8 +92,10 @@ template<> class target_endian<uint8_t> : public base_endian<uint8_t> {
   static inline target_endian to_le(uint8_t n) { return target_endian(n); }
 };
 
-template<> class target_endian<int8_t> : public base_endian<int8_t> {
- public:
+template <>
+class target_endian<int8_t> : public base_endian<int8_t>
+{
+public:
   target_endian() {}
   target_endian(int8_t n) : base_endian<int8_t>(n) {}
   operator int8_t() { return value; }

--- a/util/util.mk.in
+++ b/util/util.mk.in
@@ -1,0 +1,7 @@
+util_hdrs = \
+  byteorder.h \
+
+util_install_hdrs = $(util_hdrs)
+
+fesvr_srcs = \
+  byteorder.cc \


### PR DESCRIPTION
`fesvr` and `riscv` both depend on `byteorder`. I've moved byteorder to
its own subproject which gets installed separately.

Unfortunately, there isn't a unified way of detecting the endianess and
we can't rely on autotools as this would require to install a header
file which depends on `config.h`.

As a work-around I have moved the endianess conversion functions to
their own library which gets statically linked to either spike or
libfesvr.

I haven't measured the performance impact yet and whether LTO can make
up for the loss of inlining. There might be a better way to deal with
this - I would be happy to try other proposed fixes.