### PR TITLE
Fix hedeleg to match Privileged Spec requirements

### DIFF
--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -1147,6 +1147,8 @@ void processor_t::set_csr(int which, reg_t val)
     case CSR_HEDELEG: {
       reg_t mask =
         (1 << CAUSE_MISALIGNED_FETCH) |
+        (1 << CAUSE_FETCH_ACCESS) |
+        (1 << CAUSE_ILLEGAL_INSTRUCTION) |
         (1 << CAUSE_BREAKPOINT) |
         (1 << CAUSE_MISALIGNED_LOAD) |
         (1 << CAUSE_LOAD_ACCESS) |


### PR DESCRIPTION
[Table 5.2](https://github.com/riscv/riscv-isa-manual/blob/0453d462a180927169656e6e3f7faf3042b23e5b/src/hypervisor.tex#L386-L409) requires certain bits to be writable in hedeleg.

As discussed in #668.

