### PR TITLE
Fix WFI: Resume only on pending interrupt (#672)

### DIFF
--- a/riscv/execute.cc
+++ b/riscv/execute.cc
@@ -252,6 +252,14 @@ void processor_t::step(size_t n)
 
     try
     {
+      if (halt_wfi)
+      {
+        if (state.mie & state.mip) // Resume if any pending interrupt.
+          halt_wfi = false;
+        else // End current loop
+          break;
+      }
+
       take_pending_interrupt();
 
       if (unlikely(slow_path()))
@@ -375,6 +383,7 @@ void processor_t::step(size_t n)
       // allows us to switch to other threads only once per idle loop in case
       // there is activity.
       n = ++instret;
+      halt_wfi = true;
     }
 
     state.minstret += instret;

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -338,6 +338,7 @@ public:
     HR_REGULAR, /* Regular halt request/debug interrupt. */
     HR_GROUP    /* Halt requested due to halt group. */
   } halt_request;
+  bool halt_wfi;/* Halt due to WFI. */
 
   // Return the index of a trigger that matched, or -1.
   inline int trigger_match(trigger_operation_t operation, reg_t address, reg_t data)


### PR DESCRIPTION
The origin Spike resumes WFI without checking interrupt state. (See
https://github.com/riscv/riscv-isa-sim/issues/672)
This patch fix the issue.

Besides, a simple test and the test result are provided at
https://github.com/IanJiangICT/instruction-test/blob/master/riscv/test-wfi.S
https://github.com/IanJiangICT/instruction-test/blob/master/riscv/test-wfi-log-pass.txt