### PR TITLE
intr: make MIP_SEIP writable

### DIFF
--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -974,7 +974,8 @@ void processor_t::set_csr(int which, reg_t val)
       break;
     }
     case CSR_MIP: {
-      reg_t mask = (supervisor_ints | hypervisor_ints) & (MIP_SSIP | MIP_STIP | vssip_int);
+      reg_t mask = (supervisor_ints | hypervisor_ints) &
+                   (MIP_SEIP | MIP_SSIP | MIP_STIP | vssip_int);
       state.mip = (state.mip & ~mask) | (val & mask);
       break;
     }


### PR DESCRIPTION
based on riscv-privilege spec, section 3.1.9

"If supervisor mode is implemented, bits mip.SEIP and mie.SEIE are
the interrupt-pending and interrupt-enable bits for supervisor-level
external interrupts. SEIP is writable in mip, and may be written by M-mode
software to indicate to S-mode that an external interrupt is pending"

Signed-off-by: Chih-Min Chao <chihmin.chao@sifive.com>