### PR TITLE
Bug fix: vsstatus should also include XS and UBE fields

### DIFF
--- a/riscv/encoding.h
+++ b/riscv/encoding.h
@@ -54,9 +54,9 @@
 #define SSTATUS_UXL         0x0000000300000000
 #define SSTATUS64_SD        0x8000000000000000
 
-#define SSTATUS_VS_MASK     (SSTATUS_SIE | SSTATUS_SPIE | \
-                             SSTATUS_SPP | SSTATUS_FS | SSTATUS_SUM | \
-                             SSTATUS_MXR | SSTATUS_UXL)
+#define SSTATUS_VS_MASK     (SSTATUS_SIE | SSTATUS_SPIE | SSTATUS_UBE | \
+                             SSTATUS_SPP | SSTATUS_XS | SSTATUS_FS | \
+                             SSTATUS_SUM | SSTATUS_MXR | SSTATUS_UXL)
 
 #define HSTATUS_VSXL        0x300000000
 #define HSTATUS_VTSR        0x00400000


### PR DESCRIPTION
The [spec says](https://github.com/riscv/riscv-isa-manual/blob/0453d462a180927169656e6e3f7faf3042b23e5b/src/hypervisor.tex#L1247-L1252) the XS and UBE fields are part of `vsstatus`.
