### PR TITLE
Fix `stx_ino` member name in commit b65ead8

### DIFF
--- a/configure
+++ b/configure
@@ -4756,8 +4756,8 @@ else
 fi
 
 
-ac_fn_cxx_check_member "$LINENO" "struct statx" "ino" "ac_cv_member_struct_statx_ino" "$ac_includes_default"
-if test "x$ac_cv_member_struct_statx_ino" = xyes; then :
+ac_fn_cxx_check_member "$LINENO" "struct statx" "stx_ino" "ac_cv_member_struct_statx_stx_ino" "$ac_includes_default"
+if test "x$ac_cv_member_struct_statx_stx_ino" = xyes; then :
 
 cat >>confdefs.h <<_ACEOF
 #define HAVE_STATX 1

--- a/fesvr/fesvr.ac
+++ b/fesvr/fesvr.ac
@@ -1,6 +1,6 @@
 AC_CHECK_LIB(pthread, pthread_create, [], [AC_MSG_ERROR([libpthread is required])])
 
-AC_CHECK_MEMBER(struct statx.ino,
+AC_CHECK_MEMBER(struct statx.stx_ino,
   AC_DEFINE_UNQUOTED(HAVE_STATX, 1, [Define to 1 if struct statx exists.]),
   ,
 )


### PR DESCRIPTION
The member name in kernel header is `stx_ino` instead of `ino`, this commit fixes it.