### PR TITLE
Fix segfault when executing 'csrw pmpaddr15' when n_pmp==16

### DIFF
--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -116,7 +116,7 @@ bool pmpaddr_csr_t::unlogged_write(const reg_t val) noexcept {
 }
 
 bool pmpaddr_csr_t::next_locked_and_tor() const noexcept {
-  if (pmpidx >= state->max_pmp) return false;  // this is the last entry
+  if (pmpidx+1 >= state->max_pmp) return false;  // this is the last entry
   bool next_locked = state->pmpaddr[pmpidx+1]->cfg & PMP_L;
   bool next_tor = (state->pmpaddr[pmpidx+1]->cfg & PMP_A) == PMP_TOR;
   return next_locked && next_tor;


### PR DESCRIPTION
Off-by-one error introduced in 69008075a1f3f9d7ed6fec3489c50e5d7701d366