### PR TITLE
rvp: sign-extension for p-ext insns

### DIFF
--- a/riscv/decode.h
+++ b/riscv/decode.h
@@ -2770,7 +2770,7 @@ for (reg_t i = 0; i < P.VU.vlmax && P.VU.vl != 0; ++i) { \
 
 #define P_LOOP_END() \
   } \
-  WRITE_RD(rd_tmp);
+  WRITE_RD(sext_xlen(rd_tmp));
 
 #define P_PAIR_LOOP_END() \
   } \
@@ -2778,7 +2778,7 @@ for (reg_t i = 0; i < P.VU.vlmax && P.VU.vl != 0; ++i) { \
     WRITE_RD_PAIR(rd_tmp); \
   } \
   else { \
-    WRITE_RD(rd_tmp); \
+    WRITE_RD(sext_xlen(rd_tmp)); \
   }
 
 #define P_REDUCTION_LOOP_END(BIT, IS_SAT) \
@@ -2789,7 +2789,7 @@ for (reg_t i = 0; i < P.VU.vlmax && P.VU.vl != 0; ++i) { \
     type_usew_t<BIT>::type pd = pd_res; \
     WRITE_PD(); \
   } \
-  WRITE_RD(rd_tmp);
+  WRITE_RD(sext_xlen(rd_tmp));
 
 #define P_REDUCTION_ULOOP_END(BIT, IS_SAT) \
     } \
@@ -2799,7 +2799,7 @@ for (reg_t i = 0; i < P.VU.vlmax && P.VU.vl != 0; ++i) { \
     type_usew_t<BIT>::type pd = pd_res; \
     WRITE_PD(); \
   } \
-  WRITE_RD(rd_tmp);
+  WRITE_RD(sext_xlen(rd_tmp));
 
 #define P_SUNPKD8(X, Y) \
   require_extension('P'); \
@@ -2815,7 +2815,7 @@ for (reg_t i = 0; i < P.VU.vlmax && P.VU.vl != 0; ++i) { \
   } else { \
     memcpy(&rd_tmp, pd, 4); \
   } \
-  WRITE_RD(rd_tmp);
+  WRITE_RD(sext_xlen(rd_tmp));
 
 #define P_ZUNPKD8(X, Y) \
   require_extension('P'); \
@@ -2831,7 +2831,7 @@ for (reg_t i = 0; i < P.VU.vlmax && P.VU.vl != 0; ++i) { \
   } else { \
     memcpy(&rd_tmp, pd, 4); \
   } \
-  WRITE_RD(rd_tmp);
+  WRITE_RD(sext_xlen(rd_tmp));
 
 #define P_PK(BIT, X, Y) \
   require_extension('P'); \
@@ -2843,7 +2843,7 @@ for (reg_t i = 0; i < P.VU.vlmax && P.VU.vl != 0; ++i) { \
     rd_tmp = set_field(rd_tmp, make_mask64((i * 2 + 1) * BIT, BIT), \
       P_UFIELD(RS1, i * 2 + X, BIT)); \
   } \
-  WRITE_RD(rd_tmp);
+  WRITE_RD(sext_xlen(rd_tmp));
 
 #define P_64_PROFILE_BASE() \
   require_extension('P'); \
@@ -2900,7 +2900,7 @@ for (reg_t i = 0; i < P.VU.vlmax && P.VU.vl != 0; ++i) { \
   if (xlen == 32) { \
     WRITE_RD_PAIR(rd); \
   } else { \
-    WRITE_RD(rd); \
+    WRITE_RD(sext_xlen(rd)); \
   }
 
 #define DEBUG_START             0x0

--- a/riscv/insns/ave.h
+++ b/riscv/insns/ave.h
@@ -2,4 +2,4 @@ require_extension('P');
 sreg_t rs1 = RS1;
 sreg_t rs2 = RS2;
 sreg_t carry = (rs1 & 1) | (rs2 & 1);
-WRITE_RD((rs1 >> 1) + (rs2 >> 1) + carry);
+WRITE_RD(sext_xlen((rs1 >> 1) + (rs2 >> 1) + carry));

--- a/riscv/insns/bitrev.h
+++ b/riscv/insns/bitrev.h
@@ -9,4 +9,4 @@ for (size_t i = 0; i <= msb; i++) {
   n >>= 1;
 }
 
-WRITE_RD(rev);
+WRITE_RD(sext_xlen(rev));

--- a/riscv/insns/bitrevi.h
+++ b/riscv/insns/bitrevi.h
@@ -9,4 +9,4 @@ for (size_t i = 0; i <= msb; i++) {
   n >>= 1;
 }
 
-WRITE_RD(rev);
+WRITE_RD(sext_xlen(rev));

--- a/riscv/insns/sra_u.h
+++ b/riscv/insns/sra_u.h
@@ -3,7 +3,7 @@ sreg_t rs1 = sext_xlen(RS1);
 reg_t sa = get_field(RS2, make_mask64(0, xlen == 32 ? 5 : 6));
 
 if (sa > 0) {
-  WRITE_RD(((rs1 >> (sa - 1)) + 1) >> 1);
+  WRITE_RD(sext_xlen(((rs1 >> (sa - 1)) + 1) >> 1));
 } else {
-  WRITE_RD(rs1);
+  WRITE_RD(sext_xlen(rs1));
 }

--- a/riscv/insns/srai_u.h
+++ b/riscv/insns/srai_u.h
@@ -3,7 +3,7 @@ sreg_t rs1 = sext_xlen(RS1);
 reg_t sa = xlen == 32 ? insn.p_imm5() : insn.p_imm6();
 
 if (sa > 0) {
-  WRITE_RD(((rs1 >> (sa - 1)) + 1) >> 1);
+  WRITE_RD(sext_xlen(((rs1 >> (sa - 1)) + 1) >> 1));
 } else {
-  WRITE_RD(rs1);
+  WRITE_RD(sext_xlen(rs1));
 }


### PR DESCRIPTION
Hi @hope51607! Recently I detected some bug in rvb insns (check: https://github.com/riscv/riscv-isa-sim/issues/682).
It seems like bitrev[i] insns and some macros have the same problem.
I kindly ask you to check if there are any other not sign-extended rvp-insns.