### PR TITLE
Display 32 bits

### DIFF
--- a/fesvr/htif.cc
+++ b/fesvr/htif.cc
@@ -24,7 +24,7 @@
 #endif
 
 #ifndef TARGET_ARCH
-# define TARGET_ARCH "riscv64-unknown-elf"
+# define TARGET_ARCH "riscv32-unknown-elf"
 #endif
 
 #ifndef TARGET_DIR

--- a/fesvr/htif.cc
+++ b/fesvr/htif.cc
@@ -24,7 +24,7 @@
 #endif
 
 #ifndef TARGET_ARCH
-# define TARGET_ARCH "riscv32-unknown-elf"
+# define TARGET_ARCH "riscv64-unknown-elf"
 #endif
 
 #ifndef TARGET_DIR

--- a/riscv/interactive.cc
+++ b/riscv/interactive.cc
@@ -184,8 +184,8 @@ void sim_t::interactive_pc(const std::string& cmd, const std::vector<std::string
 
   processor_t *p = get_core(args[0]);
   int max_xlen = p->get_max_xlen();
-  fprintf(stderr, max_xlen==32 ? "0x%08" PRIx32 "\n" :
-                                 "0x%016" PRIx64 "\n", get_pc(args));
+  fprintf(stderr, max_xlen==32 ? "0x%08" PRIx64 "\n" :
+                                 "0x%016" PRIx64 "\n", ERASE_32MSB(max_xlen,get_pc(args)));
 }
 
 reg_t sim_t::get_reg(const std::vector<std::string>& args)
@@ -288,14 +288,14 @@ void sim_t::interactive_reg(const std::string& cmd, const std::vector<std::strin
     // Show all the regs!
 
     for (int r = 0; r < NXPR; ++r) {
-      fprintf(stderr, max_xlen==32 ? "%-4s: 0x%08" PRIx32 "  " :
-                      "%-4s: 0x%016" PRIx64 "  ", xpr_name[r], p->get_state()->XPR[r]);
+      fprintf(stderr, max_xlen==32 ? "%-4s: 0x%08" PRIx64 "  " :
+                      "%-4s: 0x%016" PRIx64 "  ", xpr_name[r], ERASE_32MSB(max_xlen,p->get_state()->XPR[r]));
       if ((r + 1) % 4 == 0)
         fprintf(stderr, "\n");
     }
   } else
-      fprintf(stderr, max_xlen==32 ? "0x%08" PRIx32 "\n" :
-                     "0x%016" PRIx64 "\n", get_reg(args));
+      fprintf(stderr, max_xlen==32 ? "0x%08" PRIx64 "\n" :
+                     "0x%016" PRIx64 "\n", ERASE_32MSB(max_xlen,get_reg(args)));
 }
 
 union fpr

--- a/riscv/interactive.cc
+++ b/riscv/interactive.cc
@@ -179,7 +179,13 @@ reg_t sim_t::get_pc(const std::vector<std::string>& args)
 
 void sim_t::interactive_pc(const std::string& cmd, const std::vector<std::string>& args)
 {
-  fprintf(stderr, "0x%016" PRIx64 "\n", get_pc(args));
+  if(args.size() != 1)
+    throw trap_interactive();
+
+  processor_t *p = get_core(args[0]);
+  int max_xlen = p->get_max_xlen();
+  fprintf(stderr, max_xlen==32 ? "0x%08" PRIx32 "\n" :
+                                 "0x%016" PRIx64 "\n", get_pc(args));
 }
 
 reg_t sim_t::get_reg(const std::vector<std::string>& args)
@@ -272,17 +278,24 @@ void sim_t::interactive_vreg(const std::string& cmd, const std::vector<std::stri
 
 void sim_t::interactive_reg(const std::string& cmd, const std::vector<std::string>& args)
 {
+  if(args.size() < 1)
+     throw trap_interactive();
+
+  processor_t *p = get_core(args[0]);
+  int max_xlen = p->get_max_xlen();
+
   if (args.size() == 1) {
     // Show all the regs!
-    processor_t *p = get_core(args[0]);
 
     for (int r = 0; r < NXPR; ++r) {
-      fprintf(stderr, "%-4s: 0x%016" PRIx64 "  ", xpr_name[r], p->get_state()->XPR[r]);
+      fprintf(stderr, max_xlen==32 ? "%-4s: 0x%08" PRIx32 "  " :
+                      "%-4s: 0x%016" PRIx64 "  ", xpr_name[r], p->get_state()->XPR[r]);
       if ((r + 1) % 4 == 0)
         fprintf(stderr, "\n");
     }
   } else
-    fprintf(stderr, "0x%016" PRIx64 "\n", get_reg(args));
+      fprintf(stderr, max_xlen==32 ? "0x%08" PRIx32 "\n" :
+                     "0x%016" PRIx64 "\n", get_reg(args));
 }
 
 union fpr
@@ -404,6 +417,10 @@ void sim_t::interactive_until(const std::string& cmd, const std::vector<std::str
   reg_t val = strtol(args[args.size()-1].c_str(),NULL,16);
   if(val == LONG_MAX)
     val = strtoul(args[args.size()-1].c_str(),NULL,16);
+
+  // mask bits above max_xlen
+  int max_xlen = procs[strtol(args[1].c_str(),NULL,10)]->get_max_xlen();
+  if (max_xlen == 32) val &= 0xFFFFFFFF;
   
   std::vector<std::string> args2;
   args2 = std::vector<std::string>(args.begin()+1,args.end()-1);
@@ -423,6 +440,9 @@ void sim_t::interactive_until(const std::string& cmd, const std::vector<std::str
     try
     {
       reg_t current = (this->*func)(args2);
+
+      // mask bits above max_xlen
+      if (max_xlen == 32) current &= 0xFFFFFFFF;
 
       if (cmd_until == (current == val))
         break;

--- a/riscv/interactive.cc
+++ b/riscv/interactive.cc
@@ -371,7 +371,10 @@ reg_t sim_t::get_mem(const std::vector<std::string>& args)
 
 void sim_t::interactive_mem(const std::string& cmd, const std::vector<std::string>& args)
 {
-  fprintf(stderr, "0x%016" PRIx64 "\n", get_mem(args));
+  int max_xlen = procs[0]->get_max_xlen();
+
+  fprintf(stderr, max_xlen==32 ? "0x%08" PRIx64 "\n" :
+                  "0x%016" PRIx64 "\n", ERASE_32MSB(max_xlen,get_mem(args)));
 }
 
 void sim_t::interactive_str(const std::string& cmd, const std::vector<std::string>& args)

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -780,9 +780,9 @@ void processor_t::disasm(insn_t insn)
       fprintf(log_file, "core %3d: Executed %" PRIx64 " times\n", id, executions);
     }
 
-    fprintf(log_file, max_xlen==32 ? "core %3d: 0x%08" PRIx32 " (0x%08" PRIx32 ") %s\n" :
+    fprintf(log_file, max_xlen==32 ? "core %3d: 0x%08" PRIx64 " (0x%08" PRIx32 ") %s\n" :
                       "core %3d: 0x%016" PRIx64 " (0x%08" PRIx32 ") %s\n",
-            id, state.pc, bits, disassembler->disassemble(insn).c_str());
+            id, ERASE_32MSB(max_xlen,state.pc), bits, disassembler->disassemble(insn).c_str());
     last_pc = state.pc;
     last_bits = bits;
     executions = 1;

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -780,7 +780,8 @@ void processor_t::disasm(insn_t insn)
       fprintf(log_file, "core %3d: Executed %" PRIx64 " times\n", id, executions);
     }
 
-    fprintf(log_file, "core %3d: 0x%016" PRIx64 " (0x%08" PRIx64 ") %s\n",
+    fprintf(log_file, max_xlen==32 ? "core %3d: 0x%08" PRIx32 " (0x%08" PRIx32 ") %s\n" :
+                      "core %3d: 0x%016" PRIx64 " (0x%08" PRIx32 ") %s\n",
             id, state.pc, bits, disassembler->disassemble(insn).c_str());
     last_pc = state.pc;
     last_bits = bits;

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -667,11 +667,13 @@ void processor_t::enter_debug_mode(uint8_t cause)
 void processor_t::take_trap(trap_t& t, reg_t epc)
 {
   if (debug) {
-    fprintf(log_file, "core %3d: exception %s, epc 0x%016" PRIx64 "\n",
-            id, t.name(), epc);
+    fprintf(log_file, max_xlen==32 ? "core %3d: exception %s, epc 0x%08" PRIx64 "\n" :
+                                     "core %3d: exception %s, epc 0x%016" PRIx64 "\n",
+            id, t.name(), ERASE_32MSB(max_xlen,epc));
     if (t.has_tval())
-      fprintf(log_file, "core %3d:           tval 0x%016" PRIx64 "\n",
-              id, t.get_tval());
+      fprintf(log_file,  max_xlen==32 ? "core %3d:           tval 0x%08" PRIx64 "\n" :
+                                        "core %3d:           tval 0x%016" PRIx64 "\n",
+              id, ERASE_32MSB(max_xlen,t.get_tval()));
   }
 
   if (state.debug_mode) {

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -553,4 +553,6 @@ reg_t illegal_instruction(processor_t* p, insn_t insn, reg_t pc);
   extern reg_t rv64_##name(processor_t*, insn_t, reg_t); \
   proc->register_insn((insn_desc_t){match, mask, rv32_##name, rv64_##name,archen});
 
+#define ERASE_32MSB(m,n) (m==32 ? n & 0xffffffff : n)
+
 #endif


### PR DESCRIPTION
This PR addresses the following bugs:

- Even when using configure `--with-isa=rv32i --target=riscv32-unknown-elf`, pc and registers are shown as 64-bit values.
 
This PR shows only the lower 32 bits of pc and registers if max_xlen==32.

- The `until` command uses 64 bits for rv32. To stop correctly, for example, `until pc 0 0xffffffff80000000` must be used.

This PR compares only the lower 32 bits if max_xlen==32, so `until pc 0 0x80000000` works as expected.

- `pk` must be installed manually in `riscv64-unknown-elf/bin/` for `spike pk` to find it.

This PR makes spike look for pk in `riscv32-unknown-elf/bin/`. However, it does so unconditionally. Configure using `--target=riscv64-unknown-elf` will certainly fail to work correctly. If possible, please advise how to adjust the spike search path depending on `--target`.

This PR has only been tested for
`
../configure --prefix=$RISCV --with-isa=rv32i --target=riscv32-unknown-elf --enable-histogram
`