### PR TITLE
Fix #820 by relocating definition of P and require macros

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -38,7 +38,7 @@ scripts_dir  := $(src_dir)/scripts
 
 HAVE_INT128 := @HAVE_INT128@
 HAVE_DLOPEN := @HAVE_DLOPEN@
-HAVE_CLANG_PCH := $(and @HAVE_CLANG_PCH@, $(if @BOOST_ASIO_LIB@,,yes))
+HAVE_CLANG_PCH := @HAVE_CLANG_PCH@
 
 # If the version information is not in the configure script, then we
 # assume that we are in a working directory. We use the vcs-version.sh

--- a/customext/cflush.cc
+++ b/customext/cflush.cc
@@ -1,3 +1,4 @@
+#include "insn_macros.h"
 #include "extension.h"
 #include <cstring>
 

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -8,6 +8,8 @@
 #include "decode.h"
 // For trap_virtual_instruction and trap_illegal_instruction:
 #include "trap.h"
+// For require():
+#include "insn_macros.h"
 
 // STATE macro used by require_privilege() macro:
 #undef STATE

--- a/riscv/decode.h
+++ b/riscv/decode.h
@@ -174,7 +174,6 @@ private:
 // helpful macros, etc
 #define MMU (*p->get_mmu())
 #define STATE (*p->get_state())
-#define P (*p)
 #define FLEN (p->get_flen())
 #define READ_REG(reg) STATE.XPR[reg]
 #define READ_FREG(reg) STATE.FPR[reg]
@@ -241,7 +240,6 @@ private:
 #define get_field(reg, mask) (((reg) & (decltype(reg))(mask)) / ((mask) & ~((mask) << 1)))
 #define set_field(reg, mask, val) (((reg) & ~(decltype(reg))(mask)) | (((decltype(reg))(val) * ((mask) & ~((mask) << 1))) & (decltype(reg))(mask)))
 
-#define require(x) do { if (unlikely(!(x))) throw trap_illegal_instruction(insn.bits()); } while (0)
 #define require_privilege(p) require(STATE.prv >= (p))
 #define require_novirt() if (unlikely(STATE.v)) throw trap_virtual_instruction(insn.bits())
 #define require_rv64 require(xlen == 64)

--- a/riscv/insn_macros.h
+++ b/riscv/insn_macros.h
@@ -1,0 +1,9 @@
+#ifndef _RISCV_INSN_MACROS_H
+#define _RISCV_INSN_MACROS_H
+
+// These conflict with Boost headers so can't be included from insn_template.h
+#define P (*p)
+
+#define require(x) do { if (unlikely(!(x))) throw trap_illegal_instruction(insn.bits()); } while (0)
+
+#endif

--- a/riscv/insn_template.cc
+++ b/riscv/insn_template.cc
@@ -1,6 +1,7 @@
 // See LICENSE for license details.
 
 #include "insn_template.h"
+#include "insn_macros.h"
 
 reg_t rv32_NAME(processor_t* p, insn_t insn, reg_t pc)
 {

--- a/riscv/interactive.cc
+++ b/riscv/interactive.cc
@@ -353,19 +353,19 @@ void sim_t::interactive_vreg(const std::string& cmd, const std::vector<std::stri
       uint64_t val;
       switch(elen){
         case 8:
-          val = P.VU.elt<uint64_t>(r, e);
+          val = p->VU.elt<uint64_t>(r, e);
           out << std::dec << "[" << e << "]: 0x" << std::hex << std::setfill ('0') << std::setw(16) << val << "  ";
           break;
         case 4:
-          val = P.VU.elt<uint32_t>(r, e);
+          val = p->VU.elt<uint32_t>(r, e);
           out << std::dec << "[" << e << "]: 0x" << std::hex << std::setfill ('0') << std::setw(8) << (uint32_t)val << "  ";
           break;
         case 2:
-          val = P.VU.elt<uint16_t>(r, e);
+          val = p->VU.elt<uint16_t>(r, e);
           out << std::dec << "[" << e << "]: 0x" << std::hex << std::setfill ('0') << std::setw(8) << (uint16_t)val << "  ";
           break;
         case 1:
-          val = P.VU.elt<uint8_t>(r, e);
+          val = p->VU.elt<uint8_t>(r, e);
           out << std::dec << "[" << e << "]: 0x" << std::hex << std::setfill ('0') << std::setw(8) << (int)(uint8_t)val << "  ";
           break;
       }


### PR DESCRIPTION
Fixes a namespace conflict with Boost, allow us to use precompiled headers with Clang again.