### PR TITLE
Convert mstatush to csr_t

### DIFF
--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -442,6 +442,21 @@ bool mstatus_csr_t::unlogged_write(const reg_t val) noexcept {
   return true;
 }
 
+// implement class mstatush_csr_t
+mstatush_csr_t::mstatush_csr_t(processor_t* const proc, const reg_t addr, mstatus_csr_t_p mstatus):
+  csr_t(proc, addr),
+  mstatus(mstatus),
+  mask(MSTATUSH_MPV | MSTATUSH_GVA | MSTATUSH_SBE | MSTATUSH_MBE) {
+}
+
+reg_t mstatush_csr_t::read() const noexcept {
+  return (mstatus->read() >> 32) & mask;
+}
+
+bool mstatush_csr_t::unlogged_write(const reg_t val) noexcept {
+  return true;  // recreate bug #812; fix coming soon
+}
+
 // implement class sstatus_csr_t
 sstatus_csr_t::sstatus_csr_t(processor_t* const proc, csr_t_p orig, csr_t_p virt):
   virtualized_csr_t(proc, orig, virt) {

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -454,7 +454,7 @@ reg_t mstatush_csr_t::read() const noexcept {
 }
 
 bool mstatush_csr_t::unlogged_write(const reg_t val) noexcept {
-  return true;  // recreate bug #812; fix coming soon
+  return mstatus->unlogged_write((mstatus->written_value() & ~(mask << 32)) | ((val & mask) << 32));
 }
 
 // implement class sstatus_csr_t

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -225,6 +225,7 @@ class mstatus_csr_t: public base_status_csr_t {
   virtual bool unlogged_write(const reg_t val) noexcept override;
  private:
   reg_t val;
+  friend class mstatush_csr_t;
 };
 
 typedef std::shared_ptr<mstatus_csr_t> mstatus_csr_t_p;

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -230,6 +230,18 @@ class mstatus_csr_t: public base_status_csr_t {
 typedef std::shared_ptr<mstatus_csr_t> mstatus_csr_t_p;
 
 
+class mstatush_csr_t: public csr_t {
+ public:
+  mstatush_csr_t(processor_t* const proc, const reg_t addr, mstatus_csr_t_p mstatus);
+  virtual reg_t read() const noexcept override;
+ protected:
+  virtual bool unlogged_write(const reg_t val) noexcept override;
+ private:
+  mstatus_csr_t_p mstatus;
+  const reg_t mask;
+};
+
+
 class sstatus_csr_t: public virtualized_csr_t {
  public:
   sstatus_csr_t(processor_t* const proc, csr_t_p orig, csr_t_p virt);

--- a/riscv/encoding.h
+++ b/riscv/encoding.h
@@ -38,6 +38,8 @@
 
 #define MSTATUSH_SBE        0x00000010
 #define MSTATUSH_MBE        0x00000020
+#define MSTATUSH_GVA        0x00000040
+#define MSTATUSH_MPV        0x00000080
 
 #define SSTATUS_UIE         0x00000001
 #define SSTATUS_SIE         0x00000002

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -1162,7 +1162,7 @@ reg_t processor_t::get_csr(int which, insn_t insn, bool write, bool peek)
       ret((VU.vxsat << VCSR_VXSAT_SHIFT) | (VU.vxrm << VCSR_VXRM_SHIFT));
     case CSR_MSTATUSH:
       if (xlen == 32)
-        ret((state.mstatus->read() >> 32) & (MSTATUSH_SBE | MSTATUSH_MBE));
+        ret((state.mstatus->read() >> 32) & (MSTATUSH_MPV | MSTATUSH_GVA | MSTATUSH_SBE | MSTATUSH_MBE));
       break;
     case CSR_MARCHID: ret(5);
     case CSR_MIMPID: ret(0);

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -355,6 +355,7 @@ void state_t::reset(processor_t* const proc, reg_t max_isa)
   v = false;
   csrmap[CSR_MISA] = misa = std::make_shared<misa_csr_t>(proc, CSR_MISA, max_isa);
   csrmap[CSR_MSTATUS] = mstatus = std::make_shared<mstatus_csr_t>(proc, CSR_MSTATUS);
+  if (xlen == 32) csrmap[CSR_MSTATUSH] = std::make_shared<mstatush_csr_t>(proc, CSR_MSTATUSH, mstatus);
   csrmap[CSR_MEPC] = mepc = std::make_shared<epc_csr_t>(proc, CSR_MEPC);
   csrmap[CSR_MTVAL] = mtval = std::make_shared<basic_csr_t>(proc, CSR_MTVAL, 0);
   csrmap[CSR_MSCRATCH] = std::make_shared<basic_csr_t>(proc, CSR_MSCRATCH, 0);
@@ -1160,10 +1161,6 @@ reg_t processor_t::get_csr(int which, insn_t insn, bool write, bool peek)
       if (!extension_enabled('V'))
         break;
       ret((VU.vxsat << VCSR_VXSAT_SHIFT) | (VU.vxrm << VCSR_VXRM_SHIFT));
-    case CSR_MSTATUSH:
-      if (xlen == 32)
-        ret((state.mstatus->read() >> 32) & (MSTATUSH_MPV | MSTATUSH_GVA | MSTATUSH_SBE | MSTATUSH_MBE));
-      break;
     case CSR_MARCHID: ret(5);
     case CSR_MIMPID: ret(0);
     case CSR_MVENDORID: ret(0);


### PR DESCRIPTION
Also fixes #812 by making bits `MPV` and `GVA` writable when Hypervisor is enabled.