### PR TITLE
Convert sentropy and minor CSRs to csr_t

### DIFF
--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -1156,3 +1156,24 @@ bool composite_csr_t::unlogged_write(const reg_t val) noexcept {
   lower_csr->write(val);
   return false;  // logging is done only by the underlying CSRs
 }
+
+
+sentropy_csr_t::sentropy_csr_t(processor_t* const proc, const reg_t addr):
+  csr_t(proc, addr) {
+}
+
+void sentropy_csr_t::verify_permissions(insn_t insn, bool write) const {
+  /* Read-only access disallowed due to wipe-on-read side effect */
+  if (!proc->extension_enabled(EXT_ZKR) || !write)
+    throw trap_illegal_instruction(insn.bits());
+  csr_t::verify_permissions(insn, write);
+}
+
+reg_t sentropy_csr_t::read() const noexcept {
+  return proc->es.get_sentropy();
+}
+
+bool sentropy_csr_t::unlogged_write(const reg_t val) noexcept {
+  proc->es.set_sentropy(val);
+  return true;
+}

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -603,4 +603,15 @@ class composite_csr_t: public csr_t {
   const unsigned upper_lsb;
 };
 
+
+class sentropy_csr_t: public csr_t {
+ public:
+  sentropy_csr_t(processor_t* const proc, const reg_t addr);
+  virtual void verify_permissions(insn_t insn, bool write) const override;
+  virtual reg_t read() const noexcept override;
+ protected:
+  virtual bool unlogged_write(const reg_t val) noexcept override;
+};
+
+
 #endif

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -531,6 +531,7 @@ void state_t::reset(processor_t* const proc, reg_t max_isa)
   csrmap[CSR_MARCHID] = std::make_shared<const_csr_t>(proc, CSR_MARCHID, 5);
   csrmap[CSR_MIMPID] = std::make_shared<const_csr_t>(proc, CSR_MIMPID, 0);
   csrmap[CSR_MVENDORID] = std::make_shared<const_csr_t>(proc, CSR_MVENDORID, 0);
+  csrmap[CSR_MHARTID] = std::make_shared<const_csr_t>(proc, CSR_MHARTID, proc->get_id());
 
   serialized = false;
 
@@ -1048,7 +1049,6 @@ reg_t processor_t::get_csr(int which, insn_t insn, bool write, bool peek)
       if (!extension_enabled('V'))
         break;
       ret((VU.vxsat << VCSR_VXSAT_SHIFT) | (VU.vxrm << VCSR_VXRM_SHIFT));
-    case CSR_MHARTID: ret(id);
     case CSR_VSTART:
       require_vector_vs;
       if (!extension_enabled('V'))

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -528,6 +528,8 @@ void state_t::reset(processor_t* const proc, reg_t max_isa)
 
   csrmap[CSR_SENTROPY] = std::make_shared<sentropy_csr_t>(proc, CSR_SENTROPY);
 
+  csrmap[CSR_MARCHID] = std::make_shared<const_csr_t>(proc, CSR_MARCHID, 5);
+
   serialized = false;
 
 #ifdef RISCV_ENABLE_COMMITLOG
@@ -1044,7 +1046,6 @@ reg_t processor_t::get_csr(int which, insn_t insn, bool write, bool peek)
       if (!extension_enabled('V'))
         break;
       ret((VU.vxsat << VCSR_VXSAT_SHIFT) | (VU.vxrm << VCSR_VXRM_SHIFT));
-    case CSR_MARCHID: ret(5);
     case CSR_MIMPID: ret(0);
     case CSR_MVENDORID: ret(0);
     case CSR_MHARTID: ret(id);

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -1047,7 +1047,7 @@ reg_t processor_t::get_csr(int which, insn_t insn, bool write, bool peek)
       if (!extension_enabled(EXT_ZKR))
         break;
       /* Read-only access disallowed due to wipe-on-read side effect */
-      if (!write)
+      if (!write && !peek)
         break;
       ret(es.get_sentropy());
     case CSR_VCSR:

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -530,6 +530,7 @@ void state_t::reset(processor_t* const proc, reg_t max_isa)
 
   csrmap[CSR_MARCHID] = std::make_shared<const_csr_t>(proc, CSR_MARCHID, 5);
   csrmap[CSR_MIMPID] = std::make_shared<const_csr_t>(proc, CSR_MIMPID, 0);
+  csrmap[CSR_MVENDORID] = std::make_shared<const_csr_t>(proc, CSR_MVENDORID, 0);
 
   serialized = false;
 
@@ -1047,7 +1048,6 @@ reg_t processor_t::get_csr(int which, insn_t insn, bool write, bool peek)
       if (!extension_enabled('V'))
         break;
       ret((VU.vxsat << VCSR_VXSAT_SHIFT) | (VU.vxrm << VCSR_VXRM_SHIFT));
-    case CSR_MVENDORID: ret(0);
     case CSR_MHARTID: ret(id);
     case CSR_VSTART:
       require_vector_vs;

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -529,6 +529,7 @@ void state_t::reset(processor_t* const proc, reg_t max_isa)
   csrmap[CSR_SENTROPY] = std::make_shared<sentropy_csr_t>(proc, CSR_SENTROPY);
 
   csrmap[CSR_MARCHID] = std::make_shared<const_csr_t>(proc, CSR_MARCHID, 5);
+  csrmap[CSR_MIMPID] = std::make_shared<const_csr_t>(proc, CSR_MIMPID, 0);
 
   serialized = false;
 
@@ -1046,7 +1047,6 @@ reg_t processor_t::get_csr(int which, insn_t insn, bool write, bool peek)
       if (!extension_enabled('V'))
         break;
       ret((VU.vxsat << VCSR_VXSAT_SHIFT) | (VU.vxrm << VCSR_VXRM_SHIFT));
-    case CSR_MIMPID: ret(0);
     case CSR_MVENDORID: ret(0);
     case CSR_MHARTID: ret(id);
     case CSR_VSTART:

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -525,6 +525,9 @@ void state_t::reset(processor_t* const proc, reg_t max_isa)
   csrmap[CSR_FRM] = frm = std::make_shared<float_csr_t>(proc, CSR_FRM, FSR_RD >> FSR_RD_SHIFT, 0);
   assert(FSR_AEXC_SHIFT == 0);  // composite_csr_t assumes fflags begins at bit 0
   csrmap[CSR_FCSR] = std::make_shared<composite_csr_t>(proc, CSR_FFLAGS, frm, fflags, FSR_RD_SHIFT);
+
+  csrmap[CSR_SENTROPY] = std::make_shared<sentropy_csr_t>(proc, CSR_SENTROPY);
+
   serialized = false;
 
 #ifdef RISCV_ENABLE_COMMITLOG
@@ -976,9 +979,6 @@ void processor_t::set_csr(int which, reg_t val)
 
   switch (which)
   {
-    case CSR_SENTROPY:
-      es.set_sentropy(val);
-      break;
     case CSR_VCSR:
       dirty_vs_state;
       VU.vxsat = (val & VCSR_VXSAT) >> VCSR_VXSAT_SHIFT;
@@ -1015,10 +1015,6 @@ void processor_t::set_csr(int which, reg_t val)
     case CSR_VXRM:
       LOG_CSR(CSR_VXRM);
       break;
-
-    case CSR_SENTROPY:
-      LOG_CSR(which);
-      break;
   }
 #endif
 }
@@ -1043,13 +1039,6 @@ reg_t processor_t::get_csr(int which, insn_t insn, bool write, bool peek)
 
   switch (which)
   {
-    case CSR_SENTROPY:
-      if (!extension_enabled(EXT_ZKR))
-        break;
-      /* Read-only access disallowed due to wipe-on-read side effect */
-      if (!write && !peek)
-        break;
-      ret(es.get_sentropy());
     case CSR_VCSR:
       require_vector_vs;
       if (!extension_enabled('V'))

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -468,8 +468,6 @@ private:
   std::vector<bool> extension_table;
   std::vector<bool> impl_table;
 
-  entropy_source es; // Crypto ISE Entropy source.
-
   std::vector<insn_desc_t> instructions;
   std::map<reg_t,uint64_t> pc_histogram;
 
@@ -500,6 +498,8 @@ private:
   // Track repeated executions for processor_t::disasm()
   uint64_t last_pc, last_bits, executions;
 public:
+  entropy_source es; // Crypto ISE Entropy source.
+
   reg_t n_pmp;
   reg_t lg_pmp_granularity;
   reg_t pmp_tor_mask() { return -(reg_t(1) << (lg_pmp_granularity - PMP_SHIFT)); }


### PR DESCRIPTION
See #793 for rationale.

This covers the following CSRs:

* sentropy (from the Zkr extension)
* marchid
* mimpid
* mvendorid
* mhartid

The write-only nature of sentropy is unique, and showed a problem when enabling logging, as explained in [this fix](https://github.com/riscv-software-src/riscv-isa-sim/commit/3083b125d69fec064a29f467274a9af13b79698f).

Perhaps it's not useful to log writes to sentropy at all?