### PR TITLE
Implement JTAG BYPASS register.

### DIFF
--- a/riscv/jtag_dtm.h
+++ b/riscv/jtag_dtm.h
@@ -54,6 +54,7 @@ class jtag_dtm_t
     const unsigned abits = 6;
     uint32_t dtmcontrol;
     uint64_t dmi;
+    unsigned bypass;
     // Number of Run-Test/Idle cycles needed before we call this access
     // complete.
     unsigned rti_remaining;


### PR DESCRIPTION
This allows spike to be put into a virtual scan chain with other
remote_bitbang JTAG devices.