### PR TITLE
Add Multiple Extension Support

### DIFF
--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -295,7 +295,7 @@ public:
            supports_extension('D') ? 64 :
            supports_extension('F') ? 32 : 0;
   }
-  extension_t* get_extension() { return ext; }
+  extension_t* get_extension(const char* name = NULL);
   bool supports_extension(unsigned char ext) {
     if (ext >= 'A' && ext <= 'Z')
       return ((state.misa >> (ext - 'A')) & 1);
@@ -430,7 +430,8 @@ public:
 private:
   simif_t* sim;
   mmu_t* mmu; // main memory is always accessed via the mmu
-  extension_t* ext;
+  std::vector<extension_t*> ext;
+  std::unordered_map<std::string, int> ext_indices;
   disassembler_t* disassembler;
   state_t state;
   uint32_t id;


### PR DESCRIPTION
Hi,

I am an undergraduate student at UC Berkeley's ADEPT lab, and I am currently working on simulating with multiple extensions enabled on spike. Spike currently only allows one extension.

This simple PR replaces the `ext` pointer in `processor_t` with an C++ vector, as well as replacing `rocc_t` abstract class with a set of macros (since `rocc_t` cannot embed the extension name needed for lookup in its callback function). 

Any feedback will be appreciated. Thanks!