### PR TITLE
rvk: Sign-extension for sha256 insns

### DIFF
--- a/riscv/insns/sha256sig0.h
+++ b/riscv/insns/sha256sig0.h
@@ -6,7 +6,7 @@ require_extension('K');
 uint32_t a = RS1;
 
 WRITE_RD(
-    ROR32(a, 7) ^ ROR32(a,18) ^ (a >> 3)
+    sext_xlen(ROR32(a, 7) ^ ROR32(a,18) ^ (a >> 3))
 );
 
 #undef ROR32

--- a/riscv/insns/sha256sig1.h
+++ b/riscv/insns/sha256sig1.h
@@ -6,7 +6,7 @@ require_extension('K');
 uint32_t a = RS1;
 
 WRITE_RD(
-    ROR32(a, 17) ^ ROR32(a,19) ^ (a >> 10)
+    sext_xlen(ROR32(a, 17) ^ ROR32(a,19) ^ (a >> 10))
 );
 
 #undef ROR32

--- a/riscv/insns/sha256sum0.h
+++ b/riscv/insns/sha256sum0.h
@@ -6,7 +6,7 @@ require_extension('K');
 uint32_t a = RS1;
 
 WRITE_RD(
-    ROR32(a, 2) ^ ROR32(a,13) ^ ROR32(a, 22)
+    sext_xlen(ROR32(a, 2) ^ ROR32(a,13) ^ ROR32(a, 22))
 );
 
 #undef ROR32

--- a/riscv/insns/sha256sum1.h
+++ b/riscv/insns/sha256sum1.h
@@ -6,7 +6,7 @@ require_extension('K');
 uint32_t a = RS1;
 
 WRITE_RD(
-    ROR32(a, 6) ^ ROR32(a,11) ^ ROR32(a, 25)
+    sext_xlen(ROR32(a, 6) ^ ROR32(a,11) ^ ROR32(a, 25))
 );
 
 #undef ROR32


### PR DESCRIPTION
See #682 or #685 -- k-ext insns have the same problem.
There are a few fixes -- I kindly ask to check all the not-RV64-only insns.