### PR TITLE
add option --cmd to read commands from file

### DIFF
--- a/riscv/sim.cc
+++ b/riscv/sim.cc
@@ -36,11 +36,11 @@ sim_t::sim_t(const char* isa, const char* priv, const char* varch,
              std::vector<int> const hartids,
              const debug_module_config_t &dm_config,
              const char *log_path,
-             bool dtb_enabled, const char *dtb_file
+             bool dtb_enabled, const char *dtb_file,
 #ifdef HAVE_BOOST_ASIO
-             , io_service *io_service_ptr, tcp::acceptor *acceptor_ptr // option -s
+             io_service *io_service_ptr, tcp::acceptor *acceptor_ptr, // option -s
 #endif
-             )
+             FILE *cmd_file) // needed for command line option --cmd
   : htif_t(args),
     mems(mems),
     plugin_devices(plugin_devices),
@@ -52,6 +52,7 @@ sim_t::sim_t(const char* isa, const char* priv, const char* varch,
     dtb_file(dtb_file ? dtb_file : ""),
     dtb_enabled(dtb_enabled),
     log_file(log_path),
+    cmd_file(cmd_file),
 #ifdef HAVE_BOOST_ASIO
     io_service_ptr(io_service_ptr), // socket interface
     acceptor_ptr(acceptor_ptr),

--- a/riscv/sim.h
+++ b/riscv/sim.h
@@ -52,11 +52,11 @@ public:
         std::vector<std::pair<reg_t, abstract_device_t*>> plugin_devices,
         const std::vector<std::string>& args, const std::vector<int> hartids,
         const debug_module_config_t &dm_config, const char *log_path,
-        bool dtb_enabled, const char *dtb_file
+        bool dtb_enabled, const char *dtb_file,
 #ifdef HAVE_BOOST_ASIO
-        , io_service *io_service_ptr_ctor, tcp::acceptor *acceptor_ptr_ctor  // option -s
+        io_service *io_service_ptr_ctor, tcp::acceptor *acceptor_ptr_ctor,  // option -s
 #endif
-        );
+        FILE *cmd_file); // needed for command line option --cmd
   ~sim_t();
 
   // run the simulation to completion
@@ -100,6 +100,8 @@ private:
   std::unique_ptr<clint_t> clint;
   bus_t bus;
   log_file_t log_file;
+
+  FILE *cmd_file; // pointer to debug command input file
 
 #ifdef HAVE_BOOST_ASIO
   // the following are needed for command socket interface


### PR DESCRIPTION
This PR adds the option `--cmd=<name>` to the spike command line.
This new option is only useful if used together with option -d.
Before accepting interactive debug commands, the option `--cmd` reads and executes commands from the file given by `<name>`. However, if the last line of the command file is `quit`, the simulation ends without accepting any interactive command.

This option is useful, for example, to automatically simulate until the start of `main` before accepting interactive commands. To achieve this, the command file would contain, e. g., `until pc 0 0x00010144`, where `0x00010144` would have been obtained using `objdump`.

This option can also be used for regression tests in a more flexible way than option `-l`.
Such a regression test is not only useful for simulated executable RISC-V code but also for regression tests of spike itself.

This PR was part of #700, but had been removed from that PR because it was not directly related to it.