### PR TITLE
fesvr: replace use of `std::vector::operator[0]`

### DIFF
--- a/fesvr/device.cc
+++ b/fesvr/device.cc
@@ -110,10 +110,10 @@ void disk_t::handle_read(command_t cmd)
   cmd.memif().read(cmd.payload(), sizeof(req), &req);
 
   std::vector<uint8_t> buf(req.size);
-  if ((size_t)::pread(fd, &buf[0], buf.size(), req.offset) != req.size)
+  if ((size_t)::pread(fd, buf.data(), buf.size(), req.offset) != req.size)
     throw std::runtime_error("could not read " + id + " @ " + std::to_string(req.offset));
 
-  cmd.memif().write(req.addr, buf.size(), &buf[0]);
+  cmd.memif().write(req.addr, buf.size(), buf.data());
   cmd.respond(req.tag);
 }
 
@@ -123,9 +123,9 @@ void disk_t::handle_write(command_t cmd)
   cmd.memif().read(cmd.payload(), sizeof(req), &req);
 
   std::vector<uint8_t> buf(req.size);
-  cmd.memif().read(req.addr, buf.size(), &buf[0]);
+  cmd.memif().read(req.addr, buf.size(), buf.data());
 
-  if ((size_t)::pwrite(fd, &buf[0], buf.size(), req.offset) != req.size)
+  if ((size_t)::pwrite(fd, buf.data(), buf.size(), req.offset) != req.size)
     throw std::runtime_error("could not write " + id + " @ " + std::to_string(req.offset));
 
   cmd.respond(req.tag);

--- a/fesvr/elfloader.cc
+++ b/fesvr/elfloader.cc
@@ -56,7 +56,7 @@ std::map<std::string, uint64_t> load_elf(const char* fn, memif_t* memif, reg_t* 
         if (size_t pad = bswap(ph[i].p_memsz) - bswap(ph[i].p_filesz)) {       \
           zeros.resize(pad);                                                   \
           memif->write(bswap(ph[i].p_paddr) + bswap(ph[i].p_filesz), pad,      \
-                       &zeros[0]);                                             \
+                       zeros.data());                                          \
         }                                                                      \
       }                                                                        \
     }                                                                          \

--- a/fesvr/elfloader.cc
+++ b/fesvr/elfloader.cc
@@ -40,49 +40,56 @@ std::map<std::string, uint64_t> load_elf(const char* fn, memif_t* memif, reg_t* 
   std::vector<uint8_t> zeros;
   std::map<std::string, uint64_t> symbols;
 
-  #define LOAD_ELF(ehdr_t, phdr_t, shdr_t, sym_t, bswap) do { \
-    ehdr_t* eh = (ehdr_t*)buf; \
-    phdr_t* ph = (phdr_t*)(buf + bswap(eh->e_phoff)); \
-    *entry = bswap(eh->e_entry); \
-    assert(size >= bswap(eh->e_phoff) + bswap(eh->e_phnum)*sizeof(*ph)); \
-    for (unsigned i = 0; i < bswap(eh->e_phnum); i++) {			\
-      if(bswap(ph[i].p_type) == PT_LOAD && bswap(ph[i].p_memsz)) {	\
-        if (bswap(ph[i].p_filesz)) {					\
-          assert(size >= bswap(ph[i].p_offset) + bswap(ph[i].p_filesz)); \
-          memif->write(bswap(ph[i].p_paddr), bswap(ph[i].p_filesz), (uint8_t*)buf + bswap(ph[i].p_offset)); \
-        } \
-        zeros.resize(bswap(ph[i].p_memsz) - bswap(ph[i].p_filesz)); \
-        memif->write(bswap(ph[i].p_paddr) + bswap(ph[i].p_filesz), bswap(ph[i].p_memsz) - bswap(ph[i].p_filesz), &zeros[0]); \
-      } \
-    } \
-    shdr_t* sh = (shdr_t*)(buf + bswap(eh->e_shoff)); \
-    assert(size >= bswap(eh->e_shoff) + bswap(eh->e_shnum)*sizeof(*sh)); \
-    assert(bswap(eh->e_shstrndx) < bswap(eh->e_shnum)); \
-    assert(size >= bswap(sh[bswap(eh->e_shstrndx)].sh_offset) + bswap(sh[bswap(eh->e_shstrndx)].sh_size)); \
-    char *shstrtab = buf + bswap(sh[bswap(eh->e_shstrndx)].sh_offset);	\
-    unsigned strtabidx = 0, symtabidx = 0; \
-    for (unsigned i = 0; i < bswap(eh->e_shnum); i++) {		     \
-      unsigned max_len = bswap(sh[bswap(eh->e_shstrndx)].sh_size) - bswap(sh[i].sh_name); \
-      assert(bswap(sh[i].sh_name) < bswap(sh[bswap(eh->e_shstrndx)].sh_size));	\
-      assert(strnlen(shstrtab + bswap(sh[i].sh_name), max_len) < max_len); \
-      if (bswap(sh[i].sh_type) & SHT_NOBITS) continue; \
-      assert(size >= bswap(sh[i].sh_offset) + bswap(sh[i].sh_size)); \
-      if (strcmp(shstrtab + bswap(sh[i].sh_name), ".strtab") == 0) \
-        strtabidx = i; \
-      if (strcmp(shstrtab + bswap(sh[i].sh_name), ".symtab") == 0) \
-        symtabidx = i; \
-    } \
-    if (strtabidx && symtabidx) { \
-      char* strtab = buf + bswap(sh[strtabidx].sh_offset); \
-      sym_t* sym = (sym_t*)(buf + bswap(sh[symtabidx].sh_offset)); \
-      for (unsigned i = 0; i < bswap(sh[symtabidx].sh_size)/sizeof(sym_t); i++) { \
-        unsigned max_len = bswap(sh[strtabidx].sh_size) - bswap(sym[i].st_name); \
-        assert(bswap(sym[i].st_name) < bswap(sh[strtabidx].sh_size));	\
-        assert(strnlen(strtab + bswap(sym[i].st_name), max_len) < max_len); \
-        symbols[strtab + bswap(sym[i].st_name)] = bswap(sym[i].st_value); \
-      } \
-    } \
-  } while(0)
+#define LOAD_ELF(ehdr_t, phdr_t, shdr_t, sym_t, bswap)                         \
+  do {                                                                         \
+    ehdr_t* eh = (ehdr_t*)buf;                                                 \
+    phdr_t* ph = (phdr_t*)(buf + bswap(eh->e_phoff));                          \
+    *entry = bswap(eh->e_entry);                                               \
+    assert(size >= bswap(eh->e_phoff) + bswap(eh->e_phnum) * sizeof(*ph));     \
+    for (unsigned i = 0; i < bswap(eh->e_phnum); i++) {                        \
+      if (bswap(ph[i].p_type) == PT_LOAD && bswap(ph[i].p_memsz)) {            \
+        if (bswap(ph[i].p_filesz)) {                                           \
+          assert(size >= bswap(ph[i].p_offset) + bswap(ph[i].p_filesz));       \
+          memif->write(bswap(ph[i].p_paddr), bswap(ph[i].p_filesz),            \
+                       (uint8_t*)buf + bswap(ph[i].p_offset));                 \
+        }                                                                      \
+        zeros.resize(bswap(ph[i].p_memsz) - bswap(ph[i].p_filesz));            \
+        memif->write(bswap(ph[i].p_paddr) + bswap(ph[i].p_filesz),             \
+                     bswap(ph[i].p_memsz) - bswap(ph[i].p_filesz), &zeros[0]); \
+      }                                                                        \
+    }                                                                          \
+    shdr_t* sh = (shdr_t*)(buf + bswap(eh->e_shoff));                          \
+    assert(size >= bswap(eh->e_shoff) + bswap(eh->e_shnum) * sizeof(*sh));     \
+    assert(bswap(eh->e_shstrndx) < bswap(eh->e_shnum));                        \
+    assert(size >= bswap(sh[bswap(eh->e_shstrndx)].sh_offset) +                \
+                       bswap(sh[bswap(eh->e_shstrndx)].sh_size));              \
+    char* shstrtab = buf + bswap(sh[bswap(eh->e_shstrndx)].sh_offset);         \
+    unsigned strtabidx = 0, symtabidx = 0;                                     \
+    for (unsigned i = 0; i < bswap(eh->e_shnum); i++) {                        \
+      unsigned max_len =                                                       \
+          bswap(sh[bswap(eh->e_shstrndx)].sh_size) - bswap(sh[i].sh_name);     \
+      assert(bswap(sh[i].sh_name) < bswap(sh[bswap(eh->e_shstrndx)].sh_size)); \
+      assert(strnlen(shstrtab + bswap(sh[i].sh_name), max_len) < max_len);     \
+      if (bswap(sh[i].sh_type) & SHT_NOBITS) continue;                         \
+      assert(size >= bswap(sh[i].sh_offset) + bswap(sh[i].sh_size));           \
+      if (strcmp(shstrtab + bswap(sh[i].sh_name), ".strtab") == 0)             \
+        strtabidx = i;                                                         \
+      if (strcmp(shstrtab + bswap(sh[i].sh_name), ".symtab") == 0)             \
+        symtabidx = i;                                                         \
+    }                                                                          \
+    if (strtabidx && symtabidx) {                                              \
+      char* strtab = buf + bswap(sh[strtabidx].sh_offset);                     \
+      sym_t* sym = (sym_t*)(buf + bswap(sh[symtabidx].sh_offset));             \
+      for (unsigned i = 0; i < bswap(sh[symtabidx].sh_size) / sizeof(sym_t);   \
+           i++) {                                                              \
+        unsigned max_len =                                                     \
+            bswap(sh[strtabidx].sh_size) - bswap(sym[i].st_name);              \
+        assert(bswap(sym[i].st_name) < bswap(sh[strtabidx].sh_size));          \
+        assert(strnlen(strtab + bswap(sym[i].st_name), max_len) < max_len);    \
+        symbols[strtab + bswap(sym[i].st_name)] = bswap(sym[i].st_value);      \
+      }                                                                        \
+    }                                                                          \
+  } while (0)
 
   if (IS_ELFLE(*eh64)) {
     memif->set_target_endianness(memif_endianness_little);

--- a/fesvr/elfloader.cc
+++ b/fesvr/elfloader.cc
@@ -53,9 +53,11 @@ std::map<std::string, uint64_t> load_elf(const char* fn, memif_t* memif, reg_t* 
           memif->write(bswap(ph[i].p_paddr), bswap(ph[i].p_filesz),            \
                        (uint8_t*)buf + bswap(ph[i].p_offset));                 \
         }                                                                      \
-        zeros.resize(bswap(ph[i].p_memsz) - bswap(ph[i].p_filesz));            \
-        memif->write(bswap(ph[i].p_paddr) + bswap(ph[i].p_filesz),             \
-                     bswap(ph[i].p_memsz) - bswap(ph[i].p_filesz), &zeros[0]); \
+        if (size_t pad = bswap(ph[i].p_memsz) - bswap(ph[i].p_filesz)) {       \
+          zeros.resize(pad);                                                   \
+          memif->write(bswap(ph[i].p_paddr) + bswap(ph[i].p_filesz), pad,      \
+                       &zeros[0]);                                             \
+        }                                                                      \
       }                                                                        \
     }                                                                          \
     shdr_t* sh = (shdr_t*)(buf + bswap(eh->e_shoff));                          \

--- a/fesvr/htif.cc
+++ b/fesvr/htif.cc
@@ -169,7 +169,7 @@ void htif_t::stop()
   if (!sig_file.empty() && sig_len) // print final torture test signature
   {
     std::vector<uint8_t> buf(sig_len);
-    mem.read(sig_addr, sig_len, &buf[0]);
+    mem.read(sig_addr, sig_len, buf.data());
 
     std::ofstream sigs(sig_file);
     assert(sigs && "can't open signature file!");


### PR DESCRIPTION
This replaces multiple uses of `std::vector::operator[]` where the
parameter is a constant `0` with the use of C++11's `std::vector::data`
method.  This fixes the root cause of invalid memory accesses.
`std::vector::operator[]` is an unchecked memory access, and when the
buffers are zero-sized (that is the buffer container is empty) either
due to a 0 padding in the case of elfloader or NULL parameters to
syscalls where permitted, the unchecked access may cause an invalid
memory access.  The use of `std::vector::data` is permitted even in such
a case, though the returned memory may not be dereferenced.  The general
usage of the returned pointer is to pass to `memif_t`, which is careful
about 0-sized buffer accesses, and so passing the result of
`std::vector::data` is safe.  This is theoretically a better access
pattern as it also avoids having the compiler to re-materialize the
pointer from the de-referenced location.