### PR TITLE
Add `--dtb` option to help message

### DIFF
--- a/spike_main/spike.cc
+++ b/spike_main/spike.cc
@@ -51,6 +51,7 @@ static void help(int exit_code = 1)
   fprintf(stderr, "  --rbb-port=<port>     Listen on <port> for remote bitbang connection\n");
   fprintf(stderr, "  --dump-dts            Print device tree string and exit\n");
   fprintf(stderr, "  --disable-dtb         Don't write the device tree blob into memory\n");
+  fprintf(stderr, "  --dtb=<path>          Overwrite the device tree binary blob that will be used\n");
   fprintf(stderr, "  --kernel=<path>       Load kernel flat image into memory\n");
   fprintf(stderr, "  --initrd=<path>       Load kernel initrd into memory\n");
   fprintf(stderr, "  --bootargs=<args>     Provide custom bootargs for kernel [default: console=hvc0 earlycon=sbi]\n");


### PR DESCRIPTION
Currently, the `--dtb` option is available as an option, but is not shown inside the help message.