### PR TITLE
rvk: Sign-extension for aes32 insns

### DIFF
--- a/riscv/insns/aes32dsi.h
+++ b/riscv/insns/aes32dsi.h
@@ -12,5 +12,5 @@ uint32_t     u = x;
 
 u = (u << (8*bs)) | (u >> (32-8*bs));
 
-WRITE_RD(u ^ RS1);
+WRITE_RD(sext_xlen(u ^ RS1));
 

--- a/riscv/insns/aes32dsmi.h
+++ b/riscv/insns/aes32dsmi.h
@@ -17,5 +17,5 @@ u = (AES_GFMUL(x,0xb) << 24) |
 
 u = (u << (8*bs)) | (u >> (32-8*bs));
 
-WRITE_RD(u ^ RS1);
+WRITE_RD(sext_xlen(u ^ RS1));
 

--- a/riscv/insns/aes32esi.h
+++ b/riscv/insns/aes32esi.h
@@ -12,5 +12,5 @@ uint32_t     u = x;
 
 u = (u << (8*bs)) | (u >> (32-8*bs));
 
-WRITE_RD(u ^ RS1);
+WRITE_RD(sext_xlen(u ^ RS1));
 

--- a/riscv/insns/aes32esmi.h
+++ b/riscv/insns/aes32esmi.h
@@ -17,5 +17,5 @@ u = (AES_GFMUL(x,3) << 24) |
 
 u = (u << (8*bs)) | (u >> (32-8*bs));
 
-WRITE_RD(u ^ RS1);
+WRITE_RD(sext_xlen(u ^ RS1));
 


### PR DESCRIPTION
This fixes the same problem as #739  but for aes* insns.