### PR TITLE
Properly check CSR permissions for floating-point CSRs

### DIFF
--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -1145,6 +1145,7 @@ float_csr_t::float_csr_t(processor_t* const proc, const reg_t addr, const reg_t 
 }
 
 void float_csr_t::verify_permissions(insn_t insn, bool write) const {
+  masked_csr_t::verify_permissions(insn, write);
   require_fp;
   if (!proc->extension_enabled('F'))
     throw trap_illegal_instruction(insn.bits());


### PR DESCRIPTION
We were not properly checking for Machine-level or Supervisor-level CSR accessibility on `frm`, `fflags`, or `fcsr`.

Since those three are all User-accessible, this has no functional effect, but it's the safe thing to do.