### PR TITLE
PTE N bit moved from bit 62 to bit 63

### DIFF
--- a/riscv/encoding.h
+++ b/riscv/encoding.h
@@ -221,7 +221,7 @@
 #define PTE_A     0x040 /* Accessed */
 #define PTE_D     0x080 /* Dirty */
 #define PTE_SOFT  0x300 /* Reserved for Software */
-#define PTE_N     0x4000000000000000 /* Svnapot: NAPOT translation contiguity */
+#define PTE_N     0x8000000000000000 /* Svnapot: NAPOT translation contiguity */
 
 #define PTE_PPN_SHIFT 10
 


### PR DESCRIPTION
Updated spec draft available here:

https://github.com/riscv/virtual-memory/blob/main/specs/628-Svnapot.pdf