### PR TITLE
Fix VSIE CSR write emulation

### DIFF
--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -413,7 +413,7 @@ void state_t::reset(processor_t* const proc, reg_t max_isa)
   auto vsip_vsie_accr = std::make_shared<generic_int_accessor_t>(this,
                                                                  MIP_VS_MASK,   // read_mask
                                                                  MIP_VSSIP,     // ip_write_mask
-                                                                 MIP_VSSIP,     // ie_write_mask
+                                                                 MIP_VS_MASK,   // ie_write_mask
                                                                  false,         // mask_mideleg
                                                                  true,          // mask_hideleg
                                                                  1);            // shiftamt


### PR DESCRIPTION
The VSIE CSR write emulation is broken in latest Spike because
it is allowing only VSSIE bit to be update. This patches fixes
ie_write_mask for VSIE CSR to allow VSTIE, VSSIE, and VSEIE
bits to be updated.

With this patch, we have both Xvisor RISC-V and KVM RISC-V
working again on Spike.

Fixes: 5c1d635c6e56 ("Convert sie/hie/vsie to csr_t family")
Signed-off-by: Anup Patel <anup.patel@wdc.com>