### PR TITLE
Add alignment check for lr instruction

### DIFF
--- a/riscv/insns/lr_d.h
+++ b/riscv/insns/lr_d.h
@@ -1,5 +1,5 @@
 require_extension('A');
 require_rv64;
 auto res = MMU.load_int64(RS1, true);
-MMU.acquire_load_reservation(RS1);
+MMU.acquire_load_reservation(RS1, 8);
 WRITE_RD(res);

--- a/riscv/insns/lr_w.h
+++ b/riscv/insns/lr_w.h
@@ -1,4 +1,4 @@
 require_extension('A');
 auto res = MMU.load_int32(RS1, true);
-MMU.acquire_load_reservation(RS1);
+MMU.acquire_load_reservation(RS1, 4);
 WRITE_RD(res);

--- a/riscv/mmu.h
+++ b/riscv/mmu.h
@@ -253,8 +253,11 @@ public:
     load_reservation_address = (reg_t)-1;
   }
 
-  inline void acquire_load_reservation(reg_t vaddr)
+  inline void acquire_load_reservation(reg_t vaddr, size_t size)
   {
+    if (vaddr & (size-1))
+      load_reserved_address_misaligned(vaddr);
+
     reg_t paddr = translate(vaddr, 1, LOAD, 0);
     if (auto host_addr = sim->addr_to_mem(paddr))
       load_reservation_address = refill_tlb(vaddr, paddr, host_addr, LOAD).target_offset + vaddr;


### PR DESCRIPTION
Alignment check is privided for sc_w and sc_d, but missing for lr instruction.
The spec says:
> For **LR and SC,** the A extension requires that the address held in {rs1} be naturally aligned to the size of the operand (i.e.,eight-byte aligned for 64-bit words and four-byte aligned for 32-bitwords).  If the address is not naturally aligned, an address-misalignedexception or an access-fault exception will be generated. 

