### PR TITLE
fix require fp since spec said <When V=1, both vsstatus.FS and the HS…

### DIFF
--- a/riscv/decode.h
+++ b/riscv/decode.h
@@ -241,7 +241,7 @@ private:
 #define require_extension(s) require(p->supports_extension(s))
 #define require_either_extension(A,B) require(p->supports_extension(A) || p->supports_extension(B));
 #define require_impl(s) require(p->supports_impl(s))
-#define require_fp require((((STATE.mstatus & MSTATUS_FS) != 0) & (STATE.v == 0)) | (((STATE.mstatus & MSTATUS_FS) != 0) & ((STATE.vsstatus & SSTATUS_FS) != 0) & STATE.v))
+#define require_fp require((((STATE.mstatus & MSTATUS_FS) != 0) && (STATE.v == 0)) || (((STATE.mstatus & MSTATUS_FS) != 0) && ((STATE.vsstatus & SSTATUS_FS) != 0) && STATE.v))
 #define require_accelerator require((STATE.mstatus & MSTATUS_XS) != 0)
 
 #define require_vector_vs require((STATE.mstatus & MSTATUS_VS) != 0);

--- a/riscv/decode.h
+++ b/riscv/decode.h
@@ -241,7 +241,7 @@ private:
 #define require_extension(s) require(p->supports_extension(s))
 #define require_either_extension(A,B) require(p->supports_extension(A) || p->supports_extension(B));
 #define require_impl(s) require(p->supports_impl(s))
-#define require_fp require((STATE.mstatus & MSTATUS_FS) != 0)
+#define require_fp require((((STATE.mstatus & MSTATUS_FS) != 0) & (STATE.v == 0)) | (((STATE.mstatus & MSTATUS_FS) != 0) & ((STATE.vsstatus & SSTATUS_FS) != 0) & STATE.v))
 #define require_accelerator require((STATE.mstatus & MSTATUS_XS) != 0)
 
 #define require_vector_vs require((STATE.mstatus & MSTATUS_VS) != 0);


### PR DESCRIPTION
…-level sstatus.FS are in effect>

In spec page 91, When V=1, both vsstatus.FS and the HS-level sstatus.FS are in effect. Attempts to execute a floating-point instruction when either field is 0 (Off) raise an illegal-instruction exception.