### PR TITLE
configure option --with-target

### DIFF
--- a/config.h.in
+++ b/config.h.in
@@ -126,6 +126,9 @@
 /* Define to 1 if you have the ANSI C header files. */
 #undef STDC_HEADERS
 
+/* Default value for --with-target switch */
+#undef TARGET_ARCH
+
 /* Define WORDS_BIGENDIAN to 1 if your processor stores words with the most
    significant byte first (like Motorola and SPARC, unlike Intel). */
 #if defined AC_APPLE_UNIVERSAL_BUILD

--- a/configure
+++ b/configure
@@ -714,6 +714,7 @@ with_boost_regex
 with_isa
 with_priv
 with_varch
+with_target
 enable_commitlog
 enable_histogram
 enable_dirty
@@ -1394,6 +1395,8 @@ Optional Packages:
   --with-priv=MSU         Sets the default RISC-V privilege modes supported
   --with-varch=vlen:128,elen:64,slen:128
                           Sets the default vector config
+  --with-target=riscv64-unknown-elf
+                          Sets the default target config
 
 Some influential environment variables:
   CC          C compiler command
@@ -5922,6 +5925,22 @@ _ACEOF
 
 fi
 
+
+
+# Check whether --with-target was given.
+if test "${with_target+set}" = set; then :
+  withval=$with_target;
+cat >>confdefs.h <<_ACEOF
+#define TARGET_ARCH "$withval"
+_ACEOF
+
+else
+
+cat >>confdefs.h <<_ACEOF
+#define TARGET_ARCH "riscv64-unknown-elf"
+_ACEOF
+
+fi
 
 
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for library containing dlopen" >&5

--- a/riscv/riscv.ac
+++ b/riscv/riscv.ac
@@ -26,6 +26,11 @@ AC_ARG_WITH(varch,
   AC_DEFINE_UNQUOTED([DEFAULT_VARCH], "$withval", [Default value for --varch switch]),
   AC_DEFINE_UNQUOTED([DEFAULT_VARCH], ["vlen:128,elen:64,slen:128"], [Default value for --varch switch]))
 
+AC_ARG_WITH(target,
+	[AS_HELP_STRING([--with-target=riscv64-unknown-elf],
+		[Sets the default target config])],
+  AC_DEFINE_UNQUOTED([TARGET_ARCH], "$withval", [Default value for --target switch]),
+  AC_DEFINE_UNQUOTED([TARGET_ARCH], ["riscv64-unknown-elf"], [Default value for --target switch]))
 
 AC_SEARCH_LIBS([dlopen], [dl dld], [
   AC_DEFINE([HAVE_DLOPEN], [], [Dynamic library loading is supported])


### PR DESCRIPTION
This PR adds a new configure option `--with-target`.
Using `--with-target=riscv32-unknown-elf` is a cleaner way to solve issue #589
than using `CXXFLAGS="-DTARGET_ARCH=\\\"riscv32-unknown-elf\\\""`.

This PR was part of #700, but had been removed from that PR because it was not related to it.