### PR TITLE
add option --log=<name> to command line help

### DIFF
--- a/spike_main/spike.cc
+++ b/spike_main/spike.cc
@@ -34,6 +34,7 @@ static void help(int exit_code = 1)
 #endif
   fprintf(stderr, "  -h, --help            Print this help message\n");
   fprintf(stderr, "  -H                    Start halted, allowing a debugger to connect\n");
+  fprintf(stderr, "  --log=<name>          File name for option -l\n");
   fprintf(stderr, "  --isa=<name>          RISC-V ISA string [default %s]\n", DEFAULT_ISA);
   fprintf(stderr, "  --priv=<m|mu|msu>     RISC-V privilege modes supported [default %s]\n", DEFAULT_PRIV);
   fprintf(stderr, "  --varch=<name>        RISC-V Vector uArch string [default %s]\n", DEFAULT_VARCH);


### PR DESCRIPTION
This PR adds the option `--log=<name>` to the spike command line help listing.

The option `--log` had been implemented in March 2020 but had not been included in the listing of options which is provided by spike command line help.

As far as I can see, the same effect as `--log=<name>` can be achieved by adding `2><name>` to the spike command line. So, alternatively to this PR, another PR could be proposed to remove the implementation of the `--log` option. This would have the benefit of eliminating the function `processor_t::debug_output_log` and simplifying the functions `processor_t::take_trap` and `processor_t::disasm`.
However, any script out there using `--log` would become broken.

This PR was originally included in PR #700, but has been removed from that PR because it was not related to it.