### PR TITLE
Convert remaining hypervisor CSRs to csr_t

### DIFF
--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -725,16 +725,6 @@ bool masked_csr_t::unlogged_write(const reg_t val) noexcept {
 }
 
 
-// implement class counteren_csr_t
-counteren_csr_t::counteren_csr_t(processor_t* const proc, const reg_t addr):
-  basic_csr_t(proc, addr, 0) {
-}
-
-bool counteren_csr_t::unlogged_write(const reg_t val) noexcept {
-  return basic_csr_t::unlogged_write(val & 0xffffffffULL);
-}
-
-
 // implement class base_atp_csr_t and family
 base_atp_csr_t::base_atp_csr_t(processor_t* const proc, const reg_t addr):
   basic_csr_t(proc, addr, 0) {

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -612,7 +612,7 @@ void generic_int_accessor_t::ie_write(const reg_t val) noexcept {
 }
 
 reg_t generic_int_accessor_t::deleg_mask() const {
-  const reg_t hideleg_mask = mask_hideleg ? state->hideleg : (reg_t)~0;
+  const reg_t hideleg_mask = mask_hideleg ? state->hideleg->read() : (reg_t)~0;
   const reg_t mideleg_mask = mask_mideleg ? state->mideleg->read() : (reg_t)~0;
   return hideleg_mask & mideleg_mask;
 }

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -920,3 +920,14 @@ void counter_proxy_csr_t::verify_permissions(insn_t insn, bool write) const {
       throw trap_illegal_instruction(insn.bits());
   }
 }
+
+
+hypervisor_csr_t::hypervisor_csr_t(processor_t* const proc, const reg_t addr):
+  basic_csr_t(proc, addr, 0) {
+}
+
+void hypervisor_csr_t::verify_permissions(insn_t insn, bool write) const {
+  basic_csr_t::verify_permissions(insn, write);
+  if (!proc->extension_enabled('H'))
+    throw trap_illegal_instruction(insn.bits());
+}

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -710,15 +710,13 @@ bool medeleg_csr_t::unlogged_write(const reg_t val) noexcept {
 }
 
 
-// implement class hstatus_csr_t
-hstatus_csr_t::hstatus_csr_t(processor_t* const proc, const reg_t addr):
-  basic_csr_t(proc, addr, set_field((reg_t)0, HSTATUS_VSXL, xlen_to_uxl(proc->get_const_xlen()))) {
+// implement class masked_csr_t
+masked_csr_t::masked_csr_t(processor_t* const proc, const reg_t addr, const reg_t mask, const reg_t init):
+  basic_csr_t(proc, addr, init),
+  mask(mask) {
 }
 
-bool hstatus_csr_t::unlogged_write(const reg_t val) noexcept {
-  const reg_t mask = HSTATUS_VTSR | HSTATUS_VTW
-    | (proc->supports_impl(IMPL_MMU) ? HSTATUS_VTVM : 0)
-    | HSTATUS_HU | HSTATUS_SPVP | HSTATUS_SPV | HSTATUS_GVA;
+bool masked_csr_t::unlogged_write(const reg_t val) noexcept {
   return basic_csr_t::unlogged_write((read() & ~mask) | (val & mask));
 }
 

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -488,4 +488,12 @@ class counter_proxy_csr_t: public proxy_csr_t {
   bool myenable(csr_t_p counteren) const noexcept;
 };
 
+
+// For machine-level CSRs that only exist with Hypervisor
+class hypervisor_csr_t: public basic_csr_t {
+ public:
+  hypervisor_csr_t(processor_t* const proc, const reg_t addr);
+  virtual void verify_permissions(insn_t insn, bool write) const override;
+};
+
 #endif

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -384,15 +384,6 @@ class masked_csr_t: public basic_csr_t {
 };
 
 
-// Used for mcounteren, scounteren, hcounteren
-class counteren_csr_t: public basic_csr_t {
- public:
-  counteren_csr_t(processor_t* const proc, const reg_t addr);
- protected:
-  virtual bool unlogged_write(const reg_t val) noexcept override;
-};
-
-
 // For satp and vsatp
 // These are three classes in order to handle the [V]TVM bits permission checks
 class base_atp_csr_t: public basic_csr_t {

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -499,4 +499,14 @@ class hypervisor_csr_t: public basic_csr_t {
   virtual void verify_permissions(insn_t insn, bool write) const override;
 };
 
+
+class hgatp_csr_t: public basic_csr_t {
+ public:
+  hgatp_csr_t(processor_t* const proc, const reg_t addr);
+  virtual void verify_permissions(insn_t insn, bool write) const override;
+ protected:
+  virtual bool unlogged_write(const reg_t val) noexcept override;
+};
+
+
 #endif

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -373,11 +373,14 @@ class medeleg_csr_t: public basic_csr_t {
 };
 
 
-class hstatus_csr_t: public basic_csr_t {
+// For CSRs with certain bits hardwired
+class masked_csr_t: public basic_csr_t {
  public:
-  hstatus_csr_t(processor_t* const proc, const reg_t addr);
+  masked_csr_t(processor_t* const proc, const reg_t addr, const reg_t mask, const reg_t init);
  protected:
   virtual bool unlogged_write(const reg_t val) noexcept override;
+ private:
+  const reg_t mask;
 };
 
 

--- a/riscv/mmu.cc
+++ b/riscv/mmu.cc
@@ -263,7 +263,7 @@ reg_t mmu_t::s2xlate(reg_t gva, reg_t gpa, access_type type, access_type trap_ty
   if (!virt)
     return gpa;
 
-  vm_info vm = decode_vm_info(proc->get_const_xlen(), true, 0, proc->get_state()->hgatp);
+  vm_info vm = decode_vm_info(proc->get_const_xlen(), true, 0, proc->get_state()->hgatp->read());
   if (vm.levels == 0)
     return gpa;
 

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -471,6 +471,7 @@ void state_t::reset(processor_t* const proc, reg_t max_isa)
     | HSTATUS_HU | HSTATUS_SPVP | HSTATUS_SPV | HSTATUS_GVA;
   csrmap[CSR_HSTATUS] = hstatus = std::make_shared<masked_csr_t>(proc, CSR_HSTATUS, hstatus_mask, hstatus_init);
   csrmap[CSR_HGEIE] = std::make_shared<const_csr_t>(proc, CSR_HGEIE, 0);
+  csrmap[CSR_HGEIP] = std::make_shared<const_csr_t>(proc, CSR_HGEIP, 0);
   csrmap[CSR_HIDELEG] = hideleg = std::make_shared<masked_csr_t>(proc, CSR_HIDELEG, MIP_VS_MASK, 0);
   const reg_t hedeleg_mask =
     (1 << CAUSE_MISALIGNED_FETCH) |
@@ -1190,7 +1191,6 @@ reg_t processor_t::get_csr(int which, insn_t insn, bool write, bool peek)
         require_privilege(PRV_M);
       ret(state.hgatp);
     }
-    case CSR_HGEIP: ret(0);
     case CSR_TSELECT: ret(state.tselect);
     case CSR_TDATA1:
       if (state.tselect < state.num_triggers) {

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -457,6 +457,7 @@ void state_t::reset(processor_t* const proc, reg_t max_isa)
   csrmap[CSR_MTVAL2] = mtval2 = std::make_shared<hypervisor_csr_t>(proc, CSR_MTVAL2);
   csrmap[CSR_MTINST] = mtinst = std::make_shared<hypervisor_csr_t>(proc, CSR_MTINST);
   csrmap[CSR_HSTATUS] = hstatus = std::make_shared<hstatus_csr_t>(proc, CSR_HSTATUS);
+  csrmap[CSR_HGEIE] = std::make_shared<const_csr_t>(proc, CSR_HGEIE, 0);
   hideleg = 0;
   hedeleg = 0;
   csrmap[CSR_HCOUNTEREN] = hcounteren = std::make_shared<counteren_csr_t>(proc, CSR_HCOUNTEREN);
@@ -1001,9 +1002,6 @@ void processor_t::set_csr(int which, reg_t val)
       state.hideleg = (state.hideleg & ~mask) | (val & mask);
       break;
     }
-    case CSR_HGEIE:
-      /* Ignore */
-      break;
     case CSR_HTVAL:
       state.htval = val;
       break;
@@ -1200,7 +1198,6 @@ reg_t processor_t::get_csr(int which, insn_t insn, bool write, bool peek)
     case CSR_MHARTID: ret(id);
     case CSR_HEDELEG: ret(state.hedeleg);
     case CSR_HIDELEG: ret(state.hideleg);
-    case CSR_HGEIE: ret(0);
     case CSR_HTVAL: ret(state.htval);
     case CSR_HTINST: ret(state.htinst);
     case CSR_HGATP: {

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -440,9 +440,10 @@ void state_t::reset(processor_t* const proc, reg_t max_isa)
 
   csrmap[CSR_MEDELEG] = medeleg = std::make_shared<medeleg_csr_t>(proc, CSR_MEDELEG);
   csrmap[CSR_MIDELEG] = mideleg = std::make_shared<mideleg_csr_t>(proc, CSR_MIDELEG);
-  mcounteren = std::make_shared<counteren_csr_t>(proc, CSR_MCOUNTEREN);
+  const reg_t counteren_mask = 0xffffffffULL;
+  mcounteren = std::make_shared<masked_csr_t>(proc, CSR_MCOUNTEREN, counteren_mask, 0);
   if (proc->extension_enabled_const('U')) csrmap[CSR_MCOUNTEREN] = mcounteren;
-  csrmap[CSR_SCOUNTEREN] = scounteren = std::make_shared<counteren_csr_t>(proc, CSR_SCOUNTEREN);
+  csrmap[CSR_SCOUNTEREN] = scounteren = std::make_shared<masked_csr_t>(proc, CSR_SCOUNTEREN, counteren_mask, 0);
   auto nonvirtual_sepc = std::make_shared<epc_csr_t>(proc, CSR_SEPC);
   csrmap[CSR_VSEPC] = vsepc = std::make_shared<epc_csr_t>(proc, CSR_VSEPC);
   csrmap[CSR_SEPC] = sepc = std::make_shared<virtualized_csr_t>(proc, nonvirtual_sepc, vsepc);
@@ -487,7 +488,7 @@ void state_t::reset(processor_t* const proc, reg_t max_isa)
     (1 << CAUSE_LOAD_PAGE_FAULT) |
     (1 << CAUSE_STORE_PAGE_FAULT);
   csrmap[CSR_HEDELEG] = hedeleg = std::make_shared<masked_csr_t>(proc, CSR_HEDELEG, hedeleg_mask, 0);
-  csrmap[CSR_HCOUNTEREN] = hcounteren = std::make_shared<counteren_csr_t>(proc, CSR_HCOUNTEREN);
+  csrmap[CSR_HCOUNTEREN] = hcounteren = std::make_shared<masked_csr_t>(proc, CSR_HCOUNTEREN, counteren_mask, 0);
   csrmap[CSR_HTVAL] = htval = std::make_shared<basic_csr_t>(proc, CSR_HTVAL, 0);
   csrmap[CSR_HTINST] = htinst = std::make_shared<basic_csr_t>(proc, CSR_HTINST, 0);
   csrmap[CSR_HGATP] = hgatp = std::make_shared<hgatp_csr_t>(proc, CSR_HGATP);

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -332,6 +332,15 @@ void processor_t::parse_isa_string(const char* str)
   }
 }
 
+static int xlen_to_uxl(int xlen)
+{
+  if (xlen == 32)
+    return 1;
+  if (xlen == 64)
+    return 2;
+  abort();
+}
+
 void state_t::reset(processor_t* const proc, reg_t max_isa)
 {
   pc = DEFAULT_RSTVEC;
@@ -456,7 +465,11 @@ void state_t::reset(processor_t* const proc, reg_t max_isa)
   csrmap[CSR_SCAUSE] = scause = std::make_shared<virtualized_csr_t>(proc, nonvirtual_scause, vscause);
   csrmap[CSR_MTVAL2] = mtval2 = std::make_shared<hypervisor_csr_t>(proc, CSR_MTVAL2);
   csrmap[CSR_MTINST] = mtinst = std::make_shared<hypervisor_csr_t>(proc, CSR_MTINST);
-  csrmap[CSR_HSTATUS] = hstatus = std::make_shared<hstatus_csr_t>(proc, CSR_HSTATUS);
+  const reg_t hstatus_init = set_field((reg_t)0, HSTATUS_VSXL, xlen_to_uxl(proc->get_const_xlen()));
+  const reg_t hstatus_mask = HSTATUS_VTSR | HSTATUS_VTW
+    | (proc->supports_impl(IMPL_MMU) ? HSTATUS_VTVM : 0)
+    | HSTATUS_HU | HSTATUS_SPVP | HSTATUS_SPV | HSTATUS_GVA;
+  csrmap[CSR_HSTATUS] = hstatus = std::make_shared<masked_csr_t>(proc, CSR_HSTATUS, hstatus_mask, hstatus_init);
   csrmap[CSR_HGEIE] = std::make_shared<const_csr_t>(proc, CSR_HGEIE, 0);
   hideleg = 0;
   hedeleg = 0;
@@ -719,15 +732,6 @@ void processor_t::take_interrupt(reg_t pending_interrupts)
 
     throw trap_t(((reg_t)1 << (max_xlen-1)) | ctz(enabled_interrupts));
   }
-}
-
-static int xlen_to_uxl(int xlen)
-{
-  if (xlen == 32)
-    return 1;
-  if (xlen == 64)
-    return 2;
-  abort();
 }
 
 reg_t processor_t::legalize_privilege(reg_t prv)

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -461,7 +461,7 @@ void state_t::reset(processor_t* const proc, reg_t max_isa)
   hideleg = 0;
   hedeleg = 0;
   csrmap[CSR_HCOUNTEREN] = hcounteren = std::make_shared<counteren_csr_t>(proc, CSR_HCOUNTEREN);
-  htval = 0;
+  csrmap[CSR_HTVAL] = htval = std::make_shared<basic_csr_t>(proc, CSR_HTVAL, 0);
   htinst = 0;
   hgatp = 0;
   auto nonvirtual_sstatus = std::make_shared<sstatus_proxy_csr_t>(proc, CSR_SSTATUS, mstatus);
@@ -855,7 +855,7 @@ void processor_t::take_trap(trap_t& t, reg_t epc)
     state.scause->write(t.cause());
     state.sepc->write(epc);
     state.stval->write(t.get_tval());
-    state.htval = t.get_tval2();
+    state.htval->write(t.get_tval2());
     state.htinst = t.get_tinst();
 
     reg_t s = state.sstatus->read();
@@ -1002,9 +1002,6 @@ void processor_t::set_csr(int which, reg_t val)
       state.hideleg = (state.hideleg & ~mask) | (val & mask);
       break;
     }
-    case CSR_HTVAL:
-      state.htval = val;
-      break;
     case CSR_HTINST:
       state.htinst = val;
       break;
@@ -1198,7 +1195,6 @@ reg_t processor_t::get_csr(int which, insn_t insn, bool write, bool peek)
     case CSR_MHARTID: ret(id);
     case CSR_HEDELEG: ret(state.hedeleg);
     case CSR_HIDELEG: ret(state.hideleg);
-    case CSR_HTVAL: ret(state.htval);
     case CSR_HTINST: ret(state.htinst);
     case CSR_HGATP: {
       if (!state.v && get_field(state.mstatus->read(), MSTATUS_TVM))

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -184,7 +184,7 @@ struct state_t
   virtualized_csr_t_p satp;
   csr_t_p scause;
 
-  reg_t mtval2;
+  csr_t_p mtval2;
   reg_t mtinst;
   csr_t_p hstatus;
   reg_t hideleg;

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -191,7 +191,7 @@ struct state_t
   reg_t hedeleg;
   csr_t_p hcounteren;
   csr_t_p htval;
-  reg_t htinst;
+  csr_t_p htinst;
   reg_t hgatp;
   sstatus_csr_t_p sstatus;
   vsstatus_csr_t_p vsstatus;

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -185,7 +185,7 @@ struct state_t
   csr_t_p scause;
 
   csr_t_p mtval2;
-  reg_t mtinst;
+  csr_t_p mtinst;
   csr_t_p hstatus;
   reg_t hideleg;
   reg_t hedeleg;

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -192,7 +192,7 @@ struct state_t
   csr_t_p hcounteren;
   csr_t_p htval;
   csr_t_p htinst;
-  reg_t hgatp;
+  csr_t_p hgatp;
   sstatus_csr_t_p sstatus;
   vsstatus_csr_t_p vsstatus;
   csr_t_p vstvec;

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -190,7 +190,7 @@ struct state_t
   reg_t hideleg;
   reg_t hedeleg;
   csr_t_p hcounteren;
-  reg_t htval;
+  csr_t_p htval;
   reg_t htinst;
   reg_t hgatp;
   sstatus_csr_t_p sstatus;

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -187,7 +187,7 @@ struct state_t
   csr_t_p mtval2;
   csr_t_p mtinst;
   csr_t_p hstatus;
-  reg_t hideleg;
+  csr_t_p hideleg;
   csr_t_p hedeleg;
   csr_t_p hcounteren;
   csr_t_p htval;

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -188,7 +188,7 @@ struct state_t
   csr_t_p mtinst;
   csr_t_p hstatus;
   reg_t hideleg;
-  reg_t hedeleg;
+  csr_t_p hedeleg;
   csr_t_p hcounteren;
   csr_t_p htval;
   csr_t_p htinst;


### PR DESCRIPTION
See #793 for rationale.

This covers the following CSRs:
* mtval2
* mtinst
* hgeie
* htval
* htinst
* hedeleg
* hideleg
* hgeip
* hgatp

The only functional change intended is in the commit log. These registers were not being logged at all previously.

cc @neelgala 