### PR TITLE
Fix macro for PKxx16 & PKxx32 commands.

### DIFF
--- a/riscv/decode.h
+++ b/riscv/decode.h
@@ -2836,13 +2836,12 @@ for (reg_t i = 0; i < P.VU.vlmax && P.VU.vl != 0; ++i) { \
 #define P_PK(BIT, X, Y) \
   require_extension('P'); \
   require(BIT == e16 || BIT == e32); \
-  reg_t size = BIT / 8 * 2; \
-  reg_t rd_tmp = 0; \
-  type_usew_t<BIT>::type pd[2] = { \
-    P_UFIELD(RS1, Y, BIT), \
-    P_UFIELD(RS1, X, BIT) \
-  }; \
-  memcpy(&rd_tmp, pd, size); \
+  reg_t rd_tmp = 0, rs1 = RS1, rs2 = RS2; \
+    rd_tmp = set_field(rd_tmp, make_mask64(i * 2 * BIT, BIT), \
+      P_UFIELD(RS2, i * 2 + Y, BIT)); \
+    rd_tmp = set_field(rd_tmp, make_mask64((i * 2 + 1) * BIT, BIT), \
+      P_UFIELD(RS1, i * 2 + X, BIT)); \
+  } \
   WRITE_RD(rd_tmp);
 
 #define P_64_PROFILE_BASE() \


### PR DESCRIPTION
Now this correctly works for PKBB32, PKBT32, PKTB32 and PKTT32 (rv64-only).