### PR TITLE
Fix compiler warning

### DIFF
--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -782,8 +782,8 @@ void processor_t::disasm(insn_t insn)
       fprintf(log_file, "core %3d: Executed %" PRIx64 " times\n", id, executions);
     }
 
-    fprintf(log_file, max_xlen==32 ? "core %3d: 0x%08" PRIx64 " (0x%08" PRIx32 ") %s\n" :
-                      "core %3d: 0x%016" PRIx64 " (0x%08" PRIx32 ") %s\n",
+    fprintf(log_file, max_xlen==32 ? "core %3d: 0x%08" PRIx64 " (0x%08" PRIx64 ") %s\n" :
+                      "core %3d: 0x%016" PRIx64 " (0x%08" PRIx64 ") %s\n",
             id, ERASE_32MSB(max_xlen,state.pc), bits, disassembler->disassemble(insn).c_str());
     last_pc = state.pc;
     last_bits = bits;


### PR DESCRIPTION
At compile time, gcc complains with:
../riscv/processor.cc:787:94: warning: format ‘%x’ expects argument of type ‘unsigned int’, but argument 5 has type ‘uint64_t {aka long unsigned int}’ [-Wformat=]

The variable 'bits' is an uint64_t, so that PRIx64 should be used to print it out.


Imho, pull request 'Display 32 bits #693' should have taken advantage of the printf specifier * to format pc, addresses, etc...
instead of this awkward serie of 
    fprintf(stderr, max_xlen==32 ? "fmt32" : "fmt64", ... );