### PR TITLE
Convert debug csrs to csr_t

### DIFF
--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -952,3 +952,12 @@ bool hgatp_csr_t::unlogged_write(const reg_t val) noexcept {
   mask &= ~(reg_t)3;
   return basic_csr_t::unlogged_write((read() & ~mask) | (val & mask));
 }
+
+
+tselect_csr_t::tselect_csr_t(processor_t* const proc, const reg_t addr):
+  basic_csr_t(proc, addr, 0) {
+}
+
+bool tselect_csr_t::unlogged_write(const reg_t val) noexcept {
+  return basic_csr_t::unlogged_write((val < state->num_triggers) ? val : read());
+}

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -1057,3 +1057,47 @@ void dpc_csr_t::verify_permissions(insn_t insn, bool write) const {
   if (!state->debug_mode)
     throw trap_illegal_instruction(insn.bits());
 }
+
+
+dcsr_csr_t::dcsr_csr_t(processor_t* const proc, const reg_t addr):
+  csr_t(proc, addr) {
+}
+
+void dcsr_csr_t::verify_permissions(insn_t insn, bool write) const {
+  csr_t::verify_permissions(insn, write);
+  if (!state->debug_mode)
+    throw trap_illegal_instruction(insn.bits());
+}
+
+reg_t dcsr_csr_t::read() const noexcept {
+  uint32_t v = 0;
+  v = set_field(v, DCSR_XDEBUGVER, 1);
+  v = set_field(v, DCSR_EBREAKM, ebreakm);
+  v = set_field(v, DCSR_EBREAKH, ebreakh);
+  v = set_field(v, DCSR_EBREAKS, ebreaks);
+  v = set_field(v, DCSR_EBREAKU, ebreaku);
+  v = set_field(v, DCSR_STOPCYCLE, 0);
+  v = set_field(v, DCSR_STOPTIME, 0);
+  v = set_field(v, DCSR_CAUSE, cause);
+  v = set_field(v, DCSR_STEP, step);
+  v = set_field(v, DCSR_PRV, prv);
+  return v;
+}
+
+bool dcsr_csr_t::unlogged_write(const reg_t val) noexcept {
+  prv = get_field(val, DCSR_PRV);
+  step = get_field(val, DCSR_STEP);
+  // TODO: ndreset and fullreset
+  ebreakm = get_field(val, DCSR_EBREAKM);
+  ebreakh = get_field(val, DCSR_EBREAKH);
+  ebreaks = get_field(val, DCSR_EBREAKS);
+  ebreaku = get_field(val, DCSR_EBREAKU);
+  halt = get_field(val, DCSR_HALT);
+  return true;
+}
+
+void dcsr_csr_t::write_cause_and_prv(uint8_t cause, reg_t prv) noexcept {
+  this->cause = cause;
+  this->prv = prv;
+  log_write();
+}

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -1036,3 +1036,14 @@ bool tdata2_csr_t::unlogged_write(const reg_t val) noexcept {
   vals[state->tselect->read()] = val;
   return true;
 }
+
+
+debug_mode_csr_t::debug_mode_csr_t(processor_t* const proc, const reg_t addr):
+  basic_csr_t(proc, addr, 0) {
+}
+
+void debug_mode_csr_t::verify_permissions(insn_t insn, bool write) const {
+  basic_csr_t::verify_permissions(insn, write);
+  if (!state->debug_mode)
+    throw trap_illegal_instruction(insn.bits());
+}

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -1014,3 +1014,25 @@ bool tdata1_csr_t::unlogged_write(const reg_t val) noexcept {
   proc->trigger_updated();
   return true;
 }
+
+
+tdata2_csr_t::tdata2_csr_t(processor_t* const proc, const reg_t addr, const size_t count):
+  csr_t(proc, addr),
+  vals(count, 0) {
+}
+
+reg_t tdata2_csr_t::read() const noexcept {
+  return read(state->tselect->read());
+}
+
+reg_t tdata2_csr_t::read(const size_t idx) const noexcept {
+  return vals[idx];
+}
+
+bool tdata2_csr_t::unlogged_write(const reg_t val) noexcept {
+  if (state->mcontrol[state->tselect->read()].dmode && !state->debug_mode) {
+    return false;
+  }
+  vals[state->tselect->read()] = val;
+  return true;
+}

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -961,3 +961,56 @@ tselect_csr_t::tselect_csr_t(processor_t* const proc, const reg_t addr):
 bool tselect_csr_t::unlogged_write(const reg_t val) noexcept {
   return basic_csr_t::unlogged_write((val < state->num_triggers) ? val : read());
 }
+
+
+tdata1_csr_t::tdata1_csr_t(processor_t* const proc, const reg_t addr):
+  csr_t(proc, addr) {
+}
+
+reg_t tdata1_csr_t::read() const noexcept {
+  reg_t v = 0;
+  auto xlen = proc->get_xlen();
+  mcontrol_t *mc = &state->mcontrol[state->tselect->read()];
+  v = set_field(v, MCONTROL_TYPE(xlen), mc->type);
+  v = set_field(v, MCONTROL_DMODE(xlen), mc->dmode);
+  v = set_field(v, MCONTROL_MASKMAX(xlen), mc->maskmax);
+  v = set_field(v, MCONTROL_SELECT, mc->select);
+  v = set_field(v, MCONTROL_TIMING, mc->timing);
+  v = set_field(v, MCONTROL_ACTION, mc->action);
+  v = set_field(v, MCONTROL_CHAIN, mc->chain);
+  v = set_field(v, MCONTROL_MATCH, mc->match);
+  v = set_field(v, MCONTROL_M, mc->m);
+  v = set_field(v, MCONTROL_H, mc->h);
+  v = set_field(v, MCONTROL_S, mc->s);
+  v = set_field(v, MCONTROL_U, mc->u);
+  v = set_field(v, MCONTROL_EXECUTE, mc->execute);
+  v = set_field(v, MCONTROL_STORE, mc->store);
+  v = set_field(v, MCONTROL_LOAD, mc->load);
+  return v;
+}
+
+bool tdata1_csr_t::unlogged_write(const reg_t val) noexcept {
+  mcontrol_t *mc = &state->mcontrol[state->tselect->read()];
+  if (mc->dmode && !state->debug_mode) {
+    return false;
+  }
+  auto xlen = proc->get_xlen();
+  mc->dmode = get_field(val, MCONTROL_DMODE(xlen));
+  mc->select = get_field(val, MCONTROL_SELECT);
+  mc->timing = get_field(val, MCONTROL_TIMING);
+  mc->action = (mcontrol_action_t) get_field(val, MCONTROL_ACTION);
+  mc->chain = get_field(val, MCONTROL_CHAIN);
+  mc->match = (mcontrol_match_t) get_field(val, MCONTROL_MATCH);
+  mc->m = get_field(val, MCONTROL_M);
+  mc->h = get_field(val, MCONTROL_H);
+  mc->s = get_field(val, MCONTROL_S);
+  mc->u = get_field(val, MCONTROL_U);
+  mc->execute = get_field(val, MCONTROL_EXECUTE);
+  mc->store = get_field(val, MCONTROL_STORE);
+  mc->load = get_field(val, MCONTROL_LOAD);
+  // Assume we're here because of csrw.
+  if (mc->execute)
+    mc->timing = 0;
+  proc->trigger_updated();
+  return true;
+}

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -1047,3 +1047,13 @@ void debug_mode_csr_t::verify_permissions(insn_t insn, bool write) const {
   if (!state->debug_mode)
     throw trap_illegal_instruction(insn.bits());
 }
+
+dpc_csr_t::dpc_csr_t(processor_t* const proc, const reg_t addr):
+  epc_csr_t(proc, addr) {
+}
+
+void dpc_csr_t::verify_permissions(insn_t insn, bool write) const {
+  epc_csr_t::verify_permissions(insn, write);
+  if (!state->debug_mode)
+    throw trap_illegal_instruction(insn.bits());
+}

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -508,4 +508,13 @@ class tselect_csr_t: public basic_csr_t {
 };
 
 
+class tdata1_csr_t: public csr_t {
+ public:
+  tdata1_csr_t(processor_t* const proc, const reg_t addr);
+  virtual reg_t read() const noexcept override;
+ protected:
+  virtual bool unlogged_write(const reg_t val) noexcept override;
+};
+
+
 #endif

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -543,4 +543,17 @@ class dpc_csr_t: public epc_csr_t {
   virtual void verify_permissions(insn_t insn, bool write) const override;
 };
 
+typedef struct
+{
+  uint8_t prv;
+  bool step;
+  bool ebreakm;
+  bool ebreakh;
+  bool ebreaks;
+  bool ebreaku;
+  bool halt;
+  uint8_t cause;
+} dcsr_t;
+
+
 #endif

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -500,4 +500,12 @@ class hgatp_csr_t: public basic_csr_t {
 };
 
 
+class tselect_csr_t: public basic_csr_t {
+ public:
+  tselect_csr_t(processor_t* const proc, const reg_t addr);
+ protected:
+  virtual bool unlogged_write(const reg_t val) noexcept override;
+};
+
+
 #endif

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -527,6 +527,13 @@ class tdata2_csr_t: public csr_t {
   std::vector<reg_t> vals;
 };
 
+// For CSRs that are only writable from debug mode
+class debug_mode_csr_t: public basic_csr_t {
+ public:
+  debug_mode_csr_t(processor_t* const proc, const reg_t addr);
+  virtual void verify_permissions(insn_t insn, bool write) const override;
+};
+
 typedef std::shared_ptr<tdata2_csr_t> tdata2_csr_t_p;
 
 

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -516,5 +516,18 @@ class tdata1_csr_t: public csr_t {
   virtual bool unlogged_write(const reg_t val) noexcept override;
 };
 
+class tdata2_csr_t: public csr_t {
+ public:
+  tdata2_csr_t(processor_t* const proc, const reg_t addr, const size_t count);
+  virtual reg_t read() const noexcept override;
+  reg_t read(const size_t idx) const noexcept;
+ protected:
+  virtual bool unlogged_write(const reg_t val) noexcept override;
+ private:
+  std::vector<reg_t> vals;
+};
+
+typedef std::shared_ptr<tdata2_csr_t> tdata2_csr_t_p;
+
 
 #endif

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -543,8 +543,15 @@ class dpc_csr_t: public epc_csr_t {
   virtual void verify_permissions(insn_t insn, bool write) const override;
 };
 
-typedef struct
-{
+class dcsr_csr_t: public csr_t {
+ public:
+  dcsr_csr_t(processor_t* const proc, const reg_t addr);
+  virtual void verify_permissions(insn_t insn, bool write) const override;
+  virtual reg_t read() const noexcept override;
+  void write_cause_and_prv(uint8_t cause, reg_t prv) noexcept;
+ protected:
+  virtual bool unlogged_write(const reg_t val) noexcept override;
+ public:
   uint8_t prv;
   bool step;
   bool ebreakm;
@@ -553,7 +560,8 @@ typedef struct
   bool ebreaku;
   bool halt;
   uint8_t cause;
-} dcsr_t;
+};
 
+typedef std::shared_ptr<dcsr_csr_t> dcsr_csr_t_p;
 
 #endif

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -537,4 +537,10 @@ class debug_mode_csr_t: public basic_csr_t {
 typedef std::shared_ptr<tdata2_csr_t> tdata2_csr_t_p;
 
 
+class dpc_csr_t: public epc_csr_t {
+ public:
+  dpc_csr_t(processor_t* const proc, const reg_t addr);
+  virtual void verify_permissions(insn_t insn, bool write) const override;
+};
+
 #endif

--- a/riscv/execute.cc
+++ b/riscv/execute.cc
@@ -227,7 +227,7 @@ void processor_t::step(size_t n)
     } else if (halt_request == HR_GROUP) {
       enter_debug_mode(DCSR_CAUSE_GROUP);
     } // !!!The halt bit in DCSR is deprecated.
-    else if (state.dcsr.halt) {
+    else if (state.dcsr->halt) {
       enter_debug_mode(DCSR_CAUSE_HALT);
     }
   }

--- a/riscv/insns/dret.h
+++ b/riscv/insns/dret.h
@@ -1,5 +1,5 @@
 require(STATE.debug_mode);
-set_pc_and_serialize(STATE.dpc);
+set_pc_and_serialize(STATE.dpc->read());
 p->set_privilege(STATE.dcsr.prv);
 
 /* We're not in Debug Mode anymore. */

--- a/riscv/insns/dret.h
+++ b/riscv/insns/dret.h
@@ -1,9 +1,9 @@
 require(STATE.debug_mode);
 set_pc_and_serialize(STATE.dpc->read());
-p->set_privilege(STATE.dcsr.prv);
+p->set_privilege(STATE.dcsr->prv);
 
 /* We're not in Debug Mode anymore. */
 STATE.debug_mode = false;
 
-if (STATE.dcsr.step)
+if (STATE.dcsr->step)
   STATE.single_step = STATE.STEP_STEPPING;

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -1027,9 +1027,7 @@ void processor_t::set_csr(int which, reg_t val)
       if (state.mcontrol[state.tselect].dmode && !state.debug_mode) {
         break;
       }
-      if (state.tselect < state.num_triggers) {
-        state.tdata2[state.tselect] = val;
-      }
+      state.tdata2[state.tselect] = val;
       break;
     case CSR_DCSR:
       state.dcsr.prv = get_field(val, DCSR_PRV);
@@ -1164,7 +1162,7 @@ reg_t processor_t::get_csr(int which, insn_t insn, bool write, bool peek)
     case CSR_MHARTID: ret(id);
     case CSR_TSELECT: ret(state.tselect);
     case CSR_TDATA1:
-      if (state.tselect < state.num_triggers) {
+      {
         reg_t v = 0;
         mcontrol_t *mc = &state.mcontrol[state.tselect];
         v = set_field(v, MCONTROL_TYPE(xlen), mc->type);
@@ -1183,17 +1181,8 @@ reg_t processor_t::get_csr(int which, insn_t insn, bool write, bool peek)
         v = set_field(v, MCONTROL_STORE, mc->store);
         v = set_field(v, MCONTROL_LOAD, mc->load);
         ret(v);
-      } else {
-        ret(0);
       }
-      break;
-    case CSR_TDATA2:
-      if (state.tselect < state.num_triggers) {
-        ret(state.tdata2[state.tselect]);
-      } else {
-        ret(0);
-      }
-      break;
+    case CSR_TDATA2: ret(state.tdata2[state.tselect]);
     case CSR_TDATA3: ret(0);
     case CSR_DCSR:
       {

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -964,12 +964,6 @@ void processor_t::set_csr(int which, reg_t val)
 #endif
 
   val = zext_xlen(val);
-  reg_t supervisor_ints = extension_enabled('S') ? MIP_SSIP | MIP_STIP | MIP_SEIP : 0;
-  reg_t vssip_int = extension_enabled('H') ? MIP_VSSIP : 0;
-  reg_t hypervisor_ints = extension_enabled('H') ? MIP_HS_MASK : 0;
-  reg_t coprocessor_ints = (reg_t)any_custom_extensions() << IRQ_COP;
-  reg_t delegable_ints = supervisor_ints | coprocessor_ints;
-  reg_t all_ints = delegable_ints | hypervisor_ints | MIP_MSIP | MIP_MTIP | MIP_MEIP;
   auto search = state.csrmap.find(which);
   if (search != state.csrmap.end()) {
     search->second->write(val);

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -497,8 +497,8 @@ void state_t::reset(processor_t* const proc, reg_t max_isa)
   csrmap[CSR_SSTATUS] = sstatus = std::make_shared<sstatus_csr_t>(proc, nonvirtual_sstatus, vsstatus);
 
   dpc = 0;
-  dscratch0 = 0;
-  dscratch1 = 0;
+  csrmap[CSR_DSCRATCH0] = std::make_shared<debug_mode_csr_t>(proc, CSR_DSCRATCH0);
+  csrmap[CSR_DSCRATCH1] = std::make_shared<debug_mode_csr_t>(proc, CSR_DSCRATCH1);
   memset(&this->dcsr, 0, sizeof(this->dcsr));
 
   csrmap[CSR_TSELECT] = tselect = std::make_shared<tselect_csr_t>(proc, CSR_TSELECT);
@@ -1007,12 +1007,6 @@ void processor_t::set_csr(int which, reg_t val)
     case CSR_DPC:
       state.dpc = val & ~(reg_t)1;
       break;
-    case CSR_DSCRATCH0:
-      state.dscratch0 = val;
-      break;
-    case CSR_DSCRATCH1:
-      state.dscratch1 = val;
-      break;
     case CSR_VSTART:
       dirty_vs_state;
       VU.vstart = val & (VU.get_vlen() - 1);
@@ -1058,8 +1052,6 @@ void processor_t::set_csr(int which, reg_t val)
 
     case CSR_DCSR:
     case CSR_DPC:
-    case CSR_DSCRATCH0:
-    case CSR_DSCRATCH1:
     case CSR_SENTROPY:
       LOG_CSR(which);
       break;
@@ -1144,14 +1136,6 @@ reg_t processor_t::get_csr(int which, insn_t insn, bool write, bool peek)
       if (!state.debug_mode)
         break;
       ret(state.dpc & pc_alignment_mask());
-    case CSR_DSCRATCH0:
-      if (!state.debug_mode)
-        break;
-      ret(state.dscratch0);
-    case CSR_DSCRATCH1:
-      if (!state.debug_mode)
-        break;
-      ret(state.dscratch1);
     case CSR_VSTART:
       require_vector_vs;
       if (!extension_enabled('V'))

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -508,6 +508,7 @@ void state_t::reset(processor_t* const proc, reg_t max_isa)
 
   csrmap[CSR_TDATA1] = std::make_shared<tdata1_csr_t>(proc, CSR_TDATA1);
   csrmap[CSR_TDATA2] = tdata2 = std::make_shared<tdata2_csr_t>(proc, CSR_TDATA2, num_triggers);
+  csrmap[CSR_TDATA3] = std::make_shared<const_csr_t>(proc, CSR_TDATA3, 0);
   debug_mode = false;
   single_step = STEP_NONE;
 
@@ -1098,7 +1099,6 @@ reg_t processor_t::get_csr(int which, insn_t insn, bool write, bool peek)
     case CSR_MIMPID: ret(0);
     case CSR_MVENDORID: ret(0);
     case CSR_MHARTID: ret(id);
-    case CSR_TDATA3: ret(0);
     case CSR_VSTART:
       require_vector_vs;
       if (!extension_enabled('V'))

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -507,7 +507,7 @@ void state_t::reset(processor_t* const proc, reg_t max_isa)
     item.type = 2;
 
   csrmap[CSR_TDATA1] = std::make_shared<tdata1_csr_t>(proc, CSR_TDATA1);
-  memset(this->tdata2, 0, sizeof(this->tdata2));
+  csrmap[CSR_TDATA2] = tdata2 = std::make_shared<tdata2_csr_t>(proc, CSR_TDATA2, num_triggers);
   debug_mode = false;
   single_step = STEP_NONE;
 
@@ -994,12 +994,6 @@ void processor_t::set_csr(int which, reg_t val)
       VU.vxsat = (val & VCSR_VXSAT) >> VCSR_VXSAT_SHIFT;
       VU.vxrm = (val & VCSR_VXRM) >> VCSR_VXRM_SHIFT;
       break;
-    case CSR_TDATA2:
-      if (state.mcontrol[state.tselect->read()].dmode && !state.debug_mode) {
-        break;
-      }
-      state.tdata2[state.tselect->read()] = val;
-      break;
     case CSR_DCSR:
       state.dcsr.prv = get_field(val, DCSR_PRV);
       state.dcsr.step = get_field(val, DCSR_STEP);
@@ -1062,7 +1056,6 @@ void processor_t::set_csr(int which, reg_t val)
       LOG_CSR(CSR_VXRM);
       break;
 
-    case CSR_TDATA2:
     case CSR_DCSR:
     case CSR_DPC:
     case CSR_DSCRATCH0:
@@ -1129,7 +1122,6 @@ reg_t processor_t::get_csr(int which, insn_t insn, bool write, bool peek)
     case CSR_MIMPID: ret(0);
     case CSR_MVENDORID: ret(0);
     case CSR_MHARTID: ret(id);
-    case CSR_TDATA2: ret(state.tdata2[state.tselect->read()]);
     case CSR_TDATA3: ret(0);
     case CSR_DCSR:
       {

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -499,7 +499,7 @@ void state_t::reset(processor_t* const proc, reg_t max_isa)
   csrmap[CSR_DPC] = dpc = std::make_shared<dpc_csr_t>(proc, CSR_DPC);
   csrmap[CSR_DSCRATCH0] = std::make_shared<debug_mode_csr_t>(proc, CSR_DSCRATCH0);
   csrmap[CSR_DSCRATCH1] = std::make_shared<debug_mode_csr_t>(proc, CSR_DSCRATCH1);
-  memset(&this->dcsr, 0, sizeof(this->dcsr));
+  csrmap[CSR_DCSR] = dcsr = std::make_shared<dcsr_csr_t>(proc, CSR_DCSR);
 
   csrmap[CSR_TSELECT] = tselect = std::make_shared<tselect_csr_t>(proc, CSR_TSELECT);
   memset(this->mcontrol, 0, sizeof(this->mcontrol));
@@ -612,7 +612,7 @@ void processor_t::reset()
 {
   xlen = max_xlen;
   state.reset(this, max_isa);
-  state.dcsr.halt = halt_on_reset;
+  state.dcsr->halt = halt_on_reset;
   halt_on_reset = false;
   VU.reset();
 
@@ -792,8 +792,7 @@ void processor_t::set_virt(bool virt)
 void processor_t::enter_debug_mode(uint8_t cause)
 {
   state.debug_mode = true;
-  state.dcsr.cause = cause;
-  state.dcsr.prv = state.prv;
+  state.dcsr->write_cause_and_prv(cause, state.prv);
   set_privilege(PRV_M);
   state.dpc->write(state.pc);
   state.pc = DEBUG_ROM_ENTRY;
@@ -833,9 +832,9 @@ void processor_t::take_trap(trap_t& t, reg_t epc)
   }
 
   if (t.cause() == CAUSE_BREAKPOINT && (
-              (state.prv == PRV_M && state.dcsr.ebreakm) ||
-              (state.prv == PRV_S && state.dcsr.ebreaks) ||
-              (state.prv == PRV_U && state.dcsr.ebreaku))) {
+              (state.prv == PRV_M && state.dcsr->ebreakm) ||
+              (state.prv == PRV_S && state.dcsr->ebreaks) ||
+              (state.prv == PRV_U && state.dcsr->ebreaku))) {
     enter_debug_mode(DCSR_CAUSE_SWBP);
     return;
   }
@@ -994,16 +993,6 @@ void processor_t::set_csr(int which, reg_t val)
       VU.vxsat = (val & VCSR_VXSAT) >> VCSR_VXSAT_SHIFT;
       VU.vxrm = (val & VCSR_VXRM) >> VCSR_VXRM_SHIFT;
       break;
-    case CSR_DCSR:
-      state.dcsr.prv = get_field(val, DCSR_PRV);
-      state.dcsr.step = get_field(val, DCSR_STEP);
-      // TODO: ndreset and fullreset
-      state.dcsr.ebreakm = get_field(val, DCSR_EBREAKM);
-      state.dcsr.ebreakh = get_field(val, DCSR_EBREAKH);
-      state.dcsr.ebreaks = get_field(val, DCSR_EBREAKS);
-      state.dcsr.ebreaku = get_field(val, DCSR_EBREAKU);
-      state.dcsr.halt = get_field(val, DCSR_HALT);
-      break;
     case CSR_VSTART:
       dirty_vs_state;
       VU.vstart = val & (VU.get_vlen() - 1);
@@ -1047,7 +1036,6 @@ void processor_t::set_csr(int which, reg_t val)
       LOG_CSR(CSR_VXRM);
       break;
 
-    case CSR_DCSR:
     case CSR_SENTROPY:
       LOG_CSR(which);
       break;
@@ -1111,23 +1099,6 @@ reg_t processor_t::get_csr(int which, insn_t insn, bool write, bool peek)
     case CSR_MVENDORID: ret(0);
     case CSR_MHARTID: ret(id);
     case CSR_TDATA3: ret(0);
-    case CSR_DCSR:
-      {
-        if (!state.debug_mode)
-          break;
-        uint32_t v = 0;
-        v = set_field(v, DCSR_XDEBUGVER, 1);
-        v = set_field(v, DCSR_EBREAKM, state.dcsr.ebreakm);
-        v = set_field(v, DCSR_EBREAKH, state.dcsr.ebreakh);
-        v = set_field(v, DCSR_EBREAKS, state.dcsr.ebreaks);
-        v = set_field(v, DCSR_EBREAKU, state.dcsr.ebreaku);
-        v = set_field(v, DCSR_STOPCYCLE, 0);
-        v = set_field(v, DCSR_STOPTIME, 0);
-        v = set_field(v, DCSR_CAUSE, state.dcsr.cause);
-        v = set_field(v, DCSR_STEP, state.dcsr.step);
-        v = set_field(v, DCSR_PRV, state.dcsr.prv);
-        ret(v);
-      }
     case CSR_VSTART:
       require_vector_vs;
       if (!extension_enabled('V'))

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -204,7 +204,7 @@ struct state_t
   reg_t dpc;
   reg_t dscratch0, dscratch1;
   dcsr_t dcsr;
-  reg_t tselect;
+  csr_t_p tselect;
   mcontrol_t mcontrol[num_triggers];
   reg_t tdata2[num_triggers];
   bool debug_mode;

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -206,7 +206,7 @@ struct state_t
   dcsr_t dcsr;
   csr_t_p tselect;
   mcontrol_t mcontrol[num_triggers];
-  reg_t tdata2[num_triggers];
+  tdata2_csr_t_p tdata2;
   bool debug_mode;
 
   static const int max_pmp = 16;
@@ -409,7 +409,7 @@ public:
         value &= 0xffffffff;
       }
 
-      auto tdata2 = state.tdata2[i];
+      auto tdata2 = state.tdata2->read(i);
       switch (state.mcontrol[i].match) {
         case MATCH_EQUAL:
           if (value != tdata2)

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -190,7 +190,7 @@ struct state_t
   csr_t_p vsatp;
 
   csr_t_p dpc;
-  dcsr_t dcsr;
+  dcsr_csr_t_p dcsr;
   csr_t_p tselect;
   mcontrol_t mcontrol[num_triggers];
   tdata2_csr_t_p tdata2;

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -201,7 +201,7 @@ struct state_t
   csr_t_p vstval;
   csr_t_p vsatp;
 
-  reg_t dpc;
+  csr_t_p dpc;
   dcsr_t dcsr;
   csr_t_p tselect;
   mcontrol_t mcontrol[num_triggers];

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -409,37 +409,38 @@ public:
         value &= 0xffffffff;
       }
 
+      auto tdata2 = state.tdata2[i];
       switch (state.mcontrol[i].match) {
         case MATCH_EQUAL:
-          if (value != state.tdata2[i])
+          if (value != tdata2)
             continue;
           break;
         case MATCH_NAPOT:
           {
-            reg_t mask = ~((1 << (cto(state.tdata2[i])+1)) - 1);
-            if ((value & mask) != (state.tdata2[i] & mask))
+            reg_t mask = ~((1 << (cto(tdata2)+1)) - 1);
+            if ((value & mask) != (tdata2 & mask))
               continue;
           }
           break;
         case MATCH_GE:
-          if (value < state.tdata2[i])
+          if (value < tdata2)
             continue;
           break;
         case MATCH_LT:
-          if (value >= state.tdata2[i])
+          if (value >= tdata2)
             continue;
           break;
         case MATCH_MASK_LOW:
           {
-            reg_t mask = state.tdata2[i] >> (xlen/2);
-            if ((value & mask) != (state.tdata2[i] & mask))
+            reg_t mask = tdata2 >> (xlen/2);
+            if ((value & mask) != (tdata2 & mask))
               continue;
           }
           break;
         case MATCH_MASK_HIGH:
           {
-            reg_t mask = state.tdata2[i] >> (xlen/2);
-            if (((value >> (xlen/2)) & mask) != (state.tdata2[i] & mask))
+            reg_t mask = tdata2 >> (xlen/2);
+            if (((value >> (xlen/2)) & mask) != (tdata2 & mask))
               continue;
           }
           break;

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -37,18 +37,6 @@ typedef std::unordered_map<reg_t, freg_t> commit_log_reg_t;
 // addr, value, size
 typedef std::vector<std::tuple<reg_t, uint64_t, uint8_t>> commit_log_mem_t;
 
-typedef struct
-{
-  uint8_t prv;
-  bool step;
-  bool ebreakm;
-  bool ebreakh;
-  bool ebreaks;
-  bool ebreaku;
-  bool halt;
-  uint8_t cause;
-} dcsr_t;
-
 typedef enum
 {
   ACTION_DEBUG_EXCEPTION = MCONTROL_ACTION_DEBUG_EXCEPTION,

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -202,7 +202,6 @@ struct state_t
   csr_t_p vsatp;
 
   reg_t dpc;
-  reg_t dscratch0, dscratch1;
   dcsr_t dcsr;
   csr_t_p tselect;
   mcontrol_t mcontrol[num_triggers];


### PR DESCRIPTION
See #793 for rationale.

This covers the following CSRs:

* tselect
* tdata1
* tdata2
* dscratch0
* dscratch1
* dpc
* dcsr
* tdata3

I ran the debug tests in riscv-tests/debug; three of them (Sv32Test, Sv39Test, Sv48Test) were already failing on master, and all the rest passed both before and after this PR.