### PR TITLE
rvk: Sign-extension of sha256 insns

### DIFF
--- a/riscv/insns/sha256sig0.h
+++ b/riscv/insns/sha256sig0.h
@@ -6,7 +6,7 @@ require_extension('K');
 uint32_t a = RS1;
 
 WRITE_RD(
-    sext_xlen(ROR32(a, 7) ^ ROR32(a,18) ^ (a >> 3))
+    sext32(ROR32(a, 7) ^ ROR32(a,18) ^ (a >> 3))
 );
 
 #undef ROR32

--- a/riscv/insns/sha256sig1.h
+++ b/riscv/insns/sha256sig1.h
@@ -6,7 +6,7 @@ require_extension('K');
 uint32_t a = RS1;
 
 WRITE_RD(
-    sext_xlen(ROR32(a, 17) ^ ROR32(a,19) ^ (a >> 10))
+    sext32(ROR32(a, 17) ^ ROR32(a,19) ^ (a >> 10))
 );
 
 #undef ROR32

--- a/riscv/insns/sha256sum0.h
+++ b/riscv/insns/sha256sum0.h
@@ -6,7 +6,7 @@ require_extension('K');
 uint32_t a = RS1;
 
 WRITE_RD(
-    sext_xlen(ROR32(a, 2) ^ ROR32(a,13) ^ ROR32(a, 22))
+    sext32(ROR32(a, 2) ^ ROR32(a,13) ^ ROR32(a, 22))
 );
 
 #undef ROR32

--- a/riscv/insns/sha256sum1.h
+++ b/riscv/insns/sha256sum1.h
@@ -6,7 +6,7 @@ require_extension('K');
 uint32_t a = RS1;
 
 WRITE_RD(
-    sext_xlen(ROR32(a, 6) ^ ROR32(a,11) ^ ROR32(a, 25))
+    sext32(ROR32(a, 6) ^ ROR32(a,11) ^ ROR32(a, 25))
 );
 
 #undef ROR32


### PR DESCRIPTION
@aswaterman, K-ext 0.9.4 spec now requires sign-extension of these insns (as rvkintrin.h does).