### PR TITLE
Fixed a segmentation fault bug

### DIFF
--- a/riscv/decode.h
+++ b/riscv/decode.h
@@ -1705,7 +1705,7 @@ reg_t index[P.VU.vlmax]; \
       } \
     } \
   } \
-  P.VU.vstart = 0; \
+  P.VU.vstart->write(0);
 
 #define VI_ST_WHOLE \
   require_vector_novtype(true, false); \


### PR DESCRIPTION
            After executing vector load/store whole register instructions,
            spike would be crashed when executed the next vector instruction.

Signed-off-by: Eric Tang <tangxingxin1008@gmail.com>