### PR TITLE
Apply scounteren only if S-mode is supported

### DIFF
--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -1405,7 +1405,7 @@ reg_t processor_t::get_csr(int which, insn_t insn, bool write, bool peek)
   uint32_t ctr_en = -1;
   if (state.prv < PRV_M)
     ctr_en &= state.mcounteren;
-  if (state.prv < PRV_S)
+  if (supports_extension('S') && state.prv < PRV_S)
     ctr_en &= state.scounteren;
   bool ctr_ok = (ctr_en >> (which & 31)) & 1;
   if (state.v)


### PR DESCRIPTION
When U-mode is enabled but S-mode is disabled, `mcounteren` should control the availability of the hardware performance-monitoring counters in U-mode, and `scounteren` should be ignored.
The current implementation (incorrectly) raises an illegal instruction trap when reading performance-monitoring counters in U-mode while S-mode is disabled, even though the counters are enabled in `mcounteren`.