### PR TITLE
fixed fdt #include to search in local diretory first

### DIFF
--- a/fdt/fdt.c
+++ b/fdt/fdt.c
@@ -5,8 +5,8 @@
  */
 #include "libfdt_env.h"
 
-#include <fdt.h>
-#include <libfdt.h>
+#include "fdt.h"
+#include "libfdt.h"
 
 #include "libfdt_internal.h"
 


### PR DESCRIPTION
Replacing `<>` by `""` fixed the problem.
Even if there is another file called `libfdt.a` in the system search path, the linker uses the file `libfdt.a` from `riscv-isa-sim/build`. 