### PR TITLE
remove uret declaration

### DIFF
--- a/disasm/disasm.cc
+++ b/disasm/disasm.cc
@@ -855,7 +855,6 @@ disassembler_t::disassembler_t(int xlen)
 
   DEFINE_NOARG(ecall);
   DEFINE_NOARG(ebreak);
-  DEFINE_NOARG(uret);
   DEFINE_NOARG(sret);
   DEFINE_NOARG(mret);
   DEFINE_NOARG(dret);


### PR DESCRIPTION
`uret` has been removed from specifications (as far as I can see). Its presence here blocks compilation as opcodes for it are no longer generated in `encodings.h` by scripts in https://github.com/riscv/riscv-opcodes/ .