### PR TITLE
fix(aes64ks1i) : fix note in riscv/insns/aes64ks1i.h

### DIFF
--- a/riscv/insns/aes64ks1i.h
+++ b/riscv/insns/aes64ks1i.h
@@ -20,7 +20,7 @@ uint8_t     rcon              = 0            ;
 uint64_t    result                           ;
 
 if(enc_rcon != 0xA) {
-    temp    = (temp >> 8) | (temp << 24); // Rotate left by 8
+    temp    = (temp >> 8) | (temp << 24); // Rotate right by 8
     rcon    = round_consts[enc_rcon];
 }
 


### PR DESCRIPTION
the note in aes64ks1i should be " rotate right by 8"