### PR TITLE
ext-h: handle mislaigned in guest

### DIFF
--- a/riscv/execute.cc
+++ b/riscv/execute.cc
@@ -189,7 +189,9 @@ static reg_t execute_insn(processor_t* p, reg_t pc, insn_fetch_t fetch)
      }
 #ifdef RISCV_ENABLE_COMMITLOG
   } catch (wait_for_interrupt_t &t) {
-      commit_log_print_insn(p, pc, fetch.insn);
+      if (p->get_log_commits_enabled()) {
+        commit_log_print_insn(p, pc, fetch.insn);
+      }
       throw;
   } catch(mem_trap_t& t) {
       //handle segfault in midlle of vector load/store

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -315,7 +315,7 @@ public:
   }
   void check_pc_alignment(reg_t pc) {
     if (unlikely(pc & ~pc_alignment_mask()))
-      throw trap_instruction_address_misaligned(pc, 0, 0);
+      throw trap_instruction_address_misaligned(state.v, pc, 0, 0);
   }
   reg_t legalize_privilege(reg_t);
   void set_privilege(reg_t);

--- a/riscv/trap.h
+++ b/riscv/trap.h
@@ -72,24 +72,18 @@ class mem_trap_t : public trap_t
   const char* name() { return "trap_"#x; } \
 };
 
-#define DECLARE_MEM_NOGVA_TRAP(n, x) class trap_##x : public mem_trap_t { \
- public: \
-  trap_##x(reg_t tval, reg_t tval2, reg_t tinst) : mem_trap_t(n, false, tval, tval2, tinst) {} \
-  const char* name() { return "trap_"#x; } \
-};
-
 #define DECLARE_MEM_GVA_TRAP(n, x) class trap_##x : public mem_trap_t { \
  public: \
   trap_##x(reg_t tval, reg_t tval2, reg_t tinst) : mem_trap_t(n, true, tval, tval2, tinst) {} \
   const char* name() { return "trap_"#x; } \
 };
 
-DECLARE_MEM_NOGVA_TRAP(CAUSE_MISALIGNED_FETCH, instruction_address_misaligned)
+DECLARE_MEM_TRAP(CAUSE_MISALIGNED_FETCH, instruction_address_misaligned)
 DECLARE_MEM_TRAP(CAUSE_FETCH_ACCESS, instruction_access_fault)
 DECLARE_INST_TRAP(CAUSE_ILLEGAL_INSTRUCTION, illegal_instruction)
 DECLARE_INST_TRAP(CAUSE_BREAKPOINT, breakpoint)
-DECLARE_MEM_NOGVA_TRAP(CAUSE_MISALIGNED_LOAD, load_address_misaligned)
-DECLARE_MEM_NOGVA_TRAP(CAUSE_MISALIGNED_STORE, store_address_misaligned)
+DECLARE_MEM_TRAP(CAUSE_MISALIGNED_LOAD, load_address_misaligned)
+DECLARE_MEM_TRAP(CAUSE_MISALIGNED_STORE, store_address_misaligned)
 DECLARE_MEM_TRAP(CAUSE_LOAD_ACCESS, load_access_fault)
 DECLARE_MEM_TRAP(CAUSE_STORE_ACCESS, store_access_fault)
 DECLARE_TRAP(CAUSE_USER_ECALL, user_ecall)


### PR DESCRIPTION
The mis-aligned exception happening in guest world should update the mstatus.gva.   The spec change is still under discussion at
https://github.com/riscv/riscv-isa-manual/issues/673