### PR TITLE
Don't make MPRV load/store virtual if MPV=1, MPP=3

### DIFF
--- a/riscv/mmu.cc
+++ b/riscv/mmu.cc
@@ -59,7 +59,7 @@ reg_t mmu_t::translate(reg_t addr, reg_t len, access_type type, uint32_t xlate_f
   if (type != FETCH) {
     if (!proc->state.debug_mode && get_field(proc->state.mstatus, MSTATUS_MPRV)) {
       mode = get_field(proc->state.mstatus, MSTATUS_MPP);
-      if (get_field(proc->state.mstatus, MSTATUS_MPV))
+      if (get_field(proc->state.mstatus, MSTATUS_MPV) && mode != 3)
         virt = true;
     }
     if (!proc->state.debug_mode && (xlate_flags & RISCV_XLATE_VIRT)) {

--- a/riscv/mmu.cc
+++ b/riscv/mmu.cc
@@ -59,7 +59,7 @@ reg_t mmu_t::translate(reg_t addr, reg_t len, access_type type, uint32_t xlate_f
   if (type != FETCH) {
     if (!proc->state.debug_mode && get_field(proc->state.mstatus, MSTATUS_MPRV)) {
       mode = get_field(proc->state.mstatus, MSTATUS_MPP);
-      if (get_field(proc->state.mstatus, MSTATUS_MPV) && mode != 3)
+      if (get_field(proc->state.mstatus, MSTATUS_MPV) && mode != PRV_M)
         virt = true;
     }
     if (!proc->state.debug_mode && (xlate_flags & RISCV_XLATE_VIRT)) {


### PR DESCRIPTION
Privileged spec says that load/store with mstatus.MPRV=1, mstatus.MPP=3 should be unmapped, irrespective of the mstatus.MPV value, see:

https://github.com/riscv/riscv-isa-manual/blob/0453d462a180927169656e6e3f7faf3042b23e5b/src/hypervisor.tex#L2023

Spike currently performs mapped 2nd stage (hgatp) translation in this case.

I'm attaching a test case that shows the behavior. Fix is to make "virt" when MPRV=1 conditional on MPV=1 && MPP!=3.

[mprv_mpv.tgz.zip](https://github.com/riscv/riscv-isa-sim/files/6090110/mprv_mpv.tgz.zip)
