### PR TITLE
rvp: insns fixes

### DIFF
--- a/riscv/decode.h
+++ b/riscv/decode.h
@@ -2444,6 +2444,7 @@ for (reg_t i = 0; i < P.VU.vlmax && P.VU.vl != 0; ++i) { \
     R = UINT##BIT##_MAX; \
     P_SET_OV(1); \
   } else if (R < 0) { \
+    P_SET_OV(1); \
     R = 0; \
   }
 
@@ -2495,10 +2496,10 @@ for (reg_t i = 0; i < P.VU.vlmax && P.VU.vl != 0; ++i) { \
 #define P_REDUCTION_LOOP_BASE(BIT, BIT_INNER, USE_RD) \
   require_extension('P'); \
   require(BIT == e16 || BIT == e32 || BIT == e64); \
-  reg_t rd_tmp = USE_RD ? RD : 0; \
-  reg_t rs1 = RS1; \
-  reg_t rs2 = RS2; \
-  sreg_t len = xlen / BIT; \
+  reg_t rd_tmp = USE_RD ? zext_xlen(RD) : 0; \
+  reg_t rs1 = zext_xlen(RS1); \
+  reg_t rs2 = zext_xlen(RS2); \
+  sreg_t len = 64 / BIT; \
   sreg_t len_inner = BIT / BIT_INNER; \
   for (sreg_t i = len - 1; i >= 0; --i) { \
     sreg_t pd_res = P_FIELD(rd_tmp, i, BIT); \
@@ -2507,10 +2508,10 @@ for (reg_t i = 0; i < P.VU.vlmax && P.VU.vl != 0; ++i) { \
 #define P_REDUCTION_ULOOP_BASE(BIT, BIT_INNER, USE_RD) \
   require_extension('P'); \
   require(BIT == e16 || BIT == e32 || BIT == e64); \
-  reg_t rd_tmp = USE_RD ? RD : 0; \
-  reg_t rs1 = RS1; \
-  reg_t rs2 = RS2; \
-  sreg_t len = xlen / BIT; \
+  reg_t rd_tmp = USE_RD ? zext_xlen(RD) : 0; \
+  reg_t rs1 = zext_xlen(RS1); \
+  reg_t rs2 = zext_xlen(RS2); \
+  sreg_t len = 64 / BIT; \
   sreg_t len_inner = BIT / BIT_INNER; \
   for (sreg_t i = len - 1; i >=0; --i) { \
     reg_t pd_res = P_UFIELD(rd_tmp, i, BIT); \

--- a/riscv/decode.h
+++ b/riscv/decode.h
@@ -2621,13 +2621,6 @@ for (reg_t i = 0; i < P.VU.vlmax && P.VU.vl != 0; ++i) { \
   WRITE_PD(); \
 }
 
-#define P_ONE_SULOOP_BODY(BIT, BODY) { \
-  P_ONE_SUPARAMS(BIT) \
-  BODY \
-  WRITE_PD(); \
-}
-
-
 #define P_MUL_LOOP_BODY(BIT, BODY) { \
   P_MUL_PARAMS(BIT) \
   BODY \
@@ -2718,11 +2711,6 @@ for (reg_t i = 0; i < P.VU.vlmax && P.VU.vl != 0; ++i) { \
 #define P_I_ULOOP(BIT, IMMBIT, BODY) \
   P_I_LOOP_BASE(BIT, IMMBIT) \
   P_ONE_ULOOP_BODY(BIT, BODY) \
-  P_LOOP_END()
-
-#define P_I_SULOOP(BIT, IMMBIT, BODY) \
-  P_I_LOOP_BASE(BIT, IMMBIT) \
-  P_ONE_SULOOP_BODY(BIT, BODY) \
   P_LOOP_END()
 
 #define P_MUL_LOOP(BIT, BODY) \

--- a/riscv/decode.h
+++ b/riscv/decode.h
@@ -2420,11 +2420,11 @@ for (reg_t i = 0; i < P.VU.vlmax && P.VU.vl != 0; ++i) { \
 
 #define WRITE_RD_PAIR(value) \
   if (MMU.is_target_big_endian()) { \
-    WRITE_REG(insn.rd() + 1, zext32(value)); \
-    WRITE_REG(insn.rd(), ((reg_t)value) >> 32); \
+    WRITE_REG(insn.rd() + 1, sext32(value)); \
+    WRITE_REG(insn.rd(), ((sreg_t)value) >> 32); \
   } else { \
-    WRITE_REG(insn.rd(), zext32(value)); \
-    WRITE_REG(insn.rd() + 1, ((reg_t)value) >> 32); \
+    WRITE_REG(insn.rd(), sext32(value)); \
+    WRITE_REG(insn.rd() + 1, ((sreg_t)value) >> 32); \
   }
 
 #define P_SET_OV(ov) \

--- a/riscv/insns/bpick.h
+++ b/riscv/insns/bpick.h
@@ -3,4 +3,4 @@ reg_t rc = RS3;
 reg_t rs1 = RS1;
 reg_t rs2 = RS2;
 
-WRITE_RD(zext_xlen((rs1 & rc) | (rs2 & ~rc)));
+WRITE_RD(sext_xlen((rs1 & rc) | (rs2 & ~rc)));

--- a/riscv/insns/insb.h
+++ b/riscv/insns/insb.h
@@ -1,3 +1,3 @@
 require_extension('P');
 reg_t bpos = (xlen == 32) ? insn.p_imm2() : insn.p_imm3();
-WRITE_RD(set_field(RD, make_mask64(bpos * 8, 8), P_B(RS1, 0)));
+WRITE_RD(sext_xlen(set_field(RD, make_mask64(bpos * 8, 8), P_B(RS1, 0))));

--- a/riscv/insns/uclip16.h
+++ b/riscv/insns/uclip16.h
@@ -1,5 +1,5 @@
-P_I_SULOOP(16, 4, {
-  int64_t uint_max = UINT64_MAX >> (64 - imm4u);
+P_I_LOOP(16, 4, {
+  int64_t uint_max = imm4u ? UINT64_MAX >> (64 - imm4u) : 0;
   pd = ps1;
 
   if (ps1 > uint_max) {

--- a/riscv/insns/uclip32.h
+++ b/riscv/insns/uclip32.h
@@ -1,5 +1,5 @@
-P_I_SULOOP(32, 5, {
-  int64_t uint_max = UINT64_MAX >> (64 - imm5u);
+P_I_LOOP(32, 5, {
+  int64_t uint_max = imm5u ? UINT64_MAX >> (64 - imm5u) : 0;
   pd = ps1;
 
   if (ps1 > uint_max) {

--- a/riscv/insns/uclip8.h
+++ b/riscv/insns/uclip8.h
@@ -1,5 +1,5 @@
-P_I_SULOOP(8, 3, {
-  int64_t uint_max = UINT64_MAX >> (64 - imm3u);
+P_I_LOOP(8, 3, {
+  int64_t uint_max = imm3u ? UINT64_MAX >> (64 - imm3u) : 0;
   pd = ps1;
 
   if (ps1 > uint_max) {


### PR DESCRIPTION
* Fixed uclipNN insns: sh >> 64 is an UB. Changed loop while P-spec says uclipNN insns work with **signed** packed values.
* Added missing OV to a saturating macro.
* Added missing sext_xlen to insb and bpick.
* Fixed P_REDUCTION_ULOOP_BASE macro so in works on all its insns but not only one.
* Rewrited P_REDUCTION_LOOP_BASE similar to P_REDUCTION_ULOOP_BASE.

Hi, @hope51607! I kindly ask you to check this patch.