### PR TITLE
Set GVA properly on breakpoint traps

### DIFF
--- a/riscv/execute.cc
+++ b/riscv/execute.cc
@@ -329,7 +329,7 @@ void processor_t::step(size_t n)
           enter_debug_mode(DCSR_CAUSE_HWBP);
           break;
         case ACTION_DEBUG_EXCEPTION: {
-          trap_breakpoint trap(/*gva*/false, t.address);
+          trap_breakpoint trap(state.v, t.address);
           take_trap(trap, pc);
           break;
         }

--- a/riscv/execute.cc
+++ b/riscv/execute.cc
@@ -329,7 +329,7 @@ void processor_t::step(size_t n)
           enter_debug_mode(DCSR_CAUSE_HWBP);
           break;
         case ACTION_DEBUG_EXCEPTION: {
-          trap_breakpoint trap(t.address);
+          trap_breakpoint trap(/*gva*/false, t.address);
           take_trap(trap, pc);
           break;
         }

--- a/riscv/execute.cc
+++ b/riscv/execute.cc
@@ -329,7 +329,7 @@ void processor_t::step(size_t n)
           enter_debug_mode(DCSR_CAUSE_HWBP);
           break;
         case ACTION_DEBUG_EXCEPTION: {
-          insn_trap_t trap(CAUSE_BREAKPOINT, t.address);
+          trap_breakpoint trap(t.address);
           take_trap(trap, pc);
           break;
         }

--- a/riscv/insns/c_ebreak.h
+++ b/riscv/insns/c_ebreak.h
@@ -1,2 +1,2 @@
 require_extension('C');
-throw trap_breakpoint(pc);
+throw trap_breakpoint(/*gva*/false, pc);

--- a/riscv/insns/c_ebreak.h
+++ b/riscv/insns/c_ebreak.h
@@ -1,2 +1,2 @@
 require_extension('C');
-throw trap_breakpoint(/*gva*/false, pc);
+throw trap_breakpoint(STATE.v, pc);

--- a/riscv/insns/ebreak.h
+++ b/riscv/insns/ebreak.h
@@ -1,1 +1,1 @@
-throw trap_breakpoint(/*gva*/false, pc);
+throw trap_breakpoint(STATE.v, pc);

--- a/riscv/insns/ebreak.h
+++ b/riscv/insns/ebreak.h
@@ -1,1 +1,1 @@
-throw trap_breakpoint(pc);
+throw trap_breakpoint(/*gva*/false, pc);

--- a/riscv/trap.h
+++ b/riscv/trap.h
@@ -68,6 +68,12 @@ class mem_trap_t : public trap_t
   const char* name() { return "trap_"#x; } \
 };
 
+#define DECLARE_INST_WITH_GVA_TRAP(n, x) class trap_##x : public insn_trap_t {  \
+ public: \
+  trap_##x(bool gva, reg_t tval) : insn_trap_t(n, gva, tval) {} \
+  const char* name() { return "trap_"#x; } \
+};
+
 #define DECLARE_MEM_TRAP(n, x) class trap_##x : public mem_trap_t { \
  public: \
   trap_##x(bool gva, reg_t tval, reg_t tval2, reg_t tinst) : mem_trap_t(n, gva, tval, tval2, tinst) {} \
@@ -83,7 +89,7 @@ class mem_trap_t : public trap_t
 DECLARE_MEM_TRAP(CAUSE_MISALIGNED_FETCH, instruction_address_misaligned)
 DECLARE_MEM_TRAP(CAUSE_FETCH_ACCESS, instruction_access_fault)
 DECLARE_INST_TRAP(CAUSE_ILLEGAL_INSTRUCTION, illegal_instruction)
-DECLARE_INST_TRAP(CAUSE_BREAKPOINT, breakpoint)
+DECLARE_INST_WITH_GVA_TRAP(CAUSE_BREAKPOINT, breakpoint)
 DECLARE_MEM_TRAP(CAUSE_MISALIGNED_LOAD, load_address_misaligned)
 DECLARE_MEM_TRAP(CAUSE_MISALIGNED_STORE, store_address_misaligned)
 DECLARE_MEM_TRAP(CAUSE_LOAD_ACCESS, load_access_fault)

--- a/riscv/trap.h
+++ b/riscv/trap.h
@@ -29,11 +29,13 @@ class trap_t
 class insn_trap_t : public trap_t
 {
  public:
-  insn_trap_t(reg_t which, reg_t tval)
-    : trap_t(which), tval(tval) {}
+  insn_trap_t(reg_t which, bool gva, reg_t tval)
+    : trap_t(which), gva(gva), tval(tval) {}
+  bool has_gva() override { return gva; }
   bool has_tval() override { return true; }
   reg_t get_tval() override { return tval; }
  private:
+  bool gva;
   reg_t tval;
 };
 
@@ -62,7 +64,7 @@ class mem_trap_t : public trap_t
 
 #define DECLARE_INST_TRAP(n, x) class trap_##x : public insn_trap_t { \
  public: \
-  trap_##x(reg_t tval) : insn_trap_t(n, tval) {} \
+  trap_##x(reg_t tval) : insn_trap_t(n, /*gva*/false, tval) {} \
   const char* name() { return "trap_"#x; } \
 };
 


### PR DESCRIPTION
Privileged spec says about `mstatus.GVA`:

> Field GVA (Guest Virtual Address) is written by the implementation whenever a trap is taken into M-mode. For any trap (breakpoint, address misaligned, access fault, page fault, or guest-page fault) that writes a guest virtual address to mtval, GVA is set to 1. For any other trap into M-mode, GVA is set to 0.

Spike was always writing GVA=0 on breakpoint traps.