### PR TITLE
Convert vector CSRs to csr_t -- completes refactoring of CSRs

### DIFF
--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -1188,8 +1188,8 @@ bool sentropy_csr_t::unlogged_write(const reg_t val) noexcept {
 
 
 
-vector_csr_t::vector_csr_t(processor_t* const proc, const reg_t addr, const reg_t mask):
-  basic_csr_t(proc, addr, 0),
+vector_csr_t::vector_csr_t(processor_t* const proc, const reg_t addr, const reg_t mask, const reg_t init):
+  basic_csr_t(proc, addr, init),
   mask(mask) {
 }
 

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -33,7 +33,9 @@ void csr_t::verify_permissions(insn_t insn, bool write) const {
       (csr_priv == PRV_HS && !proc->extension_enabled('H')))
     throw trap_illegal_instruction(insn.bits());
 
-  if ((write && csr_read_only) || priv < csr_priv) {
+  if (write && csr_read_only)
+    throw trap_illegal_instruction(insn.bits());
+  if (priv < csr_priv) {
     if (state->v && csr_priv <= PRV_HS)
       throw trap_virtual_instruction(insn.bits());
     throw trap_illegal_instruction(insn.bits());

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -1075,7 +1075,15 @@ void dpc_csr_t::verify_permissions(insn_t insn, bool write) const {
 
 
 dcsr_csr_t::dcsr_csr_t(processor_t* const proc, const reg_t addr):
-  csr_t(proc, addr) {
+  csr_t(proc, addr),
+  prv(0),
+  step(false),
+  ebreakm(false),
+  ebreakh(false),
+  ebreaks(false),
+  ebreaku(false),
+  halt(false),
+  cause(0) {
 }
 
 void dcsr_csr_t::verify_permissions(insn_t insn, bool write) const {

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -1200,6 +1200,12 @@ void vector_csr_t::verify_permissions(insn_t insn, bool write) const {
   basic_csr_t::verify_permissions(insn, write);
 }
 
+void vector_csr_t::write_raw(const reg_t val) noexcept {
+  const bool success = basic_csr_t::unlogged_write(val);
+  if (success)
+    log_write();
+}
+
 bool vector_csr_t::unlogged_write(const reg_t val) noexcept {
   if (mask == 0) return false;
   dirty_vs_state;

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -1185,3 +1185,23 @@ bool sentropy_csr_t::unlogged_write(const reg_t val) noexcept {
   proc->es.set_sentropy(val);
   return true;
 }
+
+
+
+vector_csr_t::vector_csr_t(processor_t* const proc, const reg_t addr, const reg_t mask):
+  basic_csr_t(proc, addr, 0),
+  mask(mask) {
+}
+
+void vector_csr_t::verify_permissions(insn_t insn, bool write) const {
+  require_vector_vs;
+  if (!proc->extension_enabled('V'))
+    throw trap_illegal_instruction(insn.bits());
+  basic_csr_t::verify_permissions(insn, write);
+}
+
+bool vector_csr_t::unlogged_write(const reg_t val) noexcept {
+  if (mask == 0) return false;
+  dirty_vs_state;
+  return basic_csr_t::unlogged_write(val & mask);
+}

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -618,11 +618,16 @@ class vector_csr_t: public basic_csr_t {
  public:
   vector_csr_t(processor_t* const proc, const reg_t addr, const reg_t mask);
   virtual void verify_permissions(insn_t insn, bool write) const override;
+  // Write without regard to mask, and without touching mstatus.VS
+  void write_raw(const reg_t val) noexcept;
  protected:
   virtual bool unlogged_write(const reg_t val) noexcept override;
  private:
   reg_t mask;
 };
+
+typedef std::shared_ptr<vector_csr_t> vector_csr_t_p;
+
 
 
 #endif

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -616,7 +616,7 @@ class sentropy_csr_t: public csr_t {
 
 class vector_csr_t: public basic_csr_t {
  public:
-  vector_csr_t(processor_t* const proc, const reg_t addr, const reg_t mask);
+  vector_csr_t(processor_t* const proc, const reg_t addr, const reg_t mask, const reg_t init=0);
   virtual void verify_permissions(insn_t insn, bool write) const override;
   // Write without regard to mask, and without touching mstatus.VS
   void write_raw(const reg_t val) noexcept;

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -614,4 +614,15 @@ class sentropy_csr_t: public csr_t {
 };
 
 
+class vector_csr_t: public basic_csr_t {
+ public:
+  vector_csr_t(processor_t* const proc, const reg_t addr, const reg_t mask);
+  virtual void verify_permissions(insn_t insn, bool write) const override;
+ protected:
+  virtual bool unlogged_write(const reg_t val) noexcept override;
+ private:
+  reg_t mask;
+};
+
+
 #endif

--- a/riscv/decode.h
+++ b/riscv/decode.h
@@ -368,11 +368,7 @@ inline freg_t f128_negate(freg_t a)
 #define validate_csr(which, write) ({ \
   if (!STATE.serialized) return PC_SERIALIZE_BEFORE; \
   STATE.serialized = false; \
-  /* disallow writes to read-only CSRs */ \
-  unsigned csr_read_only = get_field((which), 0xC00) == 3; \
-  if ((write) && csr_read_only) \
-    throw trap_illegal_instruction(insn.bits()); \
-  /* other permissions checks occur in get_csr */ \
+  /* permissions check occurs in get_csr */ \
   (which); })
 
 /* For debug only. This will fail if the native machine's float types are not IEEE */

--- a/riscv/decode.h
+++ b/riscv/decode.h
@@ -614,7 +614,7 @@ static inline bool is_aligned(const unsigned val, const unsigned pos)
 #define VI_GENERAL_LOOP_BASE \
   require(P.VU.vsew >= e8 && P.VU.vsew <= e64); \
   require_vector(true);\
-  reg_t vl = P.VU.vl; \
+  reg_t vl = P.VU.vl->read();                   \
   reg_t sew = P.VU.vsew; \
   reg_t rd_num = insn.rd(); \
   reg_t rs1_num = insn.rs1(); \
@@ -639,7 +639,7 @@ static inline bool is_aligned(const unsigned val, const unsigned pos)
 #define VI_LOOP_CMP_BASE \
   require(P.VU.vsew >= e8 && P.VU.vsew <= e64); \
   require_vector(true);\
-  reg_t vl = P.VU.vl; \
+  reg_t vl = P.VU.vl->read();                   \
   reg_t sew = P.VU.vsew; \
   reg_t rd_num = insn.rd(); \
   reg_t rs1_num = insn.rs1(); \
@@ -658,7 +658,7 @@ static inline bool is_aligned(const unsigned val, const unsigned pos)
 #define VI_LOOP_MASK(op) \
   require(P.VU.vsew <= e64); \
   require_vector(true);\
-  reg_t vl = P.VU.vl; \
+  reg_t vl = P.VU.vl->read();                        \
   for (reg_t i = P.VU.vstart->read(); i < vl; ++i) { \
     int midx = i / 64; \
     int mpos = i % 64; \
@@ -949,7 +949,7 @@ static inline bool is_aligned(const unsigned val, const unsigned pos)
 // reduction loop - signed
 #define VI_LOOP_REDUCTION_BASE(x) \
   require(x >= e8 && x <= e64); \
-  reg_t vl = P.VU.vl; \
+  reg_t vl = P.VU.vl->read();   \
   reg_t rd_num = insn.rd(); \
   reg_t rs1_num = insn.rs1(); \
   reg_t rs2_num = insn.rs2(); \
@@ -980,7 +980,7 @@ static inline bool is_aligned(const unsigned val, const unsigned pos)
 // reduction loop - unsgied
 #define VI_ULOOP_REDUCTION_BASE(x) \
   require(x >= e8 && x <= e64); \
-  reg_t vl = P.VU.vl; \
+  reg_t vl = P.VU.vl->read();   \
   reg_t rd_num = insn.rd(); \
   reg_t rs1_num = insn.rs1(); \
   reg_t rs2_num = insn.rs2(); \
@@ -1299,7 +1299,7 @@ VI_LOOP_END
 
 // wide reduction loop - signed
 #define VI_LOOP_WIDE_REDUCTION_BASE(sew1, sew2) \
-  reg_t vl = P.VU.vl; \
+  reg_t vl = P.VU.vl->read();                   \
   reg_t rd_num = insn.rd(); \
   reg_t rs1_num = insn.rs1(); \
   reg_t rs2_num = insn.rs2(); \
@@ -1327,7 +1327,7 @@ VI_LOOP_END
 
 // wide reduction loop - unsigned
 #define VI_ULOOP_WIDE_REDUCTION_BASE(sew1, sew2) \
-  reg_t vl = P.VU.vl; \
+  reg_t vl = P.VU.vl->read();                    \
   reg_t rd_num = insn.rd(); \
   reg_t rs1_num = insn.rs1(); \
   reg_t rs2_num = insn.rs2(); \
@@ -1521,7 +1521,7 @@ VI_LOOP_END
 
 #define VI_DUPLICATE_VREG(reg_num, idx_sew) \
 reg_t index[P.VU.vlmax]; \
-for (reg_t i = 0; i < P.VU.vlmax && P.VU.vl != 0; ++i) { \
+ for (reg_t i = 0; i < P.VU.vlmax && P.VU.vl->read() != 0; ++i) {       \
   switch(idx_sew) { \
     case e8: \
       index[i] = P.VU.elt<uint8_t>(reg_num, i); \
@@ -1540,7 +1540,7 @@ for (reg_t i = 0; i < P.VU.vlmax && P.VU.vl != 0; ++i) { \
 
 #define VI_LD(stride, offset, elt_width, is_mask_ldst) \
   const reg_t nf = insn.v_nf() + 1; \
-  const reg_t vl = is_mask_ldst ? ((P.VU.vl + 7) / 8) : P.VU.vl; \
+  const reg_t vl = is_mask_ldst ? ((P.VU.vl->read() + 7) / 8) : P.VU.vl->read(); \
   const reg_t baseAddr = RS1; \
   const reg_t vd = insn.rd(); \
   VI_CHECK_LOAD(elt_width, is_mask_ldst); \
@@ -1558,7 +1558,7 @@ for (reg_t i = 0; i < P.VU.vlmax && P.VU.vl != 0; ++i) { \
 
 #define VI_LD_INDEX(elt_width, is_seg) \
   const reg_t nf = insn.v_nf() + 1; \
-  const reg_t vl = P.VU.vl; \
+  const reg_t vl = P.VU.vl->read(); \
   const reg_t baseAddr = RS1; \
   const reg_t vd = insn.rd(); \
   if (!is_seg) \
@@ -1594,7 +1594,7 @@ for (reg_t i = 0; i < P.VU.vlmax && P.VU.vl != 0; ++i) { \
 
 #define VI_ST(stride, offset, elt_width, is_mask_ldst) \
   const reg_t nf = insn.v_nf() + 1; \
-  const reg_t vl = is_mask_ldst ? ((P.VU.vl + 7) / 8) : P.VU.vl; \
+  const reg_t vl = is_mask_ldst ? ((P.VU.vl->read() + 7) / 8) : P.VU.vl->read(); \
   const reg_t baseAddr = RS1; \
   const reg_t vs3 = insn.rd(); \
   VI_CHECK_STORE(elt_width, is_mask_ldst); \
@@ -1612,7 +1612,7 @@ for (reg_t i = 0; i < P.VU.vlmax && P.VU.vl != 0; ++i) { \
 
 #define VI_ST_INDEX(elt_width, is_seg) \
   const reg_t nf = insn.v_nf() + 1; \
-  const reg_t vl = P.VU.vl; \
+  const reg_t vl = P.VU.vl->read(); \
   const reg_t baseAddr = RS1; \
   const reg_t vs3 = insn.rd(); \
   if (!is_seg) \
@@ -1649,7 +1649,7 @@ for (reg_t i = 0; i < P.VU.vlmax && P.VU.vl != 0; ++i) { \
 #define VI_LDST_FF(elt_width) \
   const reg_t nf = insn.v_nf() + 1; \
   const reg_t sew = p->VU.vsew; \
-  const reg_t vl = p->VU.vl; \
+  const reg_t vl = p->VU.vl->read(); \
   const reg_t baseAddr = RS1; \
   const reg_t rd_num = insn.rd(); \
   VI_CHECK_LOAD(elt_width, false); \
@@ -1668,7 +1668,7 @@ for (reg_t i = 0; i < P.VU.vlmax && P.VU.vl != 0; ++i) { \
           throw; /* Only take exception on zeroth element */ \
         /* Reduce VL if an exception occurs on a later element */ \
         early_stop = true; \
-        P.VU.vl = i; \
+        P.VU.vl->write_raw(i);                  \
         break; \
       } \
       p->VU.elt<elt_width##_t>(rd_num + fn * emul, vreg_inx, true) = val; \
@@ -1765,7 +1765,7 @@ for (reg_t i = 0; i < P.VU.vlmax && P.VU.vl != 0; ++i) { \
     } \
   } \
   VI_DUPLICATE_VREG(insn.rs2(), idx_type); \
-  const reg_t vl = P.VU.vl; \
+  const reg_t vl = P.VU.vl->read(); \
   const reg_t baseAddr = RS1; \
   const reg_t vd = insn.rd(); \
   for (reg_t i = P.VU.vstart->read(); i < vl; ++i) { \
@@ -1848,7 +1848,7 @@ for (reg_t i = 0; i < P.VU.vlmax && P.VU.vl != 0; ++i) { \
           (P.VU.vsew == e64 && p->extension_enabled('D'))); \
   require_vector(true);\
   require(STATE.frm->read() < 0x5);\
-  reg_t vl = P.VU.vl; \
+  reg_t vl = P.VU.vl->read(); \
   reg_t rd_num = insn.rd(); \
   reg_t rs1_num = insn.rs1(); \
   reg_t rs2_num = insn.rs2(); \
@@ -2264,7 +2264,7 @@ for (reg_t i = 0; i < P.VU.vlmax && P.VU.vl != 0; ++i) { \
           (P.VU.vsew == e16 && p->extension_enabled('F')) || \
           (P.VU.vsew == e32 && p->extension_enabled('D'))); \
   require(STATE.frm->read() < 0x5);\
-  reg_t vl = P.VU.vl; \
+  reg_t vl = P.VU.vl->read(); \
   reg_t rd_num = insn.rd(); \
   reg_t rs1_num = insn.rs1(); \
   reg_t rs2_num = insn.rs2(); \

--- a/riscv/decode.h
+++ b/riscv/decode.h
@@ -2347,7 +2347,7 @@ for (reg_t i = 0; i < P.VU.vlmax && P.VU.vl != 0; ++i) { \
   }
 
 #define P_SET_OV(ov) \
-  P.VU.vxsat |= ov;
+  P.VU.vxsat->write(P.VU.vxsat->read() | ov);
 
 #define P_SAT(R, BIT) \
   if (R > INT##BIT##_MAX) { \

--- a/riscv/execute.cc
+++ b/riscv/execute.cc
@@ -125,7 +125,7 @@ static void commit_log_print_insn(processor_t *p, reg_t pc, insn_t insn)
                 p->VU.vsew,
                 p->VU.vflmul < 1 ? "mf" : "m",
                 p->VU.vflmul < 1 ? (reg_t)(1 / p->VU.vflmul) : (reg_t)p->VU.vflmul,
-                p->VU.vl);
+                p->VU.vl->read());
         show_vec = true;
     }
 

--- a/riscv/insns/vcompress_vm.h
+++ b/riscv/insns/vcompress_vm.h
@@ -1,5 +1,5 @@
 // vcompress vd, vs2, vs1
-require(P.VU.vstart == 0);
+require(P.VU.vstart->read() == 0);
 require_align(insn.rd(), P.VU.vflmul);
 require_align(insn.rs2(), P.VU.vflmul);
 require(insn.rd() != insn.rs2());

--- a/riscv/insns/vcpop_m.h
+++ b/riscv/insns/vcpop_m.h
@@ -5,9 +5,9 @@ reg_t vl = P.VU.vl;
 reg_t sew = P.VU.vsew;
 reg_t rd_num = insn.rd();
 reg_t rs2_num = insn.rs2();
-require(P.VU.vstart == 0);
+require(P.VU.vstart->read() == 0);
 reg_t popcount = 0;
-for (reg_t i=P.VU.vstart; i<vl; ++i) {
+for (reg_t i=P.VU.vstart->read(); i<vl; ++i) {
   const int midx = i / 32;
   const int mpos = i % 32;
 
@@ -19,5 +19,5 @@ for (reg_t i=P.VU.vstart; i<vl; ++i) {
     popcount += (vs2_lsb && do_mask);
   }
 }
-P.VU.vstart = 0;
+P.VU.vstart->write(0);
 WRITE_RD(popcount);

--- a/riscv/insns/vcpop_m.h
+++ b/riscv/insns/vcpop_m.h
@@ -1,7 +1,7 @@
 // vmpopc rd, vs2, vm
 require(P.VU.vsew >= e8 && P.VU.vsew <= e64);
 require_vector(true);
-reg_t vl = P.VU.vl;
+reg_t vl = P.VU.vl->read();
 reg_t sew = P.VU.vsew;
 reg_t rd_num = insn.rd();
 reg_t rs2_num = insn.rs2();

--- a/riscv/insns/vfirst_m.h
+++ b/riscv/insns/vfirst_m.h
@@ -5,9 +5,9 @@ reg_t vl = P.VU.vl;
 reg_t sew = P.VU.vsew;
 reg_t rd_num = insn.rd();
 reg_t rs2_num = insn.rs2();
-require(P.VU.vstart == 0);
+require(P.VU.vstart->read() == 0);
 reg_t pos = -1;
-for (reg_t i=P.VU.vstart; i < vl; ++i) {
+for (reg_t i=P.VU.vstart->read(); i < vl; ++i) {
   VI_LOOP_ELEMENT_SKIP()
 
   bool vs2_lsb = ((P.VU.elt<uint64_t>(rs2_num, midx ) >> mpos) & 0x1) == 1;
@@ -16,5 +16,5 @@ for (reg_t i=P.VU.vstart; i < vl; ++i) {
     break;
   }
 }
-P.VU.vstart = 0;
+P.VU.vstart->write(0);
 WRITE_RD(pos);

--- a/riscv/insns/vfirst_m.h
+++ b/riscv/insns/vfirst_m.h
@@ -1,7 +1,7 @@
 // vmfirst rd, vs2
 require(P.VU.vsew >= e8 && P.VU.vsew <= e64);
 require_vector(true);
-reg_t vl = P.VU.vl;
+reg_t vl = P.VU.vl->read();
 reg_t sew = P.VU.vsew;
 reg_t rd_num = insn.rd();
 reg_t rs2_num = insn.rs2();

--- a/riscv/insns/vfmerge_vfm.h
+++ b/riscv/insns/vfmerge_vfm.h
@@ -4,7 +4,7 @@ VI_VFP_COMMON;
 
 switch(P.VU.vsew) {
   case e16:
-    for (reg_t i=P.VU.vstart; i<vl; ++i) {
+    for (reg_t i=P.VU.vstart->read(); i<vl; ++i) {
       auto &vd = P.VU.elt<float16_t>(rd_num, i, true);
       auto rs1 = f16(READ_FREG(rs1_num));
       auto vs2 = P.VU.elt<float16_t>(rs2_num, i);
@@ -17,7 +17,7 @@ switch(P.VU.vsew) {
     }
     break;
   case e32:
-    for (reg_t i=P.VU.vstart; i<vl; ++i) {
+    for (reg_t i=P.VU.vstart->read(); i<vl; ++i) {
       auto &vd = P.VU.elt<float32_t>(rd_num, i, true);
       auto rs1 = f32(READ_FREG(rs1_num));
       auto vs2 = P.VU.elt<float32_t>(rs2_num, i);
@@ -30,7 +30,7 @@ switch(P.VU.vsew) {
     }
     break;
   case e64:
-    for (reg_t i=P.VU.vstart; i<vl; ++i) {
+    for (reg_t i=P.VU.vstart->read(); i<vl; ++i) {
       auto &vd = P.VU.elt<float64_t>(rd_num, i, true);
       auto rs1 = f64(READ_FREG(rs1_num));
       auto vs2 = P.VU.elt<float64_t>(rs2_num, i);
@@ -47,4 +47,4 @@ switch(P.VU.vsew) {
     break;
 }
 
-P.VU.vstart = 0;
+P.VU.vstart->write(0);

--- a/riscv/insns/vfmv_f_s.h
+++ b/riscv/insns/vfmv_f_s.h
@@ -35,4 +35,4 @@ if (FLEN == 64) {
   WRITE_FRD(f32(vs2_0));
 }
 
-P.VU.vstart = 0;
+P.VU.vstart->write(0);

--- a/riscv/insns/vfmv_s_f.h
+++ b/riscv/insns/vfmv_s_f.h
@@ -6,7 +6,7 @@ require((P.VU.vsew == e16 && p->extension_enabled(EXT_ZFH)) ||
         (P.VU.vsew == e64 && p->extension_enabled('D')));
 require(STATE.frm->read() < 0x5);
 
-reg_t vl = P.VU.vl;
+reg_t vl = P.VU.vl->read();
 
 if (vl > 0 && P.VU.vstart->read() < vl) {
   reg_t rd_num = insn.rd();

--- a/riscv/insns/vfmv_s_f.h
+++ b/riscv/insns/vfmv_s_f.h
@@ -8,7 +8,7 @@ require(STATE.frm->read() < 0x5);
 
 reg_t vl = P.VU.vl;
 
-if (vl > 0 && P.VU.vstart < vl) {
+if (vl > 0 && P.VU.vstart->read() < vl) {
   reg_t rd_num = insn.rd();
 
   switch(P.VU.vsew) {
@@ -26,4 +26,4 @@ if (vl > 0 && P.VU.vstart < vl) {
       break;
   }
 }
-P.VU.vstart = 0;
+P.VU.vstart->write(0);

--- a/riscv/insns/vfmv_v_f.h
+++ b/riscv/insns/vfmv_v_f.h
@@ -3,7 +3,7 @@ require_align(insn.rd(), P.VU.vflmul);
 VI_VFP_COMMON
 switch(P.VU.vsew) {
   case e16:
-    for (reg_t i=P.VU.vstart; i<vl; ++i) {
+    for (reg_t i=P.VU.vstart->read(); i<vl; ++i) {
       auto &vd = P.VU.elt<float16_t>(rd_num, i, true);
       auto rs1 = f16(READ_FREG(rs1_num));
 
@@ -11,7 +11,7 @@ switch(P.VU.vsew) {
     }
     break;
   case e32:
-    for (reg_t i=P.VU.vstart; i<vl; ++i) {
+    for (reg_t i=P.VU.vstart->read(); i<vl; ++i) {
       auto &vd = P.VU.elt<float32_t>(rd_num, i, true);
       auto rs1 = f32(READ_FREG(rs1_num));
 
@@ -19,7 +19,7 @@ switch(P.VU.vsew) {
     }
     break;
   case e64:
-    for (reg_t i=P.VU.vstart; i<vl; ++i) {
+    for (reg_t i=P.VU.vstart->read(); i<vl; ++i) {
       auto &vd = P.VU.elt<float64_t>(rd_num, i, true);
       auto rs1 = f64(READ_FREG(rs1_num));
 
@@ -28,4 +28,4 @@ switch(P.VU.vsew) {
     break;
 }
 
-P.VU.vstart = 0;
+P.VU.vstart->write(0);

--- a/riscv/insns/vid_v.h
+++ b/riscv/insns/vid_v.h
@@ -9,7 +9,7 @@ reg_t rs2_num = insn.rs2();
 require_align(rd_num, P.VU.vflmul);
 require_vm;
 
-for (reg_t i = P.VU.vstart ; i < P.VU.vl; ++i) {
+for (reg_t i = P.VU.vstart->read() ; i < P.VU.vl; ++i) {
   VI_LOOP_ELEMENT_SKIP();
 
   switch (sew) {
@@ -28,4 +28,4 @@ for (reg_t i = P.VU.vstart ; i < P.VU.vl; ++i) {
   }
 }
 
-P.VU.vstart = 0;
+P.VU.vstart->write(0);

--- a/riscv/insns/vid_v.h
+++ b/riscv/insns/vid_v.h
@@ -1,7 +1,7 @@
 // vmpopc rd, vs2, vm
 require(P.VU.vsew >= e8 && P.VU.vsew <= e64);
 require_vector(true);
-reg_t vl = P.VU.vl;
+reg_t vl = P.VU.vl->read();
 reg_t sew = P.VU.vsew;
 reg_t rd_num = insn.rd();
 reg_t rs1_num = insn.rs1();
@@ -9,7 +9,7 @@ reg_t rs2_num = insn.rs2();
 require_align(rd_num, P.VU.vflmul);
 require_vm;
 
-for (reg_t i = P.VU.vstart->read() ; i < P.VU.vl; ++i) {
+for (reg_t i = P.VU.vstart->read() ; i < P.VU.vl->read(); ++i) {
   VI_LOOP_ELEMENT_SKIP();
 
   switch (sew) {

--- a/riscv/insns/viota_m.h
+++ b/riscv/insns/viota_m.h
@@ -6,7 +6,7 @@ reg_t sew = P.VU.vsew;
 reg_t rd_num = insn.rd();
 reg_t rs1_num = insn.rs1();
 reg_t rs2_num = insn.rs2();
-require(P.VU.vstart == 0);
+require(P.VU.vstart->read() == 0);
 require_vm;
 require_align(rd_num, P.VU.vflmul);
 require_noover(rd_num, P.VU.vflmul, rs2_num, 1);

--- a/riscv/insns/viota_m.h
+++ b/riscv/insns/viota_m.h
@@ -1,7 +1,7 @@
 // vmpopc rd, vs2, vm
 require(P.VU.vsew >= e8 && P.VU.vsew <= e64);
 require_vector(true);
-reg_t vl = P.VU.vl;
+reg_t vl = P.VU.vl->read();
 reg_t sew = P.VU.vsew;
 reg_t rd_num = insn.rd();
 reg_t rs1_num = insn.rs1();

--- a/riscv/insns/vmsbf_m.h
+++ b/riscv/insns/vmsbf_m.h
@@ -1,7 +1,7 @@
 // vmsbf.m vd, vs2, vm
 require(P.VU.vsew >= e8 && P.VU.vsew <= e64);
 require_vector(true);
-require(P.VU.vstart == 0);
+require(P.VU.vstart->read() == 0);
 require_vm;
 require(insn.rd() != insn.rs2());
 
@@ -10,7 +10,7 @@ reg_t rd_num = insn.rd();
 reg_t rs2_num = insn.rs2();
 
 bool has_one = false;
-for (reg_t i = P.VU.vstart; i < vl; ++i) {
+for (reg_t i = P.VU.vstart->read(); i < vl; ++i) {
   const int midx = i / 64;
   const int mpos = i % 64;
   const uint64_t mmask = UINT64_C(1) << mpos; \

--- a/riscv/insns/vmsbf_m.h
+++ b/riscv/insns/vmsbf_m.h
@@ -5,7 +5,7 @@ require(P.VU.vstart->read() == 0);
 require_vm;
 require(insn.rd() != insn.rs2());
 
-reg_t vl = P.VU.vl;
+reg_t vl = P.VU.vl->read();
 reg_t rd_num = insn.rd();
 reg_t rs2_num = insn.rs2();
 

--- a/riscv/insns/vmsif_m.h
+++ b/riscv/insns/vmsif_m.h
@@ -5,7 +5,7 @@ require(P.VU.vstart->read() == 0);
 require_vm;
 require(insn.rd() != insn.rs2());
 
-reg_t vl = P.VU.vl;
+reg_t vl = P.VU.vl->read();
 reg_t rd_num = insn.rd();
 reg_t rs2_num = insn.rs2();
 

--- a/riscv/insns/vmsif_m.h
+++ b/riscv/insns/vmsif_m.h
@@ -1,7 +1,7 @@
 // vmsif.m rd, vs2, vm
 require(P.VU.vsew >= e8 && P.VU.vsew <= e64);
 require_vector(true);
-require(P.VU.vstart == 0);
+require(P.VU.vstart->read() == 0);
 require_vm;
 require(insn.rd() != insn.rs2());
 
@@ -10,7 +10,7 @@ reg_t rd_num = insn.rd();
 reg_t rs2_num = insn.rs2();
 
 bool has_one = false;
-for (reg_t i = P.VU.vstart ; i < vl; ++i) {
+for (reg_t i = P.VU.vstart->read(); i < vl; ++i) {
   const int midx = i / 64;
   const int mpos = i % 64;
   const uint64_t mmask = UINT64_C(1) << mpos; \

--- a/riscv/insns/vmsof_m.h
+++ b/riscv/insns/vmsof_m.h
@@ -5,7 +5,7 @@ require(P.VU.vstart->read() == 0);
 require_vm;
 require(insn.rd() != insn.rs2());
 
-reg_t vl = P.VU.vl;
+reg_t vl = P.VU.vl->read();
 reg_t rd_num = insn.rd();
 reg_t rs2_num = insn.rs2();
 

--- a/riscv/insns/vmsof_m.h
+++ b/riscv/insns/vmsof_m.h
@@ -1,7 +1,7 @@
 // vmsof.m rd, vs2, vm
 require(P.VU.vsew >= e8 && P.VU.vsew <= e64);
 require_vector(true);
-require(P.VU.vstart == 0);
+require(P.VU.vstart->read() == 0);
 require_vm;
 require(insn.rd() != insn.rs2());
 
@@ -10,7 +10,7 @@ reg_t rd_num = insn.rd();
 reg_t rs2_num = insn.rs2();
 
 bool has_one = false;
-for (reg_t i = P.VU.vstart ; i < vl; ++i) {
+for (reg_t i = P.VU.vstart->read() ; i < vl; ++i) {
   const int midx = i / 64;
   const int mpos = i % 64;
   const uint64_t mmask = UINT64_C(1) << mpos; \

--- a/riscv/insns/vmv_s_x.h
+++ b/riscv/insns/vmv_s_x.h
@@ -4,7 +4,7 @@ require(insn.v_vm() == 1);
 require(P.VU.vsew >= e8 && P.VU.vsew <= e64);
 reg_t vl = P.VU.vl;
 
-if (vl > 0 && P.VU.vstart < vl) {
+if (vl > 0 && P.VU.vstart->read() < vl) {
   reg_t rd_num = insn.rd();
   reg_t sew = P.VU.vsew;
 
@@ -26,4 +26,4 @@ if (vl > 0 && P.VU.vstart < vl) {
   vl = 0;
 }
 
-P.VU.vstart = 0;
+P.VU.vstart->write(0);

--- a/riscv/insns/vmv_s_x.h
+++ b/riscv/insns/vmv_s_x.h
@@ -2,7 +2,7 @@
 require_vector(true);
 require(insn.v_vm() == 1);
 require(P.VU.vsew >= e8 && P.VU.vsew <= e64);
-reg_t vl = P.VU.vl;
+reg_t vl = P.VU.vl->read();
 
 if (vl > 0 && P.VU.vstart->read() < vl) {
   reg_t rd_num = insn.rd();

--- a/riscv/insns/vmv_x_s.h
+++ b/riscv/insns/vmv_x_s.h
@@ -28,4 +28,4 @@ if (!(rs1 >= 0 && rs1 < (P.VU.get_vlen() / sew))) {
   }
 }
 
-P.VU.vstart = 0;
+P.VU.vstart->write(0);

--- a/riscv/insns/vmvnfr_v.h
+++ b/riscv/insns/vmvnfr_v.h
@@ -9,9 +9,9 @@ require_align(vs2, len);
 const reg_t size = len * P.VU.vlenb;
 
 //register needs one-by-one copy to keep commitlog correct
-if (vd != vs2 && P.VU.vstart < size) {
-  reg_t i = P.VU.vstart / P.VU.vlenb;
-  reg_t off = P.VU.vstart % P.VU.vlenb;
+if (vd != vs2 && P.VU.vstart->read() < size) {
+  reg_t i = P.VU.vstart->read() / P.VU.vlenb;
+  reg_t off = P.VU.vstart->read() % P.VU.vlenb;
   if (off) {
     memcpy(&P.VU.elt<uint8_t>(vd + i, off, true),
            &P.VU.elt<uint8_t>(vs2 + i, off), P.VU.vlenb - off);
@@ -24,4 +24,4 @@ if (vd != vs2 && P.VU.vstart < size) {
   }
 }
 
-P.VU.vstart = 0;
+P.VU.vstart->write(0);

--- a/riscv/insns/vnclip_wi.h
+++ b/riscv/insns/vnclip_wi.h
@@ -15,10 +15,10 @@ VI_VVXI_LOOP_NARROW
   // saturation
   if (result < int_min) {
     result = int_min;
-    P.VU.vxsat = 1;
+    P_SET_OV(1);
   } else if (result > int_max) {
     result = int_max;
-    P.VU.vxsat = 1;
+    P_SET_OV(1);
   }
 
   vd = result;

--- a/riscv/insns/vnclip_wv.h
+++ b/riscv/insns/vnclip_wv.h
@@ -15,10 +15,10 @@ VI_VVXI_LOOP_NARROW
   // saturation
   if (result < int_min) {
     result = int_min;
-    P.VU.vxsat = 1;
+    P_SET_OV(1);
   } else if (result > int_max) {
     result = int_max;
-    P.VU.vxsat = 1;
+    P_SET_OV(1);
   }
 
   vd = result;

--- a/riscv/insns/vnclip_wx.h
+++ b/riscv/insns/vnclip_wx.h
@@ -15,10 +15,10 @@ VI_VVXI_LOOP_NARROW
   // saturation
   if (result < int_min) {
     result = int_min;
-    P.VU.vxsat = 1;
+    P_SET_OV(1);
   } else if (result > int_max) {
     result = int_max;
-    P.VU.vxsat = 1;
+    P_SET_OV(1);
   }
 
   vd = result;

--- a/riscv/insns/vnclipu_wi.h
+++ b/riscv/insns/vnclipu_wi.h
@@ -16,7 +16,7 @@ VI_VVXI_LOOP_NARROW
   // saturation
   if (result & sign_mask) {
     result = uint_max;
-    P.VU.vxsat = 1;
+    P_SET_OV(1);
   }
 
   vd = result;

--- a/riscv/insns/vnclipu_wv.h
+++ b/riscv/insns/vnclipu_wv.h
@@ -15,7 +15,7 @@ VI_VVXI_LOOP_NARROW
   // saturation
   if (result & sign_mask) {
     result = uint_max;
-    P.VU.vxsat = 1;
+    P_SET_OV(1);
   }
 
   vd = result;

--- a/riscv/insns/vnclipu_wx.h
+++ b/riscv/insns/vnclipu_wx.h
@@ -15,7 +15,7 @@ VI_VVXI_LOOP_NARROW
   // saturation
   if (result & sign_mask) {
     result = uint_max;
-    P.VU.vxsat = 1;
+    P_SET_OV(1);
   }
 
   vd = result;

--- a/riscv/insns/vrgather_vi.h
+++ b/riscv/insns/vrgather_vi.h
@@ -8,7 +8,7 @@ reg_t zimm5 = insn.v_zimm5();
 
 VI_LOOP_BASE
 
-for (reg_t i = P.VU.vstart; i < vl; ++i) {
+for (reg_t i = P.VU.vstart->read(); i < vl; ++i) {
   VI_LOOP_ELEMENT_SKIP();
 
   switch (sew) {

--- a/riscv/insns/vsadd_vi.h
+++ b/riscv/insns/vsadd_vi.h
@@ -24,5 +24,5 @@ default: {
   break;
 }
 }
-P.VU.vxsat |= sat;
+P_SET_OV(sat);
 VI_LOOP_END

--- a/riscv/insns/vsadd_vv.h
+++ b/riscv/insns/vsadd_vv.h
@@ -24,6 +24,5 @@ default: {
   break;
 }
 }
-P.VU.vxsat |= sat;
+P_SET_OV(sat);
 VI_LOOP_END
-

--- a/riscv/insns/vsadd_vx.h
+++ b/riscv/insns/vsadd_vx.h
@@ -24,5 +24,5 @@ default: {
   break;
 }
 }
-P.VU.vxsat |= sat;
+P_SET_OV(sat);
 VI_LOOP_END

--- a/riscv/insns/vsaddu_vi.h
+++ b/riscv/insns/vsaddu_vi.h
@@ -7,5 +7,5 @@ VI_VI_ULOOP
   sat = vd < vs2;
   vd |= -(vd < vs2);
 
-  P.VU.vxsat |= sat;
+  P_SET_OV(sat);
 })

--- a/riscv/insns/vsaddu_vv.h
+++ b/riscv/insns/vsaddu_vv.h
@@ -7,5 +7,5 @@ VI_VV_ULOOP
   sat = vd < vs2;
   vd |= -(vd < vs2);
 
-  P.VU.vxsat |= sat;
+  P_SET_OV(sat);
 })

--- a/riscv/insns/vsaddu_vx.h
+++ b/riscv/insns/vsaddu_vx.h
@@ -7,6 +7,6 @@ VI_VX_ULOOP
   sat = vd < vs2;
   vd |= -(vd < vs2);
 
-  P.VU.vxsat |= sat;
+  P_SET_OV(sat);
 
 })

--- a/riscv/insns/vslideup_vi.h
+++ b/riscv/insns/vslideup_vi.h
@@ -3,7 +3,7 @@ VI_CHECK_SLIDE(true);
 
 const reg_t offset = insn.v_zimm5();
 VI_LOOP_BASE
-if (P.VU.vstart < offset && i < offset)
+if (P.VU.vstart->read() < offset && i < offset)
   continue;
 
 switch (sew) {

--- a/riscv/insns/vslideup_vx.h
+++ b/riscv/insns/vslideup_vx.h
@@ -3,7 +3,7 @@ VI_CHECK_SLIDE(true);
 
 const reg_t offset = RS1;
 VI_LOOP_BASE
-if (P.VU.vstart < offset && i < offset)
+if (P.VU.vstart->read() < offset && i < offset)
   continue;
 
 switch (sew) {

--- a/riscv/insns/vsmul_vv.h
+++ b/riscv/insns/vsmul_vv.h
@@ -25,7 +25,7 @@ VI_VV_LOOP
   // saturation
   if (overflow) {
     result = int_max;
-    P.VU.vxsat |= 1;
+    P_SET_OV(1);
   }
 
   vd = result;

--- a/riscv/insns/vsmul_vx.h
+++ b/riscv/insns/vsmul_vx.h
@@ -26,7 +26,7 @@ VI_VX_LOOP
   // max saturation
   if (overflow) {
     result = int_max;
-    P.VU.vxsat |= 1;
+    P_SET_OV(1);
   }
 
   vd = result;

--- a/riscv/insns/vssub_vv.h
+++ b/riscv/insns/vssub_vv.h
@@ -25,5 +25,5 @@ default: {
   break;
 }
 }
-P.VU.vxsat |= sat;
+P_SET_OV(sat);
 VI_LOOP_END

--- a/riscv/insns/vssub_vx.h
+++ b/riscv/insns/vssub_vx.h
@@ -25,5 +25,5 @@ default: {
   break;
 }
 }
-P.VU.vxsat |= sat;
+P_SET_OV(sat);
 VI_LOOP_END

--- a/riscv/insns/vssubu_vv.h
+++ b/riscv/insns/vssubu_vv.h
@@ -25,6 +25,6 @@ default: {
   break;
 }
 }
-P.VU.vxsat |= sat;
+P_SET_OV(sat);
 
 VI_LOOP_END

--- a/riscv/insns/vssubu_vx.h
+++ b/riscv/insns/vssubu_vx.h
@@ -25,5 +25,5 @@ default: {
   break;
 }
 }
-P.VU.vxsat |= sat;
+P_SET_OV(sat);
 VI_LOOP_END

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -558,6 +558,7 @@ void processor_t::vectorUnit_t::reset(){
   csrmap[CSR_VXRM] = vxrm = std::make_shared<vector_csr_t>(p, CSR_VXRM, /*mask*/ 0x3ul);
   csrmap[CSR_VL] = vl = std::make_shared<vector_csr_t>(p, CSR_VL, /*mask*/ 0);
   csrmap[CSR_VTYPE] = vtype = std::make_shared<vector_csr_t>(p, CSR_VTYPE, /*mask*/ 0);
+  csrmap[CSR_VLENB] = std::make_shared<vector_csr_t>(p, CSR_VLENB, /*mask*/ 0, /*init*/ vlenb);
 
   vtype->write_raw(0);
   set_vl(0, 0, 0, -1); // default to illegal configuration
@@ -1024,11 +1025,6 @@ reg_t processor_t::get_csr(int which, insn_t insn, bool write, bool peek)
       if (!extension_enabled('V'))
         break;
       ret((VU.vxsat->read() << VCSR_VXSAT_SHIFT) | (VU.vxrm->read() << VCSR_VXRM_SHIFT));
-    case CSR_VLENB:
-      require_vector_vs;
-      if (!extension_enabled('V'))
-        break;
-      ret(VU.vlenb);
   }
 
 #undef ret

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -524,7 +524,7 @@ void state_t::reset(processor_t* const proc, reg_t max_isa)
   csrmap[CSR_FFLAGS] = fflags = std::make_shared<float_csr_t>(proc, CSR_FFLAGS, FSR_AEXC >> FSR_AEXC_SHIFT, 0);
   csrmap[CSR_FRM] = frm = std::make_shared<float_csr_t>(proc, CSR_FRM, FSR_RD >> FSR_RD_SHIFT, 0);
   assert(FSR_AEXC_SHIFT == 0);  // composite_csr_t assumes fflags begins at bit 0
-  csrmap[CSR_FCSR] = std::make_shared<composite_csr_t>(proc, CSR_FFLAGS, frm, fflags, FSR_RD_SHIFT);
+  csrmap[CSR_FCSR] = std::make_shared<composite_csr_t>(proc, CSR_FCSR, frm, fflags, FSR_RD_SHIFT);
 
   csrmap[CSR_SENTROPY] = std::make_shared<sentropy_csr_t>(proc, CSR_SENTROPY);
 

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -511,8 +511,8 @@ public:
       char reg_referenced[NVPR];
       int setvl_count;
       reg_t vlmax;
-      reg_t vtype, vlenb;
-      vector_csr_t_p vxrm, vstart, vxsat, vl;
+      reg_t vlenb;
+      vector_csr_t_p vxrm, vstart, vxsat, vl, vtype;
       reg_t vma, vta;
       reg_t vsew;
       float vflmul;
@@ -553,12 +553,12 @@ public:
         reg_referenced{0},
         setvl_count(0),
         vlmax(0),
-        vtype(0),
         vlenb(0),
         vxrm(0),
         vstart(0),
         vxsat(0),
         vl(0),
+        vtype(0),
         vma(0),
         vta(0),
         vsew(0),

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -511,8 +511,8 @@ public:
       char reg_referenced[NVPR];
       int setvl_count;
       reg_t vlmax;
-      reg_t vstart, vxrm, vl, vtype, vlenb;
-      csr_t_p vxsat;
+      reg_t vxrm, vl, vtype, vlenb;
+      vector_csr_t_p vstart, vxsat;
       reg_t vma, vta;
       reg_t vsew;
       float vflmul;
@@ -553,11 +553,11 @@ public:
         reg_referenced{0},
         setvl_count(0),
         vlmax(0),
-        vstart(0),
         vxrm(0),
         vl(0),
         vtype(0),
         vlenb(0),
+        vstart(0),
         vxsat(0),
         vma(0),
         vta(0),

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -511,8 +511,8 @@ public:
       char reg_referenced[NVPR];
       int setvl_count;
       reg_t vlmax;
-      reg_t vxrm, vl, vtype, vlenb;
-      vector_csr_t_p vstart, vxsat;
+      reg_t vl, vtype, vlenb;
+      vector_csr_t_p vxrm, vstart, vxsat;
       reg_t vma, vta;
       reg_t vsew;
       float vflmul;
@@ -553,10 +553,10 @@ public:
         reg_referenced{0},
         setvl_count(0),
         vlmax(0),
-        vxrm(0),
         vl(0),
         vtype(0),
         vlenb(0),
+        vxrm(0),
         vstart(0),
         vxsat(0),
         vma(0),
@@ -581,7 +581,7 @@ public:
       reg_t get_slen() { return VLEN; }
 
       VRM get_vround_mode() {
-        return (VRM)vxrm;
+        return (VRM)(vxrm->read());
       }
   };
 

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -546,8 +546,26 @@ public:
 
       void reset();
 
-      vectorUnit_t(){
-        reg_file = 0;
+      vectorUnit_t():
+        p(0),
+        reg_file(0),
+        reg_referenced{0},
+        setvl_count(0),
+        vlmax(0),
+        vstart(0),
+        vxrm(0),
+        vxsat(0),
+        vl(0),
+        vtype(0),
+        vlenb(0),
+        vma(0),
+        vta(0),
+        vsew(0),
+        vflmul(0),
+        ELEN(0),
+        VLEN(0),
+        vill(false),
+        vstart_alu(false) {
       }
 
       ~vectorUnit_t(){

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -511,8 +511,8 @@ public:
       char reg_referenced[NVPR];
       int setvl_count;
       reg_t vlmax;
-      reg_t vl, vtype, vlenb;
-      vector_csr_t_p vxrm, vstart, vxsat;
+      reg_t vtype, vlenb;
+      vector_csr_t_p vxrm, vstart, vxsat, vl;
       reg_t vma, vta;
       reg_t vsew;
       float vflmul;
@@ -553,12 +553,12 @@ public:
         reg_referenced{0},
         setvl_count(0),
         vlmax(0),
-        vl(0),
         vtype(0),
         vlenb(0),
         vxrm(0),
         vstart(0),
         vxsat(0),
+        vl(0),
         vma(0),
         vta(0),
         vsew(0),

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -511,7 +511,8 @@ public:
       char reg_referenced[NVPR];
       int setvl_count;
       reg_t vlmax;
-      reg_t vstart, vxrm, vxsat, vl, vtype, vlenb;
+      reg_t vstart, vxrm, vl, vtype, vlenb;
+      csr_t_p vxsat;
       reg_t vma, vta;
       reg_t vsew;
       float vflmul;
@@ -554,10 +555,10 @@ public:
         vlmax(0),
         vstart(0),
         vxrm(0),
-        vxsat(0),
         vl(0),
         vtype(0),
         vlenb(0),
+        vxsat(0),
         vma(0),
         vta(0),
         vsew(0),


### PR DESCRIPTION
See #793 for rationale.

This covers the following CSRs, all from the Vector extension:

* vxsat
* vstart
* vxrm
* vl
* vtype
* vlenb
* vcsr

The only functional change is in the commit log, where the writable CSRs above will now appear as expected.

I also cleaned up the remaining code around reading/writing CSRs.

This completes the CSR refactoring begun in #793 and continued in #804, #810, #813, #815, #816, and #818.