### PR TITLE
Forbid `csrw vsstatus` from modifying the UXL field

### DIFF
--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -1189,6 +1189,7 @@ void processor_t::set_csr(int which, reg_t val)
           ((state.vsstatus & SSTATUS_XS) == SSTATUS_XS)) {
          state.vsstatus |= (xlen == 64 ? SSTATUS64_SD : SSTATUS32_SD);
       }
+      state.vsstatus = set_field(state.vsstatus, SSTATUS_UXL, xlen_to_uxl(max_xlen));
       break;
     }
     case CSR_VSIE: {


### PR DESCRIPTION
Since this is not modifiable in the real `sstatus`, so it should not be in the virtualized version either.

Code is based on similar code for `mstatus`.

I'm working on sharing the sstatus-related code between `mstatus` and `vsstatus` to avoid this duplication, but that's a much bigger change for another PR.
