### PR TITLE
Fix bug where CSRW to vsstatus would not set SD correctly

### DIFF
--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -1209,7 +1209,7 @@ void processor_t::set_csr(int which, reg_t val)
       mask |= (supports_extension('V') ? SSTATUS_VS : 0);
       state.vsstatus = (state.vsstatus & ~mask) | (val & mask);
       state.vsstatus &= (xlen == 64 ? ~SSTATUS64_SD : ~SSTATUS32_SD);
-      if (((state.mstatus & SSTATUS_FS) == SSTATUS_FS) ||
+      if (((state.vsstatus & SSTATUS_FS) == SSTATUS_FS) ||
           ((state.vsstatus & SSTATUS_VS) == SSTATUS_VS) ||
           ((state.vsstatus & SSTATUS_XS) == SSTATUS_XS)) {
          state.vsstatus |= (xlen == 64 ? SSTATUS64_SD : SSTATUS32_SD);


### PR DESCRIPTION
If you write e.g. 0x6000 (FS=Dirty) via `csrw vsstatus`, this should also set the SD bit.

Unless `mstatus` already had FS=Dirty, this would not occur.

The priv spec says (under vsstatus): "For example, the value of the HS-level sstatus.FS [aka mstatus.FS] does not affect vsstatus.SD."
