### PR TITLE
add command of using yum when building

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ We assume that the RISCV environment variable is set to the RISC-V tools
 install path.
 
     $ apt-get install device-tree-compiler
+    $ # or
+    $ yum install dtc
     $ mkdir build
     $ cd build
     $ ../configure --prefix=$RISCV


### PR DESCRIPTION
sir, I add a command of using yum when building
I built it on my CentOS computer, but we can't find the software _'device-tree-compiler'_ on yum
cuz _'device-tree-compiler'_  was named as _'dtc'_ . 
So I've added a command to use yum, which I hope will help those who compile it in CentOS in the future, as I did