### PR TITLE
Refactor CSR modeling

### DIFF
--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -617,7 +617,7 @@ reg_t generic_int_accessor_t::deleg_mask() const {
 
 // implement class mip_proxy_csr_t
 mip_proxy_csr_t::mip_proxy_csr_t(processor_t* const proc, const reg_t addr, generic_int_accessor_t_p accr):
-  csr_t(proc, addr),
+  logged_csr_t(proc, addr),
   accr(accr) {
 }
 
@@ -625,8 +625,9 @@ reg_t mip_proxy_csr_t::read() const noexcept {
   return accr->ip_read();
 }
 
-void mip_proxy_csr_t::write(const reg_t val) noexcept {
+bool mip_proxy_csr_t::unlogged_write(const reg_t val) noexcept {
   accr->ip_write(val);
+  return false;  // accr has already logged
 }
 
 // implement class mie_proxy_csr_t

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -40,11 +40,6 @@ void csr_t::verify_permissions(insn_t insn, bool write) const {
 csr_t::~csr_t() {
 }
 
-// implement class logged_csr_t
-logged_csr_t::logged_csr_t(processor_t* const proc, const reg_t addr):
-  csr_t(proc, addr) {
-}
-
 void csr_t::write(const reg_t val) noexcept {
   const bool success = unlogged_write(val);
   if (success) {
@@ -60,7 +55,7 @@ void csr_t::log_write() const noexcept {
 
 // implement class basic_csr_t
 basic_csr_t::basic_csr_t(processor_t* const proc, const reg_t addr, const reg_t init):
-  logged_csr_t(proc, addr),
+  csr_t(proc, addr),
   val(init) {
 }
 
@@ -76,7 +71,7 @@ bool basic_csr_t::unlogged_write(const reg_t val) noexcept {
 
 // implement class pmpaddr_csr_t
 pmpaddr_csr_t::pmpaddr_csr_t(processor_t* const proc, const reg_t addr):
-  logged_csr_t(proc, addr),
+  csr_t(proc, addr),
   val(0),
   cfg(0),
   pmpidx(address - CSR_PMPADDR0) {
@@ -84,7 +79,7 @@ pmpaddr_csr_t::pmpaddr_csr_t(processor_t* const proc, const reg_t addr):
 
 
 void pmpaddr_csr_t::verify_permissions(insn_t insn, bool write) const {
-  logged_csr_t::verify_permissions(insn, write);
+  csr_t::verify_permissions(insn, write);
   // If n_pmp is zero, that means pmp is not implemented hence raise
   // trap if it tries to access the csr. I would prefer to implement
   // this by not instantiating any pmpaddr_csr_t for these regs, but
@@ -189,7 +184,7 @@ bool pmpaddr_csr_t::access_ok(access_type type, reg_t mode) const noexcept {
 
 // implement class pmpcfg_csr_t
 pmpcfg_csr_t::pmpcfg_csr_t(processor_t* const proc, const reg_t addr):
-  logged_csr_t(proc, addr) {
+  csr_t(proc, addr) {
 }
 
 reg_t pmpcfg_csr_t::read() const noexcept {
@@ -223,7 +218,7 @@ bool pmpcfg_csr_t::unlogged_write(const reg_t val) noexcept {
 
 // implement class virtualized_csr_t
 virtualized_csr_t::virtualized_csr_t(processor_t* const proc, csr_t_p orig, csr_t_p virt):
-  logged_csr_t(proc, orig->address),
+  csr_t(proc, orig->address),
   orig_csr(orig),
   virt_csr(virt) {
 }
@@ -248,7 +243,7 @@ bool virtualized_csr_t::unlogged_write(const reg_t val) noexcept {
 
 // implement class epc_csr_t
 epc_csr_t::epc_csr_t(processor_t* const proc, const reg_t addr):
-  logged_csr_t(proc, addr),
+  csr_t(proc, addr),
   val(0) {
 }
 
@@ -266,7 +261,7 @@ bool epc_csr_t::unlogged_write(const reg_t val) noexcept {
 
 // implement class tvec_csr_t
 tvec_csr_t::tvec_csr_t(processor_t* const proc, const reg_t addr):
-  logged_csr_t(proc, addr),
+  csr_t(proc, addr),
   val(0) {
 }
 
@@ -301,7 +296,7 @@ reg_t cause_csr_t::read() const noexcept {
 
 // implement class base_status_csr_t
 base_status_csr_t::base_status_csr_t(processor_t* const proc, const reg_t addr):
-  logged_csr_t(proc, addr),
+  csr_t(proc, addr),
   has_page(proc->extension_enabled_const('S') && proc->supports_impl(IMPL_MMU)),
   sstatus_write_mask(compute_sstatus_write_mask()),
   sstatus_read_mask(sstatus_write_mask | SSTATUS_UBE | SSTATUS_UXL
@@ -517,7 +512,7 @@ bool misa_csr_t::extension_enabled_const(unsigned char ext) const noexcept {
 
 // implement class mip_or_mie_csr_t
 mip_or_mie_csr_t::mip_or_mie_csr_t(processor_t* const proc, const reg_t addr):
-  logged_csr_t(proc, addr),
+  csr_t(proc, addr),
   val(0) {
 }
 
@@ -617,7 +612,7 @@ reg_t generic_int_accessor_t::deleg_mask() const {
 
 // implement class mip_proxy_csr_t
 mip_proxy_csr_t::mip_proxy_csr_t(processor_t* const proc, const reg_t addr, generic_int_accessor_t_p accr):
-  logged_csr_t(proc, addr),
+  csr_t(proc, addr),
   accr(accr) {
 }
 
@@ -632,7 +627,7 @@ bool mip_proxy_csr_t::unlogged_write(const reg_t val) noexcept {
 
 // implement class mie_proxy_csr_t
 mie_proxy_csr_t::mie_proxy_csr_t(processor_t* const proc, const reg_t addr, generic_int_accessor_t_p accr):
-  logged_csr_t(proc, addr),
+  csr_t(proc, addr),
   accr(accr) {
 }
 

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -404,7 +404,7 @@ bool mstatus_csr_t::unlogged_write(const reg_t val) noexcept {
   bool has_gva = has_mpv;
 
   reg_t mask = MSTATUS_MIE | MSTATUS_MPIE | MSTATUS_MPRV | MSTATUS_MPP
-             | (proc->extension_enabled('S') ? (MSTATUS_SIE | MSTATUS_SPIE) : 0)
+             | (proc->extension_enabled('S') ? (MSTATUS_SIE | MSTATUS_SPIE | MSTATUS_SPP) : 0)
              | MSTATUS_TW | MSTATUS_TSR
              | (has_page ? (MSTATUS_MXR | MSTATUS_SUM | MSTATUS_TVM) : 0)
              | (has_fs ? MSTATUS_FS : 0)
@@ -415,8 +415,6 @@ bool mstatus_csr_t::unlogged_write(const reg_t val) noexcept {
 
   reg_t requested_mpp = proc->legalize_privilege(get_field(val, MSTATUS_MPP));
   reg_t new_mstatus = set_field(val, MSTATUS_MPP, requested_mpp);
-  if (proc->extension_enabled('S'))
-    mask |= MSTATUS_SPP;
 
   new_mstatus = (read() & ~mask) | (new_mstatus & mask);
   new_mstatus = adjust_sd(new_mstatus);

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -525,7 +525,7 @@ reg_t mip_or_mie_csr_t::read() const noexcept {
 }
 
 void mip_or_mie_csr_t::write_with_mask(const reg_t mask, const reg_t val) noexcept {
-  backdoor_write_with_mask(mask, val);
+  this->val = (this->val & ~mask) | (val & mask);
   log_write();
 }
 

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -358,13 +358,9 @@ sstatus_proxy_csr_t::sstatus_proxy_csr_t(processor_t* const proc, const reg_t ad
 reg_t sstatus_proxy_csr_t::read() const noexcept {
   reg_t mask = SSTATUS_SIE | SSTATUS_SPIE | SSTATUS_UBE | SSTATUS_SPP
              | SSTATUS_FS | (proc->supports_extension('V') ? SSTATUS_VS : 0)
-             | SSTATUS_XS | SSTATUS_SUM | SSTATUS_MXR | SSTATUS_UXL;
-  reg_t sstatus = mstatus->read() & mask;
-  if ((sstatus & SSTATUS_FS) == SSTATUS_FS ||
-      (sstatus & SSTATUS_XS) == SSTATUS_XS ||
-      (sstatus & SSTATUS_VS) == SSTATUS_VS)
-    sstatus |= (proc->get_xlen() == 32 ? SSTATUS32_SD : SSTATUS64_SD);
-  return sstatus;
+             | SSTATUS_XS | SSTATUS_SUM | SSTATUS_MXR | SSTATUS_UXL
+             | (proc->get_xlen() == 32 ? SSTATUS32_SD : SSTATUS64_SD);
+  return mstatus->read() & mask;
 }
 
 bool sstatus_proxy_csr_t::unlogged_write(const reg_t val) noexcept {

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -330,6 +330,9 @@ bool vsstatus_csr_t::unlogged_write(const reg_t val) noexcept {
 }
 
 void vsstatus_csr_t::backdoor_write(const reg_t val) noexcept {
+  bool has_page = proc->supports_extension('S') && proc->supports_impl(IMPL_MMU);
+  if (has_page && ((val ^ read()) & (MSTATUS_MXR | MSTATUS_SUM)))
+    proc->get_mmu()->flush_tlb();
   reg_t mask = SSTATUS_VS_MASK;
   mask |= (proc->supports_extension('V') ? SSTATUS_VS : 0);
   reg_t newval = (this->val & ~mask) | (val & mask);

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -529,10 +529,6 @@ void mip_or_mie_csr_t::write_with_mask(const reg_t mask, const reg_t val) noexce
   log_write();
 }
 
-void mip_csr_t::backdoor_write_with_mask(const reg_t mask, const reg_t val) noexcept {
-  this->val = (this->val & ~mask) | (val & mask);
-}
-
 bool mip_or_mie_csr_t::unlogged_write(const reg_t val) noexcept {
   write_with_mask(write_mask(), val);
   return false; // avoid double logging: already logged by write_with_mask()
@@ -543,6 +539,9 @@ mip_csr_t::mip_csr_t(processor_t* const proc, const reg_t addr):
   mip_or_mie_csr_t(proc, addr) {
 }
 
+void mip_csr_t::backdoor_write_with_mask(const reg_t mask, const reg_t val) noexcept {
+  this->val = (this->val & ~mask) | (val & mask);
+}
 
 reg_t mip_csr_t::write_mask() const noexcept {
   const reg_t supervisor_ints = proc->extension_enabled('S') ? MIP_SSIP | MIP_STIP | MIP_SEIP : 0;

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -355,7 +355,7 @@ namespace {
 // implement class vsstatus_csr_t
 vsstatus_csr_t::vsstatus_csr_t(processor_t* const proc, const reg_t addr):
   base_status_csr_t(proc, addr),
-  val(set_field((reg_t)0, SSTATUS_UXL, xlen_to_uxl(proc->get_const_xlen()))) {
+  val(proc->get_state()->mstatus->read() & sstatus_read_mask) {
 }
 
 reg_t vsstatus_csr_t::read() const noexcept {

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -45,14 +45,14 @@ logged_csr_t::logged_csr_t(processor_t* const proc, const reg_t addr):
   csr_t(proc, addr) {
 }
 
-void logged_csr_t::write(const reg_t val) noexcept {
+void csr_t::write(const reg_t val) noexcept {
   const bool success = unlogged_write(val);
   if (success) {
     log_write();
   }
 }
 
-void logged_csr_t::log_write() const noexcept {
+void csr_t::log_write() const noexcept {
 #if defined(RISCV_ENABLE_COMMITLOG)
   proc->get_state()->log_reg_write[((address) << 4) | 4] = {read(), 0};
 #endif

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -361,7 +361,8 @@ sstatus_proxy_csr_t::sstatus_proxy_csr_t(processor_t* const proc, const reg_t ad
   logged_csr_t(proc, addr),
   mstatus(proc->get_state()->mstatus),
   write_mask(SSTATUS_SIE | SSTATUS_SPIE | SSTATUS_SPP | SSTATUS_FS
-             | SSTATUS_XS | SSTATUS_SUM | SSTATUS_MXR
+             | SSTATUS_SUM | SSTATUS_MXR
+             | (proc->any_custom_extensions() ? SSTATUS_XS : 0)
              | (proc->extension_enabled_const('V') ? SSTATUS_VS : 0)),
   read_mask(write_mask | SSTATUS_UBE | SSTATUS_UXL
             | (proc->get_const_xlen() == 32 ? SSTATUS32_SD : SSTATUS64_SD)) {

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -46,11 +46,16 @@ logged_csr_t::logged_csr_t(processor_t* const proc, const reg_t addr):
 }
 
 void logged_csr_t::write(const reg_t val) noexcept {
-  if (unlogged_write(val)) {
-#if defined(RISCV_ENABLE_COMMITLOG)
-    proc->get_state()->log_reg_write[((address) << 4) | 4] = {read(), 0};
-#endif
+  const bool success = unlogged_write(val);
+  if (success) {
+    log_write();
   }
+}
+
+void logged_csr_t::log_write() const noexcept {
+#if defined(RISCV_ENABLE_COMMITLOG)
+  proc->get_state()->log_reg_write[((address) << 4) | 4] = {read(), 0};
+#endif
 }
 
 // implement class basic_csr_t

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -348,12 +348,7 @@ bool vsstatus_csr_t::unlogged_write(const reg_t val) noexcept {
   bool has_page = proc->extension_enabled('S') && proc->supports_impl(IMPL_MMU);
   if (state->v && has_page && ((val ^ read()) & (MSTATUS_MXR | MSTATUS_SUM)))
     proc->get_mmu()->flush_tlb();
-  const reg_t mask = (SSTATUS_SIE | SSTATUS_SPIE
-                      | SSTATUS_SPP | SSTATUS_FS | SSTATUS_SUM
-                      | SSTATUS_MXR
-                      | (proc->any_custom_extensions() ? SSTATUS_XS : 0)
-                      | (proc->extension_enabled_const('V') ? SSTATUS_VS : 0));
-  reg_t newval = (this->val & ~mask) | (val & mask);
+  reg_t newval = (this->val & ~sstatus_write_mask) | (val & sstatus_write_mask);
   newval = adjust_sd(newval);
   if (proc->extension_enabled('U'))
     newval = set_field(newval, SSTATUS_UXL, xlen_to_uxl(proc->get_const_xlen()));

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -13,9 +13,19 @@ csr_t::csr_t(processor_t* const proc, const reg_t addr):
 csr_t::~csr_t() {
 }
 
+// implement class logged_csr_t
+logged_csr_t::logged_csr_t(processor_t* const proc, const reg_t addr):
+  csr_t(proc, addr) {
+}
+
+void logged_csr_t::write(const reg_t val) noexcept {
+  unlogged_write(val);
+  // Add logging here soon
+}
+
 // implement class basic_csr_t
 basic_csr_t::basic_csr_t(processor_t* const proc, const reg_t addr, const reg_t init):
-  csr_t(proc, addr),
+  logged_csr_t(proc, addr),
   val(init) {
 }
 
@@ -23,6 +33,6 @@ reg_t basic_csr_t::read() const noexcept {
   return val;
 }
 
-void basic_csr_t::write(const reg_t val) noexcept {
+void basic_csr_t::unlogged_write(const reg_t val) noexcept {
   this->val = val;
 }

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -412,19 +412,13 @@ bool mstatus_csr_t::unlogged_write(const reg_t val) noexcept {
       ))
     proc->get_mmu()->flush_tlb();
 
-  bool has_fs = proc->extension_enabled('S') || proc->extension_enabled('F')
-              || proc->extension_enabled_const('V');
-  bool has_vs = proc->extension_enabled_const('V');
   bool has_mpv = proc->extension_enabled('S') && proc->extension_enabled('H');
   bool has_gva = has_mpv;
 
-  reg_t mask = MSTATUS_MIE | MSTATUS_MPIE | MSTATUS_MPRV | MSTATUS_MPP
-             | (proc->extension_enabled('S') ? (MSTATUS_SIE | MSTATUS_SPIE | MSTATUS_SPP) : 0)
-             | MSTATUS_TW | MSTATUS_TSR
-             | (has_page ? (MSTATUS_MXR | MSTATUS_SUM | MSTATUS_TVM) : 0)
-             | (has_fs ? MSTATUS_FS : 0)
-             | (has_vs ? MSTATUS_VS : 0)
-             | (proc->any_custom_extensions() ? MSTATUS_XS : 0)
+  reg_t mask = sstatus_write_mask
+             | MSTATUS_MIE | MSTATUS_MPIE | MSTATUS_MPRV
+             | MSTATUS_MPP | MSTATUS_TW | MSTATUS_TSR
+             | (has_page ? MSTATUS_TVM : 0)
              | (has_gva ? MSTATUS_GVA : 0)
              | (has_mpv ? MSTATUS_MPV : 0);
 

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -145,6 +145,19 @@ reg_t pmpaddr_csr_t::napot_mask() const noexcept {
 }
 
 
+bool pmpaddr_csr_t::match4(reg_t cur_addr) const noexcept {
+  state_t* const state = proc->get_state();
+  uint8_t cfg = state->pmpcfg[pmpidx];
+  if ((cfg & PMP_A) == 0) return false;
+  reg_t base = tor_base_paddr();
+  reg_t tor = tor_paddr();
+  bool is_tor = (cfg & PMP_A) == PMP_TOR;
+  bool napot_match = ((cur_addr ^ tor) & napot_mask()) == 0;
+  bool tor_match = base <= cur_addr && cur_addr < tor;
+  return is_tor ? tor_match : napot_match;
+}
+
+
 // implement class pmpcfg_csr_t
 pmpcfg_csr_t::pmpcfg_csr_t(processor_t* const proc, const reg_t addr):
   logged_csr_t(proc, addr) {

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -322,6 +322,11 @@ namespace {
 
 
 bool vsstatus_csr_t::unlogged_write(const reg_t val) noexcept {
+  backdoor_write(val);
+  return true;
+}
+
+void vsstatus_csr_t::backdoor_write(const reg_t val) noexcept {
   reg_t mask = SSTATUS_VS_MASK;
   mask |= (proc->supports_extension('V') ? SSTATUS_VS : 0);
   reg_t newval = (this->val & ~mask) | (val & mask);
@@ -335,5 +340,4 @@ bool vsstatus_csr_t::unlogged_write(const reg_t val) noexcept {
     newval = set_field(newval, SSTATUS_UXL, xlen_to_uxl(proc->get_max_xlen()));
 
   this->val = newval;
-  return true;
 }

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -529,7 +529,7 @@ void mip_or_mie_csr_t::write_with_mask(const reg_t mask, const reg_t val) noexce
   log_write();
 }
 
-void mip_or_mie_csr_t::backdoor_write_with_mask(const reg_t mask, const reg_t val) noexcept {
+void mip_csr_t::backdoor_write_with_mask(const reg_t mask, const reg_t val) noexcept {
   this->val = (this->val & ~mask) | (val & mask);
 }
 

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -359,7 +359,7 @@ bool vsstatus_csr_t::unlogged_write(const reg_t val) noexcept {
 
 // implement class sstatus_proxy_csr_t
 sstatus_proxy_csr_t::sstatus_proxy_csr_t(processor_t* const proc, const reg_t addr):
-  logged_csr_t(proc, addr),
+  base_status_csr_t(proc, addr),
   mstatus(proc->get_state()->mstatus),
   write_mask(SSTATUS_SIE | SSTATUS_SPIE | SSTATUS_SPP | SSTATUS_FS
              | SSTATUS_SUM | SSTATUS_MXR

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -259,3 +259,21 @@ bool epc_csr_t::unlogged_write(const reg_t val) noexcept {
   this->val = val & ~(reg_t)1;
   return true;
 }
+
+
+// implement class tvec_csr_t
+tvec_csr_t::tvec_csr_t(processor_t* const proc, const reg_t addr):
+  logged_csr_t(proc, addr),
+  val(0) {
+}
+
+
+reg_t tvec_csr_t::read() const noexcept {
+  return val;
+}
+
+
+bool tvec_csr_t::unlogged_write(const reg_t val) noexcept {
+  this->val = val & ~(reg_t)2;
+  return true;
+}

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -180,6 +180,18 @@ bool pmpaddr_csr_t::subset_match(reg_t addr, reg_t len) const noexcept {
   return !(is_tor ? tor_homogeneous : napot_homogeneous);
 }
 
+
+bool pmpaddr_csr_t::access_ok(access_type type, reg_t mode) const noexcept {
+  state_t* const state = proc->get_state();
+  uint8_t cfg = state->pmpcfg[pmpidx];
+  return
+    (mode == PRV_M && !(cfg & PMP_L)) ||
+    (type == LOAD && (cfg & PMP_R)) ||
+    (type == STORE && (cfg & PMP_W)) ||
+    (type == FETCH && (cfg & PMP_X));
+}
+
+
 // implement class pmpcfg_csr_t
 pmpcfg_csr_t::pmpcfg_csr_t(processor_t* const proc, const reg_t addr):
   logged_csr_t(proc, addr) {

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -352,14 +352,14 @@ bool vsstatus_csr_t::unlogged_write(const reg_t val) noexcept {
 // implement class sstatus_proxy_csr_t
 sstatus_proxy_csr_t::sstatus_proxy_csr_t(processor_t* const proc, const reg_t addr):
   logged_csr_t(proc, addr),
-  mstatus(proc->get_state()->mstatus) {
+  mstatus(proc->get_state()->mstatus),
+  read_mask(SSTATUS_SIE | SSTATUS_SPIE | SSTATUS_UBE | SSTATUS_SPP
+            | SSTATUS_FS | (proc->extension_enabled_const('V') ? SSTATUS_VS : 0)
+            | SSTATUS_XS | SSTATUS_SUM | SSTATUS_MXR | SSTATUS_UXL
+            | (proc->get_const_xlen() == 32 ? SSTATUS32_SD : SSTATUS64_SD)) {
 }
 
 reg_t sstatus_proxy_csr_t::read() const noexcept {
-  reg_t read_mask = SSTATUS_SIE | SSTATUS_SPIE | SSTATUS_UBE | SSTATUS_SPP
-                  | SSTATUS_FS | (proc->extension_enabled_const('V') ? SSTATUS_VS : 0)
-                  | SSTATUS_XS | SSTATUS_SUM | SSTATUS_MXR | SSTATUS_UXL
-                  | (proc->get_const_xlen() == 32 ? SSTATUS32_SD : SSTATUS64_SD);
   return mstatus->read() & read_mask;
 }
 

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -453,6 +453,15 @@ void sstatus_csr_t::dirty(const reg_t dirties) {
   }
 }
 
+bool sstatus_csr_t::enabled(const reg_t which) {
+  if ((orig_csr->read() & which) == 0)
+    return false;
+  state_t* const state = proc->get_state();
+  if (state->v && ((virt_csr->read() & which) == 0))
+    return false;
+  return true;
+}
+
 
 // implement class misa_csr_t
 misa_csr_t::misa_csr_t(processor_t* const proc, const reg_t addr, const reg_t max_isa):

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -562,3 +562,25 @@ bool mip_csr_t::unlogged_write(const reg_t val) noexcept {
   this->val = (this->val & ~mask) | (val & mask);
   return true;
 }
+
+
+// implement class sip_csr_t
+sip_csr_t::sip_csr_t(processor_t* const proc, const reg_t addr):
+  csr_t(proc, addr) {
+}
+
+reg_t sip_csr_t::read() const noexcept {
+  state_t* const state = proc->get_state();
+  if (state->v)
+    return (state->mip->read() & state->hideleg & MIP_VS_MASK) >> 1;
+  return state->mip->read() & state->mideleg & ~MIP_HS_MASK;
+}
+
+void sip_csr_t::write(const reg_t val) noexcept {
+  state_t* const state = proc->get_state();
+
+  if (state->v)
+    state->mip->write_with_mask(state->hideleg & MIP_VSSIP, val << 1);
+  else
+    state->mip->write_with_mask(state->mideleg & MIP_SSIP, val);
+}

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -95,10 +95,6 @@ reg_t pmpaddr_csr_t::read() const noexcept {
   return val & proc->pmp_tor_mask();
 }
 
-reg_t pmpaddr_csr_t::raw_value() const noexcept {
-  return val;
-}
-
 
 bool pmpaddr_csr_t::unlogged_write(const reg_t val) noexcept {
   // If no PMPs are configured, disallow access to all. Otherwise,

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -584,3 +584,19 @@ void sip_csr_t::write(const reg_t val) noexcept {
   else
     state->mip->write_with_mask(state->mideleg & MIP_SSIP, val);
 }
+
+// implement class hvip_csr_t
+hvip_csr_t::hvip_csr_t(processor_t* const proc, const reg_t addr):
+  csr_t(proc, addr) {
+}
+
+reg_t hvip_csr_t::read() const noexcept {
+  state_t* const state = proc->get_state();
+  return state->mip->read() & MIP_VS_MASK;
+}
+
+void hvip_csr_t::write(const reg_t val) noexcept {
+  state_t* const state = proc->get_state();
+  const reg_t mask = MIP_VS_MASK;
+  state->mip->write_with_mask(mask, val);
+}

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -445,6 +445,14 @@ sstatus_csr_t::sstatus_csr_t(processor_t* const proc, csr_t_p orig, csr_t_p virt
   virtualized_csr_t(proc, orig, virt) {
 }
 
+void sstatus_csr_t::dirty(const reg_t dirties) {
+  state_t* const state = proc->get_state();
+  orig_csr->write(orig_csr->read() | dirties);
+  if (state->v) {
+    virt_csr->write(virt_csr->read() | dirties);
+  }
+}
+
 
 // implement class misa_csr_t
 misa_csr_t::misa_csr_t(processor_t* const proc, const reg_t addr, const reg_t max_isa):

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -45,10 +45,11 @@ logged_csr_t::logged_csr_t(processor_t* const proc, const reg_t addr):
 }
 
 void logged_csr_t::write(const reg_t val) noexcept {
-  unlogged_write(val);
+  if (unlogged_write(val)) {
 #if defined(RISCV_ENABLE_COMMITLOG)
-  proc->get_state()->log_reg_write[((address) << 4) | 4] = {read(), 0};
+    proc->get_state()->log_reg_write[((address) << 4) | 4] = {read(), 0};
 #endif
+  }
 }
 
 // implement class basic_csr_t
@@ -61,6 +62,7 @@ reg_t basic_csr_t::read() const noexcept {
   return val;
 }
 
-void basic_csr_t::unlogged_write(const reg_t val) noexcept {
+bool basic_csr_t::unlogged_write(const reg_t val) noexcept {
   this->val = val;
+  return true;
 }

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -356,11 +356,11 @@ sstatus_proxy_csr_t::sstatus_proxy_csr_t(processor_t* const proc, const reg_t ad
 }
 
 reg_t sstatus_proxy_csr_t::read() const noexcept {
-  reg_t mask = SSTATUS_SIE | SSTATUS_SPIE | SSTATUS_UBE | SSTATUS_SPP
-             | SSTATUS_FS | (proc->extension_enabled_const('V') ? SSTATUS_VS : 0)
-             | SSTATUS_XS | SSTATUS_SUM | SSTATUS_MXR | SSTATUS_UXL
-             | (proc->get_const_xlen() == 32 ? SSTATUS32_SD : SSTATUS64_SD);
-  return mstatus->read() & mask;
+  reg_t read_mask = SSTATUS_SIE | SSTATUS_SPIE | SSTATUS_UBE | SSTATUS_SPP
+                  | SSTATUS_FS | (proc->extension_enabled_const('V') ? SSTATUS_VS : 0)
+                  | SSTATUS_XS | SSTATUS_SUM | SSTATUS_MXR | SSTATUS_UXL
+                  | (proc->get_const_xlen() == 32 ? SSTATUS32_SD : SSTATUS64_SD);
+  return mstatus->read() & read_mask;
 }
 
 bool sstatus_proxy_csr_t::unlogged_write(const reg_t val) noexcept {

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -130,6 +130,13 @@ reg_t pmpaddr_csr_t::tor_paddr() const noexcept {
 }
 
 
+reg_t pmpaddr_csr_t::tor_base_paddr() const noexcept {
+  if (pmpidx == 0) return 0;  // entry 0 always uses 0 as base
+  state_t* const state = proc->get_state();
+  return state->pmpaddr[pmpidx-1]->tor_paddr();
+}
+
+
 reg_t pmpaddr_csr_t::napot_mask() const noexcept {
   state_t* const state = proc->get_state();
   bool is_na4 = (state->pmpcfg[pmpidx] & PMP_A) == PMP_NA4;

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -149,12 +149,10 @@ bool pmpaddr_csr_t::match4(reg_t addr) const noexcept {
   state_t* const state = proc->get_state();
   uint8_t cfg = state->pmpcfg[pmpidx];
   if ((cfg & PMP_A) == 0) return false;
-  reg_t base = tor_base_paddr();
-  reg_t tor = tor_paddr();
   bool is_tor = (cfg & PMP_A) == PMP_TOR;
-  bool napot_match = ((addr ^ tor) & napot_mask()) == 0;
-  bool tor_match = base <= addr && addr < tor;
-  return is_tor ? tor_match : napot_match;
+  if (is_tor) return tor_base_paddr() <= addr && addr < tor_paddr();
+  // NAPOT or NA4:
+  return ((addr ^ tor_paddr()) & napot_mask()) == 0;
 }
 
 

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -129,6 +129,11 @@ bool pmpaddr_csr_t::next_locked_and_tor() const noexcept {
 }
 
 
+reg_t pmpaddr_csr_t::tor_paddr() const noexcept {
+  return (val & proc->pmp_tor_mask()) << PMP_SHIFT;
+}
+
+
 // implement class pmpcfg_csr_t
 pmpcfg_csr_t::pmpcfg_csr_t(processor_t* const proc, const reg_t addr):
   logged_csr_t(proc, addr) {

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -379,9 +379,9 @@ bool vsstatus_csr_t::unlogged_write(const reg_t val) noexcept {
 
 
 // implement class sstatus_proxy_csr_t
-sstatus_proxy_csr_t::sstatus_proxy_csr_t(processor_t* const proc, const reg_t addr):
+sstatus_proxy_csr_t::sstatus_proxy_csr_t(processor_t* const proc, const reg_t addr, csr_t_p mstatus):
   base_status_csr_t(proc, addr),
-  mstatus(proc->get_state()->mstatus) {
+  mstatus(mstatus) {
 }
 
 reg_t sstatus_proxy_csr_t::read() const noexcept {

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -597,16 +597,13 @@ sip_csr_t::sip_csr_t(processor_t* const proc, const reg_t addr):
 
 // implement class hvip_csr_t
 hvip_csr_t::hvip_csr_t(processor_t* const proc, const reg_t addr):
-  csr_t(proc, addr) {
-}
-
-reg_t hvip_csr_t::read() const noexcept {
-  return state->mip->read() & MIP_VS_MASK;
-}
-
-void hvip_csr_t::write(const reg_t val) noexcept {
-  const reg_t mask = MIP_VS_MASK;
-  state->mip->write_with_mask(mask, val);
+  generic_ip_csr_t(proc,
+                   addr,
+                   MIP_VS_MASK,   // read_mask
+                   MIP_VS_MASK,   // write_mask
+                   false,         // mask_mideleg
+                   false,         // mask_hideleg
+                   0) {           // shiftamt
 }
 
 

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -12,7 +12,9 @@
 // implement class csr_t
 csr_t::csr_t(processor_t* const proc, const reg_t addr):
   proc(proc),
-  address(addr) {
+  address(addr),
+  csr_priv(get_field(addr, 0x300)),
+  csr_read_only(get_field(addr, 0xC00) == 3) {
 }
 
 void csr_t::verify_permissions(insn_t insn, bool write) const {
@@ -20,8 +22,6 @@ void csr_t::verify_permissions(insn_t insn, bool write) const {
   // privileges are insufficient, and the CSR belongs to supervisor or
   // hypervisor. Raise illegal-instruction exception otherwise.
   state_t* const state = proc->get_state();
-  unsigned csr_priv = get_field(address, 0x300);
-  bool csr_read_only = get_field(address, 0xC00) == 3;
   unsigned priv = state->prv == PRV_S && !state->v ? PRV_HS : state->prv;
 
   if ((csr_priv == PRV_S && !proc->supports_extension('S')) ||

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -585,3 +585,18 @@ void hvip_csr_t::write(const reg_t val) noexcept {
   const reg_t mask = MIP_VS_MASK;
   state->mip->write_with_mask(mask, val);
 }
+
+
+// implement class hip_csr_t
+hip_csr_t::hip_csr_t(processor_t* const proc, const reg_t addr):
+  csr_t(proc, addr) {
+}
+
+reg_t hip_csr_t::read() const noexcept {
+  return state->mip->read() & MIP_HS_MASK;
+}
+
+void hip_csr_t::write(const reg_t val) noexcept {
+  const reg_t mask = MIP_VSSIP;
+  state->mip->write_with_mask(mask, val);
+}

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -1,15 +1,21 @@
 // See LICENSE for license details.
 
 #include "csrs.h"
+// For processor_t:
+#include "processor.h"
 
 // implement class csr_t
-csr_t::csr_t(const reg_t addr): address(addr) {}
+csr_t::csr_t(processor_t* const proc, const reg_t addr):
+  proc(proc),
+  address(addr) {
+}
 
-csr_t::~csr_t() {}
+csr_t::~csr_t() {
+}
 
 // implement class basic_csr_t
-basic_csr_t::basic_csr_t(const reg_t addr, const reg_t init):
-  csr_t(addr),
+basic_csr_t::basic_csr_t(processor_t* const proc, const reg_t addr, const reg_t init):
+  csr_t(proc, addr),
   val(init) {
 }
 

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -364,10 +364,10 @@ reg_t sstatus_proxy_csr_t::read() const noexcept {
 }
 
 bool sstatus_proxy_csr_t::unlogged_write(const reg_t val) noexcept {
-  reg_t mask = SSTATUS_SIE | SSTATUS_SPIE | SSTATUS_SPP | SSTATUS_FS
-             | SSTATUS_XS | SSTATUS_SUM | SSTATUS_MXR
-             | (proc->extension_enabled_const('V') ? SSTATUS_VS : 0);
-  reg_t new_mstatus = (mstatus->read() & ~mask) | (val & mask);
+  reg_t write_mask = SSTATUS_SIE | SSTATUS_SPIE | SSTATUS_SPP | SSTATUS_FS
+                   | SSTATUS_XS | SSTATUS_SUM | SSTATUS_MXR
+                   | (proc->extension_enabled_const('V') ? SSTATUS_VS : 0);
+  reg_t new_mstatus = (mstatus->read() & ~write_mask) | (val & write_mask);
 
   mstatus->write(new_mstatus);
   return false; // avoid double logging: already logged by mstatus->write()

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -377,12 +377,18 @@ bool sstatus_proxy_csr_t::unlogged_write(const reg_t val) noexcept {
 
 // implement class mstatus_csr_t
 mstatus_csr_t::mstatus_csr_t(processor_t* const proc, const reg_t addr):
-  basic_csr_t(proc, addr,
+  logged_csr_t(proc, addr),
+  val(
 #ifdef RISCV_ENABLE_DUAL_ENDIAN
-              proc->get_mmu()->is_target_big_endian() ? MSTATUS_UBE | MSTATUS_SBE | MSTATUS_MBE :
+      proc->get_mmu()->is_target_big_endian() ? MSTATUS_UBE | MSTATUS_SBE | MSTATUS_MBE :
 #endif
-              0  // initial value for mstatus
+      0  // initial value for mstatus
   ) {
+}
+
+
+reg_t mstatus_csr_t::read() const noexcept {
+  return val;
 }
 
 
@@ -430,5 +436,6 @@ bool mstatus_csr_t::unlogged_write(const reg_t val) noexcept {
   if (proc->supports_extension('S'))
     new_mstatus = set_field(new_mstatus, MSTATUS_SXL, xlen_to_uxl(proc->get_max_xlen()));
 
-  return basic_csr_t::unlogged_write(new_mstatus);
+  this->val = new_mstatus;
+  return true;
 }

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -325,11 +325,6 @@ namespace {
 
 
 bool vsstatus_csr_t::unlogged_write(const reg_t val) noexcept {
-  backdoor_write(val);
-  return true;
-}
-
-void vsstatus_csr_t::backdoor_write(const reg_t val) noexcept {
   state_t* const state = proc->get_state();
   bool has_page = proc->supports_extension('S') && proc->supports_impl(IMPL_MMU);
   if (state->v && has_page && ((val ^ read()) & (MSTATUS_MXR | MSTATUS_SUM)))
@@ -347,6 +342,7 @@ void vsstatus_csr_t::backdoor_write(const reg_t val) noexcept {
     newval = set_field(newval, SSTATUS_UXL, xlen_to_uxl(proc->get_max_xlen()));
 
   this->val = newval;
+  return true;
 }
 
 
@@ -391,10 +387,6 @@ mstatus_csr_t::mstatus_csr_t(processor_t* const proc, const reg_t addr):
 
 
 bool mstatus_csr_t::unlogged_write(const reg_t val) noexcept {
-  return backdoor_write(val);
-}
-
-bool mstatus_csr_t::backdoor_write(const reg_t val) noexcept {
   bool has_page = proc->supports_extension('S') && proc->supports_impl(IMPL_MMU);
   if ((val ^ read()) &
       (MSTATUS_MPP | MSTATUS_MPRV

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -457,18 +457,18 @@ bool misa_csr_t::unlogged_write(const reg_t val) noexcept {
   const reg_t adjusted_val = val_supports_f ? val : val_without_d;
 
   // allow MAFDCH bits in MISA to be modified
-  reg_t mask = 0;
-  mask |= 1L << ('M' - 'A');
-  mask |= 1L << ('A' - 'A');
-  mask |= 1L << ('F' - 'A');
-  mask |= 1L << ('D' - 'A');
-  mask |= 1L << ('C' - 'A');
-  mask |= 1L << ('H' - 'A');
-  mask &= max_isa;
+  reg_t write_mask = 0;
+  write_mask |= 1L << ('M' - 'A');
+  write_mask |= 1L << ('A' - 'A');
+  write_mask |= 1L << ('F' - 'A');
+  write_mask |= 1L << ('D' - 'A');
+  write_mask |= 1L << ('C' - 'A');
+  write_mask |= 1L << ('H' - 'A');
+  write_mask &= max_isa;
 
   const reg_t old_misa = read();
   const bool prev_h = old_misa & (1L << ('H' - 'A'));
-  const reg_t new_misa = (adjusted_val & mask) | (old_misa & ~mask);
+  const reg_t new_misa = (adjusted_val & write_mask) | (old_misa & ~write_mask);
   const bool new_h = new_misa & (1L << ('H' - 'A'));
 
   // update the forced bits in MIDELEG and other CSRs

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -334,7 +334,7 @@ bool vsstatus_csr_t::unlogged_write(const reg_t val) noexcept {
     proc->get_mmu()->flush_tlb();
   const reg_t mask = (SSTATUS_SIE | SSTATUS_SPIE
                       | SSTATUS_SPP | SSTATUS_FS | SSTATUS_SUM
-                      | SSTATUS_MXR | SSTATUS_UXL
+                      | SSTATUS_MXR
                       | (proc->extension_enabled_const('V') ? SSTATUS_VS : 0));
   reg_t newval = (this->val & ~mask) | (val & mask);
   newval &= (proc->get_const_xlen() == 64 ? ~SSTATUS64_SD : ~SSTATUS32_SD);

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -301,6 +301,7 @@ reg_t cause_csr_t::read() const noexcept {
 // implement class base_status_csr_t
 base_status_csr_t::base_status_csr_t(processor_t* const proc, const reg_t addr):
   logged_csr_t(proc, addr),
+  has_page(proc->extension_enabled_const('S') && proc->supports_impl(IMPL_MMU)),
   sstatus_write_mask(compute_sstatus_write_mask()),
   sstatus_read_mask(sstatus_write_mask | SSTATUS_UBE | SSTATUS_UXL
                     | (proc->get_const_xlen() == 32 ? SSTATUS32_SD : SSTATUS64_SD)) {
@@ -308,7 +309,6 @@ base_status_csr_t::base_status_csr_t(processor_t* const proc, const reg_t addr):
 
 
 reg_t base_status_csr_t::compute_sstatus_write_mask() const noexcept {
-  const bool has_page = proc->extension_enabled('S') && proc->supports_impl(IMPL_MMU);
   // If a configuration has FS bits, they will always be accessible no
   // matter the state of misa.
   const bool has_fs = proc->extension_enabled('S') || proc->extension_enabled('F')
@@ -341,7 +341,6 @@ reg_t base_status_csr_t::adjust_sd(const reg_t val) const noexcept {
 
 
 void base_status_csr_t::maybe_flush_tlb(const reg_t newval) noexcept {
-  const bool has_page = proc->extension_enabled('S') && proc->supports_impl(IMPL_MMU);
   if ((newval ^ read()) &
       (MSTATUS_MPP | MSTATUS_MPRV
        | (has_page ? (MSTATUS_MXR | MSTATUS_SUM) : 0)
@@ -417,7 +416,6 @@ reg_t mstatus_csr_t::read() const noexcept {
 
 
 bool mstatus_csr_t::unlogged_write(const reg_t val) noexcept {
-  const bool has_page = proc->extension_enabled('S') && proc->supports_impl(IMPL_MMU);
   const bool has_mpv = proc->extension_enabled('S') && proc->extension_enabled('H');
   const bool has_gva = has_mpv;
 

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -218,3 +218,26 @@ bool pmpcfg_csr_t::unlogged_write(const reg_t val) noexcept {
   proc->get_mmu()->flush_tlb();
   return write_success;
 }
+
+
+// implement class virtualized_csr_t
+virtualized_csr_t::virtualized_csr_t(processor_t* const proc, csr_t_p orig, csr_t_p virt):
+  csr_t(proc, orig->address),
+  orig_csr(orig),
+  virt_csr(virt) {
+}
+
+
+reg_t virtualized_csr_t::read() const noexcept {
+  state_t* const state = proc->get_state();
+  return state->v ? virt_csr->read() : orig_csr->read();
+}
+
+
+void virtualized_csr_t::write(const reg_t val) noexcept {
+  state_t* const state = proc->get_state();
+  if (state->v)
+    virt_csr->write(val);
+  else
+    orig_csr->write(val);
+}

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -353,6 +353,9 @@ bool vsstatus_csr_t::unlogged_write(const reg_t val) noexcept {
 sstatus_proxy_csr_t::sstatus_proxy_csr_t(processor_t* const proc, const reg_t addr):
   logged_csr_t(proc, addr),
   mstatus(proc->get_state()->mstatus),
+  write_mask(SSTATUS_SIE | SSTATUS_SPIE | SSTATUS_SPP | SSTATUS_FS
+             | SSTATUS_XS | SSTATUS_SUM | SSTATUS_MXR
+             | (proc->extension_enabled_const('V') ? SSTATUS_VS : 0)),
   read_mask(SSTATUS_SIE | SSTATUS_SPIE | SSTATUS_UBE | SSTATUS_SPP
             | SSTATUS_FS | (proc->extension_enabled_const('V') ? SSTATUS_VS : 0)
             | SSTATUS_XS | SSTATUS_SUM | SSTATUS_MXR | SSTATUS_UXL
@@ -364,9 +367,6 @@ reg_t sstatus_proxy_csr_t::read() const noexcept {
 }
 
 bool sstatus_proxy_csr_t::unlogged_write(const reg_t val) noexcept {
-  reg_t write_mask = SSTATUS_SIE | SSTATUS_SPIE | SSTATUS_SPP | SSTATUS_FS
-                   | SSTATUS_XS | SSTATUS_SUM | SSTATUS_MXR
-                   | (proc->extension_enabled_const('V') ? SSTATUS_VS : 0);
   reg_t new_mstatus = (mstatus->read() & ~write_mask) | (val & write_mask);
 
   mstatus->write(new_mstatus);

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -517,26 +517,26 @@ bool misa_csr_t::extension_enabled_const(unsigned char ext) const noexcept {
 }
 
 
-// implement class mip_csr_t
-mip_csr_t::mip_csr_t(processor_t* const proc, const reg_t addr):
+// implement class mip_or_mie_csr_t
+mip_or_mie_csr_t::mip_or_mie_csr_t(processor_t* const proc, const reg_t addr):
   logged_csr_t(proc, addr),
   val(0) {
 }
 
-reg_t mip_csr_t::read() const noexcept {
+reg_t mip_or_mie_csr_t::read() const noexcept {
   return val;
 }
 
-void mip_csr_t::write_with_mask(const reg_t mask, const reg_t val) noexcept {
+void mip_or_mie_csr_t::write_with_mask(const reg_t mask, const reg_t val) noexcept {
   backdoor_write_with_mask(mask, val);
   log_write();
 }
 
-void mip_csr_t::backdoor_write_with_mask(const reg_t mask, const reg_t val) noexcept {
+void mip_or_mie_csr_t::backdoor_write_with_mask(const reg_t mask, const reg_t val) noexcept {
   this->val = (this->val & ~mask) | (val & mask);
 }
 
-bool mip_csr_t::unlogged_write(const reg_t val) noexcept {
+bool mip_or_mie_csr_t::unlogged_write(const reg_t val) noexcept {
   const reg_t supervisor_ints = proc->extension_enabled('S') ? MIP_SSIP | MIP_STIP | MIP_SEIP : 0;
   const reg_t vssip_int = proc->extension_enabled('H') ? MIP_VSSIP : 0;
   const reg_t hypervisor_ints = proc->extension_enabled('H') ? MIP_HS_MASK : 0;

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -302,13 +302,19 @@ reg_t cause_csr_t::read() const noexcept {
 // implement class base_status_csr_t
 base_status_csr_t::base_status_csr_t(processor_t* const proc, const reg_t addr):
   logged_csr_t(proc, addr),
-  sstatus_write_mask(SSTATUS_SIE | SSTATUS_SPIE | SSTATUS_SPP | SSTATUS_FS
-                     | SSTATUS_SUM | SSTATUS_MXR
-                     | (proc->any_custom_extensions() ? SSTATUS_XS : 0)
-                     | (proc->extension_enabled_const('V') ? SSTATUS_VS : 0)),
+  sstatus_write_mask(compute_sstatus_write_mask()),
   sstatus_read_mask(sstatus_write_mask | SSTATUS_UBE | SSTATUS_UXL
                     | (proc->get_const_xlen() == 32 ? SSTATUS32_SD : SSTATUS64_SD)) {
 }
+
+
+reg_t base_status_csr_t::compute_sstatus_write_mask() const noexcept {
+  return SSTATUS_SIE | SSTATUS_SPIE | SSTATUS_SPP | SSTATUS_FS
+    | SSTATUS_SUM | SSTATUS_MXR
+    | (proc->any_custom_extensions() ? SSTATUS_XS : 0)
+    | (proc->extension_enabled_const('V') ? SSTATUS_VS : 0);
+}
+
 
 reg_t base_status_csr_t::adjust_sd(reg_t newval) const noexcept {
   newval &= (proc->get_const_xlen() == 64 ? ~SSTATUS64_SD : ~SSTATUS32_SD);

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -321,17 +321,6 @@ reg_t base_status_csr_t::adjust_sd(reg_t newval) const noexcept {
 }
 
 
-// implement class vsstatus_csr_t
-vsstatus_csr_t::vsstatus_csr_t(processor_t* const proc, const reg_t addr):
-  base_status_csr_t(proc, addr),
-  val(0) {
-}
-
-reg_t vsstatus_csr_t::read() const noexcept {
-  return val;
-}
-
-
 namespace {
   int xlen_to_uxl(int xlen) {
     if (xlen == 32)
@@ -343,6 +332,16 @@ namespace {
 }
 
 
+// implement class vsstatus_csr_t
+vsstatus_csr_t::vsstatus_csr_t(processor_t* const proc, const reg_t addr):
+  base_status_csr_t(proc, addr),
+  val(set_field((reg_t)0, SSTATUS_UXL, xlen_to_uxl(proc->get_const_xlen()))) {
+}
+
+reg_t vsstatus_csr_t::read() const noexcept {
+  return val;
+}
+
 bool vsstatus_csr_t::unlogged_write(const reg_t val) noexcept {
   state_t* const state = proc->get_state();
   bool has_page = proc->extension_enabled('S') && proc->supports_impl(IMPL_MMU);
@@ -350,9 +349,6 @@ bool vsstatus_csr_t::unlogged_write(const reg_t val) noexcept {
     proc->get_mmu()->flush_tlb();
   reg_t newval = (this->val & ~sstatus_write_mask) | (val & sstatus_write_mask);
   newval = adjust_sd(newval);
-  if (proc->extension_enabled('U'))
-    newval = set_field(newval, SSTATUS_UXL, xlen_to_uxl(proc->get_const_xlen()));
-
   this->val = newval;
   return true;
 }

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -621,14 +621,11 @@ hip_csr_t::hip_csr_t(processor_t* const proc, const reg_t addr):
 
 // implement class vsip_csr_t
 vsip_csr_t::vsip_csr_t(processor_t* const proc, const reg_t addr):
-  csr_t(proc, addr) {
-}
-
-reg_t vsip_csr_t::read() const noexcept {
-  return (state->mip->read() & state->hideleg & MIP_VS_MASK) >> 1;
-}
-
-void vsip_csr_t::write(const reg_t val) noexcept {
-  const reg_t mask = state->hideleg & MIP_VSSIP;
-  state->mip->write_with_mask(mask, val << 1);
+  generic_ip_csr_t(proc,
+                   addr,
+                   MIP_VS_MASK,   // read_mask
+                   MIP_VSSIP,     // write_mask
+                   false,         // mask_mideleg
+                   true,          // mask_hideleg
+                   1) {           // shiftamt
 }

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -555,13 +555,13 @@ bool mip_csr_t::unlogged_write(const reg_t val) noexcept {
 // implement class generic_int_accessor_t
 generic_int_accessor_t::generic_int_accessor_t(state_t* const state,
                                                const reg_t read_mask,
-                                               const reg_t write_mask,
+                                               const reg_t ip_write_mask,
                                                const bool mask_mideleg,
                                                const bool mask_hideleg,
                                                const int shiftamt):
   state(state),
   read_mask(read_mask),
-  write_mask(write_mask),
+  ip_write_mask(ip_write_mask),
   mask_mideleg(mask_mideleg),
   mask_hideleg(mask_hideleg),
   shiftamt(shiftamt) {
@@ -572,7 +572,7 @@ reg_t generic_int_accessor_t::ip_read() const noexcept {
 }
 
 void generic_int_accessor_t::ip_write(const reg_t val) noexcept {
-  const reg_t mask = deleg_mask() & write_mask;
+  const reg_t mask = deleg_mask() & ip_write_mask;
   state->mip->write_with_mask(mask, val << shiftamt);
 }
 

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -362,9 +362,8 @@ bool vsstatus_csr_t::unlogged_write(const reg_t val) noexcept {
   bool has_page = proc->extension_enabled('S') && proc->supports_impl(IMPL_MMU);
   if (state->v && has_page && ((val ^ read()) & (MSTATUS_MXR | MSTATUS_SUM)))
     proc->get_mmu()->flush_tlb();
-  reg_t newval = (this->val & ~sstatus_write_mask) | (val & sstatus_write_mask);
-  newval = adjust_sd(newval);
-  this->val = newval;
+  const reg_t newval = (this->val & ~sstatus_write_mask) | (val & sstatus_write_mask);
+  this->val = adjust_sd(newval);
   return true;
 }
 

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -330,8 +330,9 @@ bool vsstatus_csr_t::unlogged_write(const reg_t val) noexcept {
 }
 
 void vsstatus_csr_t::backdoor_write(const reg_t val) noexcept {
+  state_t* const state = proc->get_state();
   bool has_page = proc->supports_extension('S') && proc->supports_impl(IMPL_MMU);
-  if (has_page && ((val ^ read()) & (MSTATUS_MXR | MSTATUS_SUM)))
+  if (state->v && has_page && ((val ^ read()) & (MSTATUS_MXR | MSTATUS_SUM)))
     proc->get_mmu()->flush_tlb();
   reg_t mask = SSTATUS_VS_MASK;
   mask |= (proc->supports_extension('V') ? SSTATUS_VS : 0);

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -424,11 +424,9 @@ bool mstatus_csr_t::unlogged_write(const reg_t val) noexcept {
                    | (has_mpv ? MSTATUS_MPV : 0);
 
   const reg_t requested_mpp = proc->legalize_privilege(get_field(val, MSTATUS_MPP));
-  reg_t new_mstatus = set_field(val, MSTATUS_MPP, requested_mpp);
-
-  new_mstatus = (read() & ~mask) | (new_mstatus & mask);
-  new_mstatus = adjust_sd(new_mstatus);
-  this->val = new_mstatus;
+  const reg_t adjusted_val = set_field(val, MSTATUS_MPP, requested_mpp);
+  const reg_t new_mstatus = (read() & ~mask) | (adjusted_val & mask);
+  this->val = adjust_sd(new_mstatus);
   return true;
 }
 

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -277,3 +277,20 @@ bool tvec_csr_t::unlogged_write(const reg_t val) noexcept {
   this->val = val & ~(reg_t)2;
   return true;
 }
+
+
+// implement class cause_csr_t
+cause_csr_t::cause_csr_t(processor_t* const proc, const reg_t addr):
+  basic_csr_t(proc, addr, 0) {
+}
+
+
+reg_t cause_csr_t::read() const noexcept {
+  reg_t val = basic_csr_t::read();
+  // When reading, the interrupt bit needs to adjust to xlen. Spike does
+  // not generally support dynamic xlen, but this code was (partly)
+  // there since at least 2015 (ea58df8 and c4350ef).
+  if (proc->get_max_xlen() > proc->get_xlen()) // Move interrupt bit to top of xlen
+    return val | ((val >> (proc->get_max_xlen()-1)) << (proc->get_xlen()-1));
+  return val;
+}

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -345,6 +345,7 @@ bool vsstatus_csr_t::unlogged_write(const reg_t val) noexcept {
   const reg_t mask = (SSTATUS_SIE | SSTATUS_SPIE
                       | SSTATUS_SPP | SSTATUS_FS | SSTATUS_SUM
                       | SSTATUS_MXR
+                      | (proc->any_custom_extensions() ? SSTATUS_XS : 0)
                       | (proc->extension_enabled_const('V') ? SSTATUS_VS : 0));
   reg_t newval = (this->val & ~mask) | (val & mask);
   newval = adjust_sd(newval);

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -350,7 +350,15 @@ sstatus_proxy_csr_t::sstatus_proxy_csr_t(processor_t* const proc, const reg_t ad
 }
 
 reg_t sstatus_proxy_csr_t::read() const noexcept {
-  return *mstatus;
+  reg_t mask = SSTATUS_SIE | SSTATUS_SPIE | SSTATUS_UBE | SSTATUS_SPP
+             | SSTATUS_FS | (proc->supports_extension('V') ? SSTATUS_VS : 0)
+             | SSTATUS_XS | SSTATUS_SUM | SSTATUS_MXR | SSTATUS_UXL;
+  reg_t sstatus = *mstatus & mask;
+  if ((sstatus & SSTATUS_FS) == SSTATUS_FS ||
+      (sstatus & SSTATUS_XS) == SSTATUS_XS ||
+      (sstatus & SSTATUS_VS) == SSTATUS_VS)
+    sstatus |= (proc->get_xlen() == 32 ? SSTATUS32_SD : SSTATUS64_SD);
+  return sstatus;
 }
 
 bool sstatus_proxy_csr_t::unlogged_write(const reg_t val) noexcept {

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -547,8 +547,8 @@ bool mip_csr_t::unlogged_write(const reg_t val) noexcept {
   //  * vstip is read-only -- write hvip instead
   const reg_t mask = (supervisor_ints | hypervisor_ints) &
                      (MIP_SEIP | MIP_SSIP | MIP_STIP | vssip_int);
-  this->val = (this->val & ~mask) | (val & mask);
-  return true;
+  write_with_mask(mask, val);
+  return false; // avoid double logging: already logged by write_with_mask()
 }
 
 

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -734,7 +734,7 @@ base_atp_csr_t::base_atp_csr_t(processor_t* const proc, const reg_t addr):
 
 
 bool base_atp_csr_t::unlogged_write(const reg_t val) noexcept {
-  const reg_t newval = proc->supports_impl(IMPL_MMU) ? compute_new_satp(val, read()) : 0;
+  const reg_t newval = proc->supports_impl(IMPL_MMU) ? compute_new_satp(val) : 0;
   if (newval != read())
     proc->get_mmu()->flush_tlb();
   return basic_csr_t::unlogged_write(newval);
@@ -757,7 +757,7 @@ bool base_atp_csr_t::satp_valid(reg_t val) const noexcept {
   }
 }
 
-reg_t base_atp_csr_t::compute_new_satp(reg_t val, reg_t old) const noexcept {
+reg_t base_atp_csr_t::compute_new_satp(reg_t val) const noexcept {
   reg_t rv64_ppn_mask = (reg_t(1) << (MAX_PADDR_BITS - PGSHIFT)) - 1;
 
   reg_t mode_mask = proc->get_xlen() == 32 ? SATP32_MODE : SATP64_MODE;
@@ -765,7 +765,7 @@ reg_t base_atp_csr_t::compute_new_satp(reg_t val, reg_t old) const noexcept {
   reg_t new_mask = (satp_valid(val) ? mode_mask : 0) | ppn_mask;
   reg_t old_mask = satp_valid(val) ? 0 : mode_mask;
 
-  return (new_mask & val) | (old_mask & old);
+  return (new_mask & val) | (old_mask & read());
 }
 
 satp_csr_t::satp_csr_t(processor_t* const proc, const reg_t addr):

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -438,3 +438,18 @@ bool mstatus_csr_t::unlogged_write(const reg_t val) noexcept {
   this->val = new_mstatus;
   return true;
 }
+
+
+// implement class misa_csr_t
+misa_csr_t::misa_csr_t(processor_t* const proc, const reg_t addr, const reg_t max_isa):
+  basic_csr_t(proc, addr, max_isa) {
+}
+
+bool misa_csr_t::unlogged_write(const reg_t val) noexcept {
+  abort();  // not implemented yet
+}
+
+bool misa_csr_t::supports_extension(unsigned char ext) const noexcept {
+  assert(ext >= 'A' && ext <= 'Z');
+  return (read() >> (ext - 'A')) & 1;
+}

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -89,7 +89,7 @@ void pmpaddr_csr_t::verify_permissions(insn_t insn, bool write) const {
 
 reg_t pmpaddr_csr_t::read() const noexcept {
   state_t* const state = proc->get_state();
-  reg_t i = address - CSR_PMPADDR0;
+  size_t i = address - CSR_PMPADDR0;
   if ((state->pmpcfg[i] & PMP_A) >= PMP_NAPOT)
     return val | (~proc->pmp_tor_mask() >> 1);
   return val & proc->pmp_tor_mask();

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -778,8 +778,9 @@ void satp_csr_t::verify_permissions(insn_t insn, bool write) const {
     require(state->prv >= PRV_M);
 }
 
-virtualized_satp_csr_t::virtualized_satp_csr_t(processor_t* const proc, csr_t_p orig, csr_t_p virt):
-  virtualized_csr_t(proc, orig, virt) {
+virtualized_satp_csr_t::virtualized_satp_csr_t(processor_t* const proc, satp_csr_t_p orig, csr_t_p virt):
+  virtualized_csr_t(proc, orig, virt),
+  orig_satp(orig) {
 }
 
 void virtualized_satp_csr_t::verify_permissions(insn_t insn, bool write) const {

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -631,7 +631,7 @@ void mip_proxy_csr_t::write(const reg_t val) noexcept {
 
 // implement class mie_proxy_csr_t
 mie_proxy_csr_t::mie_proxy_csr_t(processor_t* const proc, const reg_t addr, generic_int_accessor_t_p accr):
-  csr_t(proc, addr),
+  logged_csr_t(proc, addr),
   accr(accr) {
 }
 
@@ -639,8 +639,9 @@ reg_t mie_proxy_csr_t::read() const noexcept {
   return accr->ie_read();
 }
 
-void mie_proxy_csr_t::write(const reg_t val) noexcept {
+bool mie_proxy_csr_t::unlogged_write(const reg_t val) noexcept {
   accr->ie_write(val);
+  return false;  // accr has already logged
 }
 
 

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -443,7 +443,16 @@ bool mstatus_csr_t::unlogged_write(const reg_t val) noexcept {
 // implement class misa_csr_t
 misa_csr_t::misa_csr_t(processor_t* const proc, const reg_t addr, const reg_t max_isa):
   basic_csr_t(proc, addr, max_isa),
-  max_isa(max_isa) {
+  max_isa(max_isa),
+  write_mask(max_isa & (0  // allow MAFDCH bits in MISA to be modified
+                        | (1L << ('M' - 'A'))
+                        | (1L << ('A' - 'A'))
+                        | (1L << ('F' - 'A'))
+                        | (1L << ('D' - 'A'))
+                        | (1L << ('C' - 'A'))
+                        | (1L << ('H' - 'A'))
+                        )
+             ) {
 }
 
 bool misa_csr_t::unlogged_write(const reg_t val) noexcept {
@@ -455,16 +464,6 @@ bool misa_csr_t::unlogged_write(const reg_t val) noexcept {
   const bool val_supports_f = val & (1L << ('F' - 'A'));
   const reg_t val_without_d = val & ~(1L << ('D' - 'A'));
   const reg_t adjusted_val = val_supports_f ? val : val_without_d;
-
-  // allow MAFDCH bits in MISA to be modified
-  const reg_t write_mask = max_isa & (0
-                                      | (1L << ('M' - 'A'))
-                                      | (1L << ('A' - 'A'))
-                                      | (1L << ('F' - 'A'))
-                                      | (1L << ('D' - 'A'))
-                                      | (1L << ('C' - 'A'))
-                                      | (1L << ('H' - 'A'))
-                                      );
 
   const reg_t old_misa = read();
   const bool prev_h = old_misa & (1L << ('H' - 'A'));

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -1,0 +1,22 @@
+// See LICENSE for license details.
+
+#include "csrs.h"
+
+// implement class csr_t
+csr_t::csr_t(const reg_t addr): address(addr) {}
+
+csr_t::~csr_t() {}
+
+// implement class basic_csr_t
+basic_csr_t::basic_csr_t(const reg_t addr, const reg_t init):
+  csr_t(addr),
+  val(init) {
+}
+
+reg_t basic_csr_t::read() const noexcept {
+  return val;
+}
+
+void basic_csr_t::write(const reg_t val) noexcept {
+  this->val = val;
+}

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -332,8 +332,10 @@ bool vsstatus_csr_t::unlogged_write(const reg_t val) noexcept {
   bool has_page = proc->extension_enabled('S') && proc->supports_impl(IMPL_MMU);
   if (state->v && has_page && ((val ^ read()) & (MSTATUS_MXR | MSTATUS_SUM)))
     proc->get_mmu()->flush_tlb();
-  reg_t mask = SSTATUS_VS_MASK;
-  mask |= (proc->extension_enabled_const('V') ? SSTATUS_VS : 0);
+  const reg_t mask = (SSTATUS_SIE | SSTATUS_SPIE
+                      | SSTATUS_SPP | SSTATUS_FS | SSTATUS_SUM
+                      | SSTATUS_MXR | SSTATUS_UXL
+                      | (proc->extension_enabled_const('V') ? SSTATUS_VS : 0));
   reg_t newval = (this->val & ~mask) | (val & mask);
   newval &= (proc->get_const_xlen() == 64 ? ~SSTATUS64_SD : ~SSTATUS32_SD);
   if (((newval & SSTATUS_FS) == SSTATUS_FS) ||

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -361,20 +361,20 @@ bool vsstatus_csr_t::unlogged_write(const reg_t val) noexcept {
 sstatus_proxy_csr_t::sstatus_proxy_csr_t(processor_t* const proc, const reg_t addr):
   base_status_csr_t(proc, addr),
   mstatus(proc->get_state()->mstatus),
-  write_mask(SSTATUS_SIE | SSTATUS_SPIE | SSTATUS_SPP | SSTATUS_FS
-             | SSTATUS_SUM | SSTATUS_MXR
-             | (proc->any_custom_extensions() ? SSTATUS_XS : 0)
-             | (proc->extension_enabled_const('V') ? SSTATUS_VS : 0)),
-  read_mask(write_mask | SSTATUS_UBE | SSTATUS_UXL
-            | (proc->get_const_xlen() == 32 ? SSTATUS32_SD : SSTATUS64_SD)) {
+  sstatus_write_mask(SSTATUS_SIE | SSTATUS_SPIE | SSTATUS_SPP | SSTATUS_FS
+                     | SSTATUS_SUM | SSTATUS_MXR
+                     | (proc->any_custom_extensions() ? SSTATUS_XS : 0)
+                     | (proc->extension_enabled_const('V') ? SSTATUS_VS : 0)),
+  sstatus_read_mask(sstatus_write_mask | SSTATUS_UBE | SSTATUS_UXL
+                    | (proc->get_const_xlen() == 32 ? SSTATUS32_SD : SSTATUS64_SD)) {
 }
 
 reg_t sstatus_proxy_csr_t::read() const noexcept {
-  return mstatus->read() & read_mask;
+  return mstatus->read() & sstatus_read_mask;
 }
 
 bool sstatus_proxy_csr_t::unlogged_write(const reg_t val) noexcept {
-  reg_t new_mstatus = (mstatus->read() & ~write_mask) | (val & write_mask);
+  reg_t new_mstatus = (mstatus->read() & ~sstatus_write_mask) | (val & sstatus_write_mask);
 
   mstatus->write(new_mstatus);
   return false; // avoid double logging: already logged by mstatus->write()

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -301,7 +301,13 @@ reg_t cause_csr_t::read() const noexcept {
 
 // implement class base_status_csr_t
 base_status_csr_t::base_status_csr_t(processor_t* const proc, const reg_t addr):
-  logged_csr_t(proc, addr) {
+  logged_csr_t(proc, addr),
+  sstatus_write_mask(SSTATUS_SIE | SSTATUS_SPIE | SSTATUS_SPP | SSTATUS_FS
+                     | SSTATUS_SUM | SSTATUS_MXR
+                     | (proc->any_custom_extensions() ? SSTATUS_XS : 0)
+                     | (proc->extension_enabled_const('V') ? SSTATUS_VS : 0)),
+  sstatus_read_mask(sstatus_write_mask | SSTATUS_UBE | SSTATUS_UXL
+                    | (proc->get_const_xlen() == 32 ? SSTATUS32_SD : SSTATUS64_SD)) {
 }
 
 reg_t base_status_csr_t::adjust_sd(reg_t newval) const noexcept {
@@ -360,13 +366,7 @@ bool vsstatus_csr_t::unlogged_write(const reg_t val) noexcept {
 // implement class sstatus_proxy_csr_t
 sstatus_proxy_csr_t::sstatus_proxy_csr_t(processor_t* const proc, const reg_t addr):
   base_status_csr_t(proc, addr),
-  mstatus(proc->get_state()->mstatus),
-  sstatus_write_mask(SSTATUS_SIE | SSTATUS_SPIE | SSTATUS_SPP | SSTATUS_FS
-                     | SSTATUS_SUM | SSTATUS_MXR
-                     | (proc->any_custom_extensions() ? SSTATUS_XS : 0)
-                     | (proc->extension_enabled_const('V') ? SSTATUS_VS : 0)),
-  sstatus_read_mask(sstatus_write_mask | SSTATUS_UBE | SSTATUS_UXL
-                    | (proc->get_const_xlen() == 32 ? SSTATUS32_SD : SSTATUS64_SD)) {
+  mstatus(proc->get_state()->mstatus) {
 }
 
 reg_t sstatus_proxy_csr_t::read() const noexcept {

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -145,15 +145,15 @@ reg_t pmpaddr_csr_t::napot_mask() const noexcept {
 }
 
 
-bool pmpaddr_csr_t::match4(reg_t cur_addr) const noexcept {
+bool pmpaddr_csr_t::match4(reg_t addr) const noexcept {
   state_t* const state = proc->get_state();
   uint8_t cfg = state->pmpcfg[pmpidx];
   if ((cfg & PMP_A) == 0) return false;
   reg_t base = tor_base_paddr();
   reg_t tor = tor_paddr();
   bool is_tor = (cfg & PMP_A) == PMP_TOR;
-  bool napot_match = ((cur_addr ^ tor) & napot_mask()) == 0;
-  bool tor_match = base <= cur_addr && cur_addr < tor;
+  bool napot_match = ((addr ^ tor) & napot_mask()) == 0;
+  bool tor_match = base <= addr && addr < tor;
   return is_tor ? tor_match : napot_match;
 }
 

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -440,6 +440,11 @@ bool mstatus_csr_t::unlogged_write(const reg_t val) noexcept {
   return true;
 }
 
+// implement class sstatus_csr_t
+sstatus_csr_t::sstatus_csr_t(processor_t* const proc, csr_t_p orig, csr_t_p virt):
+  virtualized_csr_t(proc, orig, virt) {
+}
+
 
 // implement class misa_csr_t
 misa_csr_t::misa_csr_t(processor_t* const proc, const reg_t addr, const reg_t max_isa):

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -309,12 +309,12 @@ base_status_csr_t::base_status_csr_t(processor_t* const proc, const reg_t addr):
 
 
 reg_t base_status_csr_t::compute_sstatus_write_mask() const noexcept {
-  bool has_page = proc->extension_enabled('S') && proc->supports_impl(IMPL_MMU);
+  const bool has_page = proc->extension_enabled('S') && proc->supports_impl(IMPL_MMU);
   // If a configuration has FS bits, they will always be accessible no
   // matter the state of misa.
-  bool has_fs = proc->extension_enabled('S') || proc->extension_enabled('F')
+  const bool has_fs = proc->extension_enabled('S') || proc->extension_enabled('F')
               || proc->extension_enabled_const('V');
-  bool has_vs = proc->extension_enabled_const('V');
+  const bool has_vs = proc->extension_enabled_const('V');
   return 0
     | (proc->extension_enabled('S') ? (SSTATUS_SIE | SSTATUS_SPIE | SSTATUS_SPP) : 0)
     | (has_page ? (SSTATUS_SUM | SSTATUS_MXR) : 0)
@@ -359,7 +359,7 @@ reg_t vsstatus_csr_t::read() const noexcept {
 
 bool vsstatus_csr_t::unlogged_write(const reg_t val) noexcept {
   state_t* const state = proc->get_state();
-  bool has_page = proc->extension_enabled('S') && proc->supports_impl(IMPL_MMU);
+  const bool has_page = proc->extension_enabled('S') && proc->supports_impl(IMPL_MMU);
   if (state->v && has_page && ((val ^ read()) & (MSTATUS_MXR | MSTATUS_SUM)))
     proc->get_mmu()->flush_tlb();
   const reg_t newval = (this->val & ~sstatus_write_mask) | (val & sstatus_write_mask);
@@ -379,7 +379,7 @@ reg_t sstatus_proxy_csr_t::read() const noexcept {
 }
 
 bool sstatus_proxy_csr_t::unlogged_write(const reg_t val) noexcept {
-  reg_t new_mstatus = (mstatus->read() & ~sstatus_write_mask) | (val & sstatus_write_mask);
+  const reg_t new_mstatus = (mstatus->read() & ~sstatus_write_mask) | (val & sstatus_write_mask);
 
   mstatus->write(new_mstatus);
   return false; // avoid double logging: already logged by mstatus->write()
@@ -406,24 +406,24 @@ reg_t mstatus_csr_t::read() const noexcept {
 
 
 bool mstatus_csr_t::unlogged_write(const reg_t val) noexcept {
-  bool has_page = proc->extension_enabled('S') && proc->supports_impl(IMPL_MMU);
+  const bool has_page = proc->extension_enabled('S') && proc->supports_impl(IMPL_MMU);
   if ((val ^ read()) &
       (MSTATUS_MPP | MSTATUS_MPRV
        | (has_page ? (MSTATUS_MXR | MSTATUS_SUM) : 0)
       ))
     proc->get_mmu()->flush_tlb();
 
-  bool has_mpv = proc->extension_enabled('S') && proc->extension_enabled('H');
-  bool has_gva = has_mpv;
+  const bool has_mpv = proc->extension_enabled('S') && proc->extension_enabled('H');
+  const bool has_gva = has_mpv;
 
-  reg_t mask = sstatus_write_mask
-             | MSTATUS_MIE | MSTATUS_MPIE | MSTATUS_MPRV
-             | MSTATUS_MPP | MSTATUS_TW | MSTATUS_TSR
-             | (has_page ? MSTATUS_TVM : 0)
-             | (has_gva ? MSTATUS_GVA : 0)
-             | (has_mpv ? MSTATUS_MPV : 0);
+  const reg_t mask = sstatus_write_mask
+                   | MSTATUS_MIE | MSTATUS_MPIE | MSTATUS_MPRV
+                   | MSTATUS_MPP | MSTATUS_TW | MSTATUS_TSR
+                   | (has_page ? MSTATUS_TVM : 0)
+                   | (has_gva ? MSTATUS_GVA : 0)
+                   | (has_mpv ? MSTATUS_MPV : 0);
 
-  reg_t requested_mpp = proc->legalize_privilege(get_field(val, MSTATUS_MPP));
+  const reg_t requested_mpp = proc->legalize_privilege(get_field(val, MSTATUS_MPP));
   reg_t new_mstatus = set_field(val, MSTATUS_MPP, requested_mpp);
 
   new_mstatus = (read() & ~mask) | (new_mstatus & mask);

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -609,16 +609,13 @@ hvip_csr_t::hvip_csr_t(processor_t* const proc, const reg_t addr):
 
 // implement class hip_csr_t
 hip_csr_t::hip_csr_t(processor_t* const proc, const reg_t addr):
-  csr_t(proc, addr) {
-}
-
-reg_t hip_csr_t::read() const noexcept {
-  return state->mip->read() & MIP_HS_MASK;
-}
-
-void hip_csr_t::write(const reg_t val) noexcept {
-  const reg_t mask = MIP_VSSIP;
-  state->mip->write_with_mask(mask, val);
+  generic_ip_csr_t(proc,
+                   addr,
+                   MIP_HS_MASK,   // read_mask
+                   MIP_VSSIP,     // write_mask
+                   false,         // mask_mideleg
+                   false,         // mask_hideleg
+                   0) {           // shiftamt
 }
 
 

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -335,14 +335,14 @@ bool vsstatus_csr_t::unlogged_write(const reg_t val) noexcept {
   reg_t mask = SSTATUS_VS_MASK;
   mask |= (proc->supports_extension('V') ? SSTATUS_VS : 0);
   reg_t newval = (this->val & ~mask) | (val & mask);
-  newval &= (proc->get_xlen() == 64 ? ~SSTATUS64_SD : ~SSTATUS32_SD);
+  newval &= (proc->get_const_xlen() == 64 ? ~SSTATUS64_SD : ~SSTATUS32_SD);
   if (((newval & SSTATUS_FS) == SSTATUS_FS) ||
       ((newval & SSTATUS_VS) == SSTATUS_VS) ||
       ((newval & SSTATUS_XS) == SSTATUS_XS)) {
-    newval |= (proc->get_xlen() == 64 ? SSTATUS64_SD : SSTATUS32_SD);
+    newval |= (proc->get_const_xlen() == 64 ? SSTATUS64_SD : SSTATUS32_SD);
   }
   if (proc->supports_extension('U'))
-    newval = set_field(newval, SSTATUS_UXL, xlen_to_uxl(proc->get_max_xlen()));
+    newval = set_field(newval, SSTATUS_UXL, xlen_to_uxl(proc->get_const_xlen()));
 
   this->val = newval;
   return true;
@@ -359,7 +359,7 @@ reg_t sstatus_proxy_csr_t::read() const noexcept {
   reg_t mask = SSTATUS_SIE | SSTATUS_SPIE | SSTATUS_UBE | SSTATUS_SPP
              | SSTATUS_FS | (proc->supports_extension('V') ? SSTATUS_VS : 0)
              | SSTATUS_XS | SSTATUS_SUM | SSTATUS_MXR | SSTATUS_UXL
-             | (proc->get_xlen() == 32 ? SSTATUS32_SD : SSTATUS64_SD);
+             | (proc->get_const_xlen() == 32 ? SSTATUS32_SD : SSTATUS64_SD);
   return mstatus->read() & mask;
 }
 
@@ -425,15 +425,15 @@ bool mstatus_csr_t::unlogged_write(const reg_t val) noexcept {
   bool dirty = (new_mstatus & MSTATUS_FS) == MSTATUS_FS;
   dirty |= (new_mstatus & MSTATUS_XS) == MSTATUS_XS;
   dirty |= (new_mstatus & MSTATUS_VS) == MSTATUS_VS;
-  if (proc->get_max_xlen() == 32)
+  if (proc->get_const_xlen() == 32)
     new_mstatus = set_field(new_mstatus, MSTATUS32_SD, dirty);
   else
     new_mstatus = set_field(new_mstatus, MSTATUS64_SD, dirty);
 
   if (proc->supports_extension('U'))
-    new_mstatus = set_field(new_mstatus, MSTATUS_UXL, xlen_to_uxl(proc->get_max_xlen()));
+    new_mstatus = set_field(new_mstatus, MSTATUS_UXL, xlen_to_uxl(proc->get_const_xlen()));
   if (proc->supports_extension('S'))
-    new_mstatus = set_field(new_mstatus, MSTATUS_SXL, xlen_to_uxl(proc->get_max_xlen()));
+    new_mstatus = set_field(new_mstatus, MSTATUS_SXL, xlen_to_uxl(proc->get_const_xlen()));
 
   this->val = new_mstatus;
   return true;

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -560,16 +560,11 @@ sip_csr_t::sip_csr_t(processor_t* const proc, const reg_t addr):
 }
 
 reg_t sip_csr_t::read() const noexcept {
-  if (state->v)
-    return (state->mip->read() & state->hideleg & MIP_VS_MASK) >> 1;
   return state->mip->read() & state->mideleg & ~MIP_HS_MASK;
 }
 
 void sip_csr_t::write(const reg_t val) noexcept {
-  if (state->v)
-    state->mip->write_with_mask(state->hideleg & MIP_VSSIP, val << 1);
-  else
-    state->mip->write_with_mask(state->mideleg & MIP_SSIP, val);
+  state->mip->write_with_mask(state->mideleg & MIP_SSIP, val);
 }
 
 // implement class hvip_csr_t

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -299,9 +299,15 @@ reg_t cause_csr_t::read() const noexcept {
 }
 
 
+// implement class base_status_csr_t
+base_status_csr_t::base_status_csr_t(processor_t* const proc, const reg_t addr):
+  logged_csr_t(proc, addr) {
+}
+
+
 // implement class vsstatus_csr_t
 vsstatus_csr_t::vsstatus_csr_t(processor_t* const proc, const reg_t addr):
-  logged_csr_t(proc, addr),
+  base_status_csr_t(proc, addr),
   val(0) {
 }
 
@@ -377,7 +383,7 @@ bool sstatus_proxy_csr_t::unlogged_write(const reg_t val) noexcept {
 
 // implement class mstatus_csr_t
 mstatus_csr_t::mstatus_csr_t(processor_t* const proc, const reg_t addr):
-  logged_csr_t(proc, addr),
+  base_status_csr_t(proc, addr),
   val(
 #ifdef RISCV_ENABLE_DUAL_ENDIAN
       proc->get_mmu()->is_target_big_endian() ? MSTATUS_UBE | MSTATUS_SBE | MSTATUS_MBE :

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -457,14 +457,14 @@ bool misa_csr_t::unlogged_write(const reg_t val) noexcept {
   const reg_t adjusted_val = val_supports_f ? val : val_without_d;
 
   // allow MAFDCH bits in MISA to be modified
-  reg_t write_mask = 0;
-  write_mask |= 1L << ('M' - 'A');
-  write_mask |= 1L << ('A' - 'A');
-  write_mask |= 1L << ('F' - 'A');
-  write_mask |= 1L << ('D' - 'A');
-  write_mask |= 1L << ('C' - 'A');
-  write_mask |= 1L << ('H' - 'A');
-  write_mask &= max_isa;
+  const reg_t write_mask = max_isa & (0
+                                      | (1L << ('M' - 'A'))
+                                      | (1L << ('A' - 'A'))
+                                      | (1L << ('F' - 'A'))
+                                      | (1L << ('D' - 'A'))
+                                      | (1L << ('C' - 'A'))
+                                      | (1L << ('H' - 'A'))
+                                      );
 
   const reg_t old_misa = read();
   const bool prev_h = old_misa & (1L << ('H' - 'A'));

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -230,9 +230,12 @@ virtualized_csr_t::virtualized_csr_t(processor_t* const proc, csr_t_p orig, csr_
 
 reg_t virtualized_csr_t::read() const noexcept {
   state_t* const state = proc->get_state();
-  return state->v ? virt_csr->read() : orig_csr->read();
+  return readvirt(state->v);
 }
 
+reg_t virtualized_csr_t::readvirt(bool virt) const noexcept {
+  return virt ? virt_csr->read() : orig_csr->read();
+}
 
 void virtualized_csr_t::write(const reg_t val) noexcept {
   state_t* const state = proc->get_state();

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -600,3 +600,18 @@ void hip_csr_t::write(const reg_t val) noexcept {
   const reg_t mask = MIP_VSSIP;
   state->mip->write_with_mask(mask, val);
 }
+
+
+// implement class vsip_csr_t
+vsip_csr_t::vsip_csr_t(processor_t* const proc, const reg_t addr):
+  csr_t(proc, addr) {
+}
+
+reg_t vsip_csr_t::read() const noexcept {
+  return (state->mip->read() & state->hideleg & MIP_VS_MASK) >> 1;
+}
+
+void vsip_csr_t::write(const reg_t val) noexcept {
+  const reg_t mask = state->hideleg & MIP_VSSIP;
+  state->mip->write_with_mask(mask, val << 1);
+}

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -356,9 +356,7 @@ sstatus_proxy_csr_t::sstatus_proxy_csr_t(processor_t* const proc, const reg_t ad
   write_mask(SSTATUS_SIE | SSTATUS_SPIE | SSTATUS_SPP | SSTATUS_FS
              | SSTATUS_XS | SSTATUS_SUM | SSTATUS_MXR
              | (proc->extension_enabled_const('V') ? SSTATUS_VS : 0)),
-  read_mask(SSTATUS_SIE | SSTATUS_SPIE | SSTATUS_UBE | SSTATUS_SPP
-            | SSTATUS_FS | (proc->extension_enabled_const('V') ? SSTATUS_VS : 0)
-            | SSTATUS_XS | SSTATUS_SUM | SSTATUS_MXR | SSTATUS_UXL
+  read_mask(write_mask | SSTATUS_UBE | SSTATUS_UXL
             | (proc->get_const_xlen() == 32 ? SSTATUS32_SD : SSTATUS64_SD)) {
 }
 

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -309,10 +309,19 @@ base_status_csr_t::base_status_csr_t(processor_t* const proc, const reg_t addr):
 
 
 reg_t base_status_csr_t::compute_sstatus_write_mask() const noexcept {
-  return SSTATUS_SIE | SSTATUS_SPIE | SSTATUS_SPP | SSTATUS_FS
-    | SSTATUS_SUM | SSTATUS_MXR
+  bool has_page = proc->extension_enabled('S') && proc->supports_impl(IMPL_MMU);
+  // If a configuration has FS bits, they will always be accessible no
+  // matter the state of misa.
+  bool has_fs = proc->extension_enabled('S') || proc->extension_enabled('F')
+              || proc->extension_enabled_const('V');
+  bool has_vs = proc->extension_enabled_const('V');
+  return 0
+    | (proc->extension_enabled('S') ? (SSTATUS_SIE | SSTATUS_SPIE | SSTATUS_SPP) : 0)
+    | (has_page ? (SSTATUS_SUM | SSTATUS_MXR) : 0)
+    | (has_fs ? SSTATUS_FS : 0)
     | (proc->any_custom_extensions() ? SSTATUS_XS : 0)
-    | (proc->extension_enabled_const('V') ? SSTATUS_VS : 0);
+    | (has_vs ? SSTATUS_VS : 0)
+    ;
 }
 
 

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -3,6 +3,10 @@
 #include "csrs.h"
 // For processor_t:
 #include "processor.h"
+// For get_field():
+#include "decode.h"
+// For trap_virtual_instruction and trap_illegal_instruction:
+#include "trap.h"
 
 
 // implement class csr_t
@@ -10,6 +14,27 @@ csr_t::csr_t(processor_t* const proc, const reg_t addr):
   proc(proc),
   address(addr) {
 }
+
+void csr_t::verify_permissions(insn_t insn, bool write) const {
+  // Check permissions. Raise virtual-instruction exception if V=1,
+  // privileges are insufficient, and the CSR belongs to supervisor or
+  // hypervisor. Raise illegal-instruction exception otherwise.
+  state_t* const state = proc->get_state();
+  unsigned csr_priv = get_field(address, 0x300);
+  bool csr_read_only = get_field(address, 0xC00) == 3;
+  unsigned priv = state->prv == PRV_S && !state->v ? PRV_HS : state->prv;
+
+  if ((csr_priv == PRV_S && !proc->supports_extension('S')) ||
+      (csr_priv == PRV_HS && !proc->supports_extension('H')))
+    throw trap_illegal_instruction(insn.bits());
+
+  if ((write && csr_read_only) || priv < csr_priv) {
+    if (state->v && csr_priv <= PRV_HS)
+      throw trap_virtual_instruction(insn.bits());
+    throw trap_illegal_instruction(insn.bits());
+  }
+}
+
 
 csr_t::~csr_t() {
 }

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -715,3 +715,13 @@ bool hstatus_csr_t::unlogged_write(const reg_t val) noexcept {
     | HSTATUS_HU | HSTATUS_SPVP | HSTATUS_SPV | HSTATUS_GVA;
   return basic_csr_t::unlogged_write((read() & ~mask) | (val & mask));
 }
+
+
+// implement class counteren_csr_t
+counteren_csr_t::counteren_csr_t(processor_t* const proc, const reg_t addr):
+  basic_csr_t(proc, addr, 0) {
+}
+
+bool counteren_csr_t::unlogged_write(const reg_t val) noexcept {
+  return basic_csr_t::unlogged_write(val & 0xffffffffULL);
+}

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -89,8 +89,8 @@ void pmpaddr_csr_t::verify_permissions(insn_t insn, bool write) const {
 
 reg_t pmpaddr_csr_t::read() const noexcept {
   state_t* const state = proc->get_state();
-  size_t i = address - CSR_PMPADDR0;
-  if ((state->pmpcfg[i] & PMP_A) >= PMP_NAPOT)
+  size_t pmpidx = address - CSR_PMPADDR0;
+  if ((state->pmpcfg[pmpidx] & PMP_A) >= PMP_NAPOT)
     return val | (~proc->pmp_tor_mask() >> 1);
   return val & proc->pmp_tor_mask();
 }
@@ -110,9 +110,9 @@ bool pmpaddr_csr_t::unlogged_write(const reg_t val) noexcept {
     return false;
 
   state_t* const state = proc->get_state();
-  size_t i = address - CSR_PMPADDR0;
-  bool locked = state->pmpcfg[i] & PMP_L;
-  if (i < proc->n_pmp && !locked && !next_locked_and_tor()) {
+  size_t pmpidx = address - CSR_PMPADDR0;
+  bool locked = state->pmpcfg[pmpidx] & PMP_L;
+  if (pmpidx < proc->n_pmp && !locked && !next_locked_and_tor()) {
     this->val = val & ((reg_t(1) << (MAX_PADDR_BITS - PMP_SHIFT)) - 1);
   }
   else
@@ -123,10 +123,10 @@ bool pmpaddr_csr_t::unlogged_write(const reg_t val) noexcept {
 
 bool pmpaddr_csr_t::next_locked_and_tor() const noexcept {
   state_t* const state = proc->get_state();
-  size_t i = address - CSR_PMPADDR0;
-  if (i >= state->max_pmp) return false;  // this is the last entry
-  bool next_locked = state->pmpcfg[i+1] & PMP_L;
-  bool next_tor = (state->pmpcfg[i+1] & PMP_A) == PMP_TOR;
+  size_t pmpidx = address - CSR_PMPADDR0;
+  if (pmpidx >= state->max_pmp) return false;  // this is the last entry
+  bool next_locked = state->pmpcfg[pmpidx+1] & PMP_L;
+  bool next_tor = (state->pmpcfg[pmpidx+1] & PMP_A) == PMP_TOR;
   return next_locked && next_tor;
 }
 

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -124,8 +124,9 @@ bool pmpaddr_csr_t::unlogged_write(const reg_t val) noexcept {
 bool pmpaddr_csr_t::next_locked_and_tor() const noexcept {
   state_t* const state = proc->get_state();
   size_t i = address - CSR_PMPADDR0;
-  bool next_locked = i+1 < state->max_pmp && (state->pmpcfg[i+1] & PMP_L);
-  bool next_tor = i+1 < state->max_pmp && (state->pmpcfg[i+1] & PMP_A) == PMP_TOR;
+  if (i >= state->max_pmp) return false;  // this is the last entry
+  bool next_locked = state->pmpcfg[i+1] & PMP_L;
+  bool next_tor = (state->pmpcfg[i+1] & PMP_A) == PMP_TOR;
   return next_locked && next_tor;
 }
 

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -740,6 +740,34 @@ bool base_atp_csr_t::unlogged_write(const reg_t val) noexcept {
   return basic_csr_t::unlogged_write(newval);
 }
 
+bool processor_t::satp_valid(reg_t val) const {
+  if (xlen == 32) {
+    switch (get_field(val, SATP32_MODE)) {
+      case SATP_MODE_SV32: return supports_impl(IMPL_MMU_SV32);
+      case SATP_MODE_OFF: return true;
+      default: return false;
+    }
+  } else {
+    switch (get_field(val, SATP64_MODE)) {
+      case SATP_MODE_SV39: return supports_impl(IMPL_MMU_SV39);
+      case SATP_MODE_SV48: return supports_impl(IMPL_MMU_SV48);
+      case SATP_MODE_OFF: return true;
+      default: return false;
+    }
+  }
+}
+
+reg_t processor_t::compute_new_satp(reg_t val, reg_t old) const {
+  reg_t rv64_ppn_mask = (reg_t(1) << (MAX_PADDR_BITS - PGSHIFT)) - 1;
+
+  reg_t mode_mask = xlen == 32 ? SATP32_MODE : SATP64_MODE;
+  reg_t ppn_mask = xlen == 32 ? SATP32_PPN : SATP64_PPN & rv64_ppn_mask;
+  reg_t new_mask = (satp_valid(val) ? mode_mask : 0) | ppn_mask;
+  reg_t old_mask = satp_valid(val) ? 0 : mode_mask;
+
+  return (new_mask & val) | (old_mask & old);
+}
+
 satp_csr_t::satp_csr_t(processor_t* const proc, const reg_t addr):
   base_atp_csr_t(proc, addr) {
 }

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -426,14 +426,7 @@ bool mstatus_csr_t::unlogged_write(const reg_t val) noexcept {
     mask |= MSTATUS_SPP;
 
   new_mstatus = (read() & ~mask) | (new_mstatus & mask);
-
-  bool dirty = (new_mstatus & MSTATUS_FS) == MSTATUS_FS;
-  dirty |= (new_mstatus & MSTATUS_XS) == MSTATUS_XS;
-  dirty |= (new_mstatus & MSTATUS_VS) == MSTATUS_VS;
-  if (proc->get_const_xlen() == 32)
-    new_mstatus = set_field(new_mstatus, MSTATUS32_SD, dirty);
-  else
-    new_mstatus = set_field(new_mstatus, MSTATUS64_SD, dirty);
+  new_mstatus = adjust_sd(new_mstatus);
 
   if (proc->extension_enabled('U'))
     new_mstatus = set_field(new_mstatus, MSTATUS_UXL, xlen_to_uxl(proc->get_const_xlen()));

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -4,6 +4,7 @@
 // For processor_t:
 #include "processor.h"
 
+
 // implement class csr_t
 csr_t::csr_t(processor_t* const proc, const reg_t addr):
   proc(proc),
@@ -20,7 +21,9 @@ logged_csr_t::logged_csr_t(processor_t* const proc, const reg_t addr):
 
 void logged_csr_t::write(const reg_t val) noexcept {
   unlogged_write(val);
-  // Add logging here soon
+#if defined(RISCV_ENABLE_COMMITLOG)
+  proc->get_state()->log_reg_write[((address) << 4) | 4] = {read(), 0};
+#endif
 }
 
 // implement class basic_csr_t

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -241,3 +241,21 @@ void virtualized_csr_t::write(const reg_t val) noexcept {
   else
     orig_csr->write(val);
 }
+
+
+// implement class epc_csr_t
+epc_csr_t::epc_csr_t(processor_t* const proc, const reg_t addr):
+  logged_csr_t(proc, addr),
+  val(0) {
+}
+
+
+reg_t epc_csr_t::read() const noexcept {
+  return val & proc->pc_alignment_mask();
+}
+
+
+bool epc_csr_t::unlogged_write(const reg_t val) noexcept {
+  this->val = val & ~(reg_t)1;
+  return true;
+}

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -134,6 +134,14 @@ reg_t pmpaddr_csr_t::tor_paddr() const noexcept {
 }
 
 
+reg_t pmpaddr_csr_t::napot_mask() const noexcept {
+  state_t* const state = proc->get_state();
+  bool is_na4 = (state->pmpcfg[pmpidx] & PMP_A) == PMP_NA4;
+  reg_t mask = (val << 1) | (!is_na4) | ~proc->pmp_tor_mask();
+  return ~(mask & ~(mask + 1)) << PMP_SHIFT;
+}
+
+
 // implement class pmpcfg_csr_t
 pmpcfg_csr_t::pmpcfg_csr_t(processor_t* const proc, const reg_t addr):
   logged_csr_t(proc, addr) {

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -312,10 +312,7 @@ vsstatus_csr_t::vsstatus_csr_t(processor_t* const proc, const reg_t addr):
 }
 
 reg_t vsstatus_csr_t::read() const noexcept {
-  reg_t mask = SSTATUS_VS_MASK;
-  mask |= (proc->supports_extension('V') ? SSTATUS_VS : 0);
-  mask |= (proc->get_xlen() == 64 ? SSTATUS64_SD : SSTATUS32_SD);
-  return val & mask;
+  return val;
 }
 
 

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -395,7 +395,7 @@ bool mstatus_csr_t::backdoor_write(const reg_t val) noexcept {
   if ((val ^ read()) &
       (MSTATUS_MPP | MSTATUS_MPRV
        | (has_page ? (MSTATUS_MXR | MSTATUS_SUM) : 0)
-       | MSTATUS_MXR))
+      ))
     proc->get_mmu()->flush_tlb();
 
   bool has_fs = proc->supports_extension('S') || proc->supports_extension('F')

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -226,8 +226,8 @@ typedef std::shared_ptr<vsstatus_csr_t> vsstatus_csr_t_p;
 //    nonvirtual_sstatus of type sstatus_proxy_csr_t, and
 //    simultaneously remove the swapping of mstatus & vsstatus from
 //    set_priv().
-// 6. Move assorted manipulation code (like mstatus dirtying) into new
-//    sstatus class.
+// 6. [done] Move assorted manipulation code (like mstatus dirtying)
+//    into new sstatus class.
 
 
 class sstatus_proxy_csr_t: public base_status_csr_t {
@@ -260,6 +260,8 @@ class sstatus_csr_t: public virtualized_csr_t {
 
   // Set FS, VS, or XS bits to dirty
   void dirty(const reg_t dirties);
+  // Return true if the specified bits are not 00 (Off)
+  bool enabled(const reg_t which);
 };
 
 typedef std::shared_ptr<sstatus_csr_t> sstatus_csr_t_p;

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -234,7 +234,7 @@ typedef std::shared_ptr<vsstatus_csr_t> vsstatus_csr_t_p;
 
 class sstatus_proxy_csr_t: public base_status_csr_t {
  public:
-  sstatus_proxy_csr_t(processor_t* const proc, const reg_t addr);
+  sstatus_proxy_csr_t(processor_t* const proc, const reg_t addr, csr_t_p mstatus);
   virtual reg_t read() const noexcept override;
  protected:
   virtual bool unlogged_write(const reg_t val) noexcept override;

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -181,7 +181,7 @@ class base_status_csr_t: public logged_csr_t {
  public:
   base_status_csr_t(processor_t* const proc, const reg_t addr);
  protected:
-  reg_t adjust_sd(reg_t newval) const noexcept;
+  reg_t adjust_sd(const reg_t val) const noexcept;
   const reg_t sstatus_write_mask;
   const reg_t sstatus_read_mask;
  private:

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -358,4 +358,15 @@ class mideleg_csr_t: public basic_csr_t {
 };
 
 
+class medeleg_csr_t: public basic_csr_t {
+ public:
+  medeleg_csr_t(processor_t* const proc, const reg_t addr);
+  virtual void verify_permissions(insn_t insn, bool write) const override;
+ protected:
+  virtual bool unlogged_write(const reg_t val) noexcept override;
+ private:
+  const reg_t hypervisor_exceptions;
+};
+
+
 #endif

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -137,4 +137,17 @@ class virtualized_csr_t: public csr_t {
 };
 
 
+// For mepc, sepc, and vsepc
+class epc_csr_t: public logged_csr_t {
+ public:
+  epc_csr_t(processor_t* const proc, const reg_t addr);
+
+  virtual reg_t read() const noexcept override;
+ protected:
+  virtual bool unlogged_write(const reg_t val) noexcept override;
+ private:
+  reg_t val;
+};
+
+
 #endif

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -249,4 +249,14 @@ class mstatus_csr_t: public base_status_csr_t {
 typedef std::shared_ptr<mstatus_csr_t> mstatus_csr_t_p;
 
 
+class misa_csr_t: public basic_csr_t {
+ public:
+  misa_csr_t(processor_t* const proc, const reg_t addr, const reg_t max_isa);
+  bool supports_extension(unsigned char ext) const noexcept;
+ protected:
+  virtual bool unlogged_write(const reg_t val) noexcept override;
+};
+
+typedef std::shared_ptr<misa_csr_t> misa_csr_t_p;
+
 #endif

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -73,6 +73,7 @@ class pmpaddr_csr_t: public logged_csr_t {
  protected:
   virtual bool unlogged_write(const reg_t val) noexcept override;
  private:
+  bool next_locked_and_tor() const noexcept;
   reg_t val;
 };
 

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -180,6 +180,8 @@ class cause_csr_t: public basic_csr_t {
 class base_status_csr_t: public logged_csr_t {
  public:
   base_status_csr_t(processor_t* const proc, const reg_t addr);
+ protected:
+  reg_t adjust_sd(reg_t newval) const noexcept;
 };
 
 

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -14,6 +14,9 @@ class csr_t {
  public:
   csr_t(processor_t* const proc, const reg_t addr);
 
+  // Throw exception if read/write disallowed.
+  virtual void verify_permissions(insn_t insn, bool write) const;
+
   // read() returns the architectural value of this CSR. No permission
   // checking needed or allowed. Side effects not allowed.
   virtual reg_t read() const noexcept = 0;

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -63,4 +63,19 @@ class basic_csr_t: public logged_csr_t {
   reg_t val;
 };
 
+
+class pmpaddr_csr_t: public logged_csr_t {
+ public:
+  pmpaddr_csr_t(processor_t* const proc, const reg_t addr);
+  virtual void verify_permissions(insn_t insn, bool write) const override;
+  virtual reg_t read() const noexcept override;
+  reg_t raw_value() const noexcept;
+ protected:
+  virtual bool unlogged_write(const reg_t val) noexcept override;
+ private:
+  reg_t val;
+};
+
+typedef std::shared_ptr<pmpaddr_csr_t> pmpaddr_csr_t_p;
+
 #endif

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -182,7 +182,6 @@ class vsstatus_csr_t: public logged_csr_t {
  public:
   vsstatus_csr_t(processor_t* const proc, const reg_t addr);
   virtual reg_t read() const noexcept override;
-  void backdoor_write(const reg_t val) noexcept;
  protected:
   virtual bool unlogged_write(const reg_t val) noexcept override;
  private:
@@ -230,7 +229,6 @@ class sstatus_proxy_csr_t: public logged_csr_t {
 class mstatus_csr_t: public basic_csr_t {
  public:
   mstatus_csr_t(processor_t* const proc, const reg_t addr);
-  bool backdoor_write(const reg_t val) noexcept;
  protected:
   virtual bool unlogged_write(const reg_t val) noexcept override;
 };

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -70,6 +70,12 @@ class pmpaddr_csr_t: public logged_csr_t {
   virtual void verify_permissions(insn_t insn, bool write) const override;
   virtual reg_t read() const noexcept override;
   reg_t raw_value() const noexcept;
+
+  // Assuming this is configured as TOR, return address for top of
+  // range. Also forms bottom-of-range for next-highest pmpaddr
+  // register if that one is TOR.
+  reg_t tor_paddr() const noexcept;
+
  protected:
   virtual bool unlogged_write(const reg_t val) noexcept override;
  private:

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -257,6 +257,7 @@ class misa_csr_t: public basic_csr_t {
   virtual bool unlogged_write(const reg_t val) noexcept override;
  private:
   const reg_t max_isa;
+  const reg_t write_mask;
 };
 
 typedef std::shared_ptr<misa_csr_t> misa_csr_t_p;

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -407,11 +407,15 @@ class satp_csr_t: public base_atp_csr_t {
   virtual void verify_permissions(insn_t insn, bool write) const override;
 };
 
+typedef std::shared_ptr<satp_csr_t> satp_csr_t_p;
+
 class virtualized_satp_csr_t: public virtualized_csr_t {
  public:
-  virtualized_satp_csr_t(processor_t* const proc, csr_t_p orig, csr_t_p virt);
+  virtualized_satp_csr_t(processor_t* const proc, satp_csr_t_p orig, csr_t_p virt);
   virtual void verify_permissions(insn_t insn, bool write) const override;
   virtual void write(const reg_t val) noexcept override;
+ private:
+  satp_csr_t_p orig_satp;
 };
 
 

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -86,6 +86,9 @@ class pmpaddr_csr_t: public logged_csr_t {
   // Does a 4-byte access at the specified address match this PMP entry?
   bool match4(reg_t addr) const noexcept;
 
+  // Does the specified range match only a proper subset of this page?
+  bool subset_match(reg_t addr, reg_t len) const noexcept;
+
  protected:
   virtual bool unlogged_write(const reg_t val) noexcept override;
  private:

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -233,6 +233,7 @@ class sstatus_proxy_csr_t: public logged_csr_t {
   virtual bool unlogged_write(const reg_t val) noexcept override;
  private:
   csr_t_p mstatus;
+  const reg_t write_mask;
   const reg_t read_mask;
 };
 

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -261,9 +261,9 @@ class misa_csr_t: public basic_csr_t {
 typedef std::shared_ptr<misa_csr_t> misa_csr_t_p;
 
 
-class mip_csr_t: public logged_csr_t {
+class mip_or_mie_csr_t: public logged_csr_t {
  public:
-  mip_csr_t(processor_t* const proc, const reg_t addr);
+  mip_or_mie_csr_t(processor_t* const proc, const reg_t addr);
   virtual reg_t read() const noexcept override;
 
   void write_with_mask(const reg_t mask, const reg_t val) noexcept;
@@ -276,7 +276,7 @@ class mip_csr_t: public logged_csr_t {
   reg_t val;
 };
 
-typedef std::shared_ptr<mip_csr_t> mip_csr_t_p;
+typedef std::shared_ptr<mip_or_mie_csr_t> mip_or_mie_csr_t_p;
 
 
 // For sip, hip, hvip, vsip, sie, hie, vsie which are all just (masked

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -264,19 +264,28 @@ typedef std::shared_ptr<misa_csr_t> misa_csr_t_p;
 class mip_or_mie_csr_t: public logged_csr_t {
  public:
   mip_or_mie_csr_t(processor_t* const proc, const reg_t addr);
-  virtual reg_t read() const noexcept override;
+  virtual reg_t read() const noexcept override final;
 
   void write_with_mask(const reg_t mask, const reg_t val) noexcept;
 
   // Does not log. Used by external things (clint) that wiggle bits in mip.
   void backdoor_write_with_mask(const reg_t mask, const reg_t val) noexcept;
  protected:
-  virtual bool unlogged_write(const reg_t val) noexcept override;
+  virtual bool unlogged_write(const reg_t val) noexcept override final;
  private:
+  virtual reg_t write_mask() const noexcept = 0;
   reg_t val;
 };
 
 typedef std::shared_ptr<mip_or_mie_csr_t> mip_or_mie_csr_t_p;
+
+
+class mip_csr_t: public mip_or_mie_csr_t {
+ public:
+  mip_csr_t(processor_t* const proc, const reg_t addr);
+ private:
+  virtual reg_t write_mask() const noexcept override;
+};
 
 
 // For sip, hip, hvip, vsip, sie, hie, vsie which are all just (masked

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -205,31 +205,6 @@ class vsstatus_csr_t: public base_status_csr_t {
 typedef std::shared_ptr<vsstatus_csr_t> vsstatus_csr_t_p;
 
 
-// Problem: the vsstatus implementation of swapping mstatus & vsstatus
-// within set_priv() results in confusing code and
-// non-architecturally-compliant commitlog (e.g. `csrw sstatus` from
-// VS-mode reports that mstatus has changed when really it's only
-// vsstatus that was supposed to change).
-//
-// Goal: get all appropriate references to state.mstatus to use
-// state.sstatus instead, so it can be virtualized via the usual
-// (virtualized_csr_t) mechanism.
-//
-// 1. [done] Create one of these proxy objects as state.sstatus,
-//    with no logging. Do not put it into csrmap yet.
-// 2. [done] One by one, switch references to state.mstatus to use
-//    state.sstatus. When complete, all references to sstatus that
-//    need to be virtualized will be through this object.
-// 3. [done] Convert mstatus into a csr_t subclass.
-// 4. [done] Refactor common code into base class.
-// 5. [done] Convert sstatus to a virtualized_csr_t, with a
-//    nonvirtual_sstatus of type sstatus_proxy_csr_t, and
-//    simultaneously remove the swapping of mstatus & vsstatus from
-//    set_priv().
-// 6. [done] Move assorted manipulation code (like mstatus dirtying)
-//    into new sstatus class.
-
-
 class sstatus_proxy_csr_t: public base_status_csr_t {
  public:
   sstatus_proxy_csr_t(processor_t* const proc, const reg_t addr, csr_t_p mstatus);

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -141,8 +141,6 @@ class virtualized_csr_t: public csr_t {
   csr_t_p virt_csr;
 };
 
-typedef std::shared_ptr<virtualized_csr_t> virtualized_csr_t_p;
-
 
 // For mepc, sepc, and vsepc
 class epc_csr_t: public logged_csr_t {
@@ -259,7 +257,12 @@ typedef std::shared_ptr<mstatus_csr_t> mstatus_csr_t_p;
 class sstatus_csr_t: public virtualized_csr_t {
  public:
   sstatus_csr_t(processor_t* const proc, csr_t_p orig, csr_t_p virt);
+
+  // Set FS, VS, or XS bits to dirty
+  void dirty(const reg_t dirties);
 };
+
+typedef std::shared_ptr<sstatus_csr_t> sstatus_csr_t_p;
 
 
 class misa_csr_t: public basic_csr_t {

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -47,7 +47,8 @@ class logged_csr_t: public csr_t {
   virtual void write(const reg_t val) noexcept override final;
 
  protected:
-  virtual void unlogged_write(const reg_t val) noexcept = 0;
+  // Return value indicates success; false means no write actually occurred
+  virtual bool unlogged_write(const reg_t val) noexcept = 0;
 };
 
 
@@ -57,7 +58,7 @@ class basic_csr_t: public logged_csr_t {
   basic_csr_t(processor_t* const proc, const reg_t addr, const reg_t init);
   virtual reg_t read() const noexcept override;
  protected:
-  virtual void unlogged_write(const reg_t val) noexcept override;
+  virtual bool unlogged_write(const reg_t val) noexcept override;
  private:
   reg_t val;
 };

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -253,6 +253,7 @@ class misa_csr_t: public basic_csr_t {
  public:
   misa_csr_t(processor_t* const proc, const reg_t addr, const reg_t max_isa);
   bool extension_enabled(unsigned char ext) const noexcept;
+  bool extension_enabled_const(unsigned char ext) const noexcept;
  protected:
   virtual bool unlogged_write(const reg_t val) noexcept override;
  private:

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -50,15 +50,8 @@ class csr_t {
 typedef std::shared_ptr<csr_t> csr_t_p;
 
 
-// Parent class that records log of every write to itself
-class logged_csr_t: public csr_t {
- public:
-  logged_csr_t(processor_t* const proc, const reg_t addr);
-};
-
-
 // Basic CSRs, with XLEN bits fully readable and writable.
-class basic_csr_t: public logged_csr_t {
+class basic_csr_t: public csr_t {
  public:
   basic_csr_t(processor_t* const proc, const reg_t addr, const reg_t init);
   virtual reg_t read() const noexcept override;
@@ -69,7 +62,7 @@ class basic_csr_t: public logged_csr_t {
 };
 
 
-class pmpaddr_csr_t: public logged_csr_t {
+class pmpaddr_csr_t: public csr_t {
  public:
   pmpaddr_csr_t(processor_t* const proc, const reg_t addr);
   virtual void verify_permissions(insn_t insn, bool write) const override;
@@ -109,7 +102,7 @@ class pmpaddr_csr_t: public logged_csr_t {
 
 typedef std::shared_ptr<pmpaddr_csr_t> pmpaddr_csr_t_p;
 
-class pmpcfg_csr_t: public logged_csr_t {
+class pmpcfg_csr_t: public csr_t {
  public:
   pmpcfg_csr_t(processor_t* const proc, const reg_t addr);
   virtual reg_t read() const noexcept override;
@@ -126,7 +119,7 @@ class pmpcfg_csr_t: public logged_csr_t {
 // The csrmap will contain a virtualized_csr_t under sscratch's
 // address, plus the vsscratch basic_csr_t under its address.
 
-class virtualized_csr_t: public logged_csr_t {
+class virtualized_csr_t: public csr_t {
  public:
   virtualized_csr_t(processor_t* const proc, csr_t_p orig, csr_t_p virt);
 
@@ -142,7 +135,7 @@ class virtualized_csr_t: public logged_csr_t {
 typedef std::shared_ptr<virtualized_csr_t> virtualized_csr_t_p;
 
 // For mepc, sepc, and vsepc
-class epc_csr_t: public logged_csr_t {
+class epc_csr_t: public csr_t {
  public:
   epc_csr_t(processor_t* const proc, const reg_t addr);
 
@@ -155,7 +148,7 @@ class epc_csr_t: public logged_csr_t {
 
 
 // For mtvec, stvec, and vstvec
-class tvec_csr_t: public logged_csr_t {
+class tvec_csr_t: public csr_t {
  public:
   tvec_csr_t(processor_t* const proc, const reg_t addr);
 
@@ -177,7 +170,7 @@ class cause_csr_t: public basic_csr_t {
 
 
 // For *status family of CSRs
-class base_status_csr_t: public logged_csr_t {
+class base_status_csr_t: public csr_t {
  public:
   base_status_csr_t(processor_t* const proc, const reg_t addr);
  protected:
@@ -258,7 +251,7 @@ class misa_csr_t: public basic_csr_t {
 typedef std::shared_ptr<misa_csr_t> misa_csr_t_p;
 
 
-class mip_or_mie_csr_t: public logged_csr_t {
+class mip_or_mie_csr_t: public csr_t {
  public:
   mip_or_mie_csr_t(processor_t* const proc, const reg_t addr);
   virtual reg_t read() const noexcept override final;
@@ -329,7 +322,7 @@ typedef std::shared_ptr<generic_int_accessor_t> generic_int_accessor_t_p;
 
 
 // For all CSRs that are simply (masked & shifted) views into mip
-class mip_proxy_csr_t: public logged_csr_t {
+class mip_proxy_csr_t: public csr_t {
  public:
   mip_proxy_csr_t(processor_t* const proc, const reg_t addr, generic_int_accessor_t_p accr);
   virtual reg_t read() const noexcept override;
@@ -340,7 +333,7 @@ class mip_proxy_csr_t: public logged_csr_t {
 };
 
 // For all CSRs that are simply (masked & shifted) views into mie
-class mie_proxy_csr_t: public logged_csr_t {
+class mie_proxy_csr_t: public csr_t {
  public:
   mie_proxy_csr_t(processor_t* const proc, const reg_t addr, generic_int_accessor_t_p accr);
   virtual reg_t read() const noexcept override;

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -75,6 +75,7 @@ class pmpaddr_csr_t: public logged_csr_t {
  private:
   bool next_locked_and_tor() const noexcept;
   reg_t val;
+  const size_t pmpidx;
 };
 
 typedef std::shared_ptr<pmpaddr_csr_t> pmpaddr_csr_t_p;

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -277,8 +277,6 @@ class mip_or_mie_csr_t: public logged_csr_t {
   reg_t val;
 };
 
-typedef std::shared_ptr<mip_or_mie_csr_t> mip_or_mie_csr_t_p;
-
 
 class mip_csr_t: public mip_or_mie_csr_t {
  public:
@@ -287,12 +285,17 @@ class mip_csr_t: public mip_or_mie_csr_t {
   virtual reg_t write_mask() const noexcept override;
 };
 
+typedef std::shared_ptr<mip_csr_t> mip_csr_t_p;
+
+
 class mie_csr_t: public mip_or_mie_csr_t {
  public:
   mie_csr_t(processor_t* const proc, const reg_t addr);
  private:
   virtual reg_t write_mask() const noexcept override;
 };
+
+typedef std::shared_ptr<mie_csr_t> mie_csr_t_p;
 
 
 // For sip, hip, hvip, vsip, sie, hie, vsie which are all just (masked

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -332,11 +332,12 @@ typedef std::shared_ptr<generic_int_accessor_t> generic_int_accessor_t_p;
 
 
 // For all CSRs that are simply (masked & shifted) views into mip
-class mip_proxy_csr_t: public csr_t {
+class mip_proxy_csr_t: public logged_csr_t {
  public:
   mip_proxy_csr_t(processor_t* const proc, const reg_t addr, generic_int_accessor_t_p accr);
   virtual reg_t read() const noexcept override;
-  virtual void write(const reg_t val) noexcept override;
+ protected:
+  virtual bool unlogged_write(const reg_t val) noexcept override;
  private:
   generic_int_accessor_t_p accr;
 };

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -182,6 +182,8 @@ class base_status_csr_t: public logged_csr_t {
   base_status_csr_t(processor_t* const proc, const reg_t addr);
  protected:
   reg_t adjust_sd(reg_t newval) const noexcept;
+  const reg_t sstatus_write_mask;
+  const reg_t sstatus_read_mask;
 };
 
 
@@ -233,8 +235,6 @@ class sstatus_proxy_csr_t: public base_status_csr_t {
   virtual bool unlogged_write(const reg_t val) noexcept override;
  private:
   csr_t_p mstatus;
-  const reg_t sstatus_write_mask;
-  const reg_t sstatus_read_mask;
 };
 
 

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -7,11 +7,12 @@
 // For std::shared_ptr
 #include <memory>
 
+class processor_t;
 
 // Parent, abstract class for all CSRs
 class csr_t {
  public:
-  csr_t(const reg_t addr);
+  csr_t(processor_t* const proc, const reg_t addr);
 
   // read() returns the architectural value of this CSR. No permission
   // checking needed or allowed. Side effects not allowed.
@@ -24,6 +25,7 @@ class csr_t {
   virtual ~csr_t();
 
  private:
+  processor_t* const proc;
   const reg_t address;
 };
 
@@ -32,7 +34,7 @@ typedef std::shared_ptr<csr_t> csr_t_p;
 // Basic CSRs, with XLEN bits fully readable and writable.
 class basic_csr_t: public csr_t {
  public:
-  basic_csr_t(const reg_t addr, const reg_t init);
+  basic_csr_t(processor_t* const proc, const reg_t addr, const reg_t init);
   virtual reg_t read() const noexcept override;
   virtual void write(const reg_t val) noexcept override;
  private:

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -129,16 +129,15 @@ class pmpcfg_csr_t: public logged_csr_t {
 // The csrmap will contain a virtualized_csr_t under sscratch's
 // address, plus the vsscratch basic_csr_t under its address.
 
-class virtualized_csr_t: public csr_t {
+class virtualized_csr_t: public logged_csr_t {
  public:
   virtualized_csr_t(processor_t* const proc, csr_t_p orig, csr_t_p virt);
 
   virtual reg_t read() const noexcept override;
   // Instead of using state.v, explicitly request original or virtual:
   reg_t readvirt(bool virt) const noexcept;
-  virtual void write(const reg_t val) noexcept override;
-
  protected:
+  virtual bool unlogged_write(const reg_t val) noexcept override;
   csr_t_p orig_csr;
   csr_t_p virt_csr;
 };
@@ -416,7 +415,8 @@ class virtualized_satp_csr_t: public virtualized_csr_t {
  public:
   virtualized_satp_csr_t(processor_t* const proc, satp_csr_t_p orig, csr_t_p virt);
   virtual void verify_permissions(insn_t insn, bool write) const override;
-  virtual void write(const reg_t val) noexcept override;
+ protected:
+  virtual bool unlogged_write(const reg_t val) noexcept override;
  private:
   satp_csr_t_p orig_satp;
 };

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -11,7 +11,7 @@
 // Parent, abstract class for all CSRs
 class csr_t {
  public:
-  csr_t(const reg_t addr): address(addr) {}
+  csr_t(const reg_t addr);
 
   // read() returns the architectural value of this CSR. No permission
   // checking needed or allowed. Side effects not allowed.
@@ -21,7 +21,7 @@ class csr_t {
   // permission checking needed or allowed.
   virtual void write(const reg_t val) noexcept = 0;
 
-  virtual ~csr_t() {}
+  virtual ~csr_t();
 
  private:
   const reg_t address;
@@ -32,15 +32,9 @@ typedef std::shared_ptr<csr_t> csr_t_p;
 // Basic CSRs, with XLEN bits fully readable and writable.
 class basic_csr_t: public csr_t {
  public:
-  basic_csr_t(const reg_t addr, const reg_t init):
-    csr_t(addr),
-    val(init) {}
-  virtual reg_t read() const noexcept override {
-    return val;
-  }
-  virtual void write(const reg_t val) noexcept override {
-    this->val = val;
-  }
+  basic_csr_t(const reg_t addr, const reg_t init);
+  virtual reg_t read() const noexcept override;
+  virtual void write(const reg_t val) noexcept override;
  private:
   reg_t val;
 };

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -6,6 +6,8 @@
 #include "decode.h"
 // For std::shared_ptr
 #include <memory>
+// For access_type:
+#include "memtracer.h"
 
 class processor_t;
 
@@ -88,6 +90,9 @@ class pmpaddr_csr_t: public logged_csr_t {
 
   // Does the specified range match only a proper subset of this page?
   bool subset_match(reg_t addr, reg_t len) const noexcept;
+
+  // Is the specified access allowed given the pmpcfg privileges?
+  bool access_ok(access_type type, reg_t mode) const noexcept;
 
  protected:
   virtual bool unlogged_write(const reg_t val) noexcept override;

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -129,6 +129,8 @@ class virtualized_csr_t: public csr_t {
   virtualized_csr_t(processor_t* const proc, csr_t_p orig, csr_t_p virt);
 
   virtual reg_t read() const noexcept override;
+  // Instead of using state.v, explicitly request original or virtual:
+  reg_t readvirt(bool virt) const noexcept;
   virtual void write(const reg_t val) noexcept override;
 
  protected:

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -69,7 +69,6 @@ class pmpaddr_csr_t: public logged_csr_t {
   pmpaddr_csr_t(processor_t* const proc, const reg_t addr);
   virtual void verify_permissions(insn_t insn, bool write) const override;
   virtual reg_t read() const noexcept override;
-  reg_t raw_value() const noexcept;
 
   // Assuming this is configured as TOR, return address for top of
   // range. Also forms bottom-of-range for next-highest pmpaddr

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -303,5 +303,13 @@ class hip_csr_t: public csr_t {
   virtual void write(const reg_t val) noexcept override;
 };
 
+class vsip_csr_t: public csr_t {
+ public:
+  vsip_csr_t(processor_t* const proc, const reg_t addr);
+
+  virtual reg_t read() const noexcept override;
+  virtual void write(const reg_t val) noexcept override;
+};
+
 
 #endif

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -138,6 +138,8 @@ class virtualized_csr_t: public csr_t {
   csr_t_p virt_csr;
 };
 
+typedef std::shared_ptr<virtualized_csr_t> virtualized_csr_t_p;
+
 
 // For mepc, sepc, and vsepc
 class epc_csr_t: public logged_csr_t {
@@ -207,7 +209,7 @@ typedef std::shared_ptr<vsstatus_csr_t> vsstatus_csr_t_p;
 //    need to be virtualized will be through this object.
 // 3. [done] Convert mstatus into a csr_t subclass.
 // 4. Refactor common code into base class.
-// 5. Convert sstatus to a virtualized_csr_t, with a
+// 5. [done] Convert sstatus to a virtualized_csr_t, with a
 //    nonvirtual_sstatus of type sstatus_proxy_csr_t, and
 //    simultaneously remove the swapping of mstatus & vsstatus from
 //    set_priv().

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -84,7 +84,7 @@ class pmpaddr_csr_t: public logged_csr_t {
   reg_t napot_mask() const noexcept;
 
   // Does a 4-byte access at the specified address match this PMP entry?
-  bool match4(reg_t cur_addr) const noexcept;
+  bool match4(reg_t addr) const noexcept;
 
  protected:
   virtual bool unlogged_write(const reg_t val) noexcept override;

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -369,4 +369,12 @@ class medeleg_csr_t: public basic_csr_t {
 };
 
 
+class hstatus_csr_t: public basic_csr_t {
+ public:
+  hstatus_csr_t(processor_t* const proc, const reg_t addr);
+ protected:
+  virtual bool unlogged_write(const reg_t val) noexcept override;
+};
+
+
 #endif

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -31,12 +31,27 @@ class csr_t {
 
 typedef std::shared_ptr<csr_t> csr_t_p;
 
+
+// Parent class that records log of every write to itself
+class logged_csr_t: public csr_t {
+ public:
+  logged_csr_t(processor_t* const proc, const reg_t addr);
+
+  // Child classes must implement unlogged_write()
+  virtual void write(const reg_t val) noexcept override final;
+
+ protected:
+  virtual void unlogged_write(const reg_t val) noexcept = 0;
+};
+
+
 // Basic CSRs, with XLEN bits fully readable and writable.
-class basic_csr_t: public csr_t {
+class basic_csr_t: public logged_csr_t {
  public:
   basic_csr_t(processor_t* const proc, const reg_t addr, const reg_t init);
   virtual reg_t read() const noexcept override;
-  virtual void write(const reg_t val) noexcept override;
+ protected:
+  virtual void unlogged_write(const reg_t val) noexcept override;
  private:
   reg_t val;
 };

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -75,6 +75,10 @@ class pmpaddr_csr_t: public logged_csr_t {
   // register if that one is TOR.
   reg_t tor_paddr() const noexcept;
 
+  // Assuming this is configured as TOR, return address for bottom of
+  // range. This is tor_paddr() from the previous pmpaddr register.
+  reg_t tor_base_paddr() const noexcept;
+
   // Assuming this is configured as NAPOT or NA4, return mask for paddr.
   // E.g. for 4KiB region, returns 0xffffffff_fffff000.
   reg_t napot_mask() const noexcept;

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -285,4 +285,13 @@ class sip_csr_t: public csr_t {
 };
 
 
+class hvip_csr_t: public csr_t {
+ public:
+  hvip_csr_t(processor_t* const proc, const reg_t addr);
+
+  virtual reg_t read() const noexcept override;
+  virtual void write(const reg_t val) noexcept override;
+};
+
+
 #endif

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -52,6 +52,9 @@ class logged_csr_t: public csr_t {
  protected:
   // Return value indicates success; false means no write actually occurred
   virtual bool unlogged_write(const reg_t val) noexcept = 0;
+
+  // Record this CSR update (which has already happened) in the commit log
+  void log_write() const noexcept;
 };
 
 

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -183,6 +183,7 @@ class base_status_csr_t: public logged_csr_t {
   base_status_csr_t(processor_t* const proc, const reg_t addr);
  protected:
   reg_t adjust_sd(const reg_t val) const noexcept;
+  void maybe_flush_tlb(const reg_t newval) noexcept;
   const reg_t sstatus_write_mask;
   const reg_t sstatus_read_mask;
  private:

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -312,12 +312,9 @@ class hvip_csr_t: public generic_ip_csr_t {
   hvip_csr_t(processor_t* const proc, const reg_t addr);
 };
 
-class hip_csr_t: public csr_t {
+class hip_csr_t: public generic_ip_csr_t {
  public:
   hip_csr_t(processor_t* const proc, const reg_t addr);
-
-  virtual reg_t read() const noexcept override;
-  virtual void write(const reg_t val) noexcept override;
 };
 
 class vsip_csr_t: public csr_t {

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -287,7 +287,7 @@ class generic_int_accessor_t {
  public:
   generic_int_accessor_t(state_t* const state,
                          const reg_t read_mask,
-                         const reg_t write_mask,
+                         const reg_t ip_write_mask,
                          const bool mask_mideleg,
                          const bool mask_hideleg,
                          const int shiftamt);
@@ -296,7 +296,7 @@ class generic_int_accessor_t {
  private:
   state_t* const state;
   const reg_t read_mask;
-  const reg_t write_mask;
+  const reg_t ip_write_mask;
   const bool mask_mideleg;
   const bool mask_hideleg;
   const int shiftamt;

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -150,4 +150,17 @@ class epc_csr_t: public logged_csr_t {
 };
 
 
+// For mtvec, stvec, and vstvec
+class tvec_csr_t: public logged_csr_t {
+ public:
+  tvec_csr_t(processor_t* const proc, const reg_t addr);
+
+  virtual reg_t read() const noexcept override;
+ protected:
+  virtual bool unlogged_write(const reg_t val) noexcept override;
+ private:
+  reg_t val;
+};
+
+
 #endif

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -24,7 +24,7 @@ class csr_t {
 
   virtual ~csr_t();
 
- private:
+ protected:
   processor_t* const proc;
   const reg_t address;
 };

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -143,6 +143,7 @@ class virtualized_csr_t: public csr_t {
   csr_t_p virt_csr;
 };
 
+typedef std::shared_ptr<virtualized_csr_t> virtualized_csr_t_p;
 
 // For mepc, sepc, and vsepc
 class epc_csr_t: public logged_csr_t {
@@ -389,5 +390,29 @@ class counteren_csr_t: public basic_csr_t {
  protected:
   virtual bool unlogged_write(const reg_t val) noexcept override;
 };
+
+
+// For satp and vsatp
+// These are three classes in order to handle the [V]TVM bits permission checks
+class base_atp_csr_t: public basic_csr_t {
+ public:
+  base_atp_csr_t(processor_t* const proc, const reg_t addr);
+ protected:
+  virtual bool unlogged_write(const reg_t val) noexcept override;
+};
+
+class satp_csr_t: public base_atp_csr_t {
+ public:
+  satp_csr_t(processor_t* const proc, const reg_t addr);
+  virtual void verify_permissions(insn_t insn, bool write) const override;
+};
+
+class virtualized_satp_csr_t: public virtualized_csr_t {
+ public:
+  virtualized_satp_csr_t(processor_t* const proc, csr_t_p orig, csr_t_p virt);
+  virtual void verify_permissions(insn_t insn, bool write) const override;
+  virtual void write(const reg_t val) noexcept override;
+};
+
 
 #endif

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -76,6 +76,10 @@ class pmpaddr_csr_t: public logged_csr_t {
   // register if that one is TOR.
   reg_t tor_paddr() const noexcept;
 
+  // Assuming this is configured as NAPOT or NA4, return mask for paddr.
+  // E.g. for 4KiB region, returns 0xffffffff_fffff000.
+  reg_t napot_mask() const noexcept;
+
  protected:
   virtual bool unlogged_write(const reg_t val) noexcept override;
  private:

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -163,4 +163,13 @@ class tvec_csr_t: public logged_csr_t {
 };
 
 
+// For mcause, scause, and vscause
+class cause_csr_t: public basic_csr_t {
+ public:
+  cause_csr_t(processor_t* const proc, const reg_t addr);
+
+  virtual reg_t read() const noexcept override;
+};
+
+
 #endif

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -256,6 +256,12 @@ class mstatus_csr_t: public base_status_csr_t {
 typedef std::shared_ptr<mstatus_csr_t> mstatus_csr_t_p;
 
 
+class sstatus_csr_t: public virtualized_csr_t {
+ public:
+  sstatus_csr_t(processor_t* const proc, csr_t_p orig, csr_t_p virt);
+};
+
+
 class misa_csr_t: public basic_csr_t {
  public:
   misa_csr_t(processor_t* const proc, const reg_t addr, const reg_t max_isa);

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -83,6 +83,9 @@ class pmpaddr_csr_t: public logged_csr_t {
   // E.g. for 4KiB region, returns 0xffffffff_fffff000.
   reg_t napot_mask() const noexcept;
 
+  // Does a 4-byte access at the specified address match this PMP entry?
+  bool match4(reg_t cur_addr) const noexcept;
+
  protected:
   virtual bool unlogged_write(const reg_t val) noexcept override;
  private:

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -202,7 +202,7 @@ typedef std::shared_ptr<vsstatus_csr_t> vsstatus_csr_t_p;
 //
 // 1. [done] Create one of these proxy objects as state.sstatus,
 //    with no logging. Do not put it into csrmap yet.
-// 2. One by one, switch references to state.mstatus to use
+// 2. [done] One by one, switch references to state.mstatus to use
 //    state.sstatus. When complete, all references to sstatus that
 //    need to be virtualized will be through this object.
 // 3. Convert mstatus into a csr_t subclass.

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -26,11 +26,18 @@ class csr_t {
 
   // write() updates the architectural value of this CSR. No
   // permission checking needed or allowed.
-  virtual void write(const reg_t val) noexcept = 0;
+  // Child classes must implement unlogged_write()
+  void write(const reg_t val) noexcept;
 
   virtual ~csr_t();
 
  protected:
+  // Return value indicates success; false means no write actually occurred
+  virtual bool unlogged_write(const reg_t val) noexcept = 0;
+
+  // Record this CSR update (which has already happened) in the commit log
+  void log_write() const noexcept;
+
   processor_t* const proc;
   state_t* const state;
  public:
@@ -47,16 +54,6 @@ typedef std::shared_ptr<csr_t> csr_t_p;
 class logged_csr_t: public csr_t {
  public:
   logged_csr_t(processor_t* const proc, const reg_t addr);
-
-  // Child classes must implement unlogged_write()
-  virtual void write(const reg_t val) noexcept override final;
-
- protected:
-  // Return value indicates success; false means no write actually occurred
-  virtual bool unlogged_write(const reg_t val) noexcept = 0;
-
-  // Record this CSR update (which has already happened) in the commit log
-  void log_write() const noexcept;
 };
 
 

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -304,15 +304,19 @@ class generic_int_accessor_t {
   generic_int_accessor_t(state_t* const state,
                          const reg_t read_mask,
                          const reg_t ip_write_mask,
+                         const reg_t ie_write_mask,
                          const bool mask_mideleg,
                          const bool mask_hideleg,
                          const int shiftamt);
   reg_t ip_read() const noexcept;
   void ip_write(const reg_t val) noexcept;
+  reg_t ie_read() const noexcept;
+  void ie_write(const reg_t val) noexcept;
  private:
   state_t* const state;
   const reg_t read_mask;
   const reg_t ip_write_mask;
+  const reg_t ie_write_mask;
   const bool mask_mideleg;
   const bool mask_hideleg;
   const int shiftamt;
@@ -326,6 +330,16 @@ typedef std::shared_ptr<generic_int_accessor_t> generic_int_accessor_t_p;
 class mip_proxy_csr_t: public csr_t {
  public:
   mip_proxy_csr_t(processor_t* const proc, const reg_t addr, generic_int_accessor_t_p accr);
+  virtual reg_t read() const noexcept override;
+  virtual void write(const reg_t val) noexcept override;
+ private:
+  generic_int_accessor_t_p accr;
+};
+
+// For all CSRs that are simply (masked & shifted) views into mie
+class mie_proxy_csr_t: public csr_t {
+ public:
+  mie_proxy_csr_t(processor_t* const proc, const reg_t addr, generic_int_accessor_t_p accr);
   virtual reg_t read() const noexcept override;
   virtual void write(const reg_t val) noexcept override;
  private:

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -287,6 +287,13 @@ class mip_csr_t: public mip_or_mie_csr_t {
   virtual reg_t write_mask() const noexcept override;
 };
 
+class mie_csr_t: public mip_or_mie_csr_t {
+ public:
+  mie_csr_t(processor_t* const proc, const reg_t addr);
+ private:
+  virtual reg_t write_mask() const noexcept override;
+};
+
 
 // For sip, hip, hvip, vsip, sie, hie, vsie which are all just (masked
 // & shifted) views into mip or mie. Each pair will have one of these

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -342,11 +342,12 @@ class mip_proxy_csr_t: public csr_t {
 };
 
 // For all CSRs that are simply (masked & shifted) views into mie
-class mie_proxy_csr_t: public csr_t {
+class mie_proxy_csr_t: public logged_csr_t {
  public:
   mie_proxy_csr_t(processor_t* const proc, const reg_t addr, generic_int_accessor_t_p accr);
   virtual reg_t read() const noexcept override;
-  virtual void write(const reg_t val) noexcept override;
+ protected:
+  virtual bool unlogged_write(const reg_t val) noexcept override;
  private:
   generic_int_accessor_t_p accr;
 };

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -233,6 +233,7 @@ class sstatus_proxy_csr_t: public logged_csr_t {
   virtual bool unlogged_write(const reg_t val) noexcept override;
  private:
   csr_t_p mstatus;
+  const reg_t read_mask;
 };
 
 

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -178,10 +178,13 @@ class vsstatus_csr_t: public logged_csr_t {
  public:
   vsstatus_csr_t(processor_t* const proc, const reg_t addr);
   virtual reg_t read() const noexcept override;
+  void backdoor_write(const reg_t val) noexcept;
  protected:
   virtual bool unlogged_write(const reg_t val) noexcept override;
  private:
   reg_t val;
 };
+
+typedef std::shared_ptr<vsstatus_csr_t> vsstatus_csr_t_p;
 
 #endif

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -255,6 +255,8 @@ class misa_csr_t: public basic_csr_t {
   bool supports_extension(unsigned char ext) const noexcept;
  protected:
   virtual bool unlogged_write(const reg_t val) noexcept override;
+ private:
+  const reg_t max_isa;
 };
 
 typedef std::shared_ptr<misa_csr_t> misa_csr_t_p;

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -172,4 +172,16 @@ class cause_csr_t: public basic_csr_t {
 };
 
 
+// For vsstatus, which is its own separate architectural register
+// (unlike sstatus)
+class vsstatus_csr_t: public logged_csr_t {
+ public:
+  vsstatus_csr_t(processor_t* const proc, const reg_t addr);
+  virtual reg_t read() const noexcept override;
+ protected:
+  virtual bool unlogged_write(const reg_t val) noexcept override;
+ private:
+  reg_t val;
+};
+
 #endif

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -233,8 +233,8 @@ class sstatus_proxy_csr_t: public base_status_csr_t {
   virtual bool unlogged_write(const reg_t val) noexcept override;
  private:
   csr_t_p mstatus;
-  const reg_t write_mask;
-  const reg_t read_mask;
+  const reg_t sstatus_write_mask;
+  const reg_t sstatus_read_mask;
 };
 
 

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -397,8 +397,11 @@ class counteren_csr_t: public basic_csr_t {
 class base_atp_csr_t: public basic_csr_t {
  public:
   base_atp_csr_t(processor_t* const proc, const reg_t addr);
+  bool satp_valid(reg_t val) const noexcept;
  protected:
   virtual bool unlogged_write(const reg_t val) noexcept override;
+ private:
+  reg_t compute_new_satp(reg_t val, reg_t old) const noexcept;
 };
 
 class satp_csr_t: public base_atp_csr_t {

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -176,9 +176,16 @@ class cause_csr_t: public basic_csr_t {
 };
 
 
+// For *status family of CSRs
+class base_status_csr_t: public logged_csr_t {
+ public:
+  base_status_csr_t(processor_t* const proc, const reg_t addr);
+};
+
+
 // For vsstatus, which is its own separate architectural register
 // (unlike sstatus)
-class vsstatus_csr_t: public logged_csr_t {
+class vsstatus_csr_t: public base_status_csr_t {
  public:
   vsstatus_csr_t(processor_t* const proc, const reg_t addr);
   virtual reg_t read() const noexcept override;
@@ -215,6 +222,9 @@ typedef std::shared_ptr<vsstatus_csr_t> vsstatus_csr_t_p;
 // 6. Move assorted manipulation code (like mstatus dirtying) into new
 //    sstatus class.
 
+
+// This is not base_status_csr_t because it defers all the hard work
+// to mstatus_csr_t, which is.
 class sstatus_proxy_csr_t: public logged_csr_t {
  public:
   sstatus_proxy_csr_t(processor_t* const proc, const reg_t addr);
@@ -226,7 +236,7 @@ class sstatus_proxy_csr_t: public logged_csr_t {
 };
 
 
-class mstatus_csr_t: public logged_csr_t {
+class mstatus_csr_t: public base_status_csr_t {
  public:
   mstatus_csr_t(processor_t* const proc, const reg_t addr);
   virtual reg_t read() const noexcept override;

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -220,7 +220,7 @@ typedef std::shared_ptr<vsstatus_csr_t> vsstatus_csr_t_p;
 //    state.sstatus. When complete, all references to sstatus that
 //    need to be virtualized will be through this object.
 // 3. [done] Convert mstatus into a csr_t subclass.
-// 4. Refactor common code into base class.
+// 4. [done] Refactor common code into base class.
 // 5. [done] Convert sstatus to a virtualized_csr_t, with a
 //    nonvirtual_sstatus of type sstatus_proxy_csr_t, and
 //    simultaneously remove the swapping of mstatus & vsstatus from

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -184,6 +184,8 @@ class base_status_csr_t: public logged_csr_t {
   reg_t adjust_sd(reg_t newval) const noexcept;
   const reg_t sstatus_write_mask;
   const reg_t sstatus_read_mask;
+ private:
+  reg_t compute_sstatus_write_mask() const noexcept;
 };
 
 

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -295,5 +295,13 @@ class hvip_csr_t: public csr_t {
   virtual void write(const reg_t val) noexcept override;
 };
 
+class hip_csr_t: public csr_t {
+ public:
+  hip_csr_t(processor_t* const proc, const reg_t addr);
+
+  virtual reg_t read() const noexcept override;
+  virtual void write(const reg_t val) noexcept override;
+};
+
 
 #endif

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -279,12 +279,31 @@ class mip_csr_t: public logged_csr_t {
 typedef std::shared_ptr<mip_csr_t> mip_csr_t_p;
 
 
-class sip_csr_t: public csr_t {
+// For sip, hip, hvip, vsip, which are all just (masked & shifted) views into mip
+class generic_ip_csr_t: public csr_t {
  public:
-  sip_csr_t(processor_t* const proc, const reg_t addr);
-
+  generic_ip_csr_t(processor_t* const proc,
+                   const reg_t addr,
+                   const reg_t read_mask,
+                   const reg_t write_mask,
+                   const bool mask_mideleg,
+                   const bool mask_hideleg,
+                   const int shiftamt);
   virtual reg_t read() const noexcept override;
   virtual void write(const reg_t val) noexcept override;
+ private:
+  const reg_t read_mask;
+  const reg_t write_mask;
+  const bool mask_mideleg;
+  const bool mask_hideleg;
+  const int shiftamt;
+  reg_t deleg_mask() const;
+};
+
+
+class sip_csr_t: public generic_ip_csr_t {
+ public:
+  sip_csr_t(processor_t* const proc, const reg_t addr);
 };
 
 

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -187,4 +187,40 @@ class vsstatus_csr_t: public logged_csr_t {
 
 typedef std::shared_ptr<vsstatus_csr_t> vsstatus_csr_t_p;
 
+
+// Problem: the vsstatus implementation of swapping mstatus & vsstatus
+// within set_priv() results in confusing code and
+// non-architecturally-compliant commitlog (e.g. `csrw sstatus` from
+// VS-mode reports that mstatus has changed when really it's only
+// vsstatus that was supposed to change).
+//
+// Goal: get all appropriate references to state.mstatus to use
+// state.sstatus instead, so it can be virtualized via the usual
+// (virtualized_csr_t) mechanism.
+//
+// 1. [done] Create one of these proxy objects as state.sstatus,
+//    with no logging. Do not put it into csrmap yet.
+// 2. One by one, switch references to state.mstatus to use
+//    state.sstatus. When complete, all references to sstatus that
+//    need to be virtualized will be through this object.
+// 3. Convert mstatus into a csr_t subclass.
+// 4. Refactor common code into base class.
+// 5. Convert sstatus to a virtualized_csr_t, with a
+//    nonvirtual_sstatus of type sstatus_proxy_csr_t, and
+//    simultaneously remove the swapping of mstatus & vsstatus from
+//    set_priv().
+// 6. Move assorted manipulation code (like mstatus dirtying) into new
+//    sstatus class.
+
+class sstatus_proxy_csr_t: public logged_csr_t {
+ public:
+  sstatus_proxy_csr_t(processor_t* const proc, const reg_t addr);
+  virtual reg_t read() const noexcept override;
+ protected:
+  virtual bool unlogged_write(const reg_t val) noexcept override;
+ private:
+  reg_t* const mstatus;
+};
+
+
 #endif

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -1,0 +1,48 @@
+// See LICENSE for license details.
+#ifndef _RISCV_CSRS_H
+#define _RISCV_CSRS_H
+
+// For reg_t:
+#include "decode.h"
+// For std::shared_ptr
+#include <memory>
+
+
+// Parent, abstract class for all CSRs
+class csr_t {
+ public:
+  csr_t(const reg_t addr): address(addr) {}
+
+  // read() returns the architectural value of this CSR. No permission
+  // checking needed or allowed. Side effects not allowed.
+  virtual reg_t read() const noexcept = 0;
+
+  // write() updates the architectural value of this CSR. No
+  // permission checking needed or allowed.
+  virtual void write(const reg_t val) noexcept = 0;
+
+  virtual ~csr_t() {}
+
+ private:
+  const reg_t address;
+};
+
+typedef std::shared_ptr<csr_t> csr_t_p;
+
+// Basic CSRs, with XLEN bits fully readable and writable.
+class basic_csr_t: public csr_t {
+ public:
+  basic_csr_t(const reg_t addr, const reg_t init):
+    csr_t(addr),
+    val(init) {}
+  virtual reg_t read() const noexcept override {
+    return val;
+  }
+  virtual void write(const reg_t val) noexcept override {
+    this->val = val;
+  }
+ private:
+  reg_t val;
+};
+
+#endif

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -31,6 +31,7 @@ class csr_t {
 
  protected:
   processor_t* const proc;
+ public:
   const reg_t address;
  private:
   const unsigned csr_priv;
@@ -112,6 +113,27 @@ class pmpcfg_csr_t: public logged_csr_t {
   virtual reg_t read() const noexcept override;
  protected:
   virtual bool unlogged_write(const reg_t val) noexcept override;
+};
+
+
+// For CSRs that have a virtualized copy under another name. Each
+// instance of virtualized_csr_t will read/write one of two CSRs,
+// based on state.v. E.g. sscratch, stval, etc.
+//
+// Example: sscratch and vsscratch are both instances of basic_csr_t.
+// The csrmap will contain a virtualized_csr_t under sscratch's
+// address, plus the vsscratch basic_csr_t under its address.
+
+class virtualized_csr_t: public csr_t {
+ public:
+  virtualized_csr_t(processor_t* const proc, csr_t_p orig, csr_t_p virt);
+
+  virtual reg_t read() const noexcept override;
+  virtual void write(const reg_t val) noexcept override;
+
+ protected:
+  csr_t_p orig_csr;
+  csr_t_p virt_csr;
 };
 
 

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -225,9 +225,7 @@ typedef std::shared_ptr<vsstatus_csr_t> vsstatus_csr_t_p;
 //    sstatus class.
 
 
-// This is not base_status_csr_t because it defers all the hard work
-// to mstatus_csr_t, which is.
-class sstatus_proxy_csr_t: public logged_csr_t {
+class sstatus_proxy_csr_t: public base_status_csr_t {
  public:
   sstatus_proxy_csr_t(processor_t* const proc, const reg_t addr);
   virtual reg_t read() const noexcept override;

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -205,7 +205,7 @@ typedef std::shared_ptr<vsstatus_csr_t> vsstatus_csr_t_p;
 // 2. [done] One by one, switch references to state.mstatus to use
 //    state.sstatus. When complete, all references to sstatus that
 //    need to be virtualized will be through this object.
-// 3. Convert mstatus into a csr_t subclass.
+// 3. [done] Convert mstatus into a csr_t subclass.
 // 4. Refactor common code into base class.
 // 5. Convert sstatus to a virtualized_csr_t, with a
 //    nonvirtual_sstatus of type sstatus_proxy_csr_t, and
@@ -221,8 +221,19 @@ class sstatus_proxy_csr_t: public logged_csr_t {
  protected:
   virtual bool unlogged_write(const reg_t val) noexcept override;
  private:
-  reg_t* const mstatus;
+  csr_t_p mstatus;
 };
+
+
+class mstatus_csr_t: public basic_csr_t {
+ public:
+  mstatus_csr_t(processor_t* const proc, const reg_t addr);
+  bool backdoor_write(const reg_t val) noexcept;
+ protected:
+  virtual bool unlogged_write(const reg_t val) noexcept override;
+};
+
+typedef std::shared_ptr<mstatus_csr_t> mstatus_csr_t_p;
 
 
 #endif

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -78,4 +78,13 @@ class pmpaddr_csr_t: public logged_csr_t {
 
 typedef std::shared_ptr<pmpaddr_csr_t> pmpaddr_csr_t_p;
 
+class pmpcfg_csr_t: public logged_csr_t {
+ public:
+  pmpcfg_csr_t(processor_t* const proc, const reg_t addr);
+  virtual reg_t read() const noexcept override;
+ protected:
+  virtual bool unlogged_write(const reg_t val) noexcept override;
+};
+
+
 #endif

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -307,12 +307,9 @@ class sip_csr_t: public generic_ip_csr_t {
 };
 
 
-class hvip_csr_t: public csr_t {
+class hvip_csr_t: public generic_ip_csr_t {
  public:
   hvip_csr_t(processor_t* const proc, const reg_t addr);
-
-  virtual reg_t read() const noexcept override;
-  virtual void write(const reg_t val) noexcept override;
 };
 
 class hip_csr_t: public csr_t {

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -99,6 +99,8 @@ class pmpaddr_csr_t: public logged_csr_t {
  private:
   bool next_locked_and_tor() const noexcept;
   reg_t val;
+  friend class pmpcfg_csr_t;  // so he can access cfg
+  uint8_t cfg;
   const size_t pmpidx;
 };
 

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -317,12 +317,9 @@ class hip_csr_t: public generic_ip_csr_t {
   hip_csr_t(processor_t* const proc, const reg_t addr);
 };
 
-class vsip_csr_t: public csr_t {
+class vsip_csr_t: public generic_ip_csr_t {
  public:
   vsip_csr_t(processor_t* const proc, const reg_t addr);
-
-  virtual reg_t read() const noexcept override;
-  virtual void write(const reg_t val) noexcept override;
 };
 
 

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -382,4 +382,12 @@ class hstatus_csr_t: public basic_csr_t {
 };
 
 
+// Used for mcounteren, scounteren, hcounteren
+class counteren_csr_t: public basic_csr_t {
+ public:
+  counteren_csr_t(processor_t* const proc, const reg_t addr);
+ protected:
+  virtual bool unlogged_write(const reg_t val) noexcept override;
+};
+
 #endif

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -276,4 +276,13 @@ class mip_csr_t: public logged_csr_t {
 typedef std::shared_ptr<mip_csr_t> mip_csr_t_p;
 
 
+class sip_csr_t: public csr_t {
+ public:
+  sip_csr_t(processor_t* const proc, const reg_t addr);
+
+  virtual reg_t read() const noexcept override;
+  virtual void write(const reg_t val) noexcept override;
+};
+
+
 #endif

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -10,6 +10,7 @@
 #include "memtracer.h"
 
 class processor_t;
+class state_t;
 
 // Parent, abstract class for all CSRs
 class csr_t {
@@ -31,6 +32,7 @@ class csr_t {
 
  protected:
   processor_t* const proc;
+  state_t* const state;
  public:
   const reg_t address;
  private:

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -268,19 +268,21 @@ class mip_or_mie_csr_t: public logged_csr_t {
 
   void write_with_mask(const reg_t mask, const reg_t val) noexcept;
 
-  // Does not log. Used by external things (clint) that wiggle bits in mip.
-  void backdoor_write_with_mask(const reg_t mask, const reg_t val) noexcept;
  protected:
   virtual bool unlogged_write(const reg_t val) noexcept override final;
+  reg_t val;
  private:
   virtual reg_t write_mask() const noexcept = 0;
-  reg_t val;
 };
 
 
+// mip is special because some of the bits are driven by hardware pins
 class mip_csr_t: public mip_or_mie_csr_t {
  public:
   mip_csr_t(processor_t* const proc, const reg_t addr);
+
+  // Does not log. Used by external things (clint) that wiggle bits in mip.
+  void backdoor_write_with_mask(const reg_t mask, const reg_t val) noexcept;
  private:
   virtual reg_t write_mask() const noexcept override;
 };

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -252,7 +252,7 @@ typedef std::shared_ptr<mstatus_csr_t> mstatus_csr_t_p;
 class misa_csr_t: public basic_csr_t {
  public:
   misa_csr_t(processor_t* const proc, const reg_t addr, const reg_t max_isa);
-  bool supports_extension(unsigned char ext) const noexcept;
+  bool extension_enabled(unsigned char ext) const noexcept;
  protected:
   virtual bool unlogged_write(const reg_t val) noexcept override;
  private:

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -186,6 +186,7 @@ class base_status_csr_t: public logged_csr_t {
  protected:
   reg_t adjust_sd(const reg_t val) const noexcept;
   void maybe_flush_tlb(const reg_t newval) noexcept;
+  const bool has_page;
   const reg_t sstatus_write_mask;
   const reg_t sstatus_read_mask;
  private:

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -226,11 +226,14 @@ class sstatus_proxy_csr_t: public logged_csr_t {
 };
 
 
-class mstatus_csr_t: public basic_csr_t {
+class mstatus_csr_t: public logged_csr_t {
  public:
   mstatus_csr_t(processor_t* const proc, const reg_t addr);
+  virtual reg_t read() const noexcept override;
  protected:
   virtual bool unlogged_write(const reg_t val) noexcept override;
+ private:
+  reg_t val;
 };
 
 typedef std::shared_ptr<mstatus_csr_t> mstatus_csr_t_p;

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -30,6 +30,9 @@ class csr_t {
  protected:
   processor_t* const proc;
   const reg_t address;
+ private:
+  const unsigned csr_priv;
+  const bool csr_read_only;
 };
 
 typedef std::shared_ptr<csr_t> csr_t_p;

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -401,7 +401,7 @@ class base_atp_csr_t: public basic_csr_t {
  protected:
   virtual bool unlogged_write(const reg_t val) noexcept override;
  private:
-  reg_t compute_new_satp(reg_t val, reg_t old) const noexcept;
+  reg_t compute_new_satp(reg_t val) const noexcept;
 };
 
 class satp_csr_t: public base_atp_csr_t {

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -270,4 +270,23 @@ class misa_csr_t: public basic_csr_t {
 
 typedef std::shared_ptr<misa_csr_t> misa_csr_t_p;
 
+
+class mip_csr_t: public logged_csr_t {
+ public:
+  mip_csr_t(processor_t* const proc, const reg_t addr);
+  virtual reg_t read() const noexcept override;
+
+  void write_with_mask(const reg_t mask, const reg_t val) noexcept;
+
+  // Does not log. Used by external things (clint) that wiggle bits in mip.
+  void backdoor_write_with_mask(const reg_t mask, const reg_t val) noexcept;
+ protected:
+  virtual bool unlogged_write(const reg_t val) noexcept override;
+ private:
+  reg_t val;
+};
+
+typedef std::shared_ptr<mip_csr_t> mip_csr_t_p;
+
+
 #endif

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -72,6 +72,18 @@ class pmpaddr_csr_t: public logged_csr_t {
   virtual void verify_permissions(insn_t insn, bool write) const override;
   virtual reg_t read() const noexcept override;
 
+  // Does a 4-byte access at the specified address match this PMP entry?
+  bool match4(reg_t addr) const noexcept;
+
+  // Does the specified range match only a proper subset of this page?
+  bool subset_match(reg_t addr, reg_t len) const noexcept;
+
+  // Is the specified access allowed given the pmpcfg privileges?
+  bool access_ok(access_type type, reg_t mode) const noexcept;
+
+ protected:
+  virtual bool unlogged_write(const reg_t val) noexcept override;
+ private:
   // Assuming this is configured as TOR, return address for top of
   // range. Also forms bottom-of-range for next-highest pmpaddr
   // register if that one is TOR.
@@ -85,18 +97,6 @@ class pmpaddr_csr_t: public logged_csr_t {
   // E.g. for 4KiB region, returns 0xffffffff_fffff000.
   reg_t napot_mask() const noexcept;
 
-  // Does a 4-byte access at the specified address match this PMP entry?
-  bool match4(reg_t addr) const noexcept;
-
-  // Does the specified range match only a proper subset of this page?
-  bool subset_match(reg_t addr, reg_t len) const noexcept;
-
-  // Is the specified access allowed given the pmpcfg privileges?
-  bool access_ok(access_type type, reg_t mode) const noexcept;
-
- protected:
-  virtual bool unlogged_write(const reg_t val) noexcept override;
- private:
   bool next_locked_and_tor() const noexcept;
   reg_t val;
   friend class pmpcfg_csr_t;  // so he can access cfg

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -347,4 +347,15 @@ class mie_proxy_csr_t: public csr_t {
 };
 
 
+
+class mideleg_csr_t: public basic_csr_t {
+ public:
+  mideleg_csr_t(processor_t* const proc, const reg_t addr);
+  virtual void verify_permissions(insn_t insn, bool write) const override;
+  virtual reg_t read() const noexcept override;
+ protected:
+  virtual bool unlogged_write(const reg_t val) noexcept override;
+};
+
+
 #endif

--- a/riscv/decode.h
+++ b/riscv/decode.h
@@ -246,8 +246,8 @@ private:
 #define require_novirt() if (unlikely(STATE.v)) throw trap_virtual_instruction(insn.bits())
 #define require_rv64 require(xlen == 64)
 #define require_rv32 require(xlen == 32)
-#define require_extension(s) require(p->supports_extension(s))
-#define require_either_extension(A,B) require(p->supports_extension(A) || p->supports_extension(B));
+#define require_extension(s) require(p->extension_enabled(s))
+#define require_either_extension(A,B) require(p->extension_enabled(A) || p->extension_enabled(B));
 #define require_impl(s) require(p->supports_impl(s))
 #define require_fp require(((STATE.mstatus->read() & MSTATUS_FS) != 0) && ((STATE.v == 0) || ((STATE.vsstatus->read() & SSTATUS_FS) != 0)))
 #define require_accelerator require(((STATE.mstatus->read() & MSTATUS_XS) != 0) && ((STATE.v == 0) || ((STATE.vsstatus->read() & SSTATUS_XS) != 0)))
@@ -1844,9 +1844,9 @@ for (reg_t i = 0; i < P.VU.vlmax && P.VU.vl != 0; ++i) { \
 //
 #define VI_VFP_COMMON \
   require_fp; \
-  require((P.VU.vsew == e16 && p->supports_extension(EXT_ZFH)) || \
-          (P.VU.vsew == e32 && p->supports_extension('F')) || \
-          (P.VU.vsew == e64 && p->supports_extension('D'))); \
+  require((P.VU.vsew == e16 && p->extension_enabled(EXT_ZFH)) || \
+          (P.VU.vsew == e32 && p->extension_enabled('F')) || \
+          (P.VU.vsew == e64 && p->extension_enabled('D'))); \
   require_vector(true);\
   require(STATE.frm < 0x5);\
   reg_t vl = P.VU.vl; \
@@ -2051,8 +2051,8 @@ for (reg_t i = 0; i < P.VU.vlmax && P.VU.vl != 0; ++i) { \
 #define VI_VFP_VV_LOOP_WIDE_REDUCTION(BODY16, BODY32) \
   VI_CHECK_REDUCTION(true) \
   VI_VFP_COMMON \
-  require((P.VU.vsew == e16 && p->supports_extension('F')) || \
-          (P.VU.vsew == e32 && p->supports_extension('D'))); \
+  require((P.VU.vsew == e16 && p->extension_enabled('F')) || \
+          (P.VU.vsew == e32 && p->extension_enabled('D'))); \
   bool is_active = false; \
   switch(P.VU.vsew) { \
     case e16: {\
@@ -2261,9 +2261,9 @@ for (reg_t i = 0; i < P.VU.vlmax && P.VU.vl != 0; ++i) { \
 #define VI_VFP_LOOP_SCALE_BASE \
   require_fp; \
   require_vector(true);\
-  require((P.VU.vsew == e8 && p->supports_extension(EXT_ZFH)) || \
-          (P.VU.vsew == e16 && p->supports_extension('F')) || \
-          (P.VU.vsew == e32 && p->supports_extension('D'))); \
+  require((P.VU.vsew == e8 && p->extension_enabled(EXT_ZFH)) || \
+          (P.VU.vsew == e16 && p->extension_enabled('F')) || \
+          (P.VU.vsew == e32 && p->extension_enabled('D'))); \
   require(STATE.frm < 0x5);\
   reg_t vl = P.VU.vl; \
   reg_t rd_num = insn.rd(); \

--- a/riscv/decode.h
+++ b/riscv/decode.h
@@ -249,9 +249,9 @@ private:
 #define require_extension(s) require(p->supports_extension(s))
 #define require_either_extension(A,B) require(p->supports_extension(A) || p->supports_extension(B));
 #define require_impl(s) require(p->supports_impl(s))
-#define require_fp require(((STATE.mstatus & MSTATUS_FS) != 0) && ((STATE.v == 0) || ((STATE.vsstatus & SSTATUS_FS) != 0)))
-#define require_accelerator require(((STATE.mstatus & MSTATUS_XS) != 0) && ((STATE.v == 0) || ((STATE.vsstatus & SSTATUS_XS) != 0)))
-#define require_vector_vs require(((STATE.mstatus & MSTATUS_VS) != 0) && ((STATE.v == 0) || ((STATE.vsstatus & SSTATUS_VS) != 0)))
+#define require_fp require(((STATE.mstatus & MSTATUS_FS) != 0) && ((STATE.v == 0) || ((STATE.vsstatus->read() & SSTATUS_FS) != 0)))
+#define require_accelerator require(((STATE.mstatus & MSTATUS_XS) != 0) && ((STATE.v == 0) || ((STATE.vsstatus->read() & SSTATUS_XS) != 0)))
+#define require_vector_vs require(((STATE.mstatus & MSTATUS_VS) != 0) && ((STATE.v == 0) || ((STATE.vsstatus->read() & SSTATUS_VS) != 0)))
 #define require_vector(alu) \
   do { \
     require_vector_vs; \

--- a/riscv/decode.h
+++ b/riscv/decode.h
@@ -224,9 +224,9 @@ private:
 #define FRS1 READ_FREG(insn.rs1())
 #define FRS2 READ_FREG(insn.rs2())
 #define FRS3 READ_FREG(insn.rs3())
-#define dirty_fp_state  STATE.dirty_mstatus(MSTATUS_FS)
-#define dirty_ext_state STATE.dirty_mstatus(MSTATUS_XS)
-#define dirty_vs_state  STATE.dirty_mstatus(MSTATUS_VS)
+#define dirty_fp_state  STATE.sstatus->dirty(SSTATUS_FS)
+#define dirty_ext_state STATE.sstatus->dirty(SSTATUS_XS)
+#define dirty_vs_state  STATE.sstatus->dirty(SSTATUS_VS)
 #define DO_WRITE_FREG(reg, value) (STATE.FPR.write(reg, value), dirty_fp_state)
 #define WRITE_FRD(value) WRITE_FREG(insn.rd(), value)
  

--- a/riscv/decode.h
+++ b/riscv/decode.h
@@ -224,9 +224,9 @@ private:
 #define FRS1 READ_FREG(insn.rs1())
 #define FRS2 READ_FREG(insn.rs2())
 #define FRS3 READ_FREG(insn.rs3())
-#define dirty_fp_state  STATE.dirty_mstatus(MSTATUS_FS | (xlen == 64 ? MSTATUS64_SD : MSTATUS32_SD))
-#define dirty_ext_state STATE.dirty_mstatus(MSTATUS_XS | (xlen == 64 ? MSTATUS64_SD : MSTATUS32_SD))
-#define dirty_vs_state  STATE.dirty_mstatus(MSTATUS_VS | (xlen == 64 ? MSTATUS64_SD : MSTATUS32_SD))
+#define dirty_fp_state  STATE.dirty_mstatus(MSTATUS_FS)
+#define dirty_ext_state STATE.dirty_mstatus(MSTATUS_XS)
+#define dirty_vs_state  STATE.dirty_mstatus(MSTATUS_VS)
 #define DO_WRITE_FREG(reg, value) (STATE.FPR.write(reg, value), dirty_fp_state)
 #define WRITE_FRD(value) WRITE_FREG(insn.rd(), value)
  

--- a/riscv/decode.h
+++ b/riscv/decode.h
@@ -249,9 +249,9 @@ private:
 #define require_extension(s) require(p->supports_extension(s))
 #define require_either_extension(A,B) require(p->supports_extension(A) || p->supports_extension(B));
 #define require_impl(s) require(p->supports_impl(s))
-#define require_fp require(((STATE.mstatus & MSTATUS_FS) != 0) && ((STATE.v == 0) || ((STATE.vsstatus->read() & SSTATUS_FS) != 0)))
-#define require_accelerator require(((STATE.mstatus & MSTATUS_XS) != 0) && ((STATE.v == 0) || ((STATE.vsstatus->read() & SSTATUS_XS) != 0)))
-#define require_vector_vs require(((STATE.mstatus & MSTATUS_VS) != 0) && ((STATE.v == 0) || ((STATE.vsstatus->read() & SSTATUS_VS) != 0)))
+#define require_fp require(((STATE.mstatus->read() & MSTATUS_FS) != 0) && ((STATE.v == 0) || ((STATE.vsstatus->read() & SSTATUS_FS) != 0)))
+#define require_accelerator require(((STATE.mstatus->read() & MSTATUS_XS) != 0) && ((STATE.v == 0) || ((STATE.vsstatus->read() & SSTATUS_XS) != 0)))
+#define require_vector_vs require(((STATE.mstatus->read() & MSTATUS_VS) != 0) && ((STATE.v == 0) || ((STATE.vsstatus->read() & SSTATUS_VS) != 0)))
 #define require_vector(alu) \
   do { \
     require_vector_vs; \

--- a/riscv/decode.h
+++ b/riscv/decode.h
@@ -249,9 +249,9 @@ private:
 #define require_extension(s) require(p->extension_enabled(s))
 #define require_either_extension(A,B) require(p->extension_enabled(A) || p->extension_enabled(B));
 #define require_impl(s) require(p->supports_impl(s))
-#define require_fp require(((STATE.mstatus->read() & MSTATUS_FS) != 0) && ((STATE.v == 0) || ((STATE.vsstatus->read() & SSTATUS_FS) != 0)))
-#define require_accelerator require(((STATE.mstatus->read() & MSTATUS_XS) != 0) && ((STATE.v == 0) || ((STATE.vsstatus->read() & SSTATUS_XS) != 0)))
-#define require_vector_vs require(((STATE.mstatus->read() & MSTATUS_VS) != 0) && ((STATE.v == 0) || ((STATE.vsstatus->read() & SSTATUS_VS) != 0)))
+#define require_fp          require(STATE.sstatus->enabled(SSTATUS_FS))
+#define require_accelerator require(STATE.sstatus->enabled(SSTATUS_XS))
+#define require_vector_vs   require(STATE.sstatus->enabled(SSTATUS_VS))
 #define require_vector(alu) \
   do { \
     require_vector_vs; \

--- a/riscv/decode.h
+++ b/riscv/decode.h
@@ -224,13 +224,9 @@ private:
 #define FRS1 READ_FREG(insn.rs1())
 #define FRS2 READ_FREG(insn.rs2())
 #define FRS3 READ_FREG(insn.rs3())
-#define dirty_mstatus(bits) ({ reg_t dirties = (bits) | (xlen == 64 ? MSTATUS64_SD : MSTATUS32_SD); \
-                               STATE.mstatus |= dirties; \
-                               if (STATE.v) STATE.vsstatus |= dirties; \
-                            })
-#define dirty_fp_state  dirty_mstatus(MSTATUS_FS)
-#define dirty_ext_state dirty_mstatus(MSTATUS_XS)
-#define dirty_vs_state  dirty_mstatus(MSTATUS_VS)
+#define dirty_fp_state  STATE.dirty_mstatus(MSTATUS_FS | (xlen == 64 ? MSTATUS64_SD : MSTATUS32_SD))
+#define dirty_ext_state STATE.dirty_mstatus(MSTATUS_XS | (xlen == 64 ? MSTATUS64_SD : MSTATUS32_SD))
+#define dirty_vs_state  STATE.dirty_mstatus(MSTATUS_VS | (xlen == 64 ? MSTATUS64_SD : MSTATUS32_SD))
 #define DO_WRITE_FREG(reg, value) (STATE.FPR.write(reg, value), dirty_fp_state)
 #define WRITE_FRD(value) WRITE_FREG(insn.rd(), value)
  

--- a/riscv/encoding.h
+++ b/riscv/encoding.h
@@ -54,10 +54,6 @@
 #define SSTATUS_UXL         0x0000000300000000
 #define SSTATUS64_SD        0x8000000000000000
 
-#define SSTATUS_VS_MASK     (SSTATUS_SIE | SSTATUS_SPIE | \
-                             SSTATUS_SPP | SSTATUS_FS | SSTATUS_SUM | \
-                             SSTATUS_MXR | SSTATUS_UXL)
-
 #define HSTATUS_VSXL        0x300000000
 #define HSTATUS_VTSR        0x00400000
 #define HSTATUS_VTW         0x00200000

--- a/riscv/insns/hfence_gvma.h
+++ b/riscv/insns/hfence_gvma.h
@@ -1,4 +1,4 @@
 require_extension('H');
 require_novirt();
-require_privilege(get_field(STATE.mstatus, MSTATUS_TVM) ? PRV_M : PRV_S);
+require_privilege(get_field(STATE.mstatus->read(), MSTATUS_TVM) ? PRV_M : PRV_S);
 MMU.flush_tlb();

--- a/riscv/insns/hlv_b.h
+++ b/riscv/insns/hlv_b.h
@@ -1,4 +1,4 @@
 require_extension('H');
 require_novirt();
-require_privilege(get_field(STATE.hstatus, HSTATUS_HU) ? PRV_U : PRV_S);
+require_privilege(get_field(STATE.hstatus->read(), HSTATUS_HU) ? PRV_U : PRV_S);
 WRITE_RD(MMU.guest_load_int8(RS1));

--- a/riscv/insns/hlv_bu.h
+++ b/riscv/insns/hlv_bu.h
@@ -1,4 +1,4 @@
 require_extension('H');
 require_novirt();
-require_privilege(get_field(STATE.hstatus, HSTATUS_HU) ? PRV_U : PRV_S);
+require_privilege(get_field(STATE.hstatus->read(), HSTATUS_HU) ? PRV_U : PRV_S);
 WRITE_RD(MMU.guest_load_uint8(RS1));

--- a/riscv/insns/hlv_d.h
+++ b/riscv/insns/hlv_d.h
@@ -1,5 +1,5 @@
 require_extension('H');
 require_rv64;
 require_novirt();
-require_privilege(get_field(STATE.hstatus, HSTATUS_HU) ? PRV_U : PRV_S);
+require_privilege(get_field(STATE.hstatus->read(), HSTATUS_HU) ? PRV_U : PRV_S);
 WRITE_RD(MMU.guest_load_int64(RS1));

--- a/riscv/insns/hlv_h.h
+++ b/riscv/insns/hlv_h.h
@@ -1,4 +1,4 @@
 require_extension('H');
 require_novirt();
-require_privilege(get_field(STATE.hstatus, HSTATUS_HU) ? PRV_U : PRV_S);
+require_privilege(get_field(STATE.hstatus->read(), HSTATUS_HU) ? PRV_U : PRV_S);
 WRITE_RD(MMU.guest_load_int16(RS1));

--- a/riscv/insns/hlv_hu.h
+++ b/riscv/insns/hlv_hu.h
@@ -1,4 +1,4 @@
 require_extension('H');
 require_novirt();
-require_privilege(get_field(STATE.hstatus, HSTATUS_HU) ? PRV_U : PRV_S);
+require_privilege(get_field(STATE.hstatus->read(), HSTATUS_HU) ? PRV_U : PRV_S);
 WRITE_RD(MMU.guest_load_uint16(RS1));

--- a/riscv/insns/hlv_w.h
+++ b/riscv/insns/hlv_w.h
@@ -1,4 +1,4 @@
 require_extension('H');
 require_novirt();
-require_privilege(get_field(STATE.hstatus, HSTATUS_HU) ? PRV_U : PRV_S);
+require_privilege(get_field(STATE.hstatus->read(), HSTATUS_HU) ? PRV_U : PRV_S);
 WRITE_RD(MMU.guest_load_int32(RS1));

--- a/riscv/insns/hlv_wu.h
+++ b/riscv/insns/hlv_wu.h
@@ -1,5 +1,5 @@
 require_extension('H');
 require_rv64;
 require_novirt();
-require_privilege(get_field(STATE.hstatus, HSTATUS_HU) ? PRV_U : PRV_S);
+require_privilege(get_field(STATE.hstatus->read(), HSTATUS_HU) ? PRV_U : PRV_S);
 WRITE_RD(MMU.guest_load_uint32(RS1));

--- a/riscv/insns/hlvx_hu.h
+++ b/riscv/insns/hlvx_hu.h
@@ -1,4 +1,4 @@
 require_extension('H');
 require_novirt();
-require_privilege(get_field(STATE.hstatus, HSTATUS_HU) ? PRV_U : PRV_S);
+require_privilege(get_field(STATE.hstatus->read(), HSTATUS_HU) ? PRV_U : PRV_S);
 WRITE_RD(MMU.guest_load_x_uint16(RS1));

--- a/riscv/insns/hlvx_wu.h
+++ b/riscv/insns/hlvx_wu.h
@@ -1,4 +1,4 @@
 require_extension('H');
 require_novirt();
-require_privilege(get_field(STATE.hstatus, HSTATUS_HU) ? PRV_U : PRV_S);
+require_privilege(get_field(STATE.hstatus->read(), HSTATUS_HU) ? PRV_U : PRV_S);
 WRITE_RD(sext_xlen(MMU.guest_load_x_uint32(RS1)));

--- a/riscv/insns/hsv_b.h
+++ b/riscv/insns/hsv_b.h
@@ -1,4 +1,4 @@
 require_extension('H');
 require_novirt();
-require_privilege(get_field(STATE.hstatus, HSTATUS_HU) ? PRV_U : PRV_S);
+require_privilege(get_field(STATE.hstatus->read(), HSTATUS_HU) ? PRV_U : PRV_S);
 MMU.guest_store_uint8(RS1, RS2);

--- a/riscv/insns/hsv_d.h
+++ b/riscv/insns/hsv_d.h
@@ -1,5 +1,5 @@
 require_extension('H');
 require_rv64;
 require_novirt();
-require_privilege(get_field(STATE.hstatus, HSTATUS_HU) ? PRV_U : PRV_S);
+require_privilege(get_field(STATE.hstatus->read(), HSTATUS_HU) ? PRV_U : PRV_S);
 MMU.guest_store_uint64(RS1, RS2);

--- a/riscv/insns/hsv_h.h
+++ b/riscv/insns/hsv_h.h
@@ -1,4 +1,4 @@
 require_extension('H');
 require_novirt();
-require_privilege(get_field(STATE.hstatus, HSTATUS_HU) ? PRV_U : PRV_S);
+require_privilege(get_field(STATE.hstatus->read(), HSTATUS_HU) ? PRV_U : PRV_S);
 MMU.guest_store_uint16(RS1, RS2);

--- a/riscv/insns/hsv_w.h
+++ b/riscv/insns/hsv_w.h
@@ -1,4 +1,4 @@
 require_extension('H');
 require_novirt();
-require_privilege(get_field(STATE.hstatus, HSTATUS_HU) ? PRV_U : PRV_S);
+require_privilege(get_field(STATE.hstatus->read(), HSTATUS_HU) ? PRV_U : PRV_S);
 MMU.guest_store_uint32(RS1, RS2);

--- a/riscv/insns/mret.h
+++ b/riscv/insns/mret.h
@@ -1,5 +1,5 @@
 require_privilege(PRV_M);
-set_pc_and_serialize(p->get_state()->mepc);
+set_pc_and_serialize(p->get_state()->mepc->read());
 reg_t s = STATE.mstatus;
 reg_t prev_prv = get_field(s, MSTATUS_MPP);
 reg_t prev_virt = get_field(s, MSTATUS_MPV);

--- a/riscv/insns/mret.h
+++ b/riscv/insns/mret.h
@@ -1,6 +1,6 @@
 require_privilege(PRV_M);
 set_pc_and_serialize(p->get_state()->mepc->read());
-reg_t s = STATE.mstatus;
+reg_t s = STATE.mstatus->read();
 reg_t prev_prv = get_field(s, MSTATUS_MPP);
 reg_t prev_virt = get_field(s, MSTATUS_MPV);
 if (prev_prv != PRV_M)

--- a/riscv/insns/sfence_vma.h
+++ b/riscv/insns/sfence_vma.h
@@ -1,7 +1,7 @@
 require_extension('S');
 require_impl(IMPL_MMU);
 if (STATE.v) {
-  if (STATE.prv == PRV_U || get_field(STATE.hstatus, HSTATUS_VTVM))
+  if (STATE.prv == PRV_U || get_field(STATE.hstatus->read(), HSTATUS_VTVM))
     require_novirt();
 } else {
   require_privilege(get_field(STATE.mstatus->read(), MSTATUS_TVM) ? PRV_M : PRV_S);

--- a/riscv/insns/sfence_vma.h
+++ b/riscv/insns/sfence_vma.h
@@ -4,6 +4,6 @@ if (STATE.v) {
   if (STATE.prv == PRV_U || get_field(STATE.hstatus, HSTATUS_VTVM))
     require_novirt();
 } else {
-  require_privilege(get_field(STATE.mstatus, MSTATUS_TVM) ? PRV_M : PRV_S);
+  require_privilege(get_field(STATE.mstatus->read(), MSTATUS_TVM) ? PRV_M : PRV_S);
 }
 MMU.flush_tlb();

--- a/riscv/insns/sret.h
+++ b/riscv/insns/sret.h
@@ -1,6 +1,6 @@
 require_extension('S');
 if (STATE.v) {
-  if (STATE.prv == PRV_U || get_field(STATE.hstatus, HSTATUS_VTSR))
+  if (STATE.prv == PRV_U || get_field(STATE.hstatus->read(), HSTATUS_VTSR))
     require_novirt();
 } else {
   require_privilege(get_field(STATE.mstatus->read(), MSTATUS_TSR) ? PRV_M : PRV_S);
@@ -17,6 +17,6 @@ s = set_field(s, MSTATUS_SPP, PRV_U);
 STATE.sstatus->write(s);
 p->set_privilege(prev_prv);
 if (!STATE.v) {
-  reg_t prev_virt = get_field(STATE.hstatus, HSTATUS_SPV);
+  reg_t prev_virt = get_field(STATE.hstatus->read(), HSTATUS_SPV);
   p->set_virt(prev_virt);
 }

--- a/riscv/insns/sret.h
+++ b/riscv/insns/sret.h
@@ -3,7 +3,7 @@ if (STATE.v) {
   if (STATE.prv == PRV_U || get_field(STATE.hstatus, HSTATUS_VTSR))
     require_novirt();
 } else {
-  require_privilege(get_field(STATE.mstatus, MSTATUS_TSR) ? PRV_M : PRV_S);
+  require_privilege(get_field(STATE.mstatus->read(), MSTATUS_TSR) ? PRV_M : PRV_S);
 }
 reg_t next_pc = p->get_state()->sepc->read();
 set_pc_and_serialize(next_pc);

--- a/riscv/insns/sret.h
+++ b/riscv/insns/sret.h
@@ -5,7 +5,7 @@ if (STATE.v) {
 } else {
   require_privilege(get_field(STATE.mstatus, MSTATUS_TSR) ? PRV_M : PRV_S);
 }
-reg_t next_pc = (STATE.v) ? p->get_state()->vsepc : p->get_state()->sepc;
+reg_t next_pc = p->get_state()->sepc->read();
 set_pc_and_serialize(next_pc);
 reg_t s = STATE.mstatus;
 reg_t prev_prv = get_field(s, MSTATUS_SPP);

--- a/riscv/insns/sret.h
+++ b/riscv/insns/sret.h
@@ -7,14 +7,14 @@ if (STATE.v) {
 }
 reg_t next_pc = p->get_state()->sepc->read();
 set_pc_and_serialize(next_pc);
-reg_t s = STATE.mstatus;
+reg_t s = STATE.sstatus->read();
 reg_t prev_prv = get_field(s, MSTATUS_SPP);
 if (prev_prv != PRV_M)
   s = set_field(s, MSTATUS_MPRV, 0);
 s = set_field(s, MSTATUS_SIE, get_field(s, MSTATUS_SPIE));
 s = set_field(s, MSTATUS_SPIE, 1);
 s = set_field(s, MSTATUS_SPP, PRV_U);
-p->set_csr(CSR_MSTATUS, s);
+STATE.sstatus->write(s);
 p->set_privilege(prev_prv);
 if (!STATE.v) {
   reg_t prev_virt = get_field(STATE.hstatus, HSTATUS_SPV);

--- a/riscv/insns/vfmv_f_s.h
+++ b/riscv/insns/vfmv_f_s.h
@@ -1,9 +1,9 @@
 // vfmv_f_s: rd = vs2[0] (rs1=0)
 require_vector(true);
 require_fp;
-require((P.VU.vsew == e16 && p->supports_extension(EXT_ZFH)) ||
-        (P.VU.vsew == e32 && p->supports_extension('F')) ||
-        (P.VU.vsew == e64 && p->supports_extension('D')));
+require((P.VU.vsew == e16 && p->extension_enabled(EXT_ZFH)) ||
+        (P.VU.vsew == e32 && p->extension_enabled('F')) ||
+        (P.VU.vsew == e64 && p->extension_enabled('D')));
 require(STATE.frm < 0x5);
 
 reg_t rs2_num = insn.rs2();

--- a/riscv/insns/vfmv_s_f.h
+++ b/riscv/insns/vfmv_s_f.h
@@ -1,9 +1,9 @@
 // vfmv_s_f: vd[0] = rs1 (vs2=0)
 require_vector(true);
 require_fp;
-require((P.VU.vsew == e16 && p->supports_extension(EXT_ZFH)) ||
-        (P.VU.vsew == e32 && p->supports_extension('F')) ||
-        (P.VU.vsew == e64 && p->supports_extension('D')));
+require((P.VU.vsew == e16 && p->extension_enabled(EXT_ZFH)) ||
+        (P.VU.vsew == e32 && p->extension_enabled('F')) ||
+        (P.VU.vsew == e64 && p->extension_enabled('D')));
 require(STATE.frm < 0x5);
 
 reg_t vl = P.VU.vl;

--- a/riscv/insns/vfncvt_f_f_w.h
+++ b/riscv/insns/vfncvt_f_f_w.h
@@ -15,9 +15,9 @@ VI_VFP_CVT_SCALE
   ;
 },
 {
-  require(p->supports_extension(EXT_ZFH));
+  require(p->extension_enabled(EXT_ZFH));
 },
 {
-  require(p->supports_extension('D'));
+  require(p->extension_enabled('D'));
 },
 false, (P.VU.vsew >= 16))

--- a/riscv/insns/vfncvt_f_x_w.h
+++ b/riscv/insns/vfncvt_f_x_w.h
@@ -15,9 +15,9 @@ VI_VFP_CVT_SCALE
   ;
 },
 {
-  require(p->supports_extension(EXT_ZFH));
+  require(p->extension_enabled(EXT_ZFH));
 },
 {
-  require(p->supports_extension('F'));
+  require(p->extension_enabled('F'));
 },
 false, (P.VU.vsew >= 16))

--- a/riscv/insns/vfncvt_f_xu_w.h
+++ b/riscv/insns/vfncvt_f_xu_w.h
@@ -15,9 +15,9 @@ VI_VFP_CVT_SCALE
   ;
 },
 {
-  require(p->supports_extension(EXT_ZFH));
+  require(p->extension_enabled(EXT_ZFH));
 },
 {
-  require(p->supports_extension('F'));
+  require(p->extension_enabled('F'));
 },
 false, (P.VU.vsew >= 16))

--- a/riscv/insns/vfncvt_rod_f_f_w.h
+++ b/riscv/insns/vfncvt_rod_f_f_w.h
@@ -17,9 +17,9 @@ VI_VFP_CVT_SCALE
   ;
 },
 {
-  require(p->supports_extension(EXT_ZFH));
+  require(p->extension_enabled(EXT_ZFH));
 },
 {
-  require(p->supports_extension('F'));
+  require(p->extension_enabled('F'));
 },
 false, (P.VU.vsew >= 16))

--- a/riscv/insns/vfncvt_rtz_x_f_w.h
+++ b/riscv/insns/vfncvt_rtz_x_f_w.h
@@ -13,12 +13,12 @@ VI_VFP_CVT_SCALE
   P.VU.elt<int32_t>(rd_num, i, true) = f64_to_i32(vs2, softfloat_round_minMag, true);
 },
 {
-  require(p->supports_extension(EXT_ZFH));
+  require(p->extension_enabled(EXT_ZFH));
 },
 {
-  require(p->supports_extension('F'));
+  require(p->extension_enabled('F'));
 },
 {
-  require(p->supports_extension('D'));
+  require(p->extension_enabled('D'));
 },
 false, (P.VU.vsew <= 32))

--- a/riscv/insns/vfncvt_rtz_xu_f_w.h
+++ b/riscv/insns/vfncvt_rtz_xu_f_w.h
@@ -13,12 +13,12 @@ VI_VFP_CVT_SCALE
   P.VU.elt<uint32_t>(rd_num, i, true) = f64_to_ui32(vs2, softfloat_round_minMag, true);
 },
 {
-  require(p->supports_extension(EXT_ZFH));
+  require(p->extension_enabled(EXT_ZFH));
 },
 {
-  require(p->supports_extension('F'));
+  require(p->extension_enabled('F'));
 },
 {
-  require(p->supports_extension('D'));
+  require(p->extension_enabled('D'));
 },
 false, (P.VU.vsew <= 32))

--- a/riscv/insns/vfncvt_x_f_w.h
+++ b/riscv/insns/vfncvt_x_f_w.h
@@ -13,12 +13,12 @@ VI_VFP_CVT_SCALE
   P.VU.elt<int32_t>(rd_num, i, true) = f64_to_i32(vs2, STATE.frm, true);
 },
 {
-  require(p->supports_extension(EXT_ZFH));
+  require(p->extension_enabled(EXT_ZFH));
 },
 {
-  require(p->supports_extension('F'));
+  require(p->extension_enabled('F'));
 },
 {
-  require(p->supports_extension('D'));
+  require(p->extension_enabled('D'));
 },
 false, (P.VU.vsew <= 32))

--- a/riscv/insns/vfncvt_xu_f_w.h
+++ b/riscv/insns/vfncvt_xu_f_w.h
@@ -13,12 +13,12 @@ VI_VFP_CVT_SCALE
   P.VU.elt<uint32_t>(rd_num, i, true) = f64_to_ui32(vs2, STATE.frm, true);
 },
 {
-  require(p->supports_extension(EXT_ZFH));
+  require(p->extension_enabled(EXT_ZFH));
 },
 {
-  require(p->supports_extension('F'));
+  require(p->extension_enabled('F'));
 },
 {
-  require(p->supports_extension('D'));
+  require(p->extension_enabled('D'));
 },
 false, (P.VU.vsew <= 32))

--- a/riscv/insns/vfwcvt_f_f_v.h
+++ b/riscv/insns/vfwcvt_f_f_v.h
@@ -15,9 +15,9 @@ VI_VFP_CVT_SCALE
   ;
 },
 {
-  require(p->supports_extension(EXT_ZFH));
+  require(p->extension_enabled(EXT_ZFH));
 },
 {
-  require(p->supports_extension('D'));
+  require(p->extension_enabled('D'));
 },
 true, (P.VU.vsew >= 16))

--- a/riscv/insns/vfwcvt_f_x_v.h
+++ b/riscv/insns/vfwcvt_f_x_v.h
@@ -13,12 +13,12 @@ VI_VFP_CVT_SCALE
   P.VU.elt<float64_t>(rd_num, i, true) = i32_to_f64(vs2);
 },
 {
-  require(p->supports_extension(EXT_ZFH));
+  require(p->extension_enabled(EXT_ZFH));
 },
 {
-  require(p->supports_extension('F'));
+  require(p->extension_enabled('F'));
 },
 {
-  require(p->supports_extension('D'));
+  require(p->extension_enabled('D'));
 },
 true, (P.VU.vsew >= 8))

--- a/riscv/insns/vfwcvt_f_xu_v.h
+++ b/riscv/insns/vfwcvt_f_xu_v.h
@@ -13,12 +13,12 @@ VI_VFP_CVT_SCALE
   P.VU.elt<float64_t>(rd_num, i, true) = ui32_to_f64(vs2);
 },
 {
-  require(p->supports_extension(EXT_ZFH));
+  require(p->extension_enabled(EXT_ZFH));
 },
 {
-  require(p->supports_extension('F'));
+  require(p->extension_enabled('F'));
 },
 {
-  require(p->supports_extension('D'));
+  require(p->extension_enabled('D'));
 },
 true, (P.VU.vsew >= 8))

--- a/riscv/insns/vfwcvt_rtz_x_f_v.h
+++ b/riscv/insns/vfwcvt_rtz_x_f_v.h
@@ -15,9 +15,9 @@ VI_VFP_CVT_SCALE
   ;
 },
 {
-  require(p->supports_extension(EXT_ZFH));
+  require(p->extension_enabled(EXT_ZFH));
 },
 {
-  require(p->supports_extension('F'));
+  require(p->extension_enabled('F'));
 },
 true, (P.VU.vsew >= 16))

--- a/riscv/insns/vfwcvt_rtz_xu_f_v.h
+++ b/riscv/insns/vfwcvt_rtz_xu_f_v.h
@@ -15,9 +15,9 @@ VI_VFP_CVT_SCALE
   ;
 },
 {
-  require(p->supports_extension(EXT_ZFH));
+  require(p->extension_enabled(EXT_ZFH));
 },
 {
-  require(p->supports_extension('F'));
+  require(p->extension_enabled('F'));
 },
 true, (P.VU.vsew >= 16))

--- a/riscv/insns/vfwcvt_x_f_v.h
+++ b/riscv/insns/vfwcvt_x_f_v.h
@@ -15,9 +15,9 @@ VI_VFP_CVT_SCALE
   ;
 },
 {
-  require(p->supports_extension(EXT_ZFH));
+  require(p->extension_enabled(EXT_ZFH));
 },
 {
-  require(p->supports_extension('F'));
+  require(p->extension_enabled('F'));
 },
 true, (P.VU.vsew >= 16))

--- a/riscv/insns/vfwcvt_xu_f_v.h
+++ b/riscv/insns/vfwcvt_xu_f_v.h
@@ -15,9 +15,9 @@ VI_VFP_CVT_SCALE
   ;
 },
 {
-  require(p->supports_extension(EXT_ZFH));
+  require(p->extension_enabled(EXT_ZFH));
 },
 {
-  require(p->supports_extension('F'));
+  require(p->extension_enabled('F'));
 },
 true, (P.VU.vsew >= 16))

--- a/riscv/insns/wfi.h
+++ b/riscv/insns/wfi.h
@@ -1,6 +1,6 @@
 if (STATE.v && STATE.prv == PRV_U) {
   require_novirt();
-} else if (get_field(STATE.mstatus, MSTATUS_TW)) {
+} else if (get_field(STATE.mstatus->read(), MSTATUS_TW)) {
   require_privilege(PRV_M);
 } else if (STATE.v) { // VS-mode
   if (get_field(STATE.hstatus, HSTATUS_VTW))

--- a/riscv/insns/wfi.h
+++ b/riscv/insns/wfi.h
@@ -3,7 +3,7 @@ if (STATE.v && STATE.prv == PRV_U) {
 } else if (get_field(STATE.mstatus->read(), MSTATUS_TW)) {
   require_privilege(PRV_M);
 } else if (STATE.v) { // VS-mode
-  if (get_field(STATE.hstatus, HSTATUS_VTW))
+  if (get_field(STATE.hstatus->read(), HSTATUS_VTW))
     require_novirt();
 } else {
   require_privilege(PRV_S);

--- a/riscv/mmu.cc
+++ b/riscv/mmu.cc
@@ -221,21 +221,16 @@ reg_t mmu_t::pmp_ok(reg_t addr, reg_t len, access_type type, reg_t mode)
     return true;
 
   for (size_t i = 0; i < proc->n_pmp; i++) {
-    reg_t base = proc->state.pmpaddr[i]->tor_base_paddr();
-    reg_t tor = proc->state.pmpaddr[i]->tor_paddr();
     uint8_t cfg = proc->state.pmpcfg[i];
 
     if (cfg & PMP_A) {
-      bool is_tor = (cfg & PMP_A) == PMP_TOR;
 
       // Check each 4-byte sector of the access
       bool any_match = false;
       bool all_match = true;
       for (reg_t offset = 0; offset < len; offset += 1 << PMP_SHIFT) {
         reg_t cur_addr = addr + offset;
-        bool napot_match = ((cur_addr ^ tor) & proc->state.pmpaddr[i]->napot_mask()) == 0;
-        bool tor_match = base <= cur_addr && cur_addr < tor;
-        bool match = is_tor ? tor_match : napot_match;
+        bool match = proc->state.pmpaddr[i]->match4(cur_addr);
         any_match |= match;
         all_match &= match;
       }

--- a/riscv/mmu.cc
+++ b/riscv/mmu.cc
@@ -222,14 +222,14 @@ reg_t mmu_t::pmp_ok(reg_t addr, reg_t len, access_type type, reg_t mode)
 
   reg_t base = 0;
   for (size_t i = 0; i < proc->n_pmp; i++) {
-    reg_t tor = (proc->state.pmpaddr[i] & proc->pmp_tor_mask()) << PMP_SHIFT;
+    reg_t tor = (proc->state.pmpaddr[i]->raw_value() & proc->pmp_tor_mask()) << PMP_SHIFT;
     uint8_t cfg = proc->state.pmpcfg[i];
 
     if (cfg & PMP_A) {
       bool is_tor = (cfg & PMP_A) == PMP_TOR;
       bool is_na4 = (cfg & PMP_A) == PMP_NA4;
 
-      reg_t mask = (proc->state.pmpaddr[i] << 1) | (!is_na4) | ~proc->pmp_tor_mask();
+      reg_t mask = (proc->state.pmpaddr[i]->raw_value() << 1) | (!is_na4) | ~proc->pmp_tor_mask();
       mask = ~(mask & ~(mask + 1)) << PMP_SHIFT;
 
       // Check each 4-byte sector of the access
@@ -273,7 +273,7 @@ reg_t mmu_t::pmp_homogeneous(reg_t addr, reg_t len)
 
   reg_t base = 0;
   for (size_t i = 0; i < proc->n_pmp; i++) {
-    reg_t tor = (proc->state.pmpaddr[i] & proc->pmp_tor_mask()) << PMP_SHIFT;
+    reg_t tor = (proc->state.pmpaddr[i]->raw_value() & proc->pmp_tor_mask()) << PMP_SHIFT;
     uint8_t cfg = proc->state.pmpcfg[i];
 
     if (cfg & PMP_A) {
@@ -287,7 +287,7 @@ reg_t mmu_t::pmp_homogeneous(reg_t addr, reg_t len)
       bool tor_homogeneous = ends_before_lower || begins_after_upper ||
         (begins_after_lower && ends_before_upper);
 
-      reg_t mask = (proc->state.pmpaddr[i] << 1) | (!is_na4) | ~proc->pmp_tor_mask();
+      reg_t mask = (proc->state.pmpaddr[i]->raw_value() << 1) | (!is_na4) | ~proc->pmp_tor_mask();
       mask = ~(mask & ~(mask + 1)) << PMP_SHIFT;
       bool mask_homogeneous = ~(mask << 1) & len;
       bool napot_homogeneous = mask_homogeneous || ((addr ^ tor) / len) != 0;

--- a/riscv/mmu.cc
+++ b/riscv/mmu.cc
@@ -220,8 +220,8 @@ reg_t mmu_t::pmp_ok(reg_t addr, reg_t len, access_type type, reg_t mode)
   if (!proc || proc->n_pmp == 0)
     return true;
 
-  reg_t base = 0;
   for (size_t i = 0; i < proc->n_pmp; i++) {
+    reg_t base = proc->state.pmpaddr[i]->tor_base_paddr();
     reg_t tor = proc->state.pmpaddr[i]->tor_paddr();
     uint8_t cfg = proc->state.pmpcfg[i];
 
@@ -252,8 +252,6 @@ reg_t mmu_t::pmp_ok(reg_t addr, reg_t len, access_type type, reg_t mode)
           (type == FETCH && (cfg & PMP_X));
       }
     }
-
-    base = tor;
   }
 
   return mode == PRV_M;
@@ -267,8 +265,8 @@ reg_t mmu_t::pmp_homogeneous(reg_t addr, reg_t len)
   if (!proc)
     return true;
 
-  reg_t base = 0;
   for (size_t i = 0; i < proc->n_pmp; i++) {
+    reg_t base = proc->state.pmpaddr[i]->tor_base_paddr();
     reg_t tor = proc->state.pmpaddr[i]->tor_paddr();
     uint8_t cfg = proc->state.pmpcfg[i];
 
@@ -288,8 +286,6 @@ reg_t mmu_t::pmp_homogeneous(reg_t addr, reg_t len)
       if (!(is_tor ? tor_homogeneous : napot_homogeneous))
         return false;
     }
-
-    base = tor;
   }
 
   return true;

--- a/riscv/mmu.cc
+++ b/riscv/mmu.cc
@@ -236,12 +236,7 @@ bool mmu_t::pmp_ok(reg_t addr, reg_t len, access_type type, reg_t mode)
       if (!all_match)
         return false;
 
-      uint8_t cfg = proc->state.pmpcfg[i];
-      return
-        (mode == PRV_M && !(cfg & PMP_L)) ||
-        (type == LOAD && (cfg & PMP_R)) ||
-        (type == STORE && (cfg & PMP_W)) ||
-        (type == FETCH && (cfg & PMP_X));
+      return proc->state.pmpaddr[i]->access_ok(type, mode);
     }
   }
 

--- a/riscv/mmu.cc
+++ b/riscv/mmu.cc
@@ -267,7 +267,7 @@ reg_t mmu_t::s2xlate(reg_t gva, reg_t gpa, access_type type, access_type trap_ty
   if (vm.levels == 0)
     return gpa;
 
-  reg_t arch_mstatus = proc->state.v ? proc->state.vsstatus : proc->state.mstatus;
+  reg_t arch_mstatus = proc->state.v ? proc->state.vsstatus->read() : proc->state.mstatus;
   bool mxr = arch_mstatus & MSTATUS_MXR;
 
   reg_t base = vm.ptbase;
@@ -347,8 +347,8 @@ reg_t mmu_t::walk(reg_t addr, access_type type, reg_t mode, bool virt, bool hlvx
     return s2xlate(addr, addr & ((reg_t(2) << (proc->xlen-1))-1), type, type, virt, hlvx) & ~page_mask; // zero-extend from xlen
 
   bool s_mode = mode == PRV_S;
-  reg_t arch_vsstatus = proc->state.v ? proc->state.mstatus : proc->state.vsstatus;
-  reg_t arch_mstatus = proc->state.v ? proc->state.vsstatus : proc->state.mstatus;
+  reg_t arch_vsstatus = proc->state.v ? proc->state.mstatus : proc->state.vsstatus->read();
+  reg_t arch_mstatus = proc->state.v ? proc->state.vsstatus->read() : proc->state.mstatus;
   bool sum = (virt ? arch_vsstatus : arch_mstatus) & MSTATUS_SUM;
   bool mxr = (arch_mstatus | (virt ? arch_vsstatus : 0)) & MSTATUS_MXR;
 

--- a/riscv/mmu.cc
+++ b/riscv/mmu.cc
@@ -64,7 +64,7 @@ reg_t mmu_t::translate(reg_t addr, reg_t len, access_type type, uint32_t xlate_f
     }
     if (xlate_flags & RISCV_XLATE_VIRT) {
       virt = true;
-      mode = get_field(proc->state.hstatus, HSTATUS_SPVP);
+      mode = get_field(proc->state.hstatus->read(), HSTATUS_SPVP);
     }
   }
 

--- a/riscv/mmu.cc
+++ b/riscv/mmu.cc
@@ -53,7 +53,7 @@ reg_t mmu_t::translate(reg_t addr, reg_t len, access_type type, uint32_t xlate_f
   if (!proc)
     return addr;
 
-  bool virt = (proc) ? proc->state.v : false;
+  bool virt = proc->state.v;
   bool hlvx = xlate_flags & RISCV_XLATE_VIRT_HLVX;
   reg_t mode = proc->state.prv;
   if (type != FETCH) {

--- a/riscv/mmu.cc
+++ b/riscv/mmu.cc
@@ -347,10 +347,10 @@ reg_t mmu_t::walk(reg_t addr, access_type type, reg_t mode, bool virt, bool hlvx
     return s2xlate(addr, addr & ((reg_t(2) << (proc->xlen-1))-1), type, type, virt, hlvx) & ~page_mask; // zero-extend from xlen
 
   bool s_mode = mode == PRV_S;
-  reg_t arch_vsstatus = proc->state.v ? proc->state.mstatus : proc->state.vsstatus->read();
-  reg_t arch_mstatus = proc->state.v ? proc->state.vsstatus->read() : proc->state.mstatus;
-  bool sum = (virt ? arch_vsstatus : arch_mstatus) & MSTATUS_SUM;
-  bool mxr = (arch_mstatus | (virt ? arch_vsstatus : 0)) & MSTATUS_MXR;
+  reg_t arch_vsstatus = proc->state.v ? proc->state.sstatus->read() : proc->state.vsstatus->read();
+  reg_t arch_sstatus = proc->state.v ? proc->state.vsstatus->read() : proc->state.sstatus->read();
+  bool sum = (virt ? arch_vsstatus : arch_sstatus) & MSTATUS_SUM;
+  bool mxr = (arch_sstatus | (virt ? arch_vsstatus : 0)) & MSTATUS_MXR;
 
   // verify bits xlen-1:va_bits-1 are all equal
   int va_bits = PGSHIFT + vm.levels * vm.idxbits;

--- a/riscv/mmu.cc
+++ b/riscv/mmu.cc
@@ -263,7 +263,7 @@ reg_t mmu_t::s2xlate(reg_t gva, reg_t gpa, access_type type, access_type trap_ty
   if (!virt)
     return gpa;
 
-  vm_info vm = decode_vm_info(proc->max_xlen, true, 0, proc->get_state()->hgatp);
+  vm_info vm = decode_vm_info(proc->get_const_xlen(), true, 0, proc->get_state()->hgatp);
   if (vm.levels == 0)
     return gpa;
 
@@ -341,7 +341,7 @@ reg_t mmu_t::walk(reg_t addr, access_type type, reg_t mode, bool virt, bool hlvx
 {
   reg_t page_mask = (reg_t(1) << PGSHIFT) - 1;
   reg_t satp = (virt) ? proc->get_state()->vsatp : proc->get_state()->satp;
-  vm_info vm = decode_vm_info(proc->max_xlen, false, mode, satp);
+  vm_info vm = decode_vm_info(proc->get_const_xlen(), false, mode, satp);
   if (vm.levels == 0)
     return s2xlate(addr, addr & ((reg_t(2) << (proc->xlen-1))-1), type, type, virt, hlvx) & ~page_mask; // zero-extend from xlen
 

--- a/riscv/mmu.cc
+++ b/riscv/mmu.cc
@@ -347,9 +347,7 @@ reg_t mmu_t::walk(reg_t addr, access_type type, reg_t mode, bool virt, bool hlvx
 
   bool s_mode = mode == PRV_S;
   bool sum = proc->state.sstatus->readvirt(virt) & MSTATUS_SUM;
-  reg_t arch_vsstatus = proc->state.sstatus->readvirt(true);
-  reg_t arch_sstatus = proc->state.sstatus->readvirt(false);
-  bool mxr = (arch_sstatus | (virt ? arch_vsstatus : 0)) & MSTATUS_MXR;
+  bool mxr = (proc->state.sstatus->readvirt(false) | proc->state.sstatus->readvirt(virt)) & MSTATUS_MXR;
 
   // verify bits xlen-1:va_bits-1 are all equal
   int va_bits = PGSHIFT + vm.levels * vm.idxbits;

--- a/riscv/mmu.cc
+++ b/riscv/mmu.cc
@@ -222,7 +222,7 @@ reg_t mmu_t::pmp_ok(reg_t addr, reg_t len, access_type type, reg_t mode)
 
   reg_t base = 0;
   for (size_t i = 0; i < proc->n_pmp; i++) {
-    reg_t tor = (proc->state.pmpaddr[i]->raw_value() & proc->pmp_tor_mask()) << PMP_SHIFT;
+    reg_t tor = proc->state.pmpaddr[i]->tor_paddr();
     uint8_t cfg = proc->state.pmpcfg[i];
 
     if (cfg & PMP_A) {
@@ -273,7 +273,7 @@ reg_t mmu_t::pmp_homogeneous(reg_t addr, reg_t len)
 
   reg_t base = 0;
   for (size_t i = 0; i < proc->n_pmp; i++) {
-    reg_t tor = (proc->state.pmpaddr[i]->raw_value() & proc->pmp_tor_mask()) << PMP_SHIFT;
+    reg_t tor = proc->state.pmpaddr[i]->tor_paddr();
     uint8_t cfg = proc->state.pmpcfg[i];
 
     if (cfg & PMP_A) {

--- a/riscv/mmu.cc
+++ b/riscv/mmu.cc
@@ -267,8 +267,7 @@ reg_t mmu_t::s2xlate(reg_t gva, reg_t gpa, access_type type, access_type trap_ty
   if (vm.levels == 0)
     return gpa;
 
-  reg_t arch_sstatus = proc->state.v ? proc->state.vsstatus->read() : proc->state.sstatus->read();
-  bool mxr = arch_sstatus & MSTATUS_MXR;
+  bool mxr = proc->state.sstatus->readvirt(false) & MSTATUS_MXR;
 
   reg_t base = vm.ptbase;
   for (int i = vm.levels - 1; i >= 0; i--) {
@@ -347,9 +346,9 @@ reg_t mmu_t::walk(reg_t addr, access_type type, reg_t mode, bool virt, bool hlvx
     return s2xlate(addr, addr & ((reg_t(2) << (proc->xlen-1))-1), type, type, virt, hlvx) & ~page_mask; // zero-extend from xlen
 
   bool s_mode = mode == PRV_S;
-  reg_t arch_vsstatus = proc->state.v ? proc->state.sstatus->read() : proc->state.vsstatus->read();
-  reg_t arch_sstatus = proc->state.v ? proc->state.vsstatus->read() : proc->state.sstatus->read();
-  bool sum = (virt ? arch_vsstatus : arch_sstatus) & MSTATUS_SUM;
+  bool sum = proc->state.sstatus->readvirt(virt) & MSTATUS_SUM;
+  reg_t arch_vsstatus = proc->state.sstatus->readvirt(true);
+  reg_t arch_sstatus = proc->state.sstatus->readvirt(false);
   bool mxr = (arch_sstatus | (virt ? arch_vsstatus : 0)) & MSTATUS_MXR;
 
   // verify bits xlen-1:va_bits-1 are all equal

--- a/riscv/mmu.cc
+++ b/riscv/mmu.cc
@@ -267,8 +267,8 @@ reg_t mmu_t::s2xlate(reg_t gva, reg_t gpa, access_type type, access_type trap_ty
   if (vm.levels == 0)
     return gpa;
 
-  reg_t arch_mstatus = proc->state.v ? proc->state.vsstatus->read() : proc->state.mstatus;
-  bool mxr = arch_mstatus & MSTATUS_MXR;
+  reg_t arch_sstatus = proc->state.v ? proc->state.vsstatus->read() : proc->state.sstatus->read();
+  bool mxr = arch_sstatus & MSTATUS_MXR;
 
   reg_t base = vm.ptbase;
   for (int i = vm.levels - 1; i >= 0; i--) {

--- a/riscv/mmu.cc
+++ b/riscv/mmu.cc
@@ -340,7 +340,7 @@ reg_t mmu_t::s2xlate(reg_t gva, reg_t gpa, access_type type, access_type trap_ty
 reg_t mmu_t::walk(reg_t addr, access_type type, reg_t mode, bool virt, bool hlvx)
 {
   reg_t page_mask = (reg_t(1) << PGSHIFT) - 1;
-  reg_t satp = (virt) ? proc->get_state()->vsatp : proc->get_state()->satp;
+  reg_t satp = proc->get_state()->satp->readvirt(virt);
   vm_info vm = decode_vm_info(proc->get_const_xlen(), false, mode, satp);
   if (vm.levels == 0)
     return s2xlate(addr, addr & ((reg_t(2) << (proc->xlen-1))-1), type, type, virt, hlvx) & ~page_mask; // zero-extend from xlen

--- a/riscv/mmu.cc
+++ b/riscv/mmu.cc
@@ -215,7 +215,7 @@ tlb_entry_t mmu_t::refill_tlb(reg_t vaddr, reg_t paddr, char* host_addr, access_
   return entry;
 }
 
-reg_t mmu_t::pmp_ok(reg_t addr, reg_t len, access_type type, reg_t mode)
+bool mmu_t::pmp_ok(reg_t addr, reg_t len, access_type type, reg_t mode)
 {
   if (!proc || proc->n_pmp == 0)
     return true;

--- a/riscv/mmu.cc
+++ b/riscv/mmu.cc
@@ -57,9 +57,9 @@ reg_t mmu_t::translate(reg_t addr, reg_t len, access_type type, uint32_t xlate_f
   bool hlvx = xlate_flags & RISCV_XLATE_VIRT_HLVX;
   reg_t mode = proc->state.prv;
   if (type != FETCH) {
-    if (!proc->state.debug_mode && get_field(proc->state.mstatus, MSTATUS_MPRV)) {
-      mode = get_field(proc->state.mstatus, MSTATUS_MPP);
-      if (get_field(proc->state.mstatus, MSTATUS_MPV) && mode != PRV_M)
+    if (!proc->state.debug_mode && get_field(proc->state.mstatus->read(), MSTATUS_MPRV)) {
+      mode = get_field(proc->state.mstatus->read(), MSTATUS_MPP);
+      if (get_field(proc->state.mstatus->read(), MSTATUS_MPV) && mode != PRV_M)
         virt = true;
     }
     if (xlate_flags & RISCV_XLATE_VIRT) {
@@ -190,7 +190,7 @@ tlb_entry_t mmu_t::refill_tlb(reg_t vaddr, reg_t paddr, char* host_addr, access_
 
   tlb_entry_t entry = {host_addr - vaddr, paddr - vaddr};
 
-  if (proc && get_field(proc->state.mstatus, MSTATUS_MPRV))
+  if (proc && get_field(proc->state.mstatus->read(), MSTATUS_MPRV))
     return entry;
 
   if ((tlb_load_tag[idx] & ~TLB_CHECK_TRIGGERS) != expected_tag)

--- a/riscv/mmu.h
+++ b/riscv/mmu.h
@@ -469,7 +469,7 @@ private:
   }
 
   reg_t pmp_homogeneous(reg_t addr, reg_t len);
-  reg_t pmp_ok(reg_t addr, reg_t len, access_type type, reg_t mode);
+  bool pmp_ok(reg_t addr, reg_t len, access_type type, reg_t mode);
 
 #ifdef RISCV_ENABLE_DUAL_ENDIAN
   bool target_big_endian;

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -335,7 +335,7 @@ void state_t::reset(reg_t max_isa)
   mstatus = 0;
   mepc = 0;
   mtval = 0;
-  mscratch = 0;
+  mscratch = std::make_shared<basic_csr_t>(0);
   mtvec = 0;
   mcause = 0;
   minstret = 0;
@@ -1123,7 +1123,7 @@ void processor_t::set_csr(int which, reg_t val)
       break;
     case CSR_MEPC: state.mepc = val & ~(reg_t)1; break;
     case CSR_MTVEC: state.mtvec = val & ~(reg_t)2; break;
-    case CSR_MSCRATCH: state.mscratch = val; break;
+    case CSR_MSCRATCH: state.mscratch->write(val); break;
     case CSR_MCAUSE: state.mcause = val; break;
     case CSR_MTVAL: state.mtval = val; break;
     case CSR_MTVAL2: state.mtval2 = val; break;
@@ -1652,7 +1652,7 @@ reg_t processor_t::get_csr(int which, insn_t insn, bool write, bool peek)
     case CSR_MIP: ret(state.mip);
     case CSR_MIE: ret(state.mie);
     case CSR_MEPC: ret(state.mepc & pc_alignment_mask());
-    case CSR_MSCRATCH: ret(state.mscratch);
+    case CSR_MSCRATCH: ret(state.mscratch->read());
     case CSR_MCAUSE: ret(state.mcause);
     case CSR_MTVAL: ret(state.mtval);
     case CSR_MTVAL2:

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -510,7 +510,6 @@ void processor_t::reset()
 
   state.dcsr.halt = halt_on_reset;
   halt_on_reset = false;
-  state.mstatus->write(state.mstatus->read());  // set fixed fields
   set_csr(CSR_HSTATUS, state.hstatus);  // set VSXL
   VU.reset();
 

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -640,21 +640,17 @@ void processor_t::take_interrupt(reg_t pending_interrupts)
   m_enabled = state.prv < PRV_M || (state.prv == PRV_M && mie);
   enabled_interrupts = pending_interrupts & ~state.mideleg->read() & -m_enabled;
   if (enabled_interrupts == 0) {
-    reg_t deleg_to_hs, status;
-    reg_t hsie, hs_enabled;
-
     // HS-ints have higher priority over VS-ints
-    deleg_to_hs = state.mideleg->read() & ~state.hideleg;
-    status = state.sstatus->read();
-    hsie = get_field(status, MSTATUS_SIE);
-    hs_enabled = state.v || state.prv < PRV_S || (state.prv == PRV_S && hsie);
+    const reg_t deleg_to_hs = state.mideleg->read() & ~state.hideleg;
+    const reg_t status = state.sstatus->read();
+    const reg_t hsie = get_field(status, MSTATUS_SIE);
+    const reg_t hs_enabled = state.v || state.prv < PRV_S || (state.prv == PRV_S && hsie);
     enabled_interrupts = pending_interrupts & deleg_to_hs & -hs_enabled;
     if (state.v && enabled_interrupts == 0) {
-      reg_t vsie, vs_enabled, deleg_to_vs;
       // VS-ints have least priority and can only be taken with virt enabled
-      deleg_to_vs = state.mideleg->read() & state.hideleg;
-      vsie = get_field(state.sstatus->read(), MSTATUS_SIE);
-      vs_enabled = state.prv < PRV_S || (state.prv == PRV_S && vsie);
+      const reg_t deleg_to_vs = state.mideleg->read() & state.hideleg;
+      const reg_t vsie = get_field(state.sstatus->read(), MSTATUS_SIE);
+      const reg_t vs_enabled = state.prv < PRV_S || (state.prv == PRV_S && vsie);
       enabled_interrupts = pending_interrupts & deleg_to_vs & -vs_enabled;
     }
   }

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -603,6 +603,8 @@ void processor_t::take_interrupt(reg_t pending_interrupts)
   if (enabled_interrupts == 0) {
     // HS-ints have higher priority over VS-ints
     deleg = state.mideleg & ~state.hideleg;
+    // NB: this is always looking at architectural mstatus. Because when
+    // state.v, vsstatus & mstatus have been swapped.
     status = (state.v) ? state.vsstatus : state.mstatus;
     hsie = get_field(status, MSTATUS_SIE);
     hs_enabled = state.v || state.prv < PRV_S || (state.prv == PRV_S && hsie);
@@ -610,6 +612,8 @@ void processor_t::take_interrupt(reg_t pending_interrupts)
     if (state.v && enabled_interrupts == 0) {
       // VS-ints have least priority and can only be taken with virt enabled
       deleg = state.mideleg & state.hideleg;
+      // NB: this is actually looking at architectural vsstatus.
+      // Because when state.v, vsstatus & mstatus have been swapped.
       vsie = get_field(state.mstatus, MSTATUS_SIE);
       vs_enabled = state.prv < PRV_S || (state.prv == PRV_S && vsie);
       enabled_interrupts = pending_interrupts & deleg & -vs_enabled;

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -640,22 +640,22 @@ void processor_t::take_interrupt(reg_t pending_interrupts)
   m_enabled = state.prv < PRV_M || (state.prv == PRV_M && mie);
   enabled_interrupts = pending_interrupts & ~state.mideleg->read() & -m_enabled;
   if (enabled_interrupts == 0) {
-    reg_t deleg, status;
+    reg_t deleg_to_hs, status;
     reg_t hsie, hs_enabled;
 
     // HS-ints have higher priority over VS-ints
-    deleg = state.mideleg->read() & ~state.hideleg;
+    deleg_to_hs = state.mideleg->read() & ~state.hideleg;
     status = state.sstatus->read();
     hsie = get_field(status, MSTATUS_SIE);
     hs_enabled = state.v || state.prv < PRV_S || (state.prv == PRV_S && hsie);
-    enabled_interrupts = pending_interrupts & deleg & -hs_enabled;
+    enabled_interrupts = pending_interrupts & deleg_to_hs & -hs_enabled;
     if (state.v && enabled_interrupts == 0) {
-      reg_t vsie, vs_enabled;
+      reg_t vsie, vs_enabled, deleg_to_vs;
       // VS-ints have least priority and can only be taken with virt enabled
-      deleg = state.mideleg->read() & state.hideleg;
+      deleg_to_vs = state.mideleg->read() & state.hideleg;
       vsie = get_field(state.sstatus->read(), MSTATUS_SIE);
       vs_enabled = state.prv < PRV_S || (state.prv == PRV_S && vsie);
-      enabled_interrupts = pending_interrupts & deleg & -vs_enabled;
+      enabled_interrupts = pending_interrupts & deleg_to_vs & -vs_enabled;
     }
   }
 

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -335,7 +335,7 @@ void state_t::reset(processor_t* const proc, reg_t max_isa)
   mstatus = 0;
   mepc = 0;
   mtval = 0;
-  csrmap[CSR_MSCRATCH] = std::make_shared<basic_csr_t>(CSR_MSCRATCH, 0);
+  csrmap[CSR_MSCRATCH] = std::make_shared<basic_csr_t>(proc, CSR_MSCRATCH, 0);
   mtvec = 0;
   mcause = 0;
   minstret = 0;

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -423,7 +423,7 @@ void state_t::reset(processor_t* const proc, reg_t max_isa)
   htval = 0;
   htinst = 0;
   hgatp = 0;
-  nonvirtual_sstatus = std::make_shared<sstatus_proxy_csr_t>(proc, CSR_SSTATUS, mstatus);
+  auto nonvirtual_sstatus = std::make_shared<sstatus_proxy_csr_t>(proc, CSR_SSTATUS, mstatus);
   csrmap[CSR_VSSTATUS] = vsstatus = std::make_shared<vsstatus_csr_t>(proc, CSR_VSSTATUS);
   csrmap[CSR_SSTATUS] = sstatus = std::make_shared<sstatus_csr_t>(proc, nonvirtual_sstatus, vsstatus);
   vsatp = 0;

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -323,7 +323,7 @@ void processor_t::parse_isa_string(const char* str)
     bad_isa_string(str, "'Q' extension requires 'D'");
 }
 
-void state_t::reset(reg_t max_isa)
+void state_t::reset(processor_t* const proc, reg_t max_isa)
 {
   pc = DEFAULT_RSTVEC;
   XPR.reset();
@@ -476,7 +476,7 @@ void processor_t::enable_log_commits()
 
 void processor_t::reset()
 {
-  state.reset(max_isa);
+  state.reset(this, max_isa);
 #ifdef RISCV_ENABLE_DUAL_ENDIAN
   if (mmu->is_target_big_endian())
     state.mstatus |= MSTATUS_UBE | MSTATUS_SBE | MSTATUS_MBE;

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -779,11 +779,11 @@ void processor_t::take_trap(trap_t& t, reg_t epc)
     state.vsepc->write(epc);
     state.vstval->write(t.get_tval());
 
-    reg_t s = state.mstatus;
+    reg_t s = state.sstatus->read();
     s = set_field(s, MSTATUS_SPIE, get_field(s, MSTATUS_SIE));
     s = set_field(s, MSTATUS_SPP, state.prv);
     s = set_field(s, MSTATUS_SIE, 0);
-    set_csr(CSR_MSTATUS, s);
+    state.sstatus->write(s);
     set_privilege(PRV_S);
   } else if (state.prv <= PRV_S && bit < max_xlen && ((hsdeleg >> bit) & 1)) {
     // Handle the trap in HS-mode
@@ -796,11 +796,11 @@ void processor_t::take_trap(trap_t& t, reg_t epc)
     state.htval = t.get_tval2();
     state.htinst = t.get_tinst();
 
-    reg_t s = state.mstatus;
+    reg_t s = state.sstatus->read();
     s = set_field(s, MSTATUS_SPIE, get_field(s, MSTATUS_SIE));
     s = set_field(s, MSTATUS_SPP, state.prv);
     s = set_field(s, MSTATUS_SIE, 0);
-    set_csr(CSR_MSTATUS, s);
+    state.sstatus->write(s);
     if (supports_extension('H')) {
       s = state.hstatus;
       if (curr_virt)

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -308,18 +308,20 @@ void processor_t::parse_isa_string(const char* str)
     }
   }
 
-  state.misa = max_isa;
+  // The real state.misa hasn't been created yet, but we want to do
+  // some sanity checks on the supplied options.
+  misa_csr_t fake_misa(this, CSR_MISA, max_isa);
 
-  if (!supports_extension('I'))
+  if (!fake_misa.supports_extension('I'))
     bad_isa_string(str, "'I' extension is required");
 
-  if (supports_extension(EXT_ZFH) && !supports_extension('F'))
+  if (supports_extension(EXT_ZFH) && !fake_misa.supports_extension('F'))
     bad_isa_string(str, "'Zfh' extension requires 'F'");
 
-  if (supports_extension('D') && !supports_extension('F'))
+  if (fake_misa.supports_extension('D') && !fake_misa.supports_extension('F'))
     bad_isa_string(str, "'D' extension requires 'F'");
 
-  if (supports_extension('Q') && !supports_extension('D'))
+  if (fake_misa.supports_extension('Q') && !fake_misa.supports_extension('D'))
     bad_isa_string(str, "'Q' extension requires 'D'");
 }
 

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -901,6 +901,7 @@ void processor_t::set_csr(int which, reg_t val)
   if (search != state.csrmap.end()) {
     search->second->write(val);
   }
+  else {  // legacy non-csr_t CSRs
 
   if (which >= CSR_PMPADDR0 && which < CSR_PMPADDR0 + state.max_pmp) {
     // If no PMPs are configured, disallow access to all.  Otherwise, allow
@@ -1346,6 +1347,7 @@ void processor_t::set_csr(int which, reg_t val)
       VU.vxrm = val & 0x3ul;
       break;
   }
+  } // end legacy non-csr_t CSRs
 
 #if defined(RISCV_ENABLE_COMMITLOG)
   switch (which)

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -420,7 +420,7 @@ void state_t::reset(processor_t* const proc, reg_t max_isa)
   csrmap[CSR_HSTATUS] = hstatus = std::make_shared<hstatus_csr_t>(proc, CSR_HSTATUS);
   hideleg = 0;
   hedeleg = 0;
-  hcounteren = 0;
+  csrmap[CSR_HCOUNTEREN] = hcounteren = std::make_shared<counteren_csr_t>(proc, CSR_HCOUNTEREN);
   htval = 0;
   htinst = 0;
   hgatp = 0;
@@ -1023,9 +1023,6 @@ void processor_t::set_csr(int which, reg_t val)
       state.hideleg = (state.hideleg & ~mask) | (val & mask);
       break;
     }
-    case CSR_HCOUNTEREN:
-      state.hcounteren = val;
-      break;
     case CSR_HGEIE:
       /* Ignore */
       break;
@@ -1196,7 +1193,7 @@ reg_t processor_t::get_csr(int which, insn_t insn, bool write, bool peek)
 ({ \
   bool __ctr_ok = true; \
   if (state.v) \
-    __ctr_ok = (state.hcounteren >> (__which & 31)) & 1; \
+    __ctr_ok = (state.hcounteren->read() >> (__which & 31)) & 1;        \
   __ctr_ok; \
 })
 #define scounteren_ok(__which) \
@@ -1331,7 +1328,6 @@ reg_t processor_t::get_csr(int which, insn_t insn, bool write, bool peek)
     case CSR_MHARTID: ret(id);
     case CSR_HEDELEG: ret(state.hedeleg);
     case CSR_HIDELEG: ret(state.hideleg);
-    case CSR_HCOUNTEREN: ret(state.hcounteren);
     case CSR_HGEIE: ret(0);
     case CSR_HTVAL: ret(state.htval);
     case CSR_HTINST: ret(state.htinst);

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -348,6 +348,7 @@ void state_t::reset(processor_t* const proc, reg_t max_isa)
   mie = 0;
   csrmap[CSR_MIP] = mip = std::make_shared<mip_csr_t>(proc, CSR_MIP);
   csrmap[CSR_SIP] = std::make_shared<sip_csr_t>(proc, CSR_SIP);
+  csrmap[CSR_HVIP] = std::make_shared<hvip_csr_t>(proc, CSR_HVIP);
   medeleg = 0;
   mideleg = 0;
   mcounteren = 0;
@@ -1058,11 +1059,6 @@ void processor_t::set_csr(int which, reg_t val)
       state.mip->write_with_mask(mask, val);
       return;
     }
-    case CSR_HVIP: {
-      reg_t mask = MIP_VS_MASK;
-      state.mip->write_with_mask(mask, val);
-      return;
-    }
     case CSR_HTINST:
       state.htinst = val;
       break;
@@ -1409,7 +1405,6 @@ reg_t processor_t::get_csr(int which, insn_t insn, bool write, bool peek)
     case CSR_HGEIE: ret(0);
     case CSR_HTVAL: ret(state.htval);
     case CSR_HIP: ret(state.mip->read() & MIP_HS_MASK);
-    case CSR_HVIP: ret(state.mip->read() & MIP_VS_MASK);
     case CSR_HTINST: ret(state.htinst);
     case CSR_HGATP: {
       if (!state.v && get_field(state.mstatus->read(), MSTATUS_TVM))

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -511,7 +511,6 @@ void processor_t::reset()
   state.dcsr.halt = halt_on_reset;
   halt_on_reset = false;
   state.mstatus->write(state.mstatus->read());  // set fixed fields
-  state.vsstatus->write(state.mstatus->read());  // set UXL
   set_csr(CSR_HSTATUS, state.hstatus);  // set VSXL
   VU.reset();
 

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -900,8 +900,8 @@ void processor_t::set_csr(int which, reg_t val)
   auto search = state.csrmap.find(which);
   if (search != state.csrmap.end()) {
     search->second->write(val);
+    return;
   }
-  else {  // legacy non-csr_t CSRs
 
   if (which >= CSR_PMPADDR0 && which < CSR_PMPADDR0 + state.max_pmp) {
     // If no PMPs are configured, disallow access to all.  Otherwise, allow
@@ -1347,7 +1347,6 @@ void processor_t::set_csr(int which, reg_t val)
       VU.vxrm = val & 0x3ul;
       break;
   }
-  } // end legacy non-csr_t CSRs
 
 #if defined(RISCV_ENABLE_COMMITLOG)
   switch (which)
@@ -1417,7 +1416,6 @@ void processor_t::set_csr(int which, reg_t val)
     case CSR_STVAL:
     case CSR_MEPC:
     case CSR_MTVEC:
-    case CSR_MSCRATCH:
     case CSR_MCAUSE:
     case CSR_MTVAL:
     case CSR_MISA:

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -703,7 +703,7 @@ void processor_t::set_virt(bool virt)
     mask |= (xlen == 64 ? SSTATUS64_SD : SSTATUS32_SD);
     tmp = state.mstatus & mask;
     state.mstatus = (state.mstatus & ~mask) | (state.vsstatus->read() & mask);
-    state.vsstatus->write(tmp);
+    state.vsstatus->backdoor_write(tmp);
     state.v = virt;
   }
 }

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -330,7 +330,7 @@ void state_t::reset(processor_t* const proc, reg_t max_isa)
   FPR.reset();
 
   // This assumes xlen is always max_xlen, which is true today (see
-  // mstatus_csr_t::backdoor_write()):
+  // mstatus_csr_t::unlogged_write()):
   auto xlen = proc->get_max_xlen();
 
   prv = PRV_M;

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -347,6 +347,7 @@ void state_t::reset(processor_t* const proc, reg_t max_isa)
   minstret = 0;
   mie = 0;
   csrmap[CSR_MIP] = mip = std::make_shared<mip_csr_t>(proc, CSR_MIP);
+  csrmap[CSR_SIP] = std::make_shared<sip_csr_t>(proc, CSR_SIP);
   medeleg = 0;
   mideleg = 0;
   mcounteren = 0;
@@ -982,17 +983,6 @@ void processor_t::set_csr(int which, reg_t val)
     case CSR_MCOUNTEREN:
       state.mcounteren = val;
       break;
-    case CSR_SIP: {
-      reg_t mask;
-      if (state.v) {
-        mask = state.hideleg & MIP_VSSIP;
-        val = val << 1;
-      } else {
-        mask = state.mideleg & MIP_SSIP;
-      }
-      state.mip->write_with_mask(mask, val);
-      return;
-    }
     case CSR_SIE: {
       reg_t mask;
       if (state.v) {
@@ -1368,13 +1358,6 @@ reg_t processor_t::get_csr(int which, insn_t insn, bool write, bool peek)
         break;
       ret(state.mcounteren);
     case CSR_MCOUNTINHIBIT: ret(0);
-    case CSR_SIP: {
-      if (state.v) {
-        ret((state.mip->read() & state.hideleg & MIP_VS_MASK) >> 1);
-      } else {
-        ret(state.mip->read() & state.mideleg & ~MIP_HS_MASK);
-      }
-    }
     case CSR_SIE: {
       if (state.v) {
         ret((state.mie & state.hideleg & MIP_VS_MASK) >> 1);

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -992,6 +992,11 @@ void processor_t::set_csr(int which, reg_t val)
       break;
     }
     case CSR_MIP: {
+      // We must mask off sgeip, vstip, and vseip. All three of these
+      // bits are aliases for the same bits in hip. The hip spec says:
+      //  * sgeip is read-only -- write hgeip instead
+      //  * vseip is read-only -- write hvip instead
+      //  * vstip is read-only -- write hvip instead
       reg_t mask = (supervisor_ints | hypervisor_ints) &
                    (MIP_SEIP | MIP_SSIP | MIP_STIP | vssip_int);
       state.mip = (state.mip & ~mask) | (val & mask);

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -350,6 +350,7 @@ void state_t::reset(processor_t* const proc, reg_t max_isa)
   csrmap[CSR_SIP] = std::make_shared<sip_csr_t>(proc, CSR_SIP);
   csrmap[CSR_HVIP] = std::make_shared<hvip_csr_t>(proc, CSR_HVIP);
   csrmap[CSR_HIP] = std::make_shared<hvip_csr_t>(proc, CSR_HIP);
+  csrmap[CSR_VSIP] = std::make_shared<vsip_csr_t>(proc, CSR_VSIP);
   medeleg = 0;
   mideleg = 0;
   mcounteren = 0;
@@ -1082,11 +1083,6 @@ void processor_t::set_csr(int which, reg_t val)
       state.mie = (state.mie & ~mask) | ((val << 1) & mask);
       break;
     }
-    case CSR_VSIP: {
-      reg_t mask = state.hideleg & MIP_VSSIP;
-      state.mip->write_with_mask(mask, val << 1);
-      return;
-    }
     case CSR_VSATP:
       if (!supports_impl(IMPL_MMU))
         val = 0;
@@ -1408,7 +1404,6 @@ reg_t processor_t::get_csr(int which, insn_t insn, bool write, bool peek)
     }
     case CSR_HGEIP: ret(0);
     case CSR_VSIE: ret((state.mie & state.hideleg & MIP_VS_MASK) >> 1);
-    case CSR_VSIP: ret((state.mip->read() & state.hideleg & MIP_VS_MASK) >> 1);
     case CSR_VSATP: ret(state.vsatp);
     case CSR_TSELECT: ret(state.tselect);
     case CSR_TDATA1:

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -386,7 +386,6 @@ void state_t::reset(processor_t* const proc, reg_t max_isa)
   debug_mode = false;
   single_step = STEP_NONE;
 
-  memset(this->pmpcfg, 0, sizeof(this->pmpcfg));
   for (int i=0; i < max_pmp; ++i) {
     csrmap[CSR_PMPADDR0 + i] = pmpaddr[i] = std::make_shared<pmpaddr_csr_t>(proc, CSR_PMPADDR0 + i);
   }

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -628,17 +628,15 @@ void processor_t::set_mmu_capability(int cap)
 
 void processor_t::take_interrupt(reg_t pending_interrupts)
 {
-  reg_t enabled_interrupts, mie, m_enabled;
-
   // Do nothing if no pending interrupts
   if (!pending_interrupts) {
     return;
   }
 
   // M-ints have higher priority over HS-ints and VS-ints
-  mie = get_field(state.mstatus->read(), MSTATUS_MIE);
-  m_enabled = state.prv < PRV_M || (state.prv == PRV_M && mie);
-  enabled_interrupts = pending_interrupts & ~state.mideleg->read() & -m_enabled;
+  const reg_t mie = get_field(state.mstatus->read(), MSTATUS_MIE);
+  const reg_t m_enabled = state.prv < PRV_M || (state.prv == PRV_M && mie);
+  reg_t enabled_interrupts = pending_interrupts & ~state.mideleg->read() & -m_enabled;
   if (enabled_interrupts == 0) {
     // HS-ints have higher priority over VS-ints
     const reg_t deleg_to_hs = state.mideleg->read() & ~state.hideleg;

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -895,36 +895,6 @@ int processor_t::paddr_bits()
   return max_xlen == 64 ? 50 : 34;
 }
 
-bool processor_t::satp_valid(reg_t val) const
-{
-  if (xlen == 32) {
-    switch (get_field(val, SATP32_MODE)) {
-      case SATP_MODE_SV32: return supports_impl(IMPL_MMU_SV32);
-      case SATP_MODE_OFF: return true;
-      default: return false;
-    }
-  } else {
-    switch (get_field(val, SATP64_MODE)) {
-      case SATP_MODE_SV39: return supports_impl(IMPL_MMU_SV39);
-      case SATP_MODE_SV48: return supports_impl(IMPL_MMU_SV48);
-      case SATP_MODE_OFF: return true;
-      default: return false;
-    }
-  }
-}
-
-reg_t processor_t::compute_new_satp(reg_t val, reg_t old) const
-{
-  reg_t rv64_ppn_mask = (reg_t(1) << (MAX_PADDR_BITS - PGSHIFT)) - 1;
-
-  reg_t mode_mask = xlen == 32 ? SATP32_MODE : SATP64_MODE;
-  reg_t ppn_mask = xlen == 32 ? SATP32_PPN : SATP64_PPN & rv64_ppn_mask;
-  reg_t new_mask = (satp_valid(val) ? mode_mask : 0) | ppn_mask;
-  reg_t old_mask = satp_valid(val) ? 0 : mode_mask;
-
-  return (new_mask & val) | (old_mask & old);
-}
-
 void processor_t::set_csr(int which, reg_t val)
 {
 #if defined(RISCV_ENABLE_COMMITLOG)

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -347,10 +347,12 @@ void state_t::reset(processor_t* const proc, reg_t max_isa)
   minstret = 0;
   mie = 0;
   csrmap[CSR_MIP] = mip = std::make_shared<mip_csr_t>(proc, CSR_MIP);
-  csrmap[CSR_SIP] = std::make_shared<sip_csr_t>(proc, CSR_SIP);
   csrmap[CSR_HVIP] = std::make_shared<hvip_csr_t>(proc, CSR_HVIP);
   csrmap[CSR_HIP] = std::make_shared<hvip_csr_t>(proc, CSR_HIP);
-  csrmap[CSR_VSIP] = std::make_shared<vsip_csr_t>(proc, CSR_VSIP);
+  auto nonvirtual_sip = std::make_shared<sip_csr_t>(proc, CSR_SIP);
+  auto vsip = std::make_shared<vsip_csr_t>(proc, CSR_VSIP);
+  csrmap[CSR_VSIP] = vsip;
+  csrmap[CSR_SIP] = std::make_shared<virtualized_csr_t>(proc, nonvirtual_sip, vsip);
   medeleg = 0;
   mideleg = 0;
   mcounteren = 0;

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -917,7 +917,7 @@ void processor_t::set_csr(int which, reg_t val)
   reg_t supervisor_ints = supports_extension('S') ? MIP_SSIP | MIP_STIP | MIP_SEIP : 0;
   reg_t vssip_int = supports_extension('H') ? MIP_VSSIP : 0;
   reg_t hypervisor_ints = supports_extension('H') ? MIP_HS_MASK : 0;
-  reg_t coprocessor_ints = (!custom_extensions.empty()) << IRQ_COP;
+  reg_t coprocessor_ints = (reg_t)any_custom_extensions() << IRQ_COP;
   reg_t delegable_ints = supervisor_ints | coprocessor_ints;
   reg_t all_ints = delegable_ints | hypervisor_ints | MIP_MSIP | MIP_MTIP | MIP_MEIP;
   reg_t hypervisor_exceptions = 0
@@ -977,7 +977,7 @@ void processor_t::set_csr(int which, reg_t val)
                  | (has_page ? (MSTATUS_MXR | MSTATUS_SUM | MSTATUS_TVM) : 0)
                  | (has_fs ? MSTATUS_FS : 0)
                  | (has_vs ? MSTATUS_VS : 0)
-                 | (!custom_extensions.empty() ? MSTATUS_XS : 0)
+                 | (any_custom_extensions() ? MSTATUS_XS : 0)
                  | (has_gva ? MSTATUS_GVA : 0)
                  | (has_mpv ? MSTATUS_MPV : 0);
 

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -415,6 +415,11 @@ void state_t::reset(processor_t* const proc, reg_t max_isa)
 #endif
 }
 
+void state_t::dirty_mstatus(reg_t dirties){  // set VS, FS, or XS to Dirty
+  mstatus |= dirties;
+  vsstatus |= (v ? dirties : 0);
+}
+
 void processor_t::vectorUnit_t::reset(){
   free(reg_file);
   VLEN = get_vlen();

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -346,7 +346,7 @@ void state_t::reset(processor_t* const proc, reg_t max_isa)
   csrmap[CSR_MCAUSE] = mcause = std::make_shared<cause_csr_t>(proc, CSR_MCAUSE);
   minstret = 0;
   mie = 0;
-  csrmap[CSR_MIP] = mip = std::make_shared<mip_csr_t>(proc, CSR_MIP);
+  csrmap[CSR_MIP] = mip = std::make_shared<mip_or_mie_csr_t>(proc, CSR_MIP);
   auto sip_sie_accr = std::make_shared<generic_int_accessor_t>(this,
                                                                ~MIP_HS_MASK,  // read_mask
                                                                MIP_SSIP,      // ip_write_mask

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -346,7 +346,7 @@ void state_t::reset(processor_t* const proc, reg_t max_isa)
   csrmap[CSR_MCAUSE] = mcause = std::make_shared<cause_csr_t>(proc, CSR_MCAUSE);
   minstret = 0;
   mie = 0;
-  csrmap[CSR_MIP] = mip = std::make_shared<mip_or_mie_csr_t>(proc, CSR_MIP);
+  csrmap[CSR_MIP] = mip = std::make_shared<mip_csr_t>(proc, CSR_MIP);
   auto sip_sie_accr = std::make_shared<generic_int_accessor_t>(this,
                                                                ~MIP_HS_MASK,  // read_mask
                                                                MIP_SSIP,      // ip_write_mask

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -611,9 +611,9 @@ void processor_t::take_interrupt(reg_t pending_interrupts)
   if (enabled_interrupts == 0) {
     // HS-ints have higher priority over VS-ints
     deleg = state.mideleg & ~state.hideleg;
-    // NB: this is always looking at architectural mstatus. Because when
+    // NB: this is always looking at architectural sstatus. Because when
     // state.v, vsstatus & mstatus have been swapped.
-    status = (state.v) ? state.vsstatus->read() : state.mstatus;
+    status = (state.v) ? state.vsstatus->read() : state.sstatus->read();
     hsie = get_field(status, MSTATUS_SIE);
     hs_enabled = state.v || state.prv < PRV_S || (state.prv == PRV_S && hsie);
     enabled_interrupts = pending_interrupts & deleg & -hs_enabled;
@@ -622,7 +622,7 @@ void processor_t::take_interrupt(reg_t pending_interrupts)
       deleg = state.mideleg & state.hideleg;
       // NB: this is actually looking at architectural vsstatus.
       // Because when state.v, vsstatus & mstatus have been swapped.
-      vsie = get_field(state.mstatus, MSTATUS_SIE);
+      vsie = get_field(state.sstatus->read(), MSTATUS_SIE);
       vs_enabled = state.prv < PRV_S || (state.prv == PRV_S && vsie);
       enabled_interrupts = pending_interrupts & deleg & -vs_enabled;
     }

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -642,15 +642,13 @@ void processor_t::take_interrupt(reg_t pending_interrupts)
   if (enabled_interrupts == 0) {
     // HS-ints have higher priority over VS-ints
     const reg_t deleg_to_hs = state.mideleg->read() & ~state.hideleg;
-    const reg_t status = state.sstatus->read();
-    const reg_t hsie = get_field(status, MSTATUS_SIE);
-    const reg_t hs_enabled = state.v || state.prv < PRV_S || (state.prv == PRV_S && hsie);
+    const reg_t sie = get_field(state.sstatus->read(), MSTATUS_SIE);
+    const reg_t hs_enabled = state.v || state.prv < PRV_S || (state.prv == PRV_S && sie);
     enabled_interrupts = pending_interrupts & deleg_to_hs & -hs_enabled;
     if (state.v && enabled_interrupts == 0) {
       // VS-ints have least priority and can only be taken with virt enabled
       const reg_t deleg_to_vs = state.mideleg->read() & state.hideleg;
-      const reg_t vsie = get_field(state.sstatus->read(), MSTATUS_SIE);
-      const reg_t vs_enabled = state.prv < PRV_S || (state.prv == PRV_S && vsie);
+      const reg_t vs_enabled = state.prv < PRV_S || (state.prv == PRV_S && sie);
       enabled_interrupts = pending_interrupts & deleg_to_vs & -vs_enabled;
     }
   }

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -380,7 +380,7 @@ void state_t::reset(processor_t* const proc, reg_t max_isa)
   hgatp = 0;
   nonvirtual_sstatus = std::make_shared<sstatus_proxy_csr_t>(proc, CSR_SSTATUS, mstatus);
   csrmap[CSR_VSSTATUS] = vsstatus = std::make_shared<vsstatus_csr_t>(proc, CSR_VSSTATUS);
-  csrmap[CSR_SSTATUS] = sstatus = std::make_shared<virtualized_csr_t>(proc, nonvirtual_sstatus, vsstatus);
+  csrmap[CSR_SSTATUS] = sstatus = std::make_shared<sstatus_csr_t>(proc, nonvirtual_sstatus, vsstatus);
   vsatp = 0;
 
   dpc = 0;

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -1113,8 +1113,8 @@ void processor_t::set_csr(int which, reg_t val)
       mask &= max_isa;
 
       bool prev_h = state.misa & (1L << ('H' - 'A'));
-      state.misa = (val & mask) | (state.misa & ~mask);
-      bool new_h = state.misa & (1L << ('H' - 'A'));
+      reg_t new_misa = (val & mask) | (state.misa & ~mask);
+      bool new_h = new_misa & (1L << ('H' - 'A'));
 
       // update the forced bits in MIDELEG and other CSRs
       if (new_h && !prev_h)
@@ -1127,6 +1127,7 @@ void processor_t::set_csr(int which, reg_t val)
         state.mip &= ~MIP_HS_MASK;  // also takes care of hip, sip, hvip
         set_csr(CSR_HSTATUS, 0);
       }
+      state.misa = new_misa;
       break;
     }
     case CSR_HSTATUS: {

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -897,6 +897,11 @@ void processor_t::set_csr(int which, reg_t val)
     | (1 << CAUSE_STORE_GUEST_PAGE_FAULT)
     ;
 
+  auto search = state.csrmap.find(which);
+  if (search != state.csrmap.end()) {
+    search->second->write(val);
+  }
+
   if (which >= CSR_PMPADDR0 && which < CSR_PMPADDR0 + state.max_pmp) {
     // If no PMPs are configured, disallow access to all.  Otherwise, allow
     // access to all, but unimplemented ones are hardwired to zero.
@@ -1123,7 +1128,6 @@ void processor_t::set_csr(int which, reg_t val)
       break;
     case CSR_MEPC: state.mepc = val & ~(reg_t)1; break;
     case CSR_MTVEC: state.mtvec = val & ~(reg_t)2; break;
-    case CSR_MSCRATCH: state.mscratch->write(val); break;
     case CSR_MCAUSE: state.mcause = val; break;
     case CSR_MTVAL: state.mtval = val; break;
     case CSR_MTVAL2: state.mtval2 = val; break;

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -335,7 +335,7 @@ void state_t::reset(reg_t max_isa)
   mstatus = 0;
   mepc = 0;
   mtval = 0;
-  csrmap[CSR_MSCRATCH] = mscratch = std::make_shared<basic_csr_t>(0);
+  csrmap[CSR_MSCRATCH] = std::make_shared<basic_csr_t>(0);
   mtvec = 0;
   mcause = 0;
   minstret = 0;

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -349,28 +349,28 @@ void state_t::reset(processor_t* const proc, reg_t max_isa)
   csrmap[CSR_MIP] = mip = std::make_shared<mip_csr_t>(proc, CSR_MIP);
   auto sip_sie_accr = std::make_shared<generic_int_accessor_t>(this,
                                                                ~MIP_HS_MASK,  // read_mask
-                                                               MIP_SSIP,      // write_mask
+                                                               MIP_SSIP,      // ip_write_mask
                                                                true,          // mask_mideleg
                                                                false,         // mask_hideleg
                                                                0);            // shiftamt
 
   auto hip_hie_accr = std::make_shared<generic_int_accessor_t>(this,
                                                                MIP_HS_MASK,   // read_mask
-                                                               MIP_VSSIP,     // write_mask
+                                                               MIP_VSSIP,     // ip_write_mask
                                                                false,         // mask_mideleg
                                                                false,         // mask_hideleg
                                                                0);
 
   auto hvip_accr = std::make_shared<generic_int_accessor_t>(this,
                                                             MIP_VS_MASK,   // read_mask
-                                                            MIP_VS_MASK,   // write_mask
+                                                            MIP_VS_MASK,   // ip_write_mask
                                                             false,         // mask_mideleg
                                                             false,         // mask_hideleg
                                                             0);            // shiftamt
 
   auto vsip_vsie_accr = std::make_shared<generic_int_accessor_t>(this,
                                                                  MIP_VS_MASK,   // read_mask
-                                                                 MIP_VSSIP,     // write_mask
+                                                                 MIP_VSSIP,     // ip_write_mask
                                                                  false,         // mask_mideleg
                                                                  true,          // mask_hideleg
                                                                  1);            // shiftamt

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -341,7 +341,7 @@ void state_t::reset(processor_t* const proc, reg_t max_isa)
   csrmap[CSR_MTVAL] = mtval = std::make_shared<basic_csr_t>(proc, CSR_MTVAL, 0);
   csrmap[CSR_MSCRATCH] = std::make_shared<basic_csr_t>(proc, CSR_MSCRATCH, 0);
   csrmap[CSR_MTVEC] = mtvec = std::make_shared<tvec_csr_t>(proc, CSR_MTVEC);
-  csrmap[CSR_MCAUSE] = mcause = std::make_shared<basic_csr_t>(proc, CSR_MCAUSE, 0);
+  csrmap[CSR_MCAUSE] = mcause = std::make_shared<cause_csr_t>(proc, CSR_MCAUSE);
   minstret = 0;
   mie = 0;
   mip = 0;

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -1468,7 +1468,9 @@ reg_t processor_t::get_csr(int which, insn_t insn, bool write, bool peek)
 
   auto search = state.csrmap.find(which);
   if (search != state.csrmap.end()) {
-    ret(search->second->read());
+    if (!peek)
+      search->second->verify_permissions(insn, write);
+    return search->second->read();
   }
 
   if (which >= CSR_PMPADDR0 && which < CSR_PMPADDR0 + state.max_pmp) {

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -1155,8 +1155,8 @@ void processor_t::set_csr(int which, reg_t val)
         state.mideleg &= ~MIDELEG_FORCED_MASK;
         state.medeleg &= ~hypervisor_exceptions;
         state.mstatus &= ~(MSTATUS_GVA | MSTATUS_MPV);
-        state.mie &= ~MIP_HS_MASK;  // also takes care of hip, sip, hvip
-        state.mip &= ~MIP_HS_MASK;  // also takes care of hie, sie
+        state.mie &= ~MIP_HS_MASK;  // also takes care of hie, sie
+        state.mip &= ~MIP_HS_MASK;  // also takes care of hip, sip, hvip
         set_csr(CSR_HSTATUS, 0);
       }
       break;

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -789,12 +789,14 @@ void processor_t::take_trap(trap_t& t, reg_t epc)
     s = set_field(s, MSTATUS_SPP, state.prv);
     s = set_field(s, MSTATUS_SIE, 0);
     set_csr(CSR_MSTATUS, s);
-    s = state.hstatus;
-    if (curr_virt)
-      s = set_field(s, HSTATUS_SPVP, state.prv);
-    s = set_field(s, HSTATUS_SPV, curr_virt);
-    s = set_field(s, HSTATUS_GVA, t.has_gva());
-    set_csr(CSR_HSTATUS, s);
+    if (supports_extension('H')) {
+      s = state.hstatus;
+      if (curr_virt)
+        s = set_field(s, HSTATUS_SPVP, state.prv);
+      s = set_field(s, HSTATUS_SPV, curr_virt);
+      s = set_field(s, HSTATUS_GVA, t.has_gva());
+      set_csr(CSR_HSTATUS, s);
+    }
     set_privilege(PRV_S);
   } else {
     // Handle the trap in M-mode

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -335,7 +335,7 @@ void state_t::reset(reg_t max_isa)
   mstatus = 0;
   mepc = 0;
   mtval = 0;
-  mscratch = std::make_shared<basic_csr_t>(0);
+  csrmap[CSR_MSCRATCH] = mscratch = std::make_shared<basic_csr_t>(0);
   mtvec = 0;
   mcause = 0;
   minstret = 0;
@@ -1462,6 +1462,11 @@ reg_t processor_t::get_csr(int which, insn_t insn, bool write, bool peek)
     goto out; \
   } while (false)
 
+  auto search = state.csrmap.find(which);
+  if (search != state.csrmap.end()) {
+    ret(search->second->read());
+  }
+
   if (which >= CSR_PMPADDR0 && which < CSR_PMPADDR0 + state.max_pmp) {
     // If n_pmp is zero, that means pmp is not implemented hence raise trap if it tries to access the csr
     if (n_pmp == 0)
@@ -1652,7 +1657,6 @@ reg_t processor_t::get_csr(int which, insn_t insn, bool write, bool peek)
     case CSR_MIP: ret(state.mip);
     case CSR_MIE: ret(state.mie);
     case CSR_MEPC: ret(state.mepc & pc_alignment_mask());
-    case CSR_MSCRATCH: ret(state.mscratch->read());
     case CSR_MCAUSE: ret(state.mcause);
     case CSR_MTVAL: ret(state.mtval);
     case CSR_MTVAL2:

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -376,6 +376,7 @@ void state_t::reset(processor_t* const proc, reg_t max_isa)
   htval = 0;
   htinst = 0;
   hgatp = 0;
+  nonvirtual_sstatus = sstatus = std::make_shared<sstatus_proxy_csr_t>(proc, CSR_SSTATUS);
   csrmap[CSR_VSSTATUS] = vsstatus = std::make_shared<vsstatus_csr_t>(proc, CSR_VSSTATUS);
   vsatp = 0;
 
@@ -416,7 +417,7 @@ void state_t::reset(processor_t* const proc, reg_t max_isa)
 }
 
 void state_t::dirty_mstatus(reg_t dirties){  // set VS, FS, or XS to Dirty
-  mstatus |= dirties;
+  nonvirtual_sstatus->write(nonvirtual_sstatus->read() | dirties);
   if (v) {
     vsstatus->write(vsstatus->read() | dirties);
   }

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -335,7 +335,7 @@ void state_t::reset(reg_t max_isa)
   mstatus = 0;
   mepc = 0;
   mtval = 0;
-  csrmap[CSR_MSCRATCH] = std::make_shared<basic_csr_t>(0);
+  csrmap[CSR_MSCRATCH] = std::make_shared<basic_csr_t>(CSR_MSCRATCH, 0);
   mtvec = 0;
   mcause = 0;
   minstret = 0;

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -349,6 +349,7 @@ void state_t::reset(processor_t* const proc, reg_t max_isa)
   csrmap[CSR_MIP] = mip = std::make_shared<mip_csr_t>(proc, CSR_MIP);
   csrmap[CSR_SIP] = std::make_shared<sip_csr_t>(proc, CSR_SIP);
   csrmap[CSR_HVIP] = std::make_shared<hvip_csr_t>(proc, CSR_HVIP);
+  csrmap[CSR_HIP] = std::make_shared<hvip_csr_t>(proc, CSR_HIP);
   medeleg = 0;
   mideleg = 0;
   mcounteren = 0;
@@ -1054,11 +1055,6 @@ void processor_t::set_csr(int which, reg_t val)
     case CSR_HTVAL:
       state.htval = val;
       break;
-    case CSR_HIP: {
-      reg_t mask = MIP_VSSIP;
-      state.mip->write_with_mask(mask, val);
-      return;
-    }
     case CSR_HTINST:
       state.htinst = val;
       break;
@@ -1404,7 +1400,6 @@ reg_t processor_t::get_csr(int which, insn_t insn, bool write, bool peek)
     case CSR_HCOUNTEREN: ret(state.hcounteren);
     case CSR_HGEIE: ret(0);
     case CSR_HTVAL: ret(state.htval);
-    case CSR_HIP: ret(state.mip->read() & MIP_HS_MASK);
     case CSR_HTINST: ret(state.htinst);
     case CSR_HGATP: {
       if (!state.v && get_field(state.mstatus->read(), MSTATUS_TVM))

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -338,7 +338,7 @@ void state_t::reset(processor_t* const proc, reg_t max_isa)
   misa = max_isa;
   mstatus = 0;
   csrmap[CSR_MEPC] = mepc = std::make_shared<epc_csr_t>(proc, CSR_MEPC);
-  mtval = 0;
+  csrmap[CSR_MTVAL] = mtval = std::make_shared<basic_csr_t>(proc, CSR_MTVAL, 0);
   csrmap[CSR_MSCRATCH] = std::make_shared<basic_csr_t>(proc, CSR_MSCRATCH, 0);
   mtvec = 0;
   mcause = 0;
@@ -800,7 +800,7 @@ void processor_t::take_trap(trap_t& t, reg_t epc)
     state.pc = (state.mtvec & ~(reg_t)1) + vector;
     state.mepc->write(epc);
     state.mcause = t.cause();
-    state.mtval = t.get_tval();
+    state.mtval->write(t.get_tval());
     state.mtval2 = t.get_tval2();
     state.mtinst = t.get_tinst();
 
@@ -1095,7 +1095,6 @@ void processor_t::set_csr(int which, reg_t val)
       break;
     case CSR_MTVEC: state.mtvec = val & ~(reg_t)2; break;
     case CSR_MCAUSE: state.mcause = val; break;
-    case CSR_MTVAL: state.mtval = val; break;
     case CSR_MTVAL2: state.mtval2 = val; break;
     case CSR_MTINST: state.mtinst = val; break;
     case CSR_MISA: {
@@ -1377,7 +1376,6 @@ void processor_t::set_csr(int which, reg_t val)
     case CSR_STVAL:
     case CSR_MTVEC:
     case CSR_MCAUSE:
-    case CSR_MTVAL:
     case CSR_MISA:
     case CSR_TSELECT:
     case CSR_TDATA1:
@@ -1589,7 +1587,6 @@ reg_t processor_t::get_csr(int which, insn_t insn, bool write, bool peek)
     case CSR_MIP: ret(state.mip);
     case CSR_MIE: ret(state.mie);
     case CSR_MCAUSE: ret(state.mcause);
-    case CSR_MTVAL: ret(state.mtval);
     case CSR_MTVAL2:
       if (supports_extension('H'))
         ret(state.mtval2);

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -378,7 +378,7 @@ void state_t::reset(processor_t* const proc, reg_t max_isa)
   htval = 0;
   htinst = 0;
   hgatp = 0;
-  nonvirtual_sstatus = std::make_shared<sstatus_proxy_csr_t>(proc, CSR_SSTATUS);
+  nonvirtual_sstatus = std::make_shared<sstatus_proxy_csr_t>(proc, CSR_SSTATUS, mstatus);
   csrmap[CSR_VSSTATUS] = vsstatus = std::make_shared<vsstatus_csr_t>(proc, CSR_VSSTATUS);
   csrmap[CSR_SSTATUS] = sstatus = std::make_shared<virtualized_csr_t>(proc, nonvirtual_sstatus, vsstatus);
   vsatp = 0;

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -341,7 +341,7 @@ void state_t::reset(processor_t* const proc, reg_t max_isa)
   csrmap[CSR_MTVAL] = mtval = std::make_shared<basic_csr_t>(proc, CSR_MTVAL, 0);
   csrmap[CSR_MSCRATCH] = std::make_shared<basic_csr_t>(proc, CSR_MSCRATCH, 0);
   csrmap[CSR_MTVEC] = mtvec = std::make_shared<tvec_csr_t>(proc, CSR_MTVEC);
-  mcause = 0;
+  csrmap[CSR_MCAUSE] = mcause = std::make_shared<basic_csr_t>(proc, CSR_MCAUSE, 0);
   minstret = 0;
   mie = 0;
   mip = 0;
@@ -801,7 +801,7 @@ void processor_t::take_trap(trap_t& t, reg_t epc)
     reg_t vector = (state.mtvec->read() & 1) && interrupt ? 4*bit : 0;
     state.pc = (state.mtvec->read() & ~(reg_t)1) + vector;
     state.mepc->write(epc);
-    state.mcause = t.cause();
+    state.mcause->write(t.cause());
     state.mtval->write(t.get_tval());
     state.mtval2 = t.get_tval2();
     state.mtinst = t.get_tinst();
@@ -1083,7 +1083,6 @@ void processor_t::set_csr(int which, reg_t val)
       else
         state.scause = val;
       break;
-    case CSR_MCAUSE: state.mcause = val; break;
     case CSR_MTVAL2: state.mtval2 = val; break;
     case CSR_MTINST: state.mtinst = val; break;
     case CSR_MISA: {
@@ -1359,7 +1358,6 @@ void processor_t::set_csr(int which, reg_t val)
     case CSR_MCOUNTEREN:
     case CSR_SATP:
     case CSR_SCAUSE:
-    case CSR_MCAUSE:
     case CSR_MISA:
     case CSR_TSELECT:
     case CSR_TDATA1:
@@ -1556,7 +1554,6 @@ reg_t processor_t::get_csr(int which, insn_t insn, bool write, bool peek)
       break;
     case CSR_MIP: ret(state.mip);
     case CSR_MIE: ret(state.mie);
-    case CSR_MCAUSE: ret(state.mcause);
     case CSR_MTVAL2:
       if (supports_extension('H'))
         ret(state.mtval2);

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -419,13 +419,6 @@ void state_t::reset(processor_t* const proc, reg_t max_isa)
 #endif
 }
 
-void state_t::dirty_mstatus(reg_t dirties){  // set VS, FS, or XS to Dirty
-  nonvirtual_sstatus->write(nonvirtual_sstatus->read() | dirties);
-  if (v) {
-    vsstatus->write(vsstatus->read() | dirties);
-  }
-}
-
 void processor_t::vectorUnit_t::reset(){
   free(reg_file);
   VLEN = get_vlen();

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -511,7 +511,7 @@ void processor_t::reset()
   state.dcsr.halt = halt_on_reset;
   halt_on_reset = false;
   state.mstatus->write(state.mstatus->read());  // set fixed fields
-  state.vsstatus->write(state.mstatus->read() & SSTATUS_VS_MASK);  // set UXL
+  state.vsstatus->write(state.mstatus->read());  // set UXL
   set_csr(CSR_HSTATUS, state.hstatus);  // set VSXL
   VU.reset();
 

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -643,7 +643,7 @@ void processor_t::take_interrupt(reg_t pending_interrupts)
   if (enabled_interrupts == 0) {
     // HS-ints have higher priority over VS-ints
     deleg = state.mideleg->read() & ~state.hideleg;
-    status = state.nonvirtual_sstatus->read();
+    status = state.sstatus->read();
     hsie = get_field(status, MSTATUS_SIE);
     hs_enabled = state.v || state.prv < PRV_S || (state.prv == PRV_S && hsie);
     enabled_interrupts = pending_interrupts & deleg & -hs_enabled;

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -1100,12 +1100,14 @@ void processor_t::set_csr(int which, reg_t val)
       mask |= 1L << ('H' - 'A');
       mask &= max_isa;
 
+      bool prev_h = state.misa & (1L << ('H' - 'A'));
       state.misa = (val & mask) | (state.misa & ~mask);
+      bool new_h = state.misa & (1L << ('H' - 'A'));
 
       // update the forced bits in MIDELEG and other CSRs
-      if (supports_extension('H'))
+      if (new_h && !prev_h)
         state.mideleg |= MIDELEG_FORCED_MASK;
-      else {
+      if (!new_h && prev_h) {
         state.mideleg &= ~MIDELEG_FORCED_MASK;
         state.medeleg &= ~hypervisor_exceptions;
         state.mstatus &= ~(MSTATUS_GVA | MSTATUS_MPV);

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -203,7 +203,6 @@ struct state_t
   reg_t mstatus;
   reg_t mepc;
   reg_t mtval;
-  csr_t_p mscratch;
   reg_t mtvec;
   reg_t mcause;
   reg_t minstret;

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -196,6 +196,7 @@ struct state_t
   regfile_t<freg_t, NFPR, false> FPR;
 
   // control and status registers
+  std::unordered_map<reg_t, csr_t_p> csrmap;
   reg_t prv;    // TODO: Can this be an enum instead?
   bool v;
   reg_t misa;

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -172,7 +172,7 @@ struct state_t
   reg_t mstatus;
   csr_t_p mepc;
   csr_t_p mtval;
-  reg_t mtvec;
+  csr_t_p mtvec;
   reg_t mcause;
   reg_t minstret;
   reg_t mie;

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -184,7 +184,7 @@ struct state_t
   csr_t_p sepc;
   csr_t_p stval;
   csr_t_p stvec;
-  reg_t satp;
+  virtualized_csr_t_p satp;
   csr_t_p scause;
 
   reg_t mtval2;
@@ -202,7 +202,7 @@ struct state_t
   csr_t_p vsepc;
   csr_t_p vscause;
   csr_t_p vstval;
-  reg_t vsatp;
+  csr_t_p vsatp;
 
   reg_t dpc;
   reg_t dscratch0, dscratch1;
@@ -502,12 +502,12 @@ private:
   void build_opcode_map();
   void register_base_instructions();
   insn_func_t decode_insn(insn_t insn);
-  bool satp_valid(reg_t val) const;
-  reg_t compute_new_satp(reg_t val, reg_t old) const;
 
   // Track repeated executions for processor_t::disasm()
   uint64_t last_pc, last_bits, executions;
 public:
+  bool satp_valid(reg_t val) const;
+  reg_t compute_new_satp(reg_t val, reg_t old) const;
   reg_t n_pmp;
   reg_t lg_pmp_granularity;
   reg_t pmp_tor_mask() { return -(reg_t(1) << (lg_pmp_granularity - PMP_SHIFT)); }

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -189,7 +189,7 @@ struct state_t
 
   reg_t mtval2;
   reg_t mtinst;
-  reg_t hstatus;
+  csr_t_p hstatus;
   reg_t hideleg;
   reg_t hedeleg;
   uint32_t hcounteren;

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -182,7 +182,7 @@ struct state_t
   uint32_t mcounteren;
   uint32_t scounteren;
   csr_t_p sepc;
-  reg_t stval;
+  csr_t_p stval;
   reg_t stvec;
   reg_t satp;
   reg_t scause;
@@ -200,7 +200,7 @@ struct state_t
   reg_t vstvec;
   csr_t_p vsepc;
   reg_t vscause;
-  reg_t vstval;
+  csr_t_p vstval;
   reg_t vsatp;
 
   reg_t dpc;

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -10,10 +10,10 @@
 #include <vector>
 #include <unordered_map>
 #include <map>
-#include <memory>
 #include <cassert>
 #include "debug_rom_defines.h"
 #include "entropy_source.h"
+#include "csrs.h"
 
 using std::ostream;
 using std::stringstream;
@@ -150,44 +150,6 @@ template<>
 struct type_sew_t<64>
 {
   using type=int64_t;
-};
-
-
-// Parent, abstract class for all CSRs
-class csr_t {
- public:
-  csr_t(const reg_t addr): address(addr) {}
-
-  // read() returns the architectural value of this CSR. No permission
-  // checking needed or allowed. Side effects not allowed.
-  virtual reg_t read() const noexcept = 0;
-
-  // write() updates the architectural value of this CSR. No
-  // permission checking needed or allowed.
-  virtual void write(const reg_t val) noexcept = 0;
-
-  virtual ~csr_t() {}
-
- private:
-  const reg_t address;
-};
-
-typedef std::shared_ptr<csr_t> csr_t_p;
-
-// Basic CSRs, with XLEN bits fully readable and writable.
-class basic_csr_t: public csr_t {
- public:
-  basic_csr_t(const reg_t addr, const reg_t init):
-    csr_t(addr),
-    val(init) {}
-  virtual reg_t read() const noexcept override {
-    return val;
-  }
-  virtual void write(const reg_t val) noexcept override {
-    this->val = val;
-  }
- private:
-  reg_t val;
 };
 
 

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -173,7 +173,7 @@ struct state_t
   csr_t_p mepc;
   csr_t_p mtval;
   csr_t_p mtvec;
-  reg_t mcause;
+  csr_t_p mcause;
   reg_t minstret;
   reg_t mie;
   reg_t mip;

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -196,7 +196,7 @@ struct state_t
   reg_t htval;
   reg_t htinst;
   reg_t hgatp;
-  csr_t_p vsstatus;
+  vsstatus_csr_t_p vsstatus;
   csr_t_p vstvec;
   csr_t_p vsepc;
   csr_t_p vscause;

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -309,18 +309,18 @@ public:
   unsigned get_max_xlen() { return max_xlen; }
   std::string get_isa_string() { return isa_string; }
   unsigned get_flen() {
-    return supports_extension('Q') ? 128 :
-           supports_extension('D') ? 64 :
-           supports_extension('F') ? 32 : 0;
+    return extension_enabled('Q') ? 128 :
+           extension_enabled('D') ? 64 :
+           extension_enabled('F') ? 32 : 0;
   }
   extension_t* get_extension();
   extension_t* get_extension(const char* name);
   bool any_custom_extensions() const {
     return !custom_extensions.empty();
   }
-  bool supports_extension(unsigned char ext) {
+  bool extension_enabled(unsigned char ext) const {
     if (ext >= 'A' && ext <= 'Z')
-      return state.misa->supports_extension(ext);
+      return state.misa->extension_enabled(ext);
     else
       return extension_table[ext];
   }
@@ -329,7 +329,7 @@ public:
     return impl_table[impl];
   }
   reg_t pc_alignment_mask() {
-    return ~(reg_t)(supports_extension('C') ? 0 : 2);
+    return ~(reg_t)(extension_enabled('C') ? 0 : 2);
   }
   void check_pc_alignment(reg_t pc) {
     if (unlikely(pc & ~pc_alignment_mask()))

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -175,7 +175,7 @@ struct state_t
   csr_t_p mtvec;
   csr_t_p mcause;
   reg_t minstret;
-  reg_t mie;
+  mip_or_mie_csr_t_p mie;
   mip_or_mie_csr_t_p mip;
   reg_t medeleg;
   reg_t mideleg;
@@ -483,7 +483,7 @@ private:
   static const size_t OPCODE_CACHE_SIZE = 8191;
   insn_desc_t opcode_cache[OPCODE_CACHE_SIZE];
 
-  void take_pending_interrupt() { take_interrupt(state.mip->read() & state.mie); }
+  void take_pending_interrupt() { take_interrupt(state.mip->read() & state.mie->read()); }
   void take_interrupt(reg_t mask); // take first enabled interrupt in mask
   void take_trap(trap_t& t, reg_t epc); // take an exception
   void disasm(insn_t insn); // disassemble and print an instruction

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -179,7 +179,7 @@ struct state_t
   mip_csr_t_p mip;
   csr_t_p medeleg;
   csr_t_p mideleg;
-  uint32_t mcounteren;
+  csr_t_p mcounteren;
   uint32_t scounteren;
   csr_t_p sepc;
   csr_t_p stval;

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -10,6 +10,7 @@
 #include <vector>
 #include <unordered_map>
 #include <map>
+#include <memory>
 #include <cassert>
 #include "debug_rom_defines.h"
 #include "entropy_source.h"
@@ -151,6 +152,38 @@ struct type_sew_t<64>
   using type=int64_t;
 };
 
+
+// Parent, abstract class for all CSRs
+class csr_t {
+ public:
+  // read() returns the architectural value of this CSR. No permission
+  // checking needed or allowed. Side effects not allowed.
+  virtual reg_t read() const noexcept = 0;
+
+  // write() updates the architectural value of this CSR. No
+  // permission checking needed or allowed.
+  virtual void write(const reg_t val) noexcept = 0;
+
+  virtual ~csr_t() {}
+};
+
+typedef std::shared_ptr<csr_t> csr_t_p;
+
+// Basic CSRs, with XLEN bits fully readable and writable.
+class basic_csr_t: public csr_t {
+ public:
+  basic_csr_t(const reg_t init): val(init) {}
+  virtual reg_t read() const noexcept override {
+    return val;
+  }
+  virtual void write(const reg_t val) noexcept override {
+    this->val = val;
+  }
+ private:
+  reg_t val;
+};
+
+
 // architectural state of a RISC-V hart
 struct state_t
 {
@@ -169,7 +202,7 @@ struct state_t
   reg_t mstatus;
   reg_t mepc;
   reg_t mtval;
-  reg_t mscratch;
+  csr_t_p mscratch;
   reg_t mtvec;
   reg_t mcause;
   reg_t minstret;

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -181,7 +181,7 @@ struct state_t
   reg_t mideleg;
   uint32_t mcounteren;
   uint32_t scounteren;
-  reg_t sepc;
+  csr_t_p sepc;
   reg_t stval;
   reg_t stvec;
   reg_t satp;
@@ -198,7 +198,7 @@ struct state_t
   reg_t hgatp;
   reg_t vsstatus;
   reg_t vstvec;
-  reg_t vsepc;
+  csr_t_p vsepc;
   reg_t vscause;
   reg_t vstval;
   reg_t vsatp;

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -156,7 +156,7 @@ struct type_sew_t<64>
 // architectural state of a RISC-V hart
 struct state_t
 {
-  void reset(reg_t max_isa);
+  void reset(processor_t* const proc, reg_t max_isa);
 
   static const int num_triggers = 4;
 

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -183,7 +183,7 @@ struct state_t
   uint32_t scounteren;
   csr_t_p sepc;
   csr_t_p stval;
-  reg_t stvec;
+  csr_t_p stvec;
   reg_t satp;
   reg_t scause;
 
@@ -197,7 +197,7 @@ struct state_t
   reg_t htinst;
   reg_t hgatp;
   reg_t vsstatus;
-  reg_t vstvec;
+  csr_t_p vstvec;
   csr_t_p vsepc;
   reg_t vscause;
   csr_t_p vstval;

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -196,7 +196,7 @@ struct state_t
   reg_t htval;
   reg_t htinst;
   reg_t hgatp;
-  reg_t vsstatus;
+  csr_t_p vsstatus;
   csr_t_p vstvec;
   csr_t_p vsepc;
   csr_t_p vscause;

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -196,7 +196,6 @@ struct state_t
   reg_t htval;
   reg_t htinst;
   reg_t hgatp;
-  csr_t_p nonvirtual_sstatus;
   sstatus_csr_t_p sstatus;
   vsstatus_csr_t_p vsstatus;
   csr_t_p vstvec;

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -300,6 +300,12 @@ public:
   mmu_t* get_mmu() { return mmu; }
   state_t* get_state() { return &state; }
   unsigned get_xlen() { return xlen; }
+  unsigned get_const_xlen() {
+    // Any code that assumes a const xlen should use this method to
+    // document that assumption. If Spike ever changes to allow
+    // variable xlen, this method should be removed.
+    return xlen;
+  }
   unsigned get_max_xlen() { return max_xlen; }
   std::string get_isa_string() { return isa_string; }
   unsigned get_flen() {

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -197,7 +197,7 @@ struct state_t
   reg_t htinst;
   reg_t hgatp;
   csr_t_p nonvirtual_sstatus;
-  csr_t_p sstatus;
+  virtualized_csr_t_p sstatus;
   vsstatus_csr_t_p vsstatus;
   csr_t_p vstvec;
   csr_t_p vsepc;

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -309,6 +309,9 @@ public:
   }
   extension_t* get_extension();
   extension_t* get_extension(const char* name);
+  bool any_custom_extensions() const {
+    return !custom_extensions.empty();
+  }
   bool supports_extension(unsigned char ext) {
     if (ext >= 'A' && ext <= 'Z')
       return ((state.misa >> (ext - 'A')) & 1);

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -506,8 +506,6 @@ private:
   // Track repeated executions for processor_t::disasm()
   uint64_t last_pc, last_bits, executions;
 public:
-  bool satp_valid(reg_t val) const;
-  reg_t compute_new_satp(reg_t val, reg_t old) const;
   reg_t n_pmp;
   reg_t lg_pmp_granularity;
   reg_t pmp_tor_mask() { return -(reg_t(1) << (lg_pmp_granularity - PMP_SHIFT)); }

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -178,7 +178,7 @@ struct state_t
   mip_or_mie_csr_t_p mie;
   mip_or_mie_csr_t_p mip;
   reg_t medeleg;
-  reg_t mideleg;
+  csr_t_p mideleg;
   uint32_t mcounteren;
   uint32_t scounteren;
   csr_t_p sepc;

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -175,8 +175,8 @@ struct state_t
   csr_t_p mtvec;
   csr_t_p mcause;
   reg_t minstret;
-  mip_or_mie_csr_t_p mie;
-  mip_or_mie_csr_t_p mip;
+  mie_csr_t_p mie;
+  mip_csr_t_p mip;
   csr_t_p medeleg;
   csr_t_p mideleg;
   uint32_t mcounteren;

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -180,7 +180,7 @@ struct state_t
   csr_t_p medeleg;
   csr_t_p mideleg;
   csr_t_p mcounteren;
-  uint32_t scounteren;
+  csr_t_p scounteren;
   csr_t_p sepc;
   csr_t_p stval;
   csr_t_p stvec;

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -176,7 +176,7 @@ struct state_t
   csr_t_p mcause;
   reg_t minstret;
   reg_t mie;
-  reg_t mip;
+  mip_csr_t_p mip;
   reg_t medeleg;
   reg_t mideleg;
   uint32_t mcounteren;
@@ -485,7 +485,7 @@ private:
   static const size_t OPCODE_CACHE_SIZE = 8191;
   insn_desc_t opcode_cache[OPCODE_CACHE_SIZE];
 
-  void take_pending_interrupt() { take_interrupt(state.mip & state.mie); }
+  void take_pending_interrupt() { take_interrupt(state.mip->read() & state.mie); }
   void take_interrupt(reg_t mask); // take first enabled interrupt in mask
   void take_trap(trap_t& t, reg_t epc); // take an exception
   void disasm(insn_t insn); // disassemble and print an instruction

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -203,6 +203,8 @@ struct state_t
   csr_t_p vstval;
   reg_t vsatp;
 
+  void dirty_mstatus(reg_t dirties);  // set VS, FS, or XS to Dirty
+
   reg_t dpc;
   reg_t dscratch0, dscratch1;
   dcsr_t dcsr;

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -170,7 +170,7 @@ struct state_t
   bool v;
   reg_t misa;
   reg_t mstatus;
-  reg_t mepc;
+  csr_t_p mepc;
   reg_t mtval;
   reg_t mtvec;
   reg_t mcause;

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -168,7 +168,7 @@ struct state_t
   std::unordered_map<reg_t, csr_t_p> csrmap;
   reg_t prv;    // TODO: Can this be an enum instead?
   bool v;
-  reg_t misa;
+  misa_csr_t_p misa;
   mstatus_csr_t_p mstatus;
   csr_t_p mepc;
   csr_t_p mtval;
@@ -320,7 +320,7 @@ public:
   }
   bool supports_extension(unsigned char ext) {
     if (ext >= 'A' && ext <= 'Z')
-      return ((state.misa >> (ext - 'A')) & 1);
+      return state.misa->supports_extension(ext);
     else
       return extension_table[ext];
   }

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -156,6 +156,8 @@ struct type_sew_t<64>
 // Parent, abstract class for all CSRs
 class csr_t {
  public:
+  csr_t(const reg_t addr): address(addr) {}
+
   // read() returns the architectural value of this CSR. No permission
   // checking needed or allowed. Side effects not allowed.
   virtual reg_t read() const noexcept = 0;
@@ -165,6 +167,9 @@ class csr_t {
   virtual void write(const reg_t val) noexcept = 0;
 
   virtual ~csr_t() {}
+
+ private:
+  const reg_t address;
 };
 
 typedef std::shared_ptr<csr_t> csr_t_p;
@@ -172,7 +177,9 @@ typedef std::shared_ptr<csr_t> csr_t_p;
 // Basic CSRs, with XLEN bits fully readable and writable.
 class basic_csr_t: public csr_t {
  public:
-  basic_csr_t(const reg_t init): val(init) {}
+  basic_csr_t(const reg_t addr, const reg_t init):
+    csr_t(addr),
+    val(init) {}
   virtual reg_t read() const noexcept override {
     return val;
   }

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -214,7 +214,6 @@ struct state_t
   bool debug_mode;
 
   static const int max_pmp = 16;
-  uint8_t pmpcfg[max_pmp];
   pmpaddr_csr_t_p pmpaddr[max_pmp];
 
   uint32_t fflags;

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -171,7 +171,7 @@ struct state_t
   reg_t misa;
   reg_t mstatus;
   csr_t_p mepc;
-  reg_t mtval;
+  csr_t_p mtval;
   reg_t mtvec;
   reg_t mcause;
   reg_t minstret;

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -192,7 +192,7 @@ struct state_t
   csr_t_p hstatus;
   reg_t hideleg;
   reg_t hedeleg;
-  uint32_t hcounteren;
+  csr_t_p hcounteren;
   reg_t htval;
   reg_t htinst;
   reg_t hgatp;

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -197,15 +197,13 @@ struct state_t
   reg_t htinst;
   reg_t hgatp;
   csr_t_p nonvirtual_sstatus;
-  virtualized_csr_t_p sstatus;
+  sstatus_csr_t_p sstatus;
   vsstatus_csr_t_p vsstatus;
   csr_t_p vstvec;
   csr_t_p vsepc;
   csr_t_p vscause;
   csr_t_p vstval;
   reg_t vsatp;
-
-  void dirty_mstatus(reg_t dirties);  // set VS, FS, or XS to Dirty
 
   reg_t dpc;
   reg_t dscratch0, dscratch1;

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -196,6 +196,8 @@ struct state_t
   reg_t htval;
   reg_t htinst;
   reg_t hgatp;
+  csr_t_p nonvirtual_sstatus;
+  csr_t_p sstatus;
   vsstatus_csr_t_p vsstatus;
   csr_t_p vstvec;
   csr_t_p vsepc;

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -177,7 +177,7 @@ struct state_t
   reg_t minstret;
   mip_or_mie_csr_t_p mie;
   mip_or_mie_csr_t_p mip;
-  reg_t medeleg;
+  csr_t_p medeleg;
   csr_t_p mideleg;
   uint32_t mcounteren;
   uint32_t scounteren;

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -324,6 +324,15 @@ public:
     else
       return extension_table[ext];
   }
+  // Is this extension enabled? and abort if this extension can
+  // possibly be disabled dynamically. Useful for documenting
+  // assumptions about writable misa bits.
+  bool extension_enabled_const(unsigned char ext) const {
+    if (ext >= 'A' && ext <= 'Z')
+      return state.misa->extension_enabled_const(ext);
+    else
+      return extension_table[ext];  // assume this can't change
+  }
   void set_impl(uint8_t impl, bool val) { impl_table[impl] = val; }
   bool supports_impl(uint8_t impl) const {
     return impl_table[impl];

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -215,7 +215,7 @@ struct state_t
 
   static const int max_pmp = 16;
   uint8_t pmpcfg[max_pmp];
-  reg_t pmpaddr[max_pmp];
+  pmpaddr_csr_t_p pmpaddr[max_pmp];
 
   uint32_t fflags;
   uint32_t frm;
@@ -472,8 +472,6 @@ private:
   void disasm(insn_t insn); // disassemble and print an instruction
   int paddr_bits();
 
-  reg_t pmp_tor_mask() { return -(reg_t(1) << (lg_pmp_granularity - PMP_SHIFT)); }
-
   void enter_debug_mode(uint8_t cause);
 
   void debug_output_log(stringstream *s); // either output to interactive user or write to log file
@@ -493,10 +491,11 @@ private:
 
   // Track repeated executions for processor_t::disasm()
   uint64_t last_pc, last_bits, executions;
+public:
   reg_t n_pmp;
   reg_t lg_pmp_granularity;
+  reg_t pmp_tor_mask() { return -(reg_t(1) << (lg_pmp_granularity - PMP_SHIFT)); }
 
-public:
   class vectorUnit_t {
     public:
       processor_t* p;

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -169,7 +169,7 @@ struct state_t
   reg_t prv;    // TODO: Can this be an enum instead?
   bool v;
   reg_t misa;
-  reg_t mstatus;
+  mstatus_csr_t_p mstatus;
   csr_t_p mepc;
   csr_t_p mtval;
   csr_t_p mtvec;

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -176,7 +176,7 @@ struct state_t
   csr_t_p mcause;
   reg_t minstret;
   reg_t mie;
-  mip_csr_t_p mip;
+  mip_or_mie_csr_t_p mip;
   reg_t medeleg;
   reg_t mideleg;
   uint32_t mcounteren;

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -185,7 +185,7 @@ struct state_t
   csr_t_p stval;
   csr_t_p stvec;
   reg_t satp;
-  reg_t scause;
+  csr_t_p scause;
 
   reg_t mtval2;
   reg_t mtinst;
@@ -199,7 +199,7 @@ struct state_t
   reg_t vsstatus;
   csr_t_p vstvec;
   csr_t_p vsepc;
-  reg_t vscause;
+  csr_t_p vscause;
   csr_t_p vstval;
   reg_t vsatp;
 

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -183,7 +183,6 @@ struct state_t
   uint32_t scounteren;
   reg_t sepc;
   reg_t stval;
-  reg_t sscratch;
   reg_t stvec;
   reg_t satp;
   reg_t scause;
@@ -199,7 +198,6 @@ struct state_t
   reg_t hgatp;
   reg_t vsstatus;
   reg_t vstvec;
-  reg_t vsscratch;
   reg_t vsepc;
   reg_t vscause;
   reg_t vstval;

--- a/riscv/riscv.mk.in
+++ b/riscv/riscv.mk.in
@@ -57,6 +57,7 @@ riscv_srcs = \
 	debug_module.cc \
 	remote_bitbang.cc \
 	jtag_dtm.cc \
+	csrs.cc \
 	$(riscv_gen_srcs) \
 
 riscv_test_srcs =

--- a/riscv/riscv.mk.in
+++ b/riscv/riscv.mk.in
@@ -31,6 +31,7 @@ riscv_hdrs = \
 	debug_rom_defines.h \
 	remote_bitbang.h \
 	jtag_dtm.h \
+	csrs.h \
 
 riscv_install_hdrs = mmio_plugin.h
 


### PR DESCRIPTION
This is a work-in-progress proposal to convert Spike's CSR modeling, to switch from using simple scalar variables to objects.

# What?

Every CSR will be an instance of a [`csr_t` object](https://github.com/scottj97/riscv-isa-sim/blob/370facfab00e556982bc48c5239169f259adba29/riscv/csrs.h#L16-L41), and all reads and writes go through this interface:
```
class csr_t {
 public:
  virtual void verify_permissions(insn_t insn, bool write) const;
  virtual reg_t read() const noexcept = 0;
  virtual void write(const reg_t val) noexcept = 0;
};
```

Class `state_t` then has [`unordered_map<reg_t, csr_t*> csrmap`](https://github.com/scottj97/riscv-isa-sim/blob/370facfab00e556982bc48c5239169f259adba29/riscv/processor.h#L168) which maps each CSR by its address to its implementation. With this, [`get_csr()`](https://github.com/scottj97/riscv-isa-sim/blob/370facfab00e556982bc48c5239169f259adba29/riscv/processor.cc#L1158-L1163) becomes as simple as:
```
reg_t processor_t::get_csr(int which, insn_t insn, bool write, bool peek) {
  auto search = state.csrmap.find(which);
  if (search != state.csrmap.end()) {
    if (!peek)
      search->second->verify_permissions(insn, write);
    return search->second->read();
  }
  throw trap_illegal_instruction(insn.bits());
}
```
And [`set_csr()`](https://github.com/scottj97/riscv-isa-sim/blob/370facfab00e556982bc48c5239169f259adba29/riscv/processor.cc#L920-L924) is even simpler.

# Why?

## Robustness
* Simplifies the hypervisor virtualization of CSRs such as `sscratch`: the [`virtualized_csr_t` class](https://github.com/scottj97/riscv-isa-sim/blob/370facfab00e556982bc48c5239169f259adba29/riscv/csrs.h#L124-L144) will access either the original (_e.g._ `sscratch`) or the virtualized CSR (_e.g._ `vsscratch`) according to the current privilege mode.
* Removes the confusing [swapping](https://github.com/riscv/riscv-isa-sim/blob/5a36103e41ea43e8ba0505d78bda9a9dcc990e7c/riscv/processor.cc#L677-L679) of `state.mstatus` and `state.vsstatus` when in VS- or VU-mode (and which led to [#792](https://github.com/riscv/riscv-isa-sim/pull/792)) (see [plan](https://github.com/scottj97/riscv-isa-sim/blob/3f0df2352c7f34594cdfd5748d654f1bc3cf4c2e/riscv/csrs.h#L191-L213) and the many commits that follow to implement that plan)
* Centralizes [CSR logging](https://github.com/scottj97/riscv-isa-sim/blob/370facfab00e556982bc48c5239169f259adba29/riscv/csrs.cc#L55-L59), which today is mostly in this [duplicate switch statement](https://github.com/riscv/riscv-isa-sim/blob/20efc8288159e437928c249fcea41e77d2b254e4/riscv/processor.cc#L1353-L1435) and has been a source of [bugs](https://github.com/riscv/riscv-isa-sim/pull/639) when it gets out of sync from the actual CSR writes.
* Describes each CSR's behavior in one place
* Simplifies platform customization (which is ~50% CSR changes)
* Simplifies configurability -- optional CSRs are either created or not during init
* Side benefit: [`get_const_xlen()`](https://github.com/scottj97/riscv-isa-sim/commit/b2f58c8da07d37be5f0f89704a5e866392349a43) documents places in the code where XLEN is assumed to be constant throughout the simulation; if Spike ever grows to support variable XLEN, it will be easy to spot the places that need work
* Side benefit: [`extension_enabled_const()`](https://github.com/scottj97/riscv-isa-sim/commit/625b4a619506c7db6e7762699dd6314b5fcf8587) documents places in the code where a given `misa` extension is assumed to be constant throughout the simulation; if the requested bit is ever modified to become writable, it will be easy to spot the places that need work

## Bug fixes

* Fixes logging of hypervisor virtualized CSRs: writing _e.g._ `sscratch` from VS-mode will now correctly log that `vsscratch` was written, not `sscratch` as before
* `vsstatus` now has an [XS field](https://github.com/scottj97/riscv-isa-sim/commit/f79e0bd3615f73b3b67bbf8d2446613df38afda3) when appropriate
* `csrw` to `hie` or `vsie` will now properly log changes to `mie`, which were previously missing
* `csrw` to `hip`, `hvip`, and `vsip` will now properly log changes to `mip`, which were previously missing
* `mstatus.FS` will always [be writable](https://github.com/scottj97/riscv-isa-sim/commit/a5d14803f3dbc468554fec5970784f15f70ef790) even after `misa.F=0`; see [riscv-isa-manual#707](https://github.com/riscv/riscv-isa-manual/pull/707)
* FPU ops that write `mstatus.FS` to Dirty will now be properly logged

## Code cleanup

* Get rid of this 400+ line [switch statement](https://github.com/riscv/riscv-isa-sim/blob/20efc8288159e437928c249fcea41e77d2b254e4/riscv/processor.cc#L941-L1351) in `set_csr()`
* Get rid of this 300 line [switch statement](https://github.com/riscv/riscv-isa-sim/blob/20efc8288159e437928c249fcea41e77d2b254e4/riscv/processor.cc#L1495-L1782) in `get_csr()`
* Move functionality into localized classes instead of in the `processor_t` God object. Examples:
  * pmpaddr: compare the [original `pmp_ok()` and `pmp_homogenous()`](https://github.com/scottj97/riscv-isa-sim/blob/ea5d76121bef5e3d54bbaba21cce75d0299c461e/riscv/mmu.cc#L218-L303) with the [new implementation](https://github.com/scottj97/riscv-isa-sim/blob/370facfab00e556982bc48c5239169f259adba29/riscv/mmu.cc#L218-L259)
  * satp: moved these [methods specific to `satp`](https://github.com/scottj97/riscv-isa-sim/blob/370facfab00e556982bc48c5239169f259adba29/riscv/csrs.cc#L744-L770) (and `vsatp`) out of the global `processor_t`
  * `mip` and `mie`: all of the myriad CSRs that manipulate these two underlying registers are now expressed [relatively succinctly](https://github.com/scottj97/riscv-isa-sim/blob/370facfab00e556982bc48c5239169f259adba29/riscv/processor.cc#L356-L386)

## Drawbacks
* Quite a bit of boilerplate required for many CSRs
* Incremental recompile is slow whenever `csrs.h` changes
* Performance: informal (and inadequate) benchmarking shows approx 10% slowdown; though if `-l --log-commits` is used, there is practically no difference

# Current status

Only about half of the CSRs are converted. The remaining ones still use the old system.

# Next steps

There are many more CSRs yet to be converted. If the general approach is agreeable, I would rather not wait to merge before all are converted -- merge conflicts have been numerous and cumbersome since I first started this project. For example #788 is going to be a mess, even though I haven't yet converted the performance counters to this system.

I believe this PR is production-ready. I humbly await your review.