### PR TITLE
include freg command in help text

### DIFF
--- a/riscv/interactive.cc
+++ b/riscv/interactive.cc
@@ -199,6 +199,7 @@ void sim_t::interactive_help(const std::string& cmd, const std::vector<std::stri
   sout <<
     "Interactive commands:\n"
     "reg <core> [reg]                # Display [reg] (all if omitted) in <core>\n"
+    "freg <core> <reg>               # Display float <reg> in <core> as hex\n"
     "fregh <core> <reg>              # Display half precision <reg> in <core>\n"
     "fregs <core> <reg>              # Display single precision <reg> in <core>\n"
     "fregd <core> <reg>              # Display double precision <reg> in <core>\n"


### PR DESCRIPTION
This PR includes the `freg` command in the list displayed by the `help` command.

The `freg` command had been introduced into spike in 2017.

This PR was part of #700, but had been removed from that PR because it was not related to it.