### PR TITLE
Fix bug where hstatus.SPVP was being changed when it should not be

### DIFF
--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -763,7 +763,8 @@ void processor_t::take_trap(trap_t& t, reg_t epc)
     s = set_field(s, MSTATUS_SIE, 0);
     set_csr(CSR_MSTATUS, s);
     s = state.hstatus;
-    s = set_field(s, HSTATUS_SPVP, state.prv);
+    if (curr_virt)
+      s = set_field(s, HSTATUS_SPVP, state.prv);
     s = set_field(s, HSTATUS_SPV, curr_virt);
     s = set_field(s, HSTATUS_GVA, t.has_gva());
     set_csr(CSR_HSTATUS, s);


### PR DESCRIPTION
[Spec says](https://github.com/riscv/riscv-isa-manual/blob/0453d462a180927169656e6e3f7faf3042b23e5b/src/hypervisor.tex#L302):

> When V=1 and a trap is taken into HS-mode, bit SPVP (Supervisor Previous Virtual Privilege) is set to the privilege mode at the time of the trap, the same as `sstatus.SPP`. But if V=0 before a trap, SPVP is left unchanged on trap entry.

Spike was mistakenly setting SPVP on any trap into HS-mode, in violation of that second sentence.

cc @avpatel 