### PR TITLE
Correct RV64 vsstatus.UXL field

### DIFF
--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -460,6 +460,7 @@ void processor_t::reset()
   state.dcsr.halt = halt_on_reset;
   halt_on_reset = false;
   set_csr(CSR_MSTATUS, state.mstatus);
+  state.vsstatus = state.mstatus & SSTATUS_VS_MASK;  // set UXL
   VU.reset();
 
   if (n_pmp > 0) {


### PR DESCRIPTION
It was reading as 0, which is not a legal value.

Spike does not support dynamic multi-width; all *XL fields are wired to 64-bit (=2) when running as RV64.

In mstatus, UXL gets initialized by the call to `set_csr(CSR_MSTATUS)` here in `processor_t::reset()`, so I wait until that's complete and then copy all the visible bits over to the vsstatus reset value. (Though only bit 33, part of UXL, is nonzero.)

cc @avpatel 