### PR TITLE
Revert the redundant check for lr instruction

### DIFF
--- a/riscv/insns/lr_d.h
+++ b/riscv/insns/lr_d.h
@@ -1,5 +1,5 @@
 require_extension('A');
 require_rv64;
 auto res = MMU.load_int64(RS1, true);
-MMU.acquire_load_reservation(RS1, 8);
+MMU.acquire_load_reservation(RS1);
 WRITE_RD(res);

--- a/riscv/insns/lr_w.h
+++ b/riscv/insns/lr_w.h
@@ -1,4 +1,4 @@
 require_extension('A');
 auto res = MMU.load_int32(RS1, true);
-MMU.acquire_load_reservation(RS1, 4);
+MMU.acquire_load_reservation(RS1);
 WRITE_RD(res);

--- a/riscv/mmu.h
+++ b/riscv/mmu.h
@@ -253,11 +253,8 @@ public:
     load_reservation_address = (reg_t)-1;
   }
 
-  inline void acquire_load_reservation(reg_t vaddr, size_t size)
+  inline void acquire_load_reservation(reg_t vaddr)
   {
-    if (vaddr & (size-1))
-      load_reserved_address_misaligned(vaddr);
-
     reg_t paddr = translate(vaddr, 1, LOAD, 0);
     if (auto host_addr = sim->addr_to_mem(paddr))
       load_reservation_address = refill_tlb(vaddr, paddr, host_addr, LOAD).target_offset + vaddr;


### PR DESCRIPTION
As @scottj97 says in #713 , it's redundant since alignment check has been done in load_func.
@scottj97 please check it, thanks.