### PR TITLE
Fix a link error when compiled without optimization option "-O2"

### DIFF
--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -339,6 +339,8 @@ static int xlen_to_uxl(int xlen)
   abort();
 }
 
+const int state_t::num_triggers;
+
 void state_t::reset(processor_t* const proc, reg_t max_isa)
 {
   pc = DEFAULT_RSTVEC;


### PR DESCRIPTION
Error log:
  libriscv.a(processor.o): In function `state_t::reset(processor_t*, unsigned long)':
  .../_build/../riscv/processor.cc:509: undefined reference to `state_t::num_triggers'
  collect2: error: ld returned 1 exit status
  Makefile:349: recipe for target 'spike-log-parser' failed

Signed-off-by: Eric Tang <tangxingxin1008@gmail.com>