### PR TITLE
Patch for Torture Signature Generation Bug

### DIFF
--- a/fesvr/htif.cc
+++ b/fesvr/htif.cc
@@ -52,6 +52,8 @@ htif_t::htif_t()
 
 htif_t::htif_t(int argc, char** argv) : htif_t()
 {
+  //Set line size as 16 by default.
+  line_size = 16;
   parse_arguments(argc, argv);
   register_devices();
 }


### PR DESCRIPTION
Hi! I am the student at UC Berkeley's ADEPT lab that created the multi-extension support PR last time. I am now using torture to test the RTL code of a new RISC-V core, and I discovered a bug in the fesvr module in this repo that will cause simulator to generate the incorrect torture signature. 

Here is the bug: when `htif_t` object is created with the `argc` and `argv` constructor, the `line_size` variable is not initialized, and if we do not pass in `+signature-granularity` option, the length of a signature line will be undefined. This doesn't match the behavior of the constructor that takes a vector argument.

The current version of Spike doesn't trigger this bug, but when it is used to compile RTL testbench (as we do in ucb-bar/chipyard), this bug will corrupt the generated signature and cause torture to fail. 

Please let me know if you have any question. Thanks!