### PR TITLE
fix code style of pointer to processor_t

### DIFF
--- a/riscv/insn_macros.h
+++ b/riscv/insn_macros.h
@@ -1,9 +1,6 @@
 #ifndef _RISCV_INSN_MACROS_H
 #define _RISCV_INSN_MACROS_H
 
-// These conflict with Boost headers so can't be included from insn_template.h
-#define P (*p)
-
 #define require(x) do { if (unlikely(!(x))) throw trap_illegal_instruction(insn.bits()); } while (0)
 
 #endif

--- a/riscv/insns/vadc_vim.h
+++ b/riscv/insns/vadc_vim.h
@@ -1,7 +1,7 @@
 // vadc.vim vd, vs2, simm5, v0
 VI_XI_LOOP_WITH_CARRY
 ({
-  auto &v0 = P.VU.elt<uint64_t>(0, midx);
+  auto &v0 = p->VU.elt<uint64_t>(0, midx);
   const uint128_t op_mask = (UINT64_MAX >> (64 - sew));
   uint64_t carry = (v0 >> mpos) & 0x1;
 

--- a/riscv/insns/vadc_vvm.h
+++ b/riscv/insns/vadc_vvm.h
@@ -1,7 +1,7 @@
 // vadc.vvm vd, vs2, rs1, v0
 VI_VV_LOOP_WITH_CARRY
 ({
-  auto &v0 = P.VU.elt<uint64_t>(0, midx);
+  auto &v0 = p->VU.elt<uint64_t>(0, midx);
   const uint128_t op_mask = (UINT64_MAX >> (64 - sew));
   uint64_t carry = (v0 >> mpos) & 0x1;
 

--- a/riscv/insns/vadc_vxm.h
+++ b/riscv/insns/vadc_vxm.h
@@ -1,7 +1,7 @@
 // vadc.vxm vd, vs2, rs1, v0
 VI_XI_LOOP_WITH_CARRY
 ({
-  auto &v0 = P.VU.elt<uint64_t>(0, midx);
+  auto &v0 = p->VU.elt<uint64_t>(0, midx);
   const uint128_t op_mask = (UINT64_MAX >> (64 - sew));
   uint64_t carry = (v0 >> mpos) & 0x1;
 

--- a/riscv/insns/vcompress_vm.h
+++ b/riscv/insns/vcompress_vm.h
@@ -1,9 +1,9 @@
 // vcompress vd, vs2, vs1
-require(P.VU.vstart->read() == 0);
-require_align(insn.rd(), P.VU.vflmul);
-require_align(insn.rs2(), P.VU.vflmul);
+require(p->VU.vstart->read() == 0);
+require_align(insn.rd(), p->VU.vflmul);
+require_align(insn.rs2(), p->VU.vflmul);
 require(insn.rd() != insn.rs2());
-require_noover(insn.rd(), P.VU.vflmul, insn.rs1(), 1);
+require_noover(insn.rd(), p->VU.vflmul, insn.rs1(), 1);
 
 reg_t pos = 0;
 
@@ -11,20 +11,20 @@ VI_GENERAL_LOOP_BASE
   const int midx = i / 64;
   const int mpos = i % 64;
 
-  bool do_mask = (P.VU.elt<uint64_t>(rs1_num, midx) >> mpos) & 0x1;
+  bool do_mask = (p->VU.elt<uint64_t>(rs1_num, midx) >> mpos) & 0x1;
   if (do_mask) {
     switch (sew) {
     case e8:
-      P.VU.elt<uint8_t>(rd_num, pos, true) = P.VU.elt<uint8_t>(rs2_num, i);
+      p->VU.elt<uint8_t>(rd_num, pos, true) = p->VU.elt<uint8_t>(rs2_num, i);
       break;
     case e16:
-      P.VU.elt<uint16_t>(rd_num, pos, true) = P.VU.elt<uint16_t>(rs2_num, i);
+      p->VU.elt<uint16_t>(rd_num, pos, true) = p->VU.elt<uint16_t>(rs2_num, i);
       break;
     case e32:
-      P.VU.elt<uint32_t>(rd_num, pos, true) = P.VU.elt<uint32_t>(rs2_num, i);
+      p->VU.elt<uint32_t>(rd_num, pos, true) = p->VU.elt<uint32_t>(rs2_num, i);
       break;
     default:
-      P.VU.elt<uint64_t>(rd_num, pos, true) = P.VU.elt<uint64_t>(rs2_num, i);
+      p->VU.elt<uint64_t>(rd_num, pos, true) = p->VU.elt<uint64_t>(rs2_num, i);
       break;
     }
 

--- a/riscv/insns/vcpop_m.h
+++ b/riscv/insns/vcpop_m.h
@@ -1,23 +1,23 @@
 // vmpopc rd, vs2, vm
-require(P.VU.vsew >= e8 && P.VU.vsew <= e64);
+require(p->VU.vsew >= e8 && p->VU.vsew <= e64);
 require_vector(true);
-reg_t vl = P.VU.vl->read();
-reg_t sew = P.VU.vsew;
+reg_t vl = p->VU.vl->read();
+reg_t sew = p->VU.vsew;
 reg_t rd_num = insn.rd();
 reg_t rs2_num = insn.rs2();
-require(P.VU.vstart->read() == 0);
+require(p->VU.vstart->read() == 0);
 reg_t popcount = 0;
-for (reg_t i=P.VU.vstart->read(); i<vl; ++i) {
+for (reg_t i=p->VU.vstart->read(); i<vl; ++i) {
   const int midx = i / 32;
   const int mpos = i % 32;
 
-  bool vs2_lsb = ((P.VU.elt<uint32_t>(rs2_num, midx ) >> mpos) & 0x1) == 1;
+  bool vs2_lsb = ((p->VU.elt<uint32_t>(rs2_num, midx ) >> mpos) & 0x1) == 1;
   if (insn.v_vm() == 1) {
     popcount += vs2_lsb;
   } else {
-    bool do_mask = (P.VU.elt<uint32_t>(0, midx) >> mpos) & 0x1;
+    bool do_mask = (p->VU.elt<uint32_t>(0, midx) >> mpos) & 0x1;
     popcount += (vs2_lsb && do_mask);
   }
 }
-P.VU.vstart->write(0);
+p->VU.vstart->write(0);
 WRITE_RD(popcount);

--- a/riscv/insns/vfcvt_f_x_v.h
+++ b/riscv/insns/vfcvt_f_x_v.h
@@ -1,14 +1,14 @@
 // vfcvt.f.x.v vd, vd2, vm
 VI_VFP_VF_LOOP
 ({
-  auto vs2_i = P.VU.elt<int16_t>(rs2_num, i);
+  auto vs2_i = p->VU.elt<int16_t>(rs2_num, i);
   vd = i32_to_f16(vs2_i);
 },
 {
-  auto vs2_i = P.VU.elt<int32_t>(rs2_num, i);
+  auto vs2_i = p->VU.elt<int32_t>(rs2_num, i);
   vd = i32_to_f32(vs2_i);
 },
 {
-  auto vs2_i = P.VU.elt<int64_t>(rs2_num, i);
+  auto vs2_i = p->VU.elt<int64_t>(rs2_num, i);
   vd = i64_to_f64(vs2_i);
 })

--- a/riscv/insns/vfcvt_f_xu_v.h
+++ b/riscv/insns/vfcvt_f_xu_v.h
@@ -1,14 +1,14 @@
 // vfcvt.f.xu.v vd, vd2, vm
 VI_VFP_VF_LOOP
 ({
-  auto vs2_u = P.VU.elt<uint16_t>(rs2_num, i);
+  auto vs2_u = p->VU.elt<uint16_t>(rs2_num, i);
   vd = ui32_to_f16(vs2_u);
 },
 {
-  auto vs2_u = P.VU.elt<uint32_t>(rs2_num, i);
+  auto vs2_u = p->VU.elt<uint32_t>(rs2_num, i);
   vd = ui32_to_f32(vs2_u);
 },
 {
-  auto vs2_u = P.VU.elt<uint64_t>(rs2_num, i);
+  auto vs2_u = p->VU.elt<uint64_t>(rs2_num, i);
   vd = ui64_to_f64(vs2_u);
 })

--- a/riscv/insns/vfcvt_rtz_x_f_v.h
+++ b/riscv/insns/vfcvt_rtz_x_f_v.h
@@ -1,11 +1,11 @@
 // vfcvt.rtz.x.f.v vd, vd2, vm
 VI_VFP_VF_LOOP
 ({
-  P.VU.elt<int16_t>(rd_num, i) = f16_to_i16(vs2, softfloat_round_minMag, true);
+  p->VU.elt<int16_t>(rd_num, i) = f16_to_i16(vs2, softfloat_round_minMag, true);
 },
 {
-  P.VU.elt<int32_t>(rd_num, i) = f32_to_i32(vs2, softfloat_round_minMag, true);
+  p->VU.elt<int32_t>(rd_num, i) = f32_to_i32(vs2, softfloat_round_minMag, true);
 },
 {
-  P.VU.elt<int64_t>(rd_num, i) = f64_to_i64(vs2, softfloat_round_minMag, true);
+  p->VU.elt<int64_t>(rd_num, i) = f64_to_i64(vs2, softfloat_round_minMag, true);
 })

--- a/riscv/insns/vfcvt_rtz_xu_f_v.h
+++ b/riscv/insns/vfcvt_rtz_xu_f_v.h
@@ -1,11 +1,11 @@
 // vfcvt.rtz.xu.f.v vd, vd2, vm
 VI_VFP_VF_LOOP
 ({
-  P.VU.elt<uint16_t>(rd_num, i) = f16_to_ui16(vs2, softfloat_round_minMag, true);
+  p->VU.elt<uint16_t>(rd_num, i) = f16_to_ui16(vs2, softfloat_round_minMag, true);
 },
 {
-  P.VU.elt<uint32_t>(rd_num, i) = f32_to_ui32(vs2, softfloat_round_minMag, true);
+  p->VU.elt<uint32_t>(rd_num, i) = f32_to_ui32(vs2, softfloat_round_minMag, true);
 },
 {
-  P.VU.elt<uint64_t>(rd_num, i) = f64_to_ui64(vs2, softfloat_round_minMag, true);
+  p->VU.elt<uint64_t>(rd_num, i) = f64_to_ui64(vs2, softfloat_round_minMag, true);
 })

--- a/riscv/insns/vfcvt_x_f_v.h
+++ b/riscv/insns/vfcvt_x_f_v.h
@@ -1,11 +1,11 @@
 // vfcvt.x.f.v vd, vd2, vm
 VI_VFP_VF_LOOP
 ({
-  P.VU.elt<int16_t>(rd_num, i) = f16_to_i16(vs2, STATE.frm->read(), true);
+  p->VU.elt<int16_t>(rd_num, i) = f16_to_i16(vs2, STATE.frm->read(), true);
 },
 {
-  P.VU.elt<int32_t>(rd_num, i) = f32_to_i32(vs2, STATE.frm->read(), true);
+  p->VU.elt<int32_t>(rd_num, i) = f32_to_i32(vs2, STATE.frm->read(), true);
 },
 {
-  P.VU.elt<int64_t>(rd_num, i) = f64_to_i64(vs2, STATE.frm->read(), true);
+  p->VU.elt<int64_t>(rd_num, i) = f64_to_i64(vs2, STATE.frm->read(), true);
 })

--- a/riscv/insns/vfcvt_xu_f_v.h
+++ b/riscv/insns/vfcvt_xu_f_v.h
@@ -1,11 +1,11 @@
 // vfcvt.xu.f.v vd, vd2, vm
 VI_VFP_VV_LOOP
 ({
-  P.VU.elt<uint16_t>(rd_num, i) = f16_to_ui16(vs2, STATE.frm->read(), true);
+  p->VU.elt<uint16_t>(rd_num, i) = f16_to_ui16(vs2, STATE.frm->read(), true);
 },
 {
-  P.VU.elt<uint32_t>(rd_num, i) = f32_to_ui32(vs2, STATE.frm->read(), true);
+  p->VU.elt<uint32_t>(rd_num, i) = f32_to_ui32(vs2, STATE.frm->read(), true);
 },
 {
-  P.VU.elt<uint64_t>(rd_num, i) = f64_to_ui64(vs2, STATE.frm->read(), true);
+  p->VU.elt<uint64_t>(rd_num, i) = f64_to_ui64(vs2, STATE.frm->read(), true);
 })

--- a/riscv/insns/vfirst_m.h
+++ b/riscv/insns/vfirst_m.h
@@ -1,20 +1,20 @@
 // vmfirst rd, vs2
-require(P.VU.vsew >= e8 && P.VU.vsew <= e64);
+require(p->VU.vsew >= e8 && p->VU.vsew <= e64);
 require_vector(true);
-reg_t vl = P.VU.vl->read();
-reg_t sew = P.VU.vsew;
+reg_t vl = p->VU.vl->read();
+reg_t sew = p->VU.vsew;
 reg_t rd_num = insn.rd();
 reg_t rs2_num = insn.rs2();
-require(P.VU.vstart->read() == 0);
+require(p->VU.vstart->read() == 0);
 reg_t pos = -1;
-for (reg_t i=P.VU.vstart->read(); i < vl; ++i) {
+for (reg_t i=p->VU.vstart->read(); i < vl; ++i) {
   VI_LOOP_ELEMENT_SKIP()
 
-  bool vs2_lsb = ((P.VU.elt<uint64_t>(rs2_num, midx ) >> mpos) & 0x1) == 1;
+  bool vs2_lsb = ((p->VU.elt<uint64_t>(rs2_num, midx ) >> mpos) & 0x1) == 1;
   if (vs2_lsb) {
     pos = i;
     break;
   }
 }
-P.VU.vstart->write(0);
+p->VU.vstart->write(0);
 WRITE_RD(pos);

--- a/riscv/insns/vfmerge_vfm.h
+++ b/riscv/insns/vfmerge_vfm.h
@@ -2,42 +2,42 @@
 VI_CHECK_SSS(false);
 VI_VFP_COMMON;
 
-switch(P.VU.vsew) {
+switch(p->VU.vsew) {
   case e16:
-    for (reg_t i=P.VU.vstart->read(); i<vl; ++i) {
-      auto &vd = P.VU.elt<float16_t>(rd_num, i, true);
+    for (reg_t i=p->VU.vstart->read(); i<vl; ++i) {
+      auto &vd = p->VU.elt<float16_t>(rd_num, i, true);
       auto rs1 = f16(READ_FREG(rs1_num));
-      auto vs2 = P.VU.elt<float16_t>(rs2_num, i);
+      auto vs2 = p->VU.elt<float16_t>(rs2_num, i);
 
       int midx = i / 64;
       int mpos = i % 64;
-      bool use_first = (P.VU.elt<uint64_t>(0, midx) >> mpos) & 0x1;
+      bool use_first = (p->VU.elt<uint64_t>(0, midx) >> mpos) & 0x1;
 
       vd = use_first ? rs1 : vs2;
     }
     break;
   case e32:
-    for (reg_t i=P.VU.vstart->read(); i<vl; ++i) {
-      auto &vd = P.VU.elt<float32_t>(rd_num, i, true);
+    for (reg_t i=p->VU.vstart->read(); i<vl; ++i) {
+      auto &vd = p->VU.elt<float32_t>(rd_num, i, true);
       auto rs1 = f32(READ_FREG(rs1_num));
-      auto vs2 = P.VU.elt<float32_t>(rs2_num, i);
+      auto vs2 = p->VU.elt<float32_t>(rs2_num, i);
 
       int midx = i / 64;
       int mpos = i % 64;
-      bool use_first = (P.VU.elt<uint64_t>(0, midx) >> mpos) & 0x1;
+      bool use_first = (p->VU.elt<uint64_t>(0, midx) >> mpos) & 0x1;
 
       vd = use_first ? rs1 : vs2;
     }
     break;
   case e64:
-    for (reg_t i=P.VU.vstart->read(); i<vl; ++i) {
-      auto &vd = P.VU.elt<float64_t>(rd_num, i, true);
+    for (reg_t i=p->VU.vstart->read(); i<vl; ++i) {
+      auto &vd = p->VU.elt<float64_t>(rd_num, i, true);
       auto rs1 = f64(READ_FREG(rs1_num));
-      auto vs2 = P.VU.elt<float64_t>(rs2_num, i);
+      auto vs2 = p->VU.elt<float64_t>(rs2_num, i);
 
       int midx = i / 64;
       int mpos = i % 64;
-      bool use_first = (P.VU.elt<uint64_t>(0, midx) >> mpos) & 0x1;
+      bool use_first = (p->VU.elt<uint64_t>(0, midx) >> mpos) & 0x1;
 
       vd = use_first ? rs1 : vs2;
     }
@@ -47,4 +47,4 @@ switch(P.VU.vsew) {
     break;
 }
 
-P.VU.vstart->write(0);
+p->VU.vstart->write(0);

--- a/riscv/insns/vfmv_f_s.h
+++ b/riscv/insns/vfmv_f_s.h
@@ -1,23 +1,23 @@
 // vfmv_f_s: rd = vs2[0] (rs1=0)
 require_vector(true);
 require_fp;
-require((P.VU.vsew == e16 && p->extension_enabled(EXT_ZFH)) ||
-        (P.VU.vsew == e32 && p->extension_enabled('F')) ||
-        (P.VU.vsew == e64 && p->extension_enabled('D')));
+require((p->VU.vsew == e16 && p->extension_enabled(EXT_ZFH)) ||
+        (p->VU.vsew == e32 && p->extension_enabled('F')) ||
+        (p->VU.vsew == e64 && p->extension_enabled('D')));
 require(STATE.frm->read() < 0x5);
 
 reg_t rs2_num = insn.rs2();
 uint64_t vs2_0 = 0;
-const reg_t sew = P.VU.vsew;
+const reg_t sew = p->VU.vsew;
 switch(sew) {
   case e16:
-    vs2_0 = P.VU.elt<uint16_t>(rs2_num, 0);
+    vs2_0 = p->VU.elt<uint16_t>(rs2_num, 0);
     break;
   case e32:
-    vs2_0 = P.VU.elt<uint32_t>(rs2_num, 0);
+    vs2_0 = p->VU.elt<uint32_t>(rs2_num, 0);
     break;
   case e64:
-    vs2_0 = P.VU.elt<uint64_t>(rs2_num, 0);
+    vs2_0 = p->VU.elt<uint64_t>(rs2_num, 0);
     break;
   default:
     require(0);
@@ -35,4 +35,4 @@ if (FLEN == 64) {
   WRITE_FRD(f32(vs2_0));
 }
 
-P.VU.vstart->write(0);
+p->VU.vstart->write(0);

--- a/riscv/insns/vfmv_s_f.h
+++ b/riscv/insns/vfmv_s_f.h
@@ -1,29 +1,29 @@
 // vfmv_s_f: vd[0] = rs1 (vs2=0)
 require_vector(true);
 require_fp;
-require((P.VU.vsew == e16 && p->extension_enabled(EXT_ZFH)) ||
-        (P.VU.vsew == e32 && p->extension_enabled('F')) ||
-        (P.VU.vsew == e64 && p->extension_enabled('D')));
+require((p->VU.vsew == e16 && p->extension_enabled(EXT_ZFH)) ||
+        (p->VU.vsew == e32 && p->extension_enabled('F')) ||
+        (p->VU.vsew == e64 && p->extension_enabled('D')));
 require(STATE.frm->read() < 0x5);
 
-reg_t vl = P.VU.vl->read();
+reg_t vl = p->VU.vl->read();
 
-if (vl > 0 && P.VU.vstart->read() < vl) {
+if (vl > 0 && p->VU.vstart->read() < vl) {
   reg_t rd_num = insn.rd();
 
-  switch(P.VU.vsew) {
+  switch(p->VU.vsew) {
     case e16:
-      P.VU.elt<uint16_t>(rd_num, 0, true) = f16(FRS1).v;
+      p->VU.elt<uint16_t>(rd_num, 0, true) = f16(FRS1).v;
       break;
     case e32:
-      P.VU.elt<uint32_t>(rd_num, 0, true) = f32(FRS1).v;
+      p->VU.elt<uint32_t>(rd_num, 0, true) = f32(FRS1).v;
       break;
     case e64:
       if (FLEN == 64)
-        P.VU.elt<uint64_t>(rd_num, 0, true) = f64(FRS1).v;
+        p->VU.elt<uint64_t>(rd_num, 0, true) = f64(FRS1).v;
       else
-        P.VU.elt<uint64_t>(rd_num, 0, true) = f32(FRS1).v;
+        p->VU.elt<uint64_t>(rd_num, 0, true) = f32(FRS1).v;
       break;
   }
 }
-P.VU.vstart->write(0);
+p->VU.vstart->write(0);

--- a/riscv/insns/vfmv_v_f.h
+++ b/riscv/insns/vfmv_v_f.h
@@ -1,26 +1,26 @@
 // vfmv_vf vd, vs1
-require_align(insn.rd(), P.VU.vflmul);
+require_align(insn.rd(), p->VU.vflmul);
 VI_VFP_COMMON
-switch(P.VU.vsew) {
+switch(p->VU.vsew) {
   case e16:
-    for (reg_t i=P.VU.vstart->read(); i<vl; ++i) {
-      auto &vd = P.VU.elt<float16_t>(rd_num, i, true);
+    for (reg_t i=p->VU.vstart->read(); i<vl; ++i) {
+      auto &vd = p->VU.elt<float16_t>(rd_num, i, true);
       auto rs1 = f16(READ_FREG(rs1_num));
 
       vd = rs1;
     }
     break;
   case e32:
-    for (reg_t i=P.VU.vstart->read(); i<vl; ++i) {
-      auto &vd = P.VU.elt<float32_t>(rd_num, i, true);
+    for (reg_t i=p->VU.vstart->read(); i<vl; ++i) {
+      auto &vd = p->VU.elt<float32_t>(rd_num, i, true);
       auto rs1 = f32(READ_FREG(rs1_num));
 
       vd = rs1;
     }
     break;
   case e64:
-    for (reg_t i=P.VU.vstart->read(); i<vl; ++i) {
-      auto &vd = P.VU.elt<float64_t>(rd_num, i, true);
+    for (reg_t i=p->VU.vstart->read(); i<vl; ++i) {
+      auto &vd = p->VU.elt<float64_t>(rd_num, i, true);
       auto rs1 = f64(READ_FREG(rs1_num));
 
       vd = rs1;
@@ -28,4 +28,4 @@ switch(P.VU.vsew) {
     break;
 }
 
-P.VU.vstart->write(0);
+p->VU.vstart->write(0);

--- a/riscv/insns/vfncvt_f_f_w.h
+++ b/riscv/insns/vfncvt_f_f_w.h
@@ -4,12 +4,12 @@ VI_VFP_CVT_SCALE
   ;
 },
 {
-  auto vs2 = P.VU.elt<float32_t>(rs2_num, i);
-  P.VU.elt<float16_t>(rd_num, i, true) = f32_to_f16(vs2);
+  auto vs2 = p->VU.elt<float32_t>(rs2_num, i);
+  p->VU.elt<float16_t>(rd_num, i, true) = f32_to_f16(vs2);
 },
 {
-  auto vs2 = P.VU.elt<float64_t>(rs2_num, i);
-  P.VU.elt<float32_t>(rd_num, i, true) = f64_to_f32(vs2);
+  auto vs2 = p->VU.elt<float64_t>(rs2_num, i);
+  p->VU.elt<float32_t>(rd_num, i, true) = f64_to_f32(vs2);
 },
 {
   ;
@@ -20,4 +20,4 @@ VI_VFP_CVT_SCALE
 {
   require(p->extension_enabled('D'));
 },
-false, (P.VU.vsew >= 16))
+false, (p->VU.vsew >= 16))

--- a/riscv/insns/vfncvt_f_x_w.h
+++ b/riscv/insns/vfncvt_f_x_w.h
@@ -4,12 +4,12 @@ VI_VFP_CVT_SCALE
   ;
 },
 {
-  auto vs2 = P.VU.elt<int32_t>(rs2_num, i);
-  P.VU.elt<float16_t>(rd_num, i, true) = i32_to_f16(vs2);
+  auto vs2 = p->VU.elt<int32_t>(rs2_num, i);
+  p->VU.elt<float16_t>(rd_num, i, true) = i32_to_f16(vs2);
 },
 {
-  auto vs2 = P.VU.elt<int64_t>(rs2_num, i);
-  P.VU.elt<float32_t>(rd_num, i, true) = i64_to_f32(vs2);
+  auto vs2 = p->VU.elt<int64_t>(rs2_num, i);
+  p->VU.elt<float32_t>(rd_num, i, true) = i64_to_f32(vs2);
 },
 {
   ;
@@ -20,4 +20,4 @@ VI_VFP_CVT_SCALE
 {
   require(p->extension_enabled('F'));
 },
-false, (P.VU.vsew >= 16))
+false, (p->VU.vsew >= 16))

--- a/riscv/insns/vfncvt_f_xu_w.h
+++ b/riscv/insns/vfncvt_f_xu_w.h
@@ -4,12 +4,12 @@ VI_VFP_CVT_SCALE
   ;
 },
 {
-  auto vs2 = P.VU.elt<uint32_t>(rs2_num, i);
-  P.VU.elt<float16_t>(rd_num, i, true) = ui32_to_f16(vs2);
+  auto vs2 = p->VU.elt<uint32_t>(rs2_num, i);
+  p->VU.elt<float16_t>(rd_num, i, true) = ui32_to_f16(vs2);
 },
 {
-  auto vs2 = P.VU.elt<uint64_t>(rs2_num, i);
-  P.VU.elt<float32_t>(rd_num, i, true) = ui64_to_f32(vs2);
+  auto vs2 = p->VU.elt<uint64_t>(rs2_num, i);
+  p->VU.elt<float32_t>(rd_num, i, true) = ui64_to_f32(vs2);
 },
 {
   ;
@@ -20,4 +20,4 @@ VI_VFP_CVT_SCALE
 {
   require(p->extension_enabled('F'));
 },
-false, (P.VU.vsew >= 16))
+false, (p->VU.vsew >= 16))

--- a/riscv/insns/vfncvt_rod_f_f_w.h
+++ b/riscv/insns/vfncvt_rod_f_f_w.h
@@ -5,13 +5,13 @@ VI_VFP_CVT_SCALE
 },
 {
   softfloat_roundingMode = softfloat_round_odd;
-  auto vs2 = P.VU.elt<float32_t>(rs2_num, i);
-  P.VU.elt<float16_t>(rd_num, i, true) = f32_to_f16(vs2);
+  auto vs2 = p->VU.elt<float32_t>(rs2_num, i);
+  p->VU.elt<float16_t>(rd_num, i, true) = f32_to_f16(vs2);
 },
 {
   softfloat_roundingMode = softfloat_round_odd;
-  auto vs2 = P.VU.elt<float64_t>(rs2_num, i);
-  P.VU.elt<float32_t>(rd_num, i, true) = f64_to_f32(vs2);
+  auto vs2 = p->VU.elt<float64_t>(rs2_num, i);
+  p->VU.elt<float32_t>(rd_num, i, true) = f64_to_f32(vs2);
 },
 {
   ;
@@ -22,4 +22,4 @@ VI_VFP_CVT_SCALE
 {
   require(p->extension_enabled('F'));
 },
-false, (P.VU.vsew >= 16))
+false, (p->VU.vsew >= 16))

--- a/riscv/insns/vfncvt_rtz_x_f_w.h
+++ b/riscv/insns/vfncvt_rtz_x_f_w.h
@@ -1,16 +1,16 @@
 // vfncvt.rtz.x.f.w vd, vs2, vm
 VI_VFP_CVT_SCALE
 ({
-  auto vs2 = P.VU.elt<float16_t>(rs2_num, i);
-  P.VU.elt<int8_t>(rd_num, i, true) = f16_to_i8(vs2, softfloat_round_minMag, true);
+  auto vs2 = p->VU.elt<float16_t>(rs2_num, i);
+  p->VU.elt<int8_t>(rd_num, i, true) = f16_to_i8(vs2, softfloat_round_minMag, true);
 },
 {
-  auto vs2 = P.VU.elt<float32_t>(rs2_num, i);
-  P.VU.elt<int16_t>(rd_num, i, true) = f32_to_i16(vs2, softfloat_round_minMag, true);
+  auto vs2 = p->VU.elt<float32_t>(rs2_num, i);
+  p->VU.elt<int16_t>(rd_num, i, true) = f32_to_i16(vs2, softfloat_round_minMag, true);
 },
 {
-  auto vs2 = P.VU.elt<float64_t>(rs2_num, i);
-  P.VU.elt<int32_t>(rd_num, i, true) = f64_to_i32(vs2, softfloat_round_minMag, true);
+  auto vs2 = p->VU.elt<float64_t>(rs2_num, i);
+  p->VU.elt<int32_t>(rd_num, i, true) = f64_to_i32(vs2, softfloat_round_minMag, true);
 },
 {
   require(p->extension_enabled(EXT_ZFH));
@@ -21,4 +21,4 @@ VI_VFP_CVT_SCALE
 {
   require(p->extension_enabled('D'));
 },
-false, (P.VU.vsew <= 32))
+false, (p->VU.vsew <= 32))

--- a/riscv/insns/vfncvt_rtz_xu_f_w.h
+++ b/riscv/insns/vfncvt_rtz_xu_f_w.h
@@ -1,16 +1,16 @@
 // vfncvt.rtz.xu.f.w vd, vs2, vm
 VI_VFP_CVT_SCALE
 ({
-  auto vs2 = P.VU.elt<float16_t>(rs2_num, i);
-  P.VU.elt<uint8_t>(rd_num, i, true) = f16_to_ui8(vs2, softfloat_round_minMag, true);
+  auto vs2 = p->VU.elt<float16_t>(rs2_num, i);
+  p->VU.elt<uint8_t>(rd_num, i, true) = f16_to_ui8(vs2, softfloat_round_minMag, true);
 },
 {
-  auto vs2 = P.VU.elt<float32_t>(rs2_num, i);
-  P.VU.elt<uint16_t>(rd_num, i, true) = f32_to_ui16(vs2, softfloat_round_minMag, true);
+  auto vs2 = p->VU.elt<float32_t>(rs2_num, i);
+  p->VU.elt<uint16_t>(rd_num, i, true) = f32_to_ui16(vs2, softfloat_round_minMag, true);
 },
 {
-  auto vs2 = P.VU.elt<float64_t>(rs2_num, i);
-  P.VU.elt<uint32_t>(rd_num, i, true) = f64_to_ui32(vs2, softfloat_round_minMag, true);
+  auto vs2 = p->VU.elt<float64_t>(rs2_num, i);
+  p->VU.elt<uint32_t>(rd_num, i, true) = f64_to_ui32(vs2, softfloat_round_minMag, true);
 },
 {
   require(p->extension_enabled(EXT_ZFH));
@@ -21,4 +21,4 @@ VI_VFP_CVT_SCALE
 {
   require(p->extension_enabled('D'));
 },
-false, (P.VU.vsew <= 32))
+false, (p->VU.vsew <= 32))

--- a/riscv/insns/vfncvt_x_f_w.h
+++ b/riscv/insns/vfncvt_x_f_w.h
@@ -1,16 +1,16 @@
 // vfncvt.x.f.w vd, vs2, vm
 VI_VFP_CVT_SCALE
 ({
-  auto vs2 = P.VU.elt<float16_t>(rs2_num, i);
-  P.VU.elt<int8_t>(rd_num, i, true) = f16_to_i8(vs2, STATE.frm->read(), true);
+  auto vs2 = p->VU.elt<float16_t>(rs2_num, i);
+  p->VU.elt<int8_t>(rd_num, i, true) = f16_to_i8(vs2, STATE.frm->read(), true);
 },
 {
-  auto vs2 = P.VU.elt<float32_t>(rs2_num, i);
-  P.VU.elt<int16_t>(rd_num, i, true) = f32_to_i16(vs2, STATE.frm->read(), true);
+  auto vs2 = p->VU.elt<float32_t>(rs2_num, i);
+  p->VU.elt<int16_t>(rd_num, i, true) = f32_to_i16(vs2, STATE.frm->read(), true);
 },
 {
-  auto vs2 = P.VU.elt<float64_t>(rs2_num, i);
-  P.VU.elt<int32_t>(rd_num, i, true) = f64_to_i32(vs2, STATE.frm->read(), true);
+  auto vs2 = p->VU.elt<float64_t>(rs2_num, i);
+  p->VU.elt<int32_t>(rd_num, i, true) = f64_to_i32(vs2, STATE.frm->read(), true);
 },
 {
   require(p->extension_enabled(EXT_ZFH));
@@ -21,4 +21,4 @@ VI_VFP_CVT_SCALE
 {
   require(p->extension_enabled('D'));
 },
-false, (P.VU.vsew <= 32))
+false, (p->VU.vsew <= 32))

--- a/riscv/insns/vfncvt_xu_f_w.h
+++ b/riscv/insns/vfncvt_xu_f_w.h
@@ -1,16 +1,16 @@
 // vfncvt.xu.f.w vd, vs2, vm
 VI_VFP_CVT_SCALE
 ({
-  auto vs2 = P.VU.elt<float16_t>(rs2_num, i);
-  P.VU.elt<uint8_t>(rd_num, i, true) = f16_to_ui8(vs2, STATE.frm->read(), true);
+  auto vs2 = p->VU.elt<float16_t>(rs2_num, i);
+  p->VU.elt<uint8_t>(rd_num, i, true) = f16_to_ui8(vs2, STATE.frm->read(), true);
 },
 {
-  auto vs2 = P.VU.elt<float32_t>(rs2_num, i);
-  P.VU.elt<uint16_t>(rd_num, i, true) = f32_to_ui16(vs2, STATE.frm->read(), true);
+  auto vs2 = p->VU.elt<float32_t>(rs2_num, i);
+  p->VU.elt<uint16_t>(rd_num, i, true) = f32_to_ui16(vs2, STATE.frm->read(), true);
 },
 {
-  auto vs2 = P.VU.elt<float64_t>(rs2_num, i);
-  P.VU.elt<uint32_t>(rd_num, i, true) = f64_to_ui32(vs2, STATE.frm->read(), true);
+  auto vs2 = p->VU.elt<float64_t>(rs2_num, i);
+  p->VU.elt<uint32_t>(rd_num, i, true) = f64_to_ui32(vs2, STATE.frm->read(), true);
 },
 {
   require(p->extension_enabled(EXT_ZFH));
@@ -21,4 +21,4 @@ VI_VFP_CVT_SCALE
 {
   require(p->extension_enabled('D'));
 },
-false, (P.VU.vsew <= 32))
+false, (p->VU.vsew <= 32))

--- a/riscv/insns/vfslide1down_vf.h
+++ b/riscv/insns/vfslide1down_vf.h
@@ -3,7 +3,7 @@ VI_CHECK_SLIDE(false);
 
 VI_VFP_LOOP_BASE
 if (i != vl - 1) {
-  switch (P.VU.vsew) {
+  switch (p->VU.vsew) {
     case e16: {
       VI_XI_SLIDEDOWN_PARAMS(e16, 1);
       vd = vs2;
@@ -21,15 +21,15 @@ if (i != vl - 1) {
     break;
   }
 } else {
-  switch (P.VU.vsew) {
+  switch (p->VU.vsew) {
     case e16:
-      P.VU.elt<float16_t>(rd_num, vl - 1, true) = f16(FRS1);
+      p->VU.elt<float16_t>(rd_num, vl - 1, true) = f16(FRS1);
       break;
     case e32:
-      P.VU.elt<float32_t>(rd_num, vl - 1, true) = f32(FRS1);
+      p->VU.elt<float32_t>(rd_num, vl - 1, true) = f32(FRS1);
       break;
     case e64:
-      P.VU.elt<float64_t>(rd_num, vl - 1, true) = f64(FRS1);
+      p->VU.elt<float64_t>(rd_num, vl - 1, true) = f64(FRS1);
       break;
   }
 }

--- a/riscv/insns/vfslide1up_vf.h
+++ b/riscv/insns/vfslide1up_vf.h
@@ -3,7 +3,7 @@ VI_CHECK_SLIDE(true);
 
 VI_VFP_LOOP_BASE
 if (i != 0) {
-  switch (P.VU.vsew) {
+  switch (p->VU.vsew) {
     case e16: {
       VI_XI_SLIDEUP_PARAMS(e16, 1);
       vd = vs2;
@@ -21,15 +21,15 @@ if (i != 0) {
     break;
   }
 } else {
-  switch (P.VU.vsew) {
+  switch (p->VU.vsew) {
     case e16:
-      P.VU.elt<float16_t>(rd_num, 0, true) = f16(FRS1);
+      p->VU.elt<float16_t>(rd_num, 0, true) = f16(FRS1);
       break;
     case e32:
-      P.VU.elt<float32_t>(rd_num, 0, true) = f32(FRS1);
+      p->VU.elt<float32_t>(rd_num, 0, true) = f32(FRS1);
       break;
     case e64:
-      P.VU.elt<float64_t>(rd_num, 0, true) = f64(FRS1);
+      p->VU.elt<float64_t>(rd_num, 0, true) = f64(FRS1);
       break;
   }
 }

--- a/riscv/insns/vfwcvt_f_f_v.h
+++ b/riscv/insns/vfwcvt_f_f_v.h
@@ -4,12 +4,12 @@ VI_VFP_CVT_SCALE
   ;
 },
 {
-  auto vs2 = P.VU.elt<float16_t>(rs2_num, i);
-  P.VU.elt<float32_t>(rd_num, i, true) = f16_to_f32(vs2);
+  auto vs2 = p->VU.elt<float16_t>(rs2_num, i);
+  p->VU.elt<float32_t>(rd_num, i, true) = f16_to_f32(vs2);
 },
 {
-  auto vs2 = P.VU.elt<float32_t>(rs2_num, i);
-  P.VU.elt<float64_t>(rd_num, i, true) = f32_to_f64(vs2);
+  auto vs2 = p->VU.elt<float32_t>(rs2_num, i);
+  p->VU.elt<float64_t>(rd_num, i, true) = f32_to_f64(vs2);
 },
 {
   ;
@@ -20,4 +20,4 @@ VI_VFP_CVT_SCALE
 {
   require(p->extension_enabled('D'));
 },
-true, (P.VU.vsew >= 16))
+true, (p->VU.vsew >= 16))

--- a/riscv/insns/vfwcvt_f_x_v.h
+++ b/riscv/insns/vfwcvt_f_x_v.h
@@ -1,16 +1,16 @@
 // vfwcvt.f.x.v vd, vs2, vm
 VI_VFP_CVT_SCALE
 ({
-  auto vs2 = P.VU.elt<int8_t>(rs2_num, i);
-  P.VU.elt<float16_t>(rd_num, i, true) = i32_to_f16(vs2);
+  auto vs2 = p->VU.elt<int8_t>(rs2_num, i);
+  p->VU.elt<float16_t>(rd_num, i, true) = i32_to_f16(vs2);
 },
 {
-  auto vs2 = P.VU.elt<int16_t>(rs2_num, i);
-  P.VU.elt<float32_t>(rd_num, i, true) = i32_to_f32(vs2);
+  auto vs2 = p->VU.elt<int16_t>(rs2_num, i);
+  p->VU.elt<float32_t>(rd_num, i, true) = i32_to_f32(vs2);
 },
 {
-  auto vs2 = P.VU.elt<int32_t>(rs2_num, i);
-  P.VU.elt<float64_t>(rd_num, i, true) = i32_to_f64(vs2);
+  auto vs2 = p->VU.elt<int32_t>(rs2_num, i);
+  p->VU.elt<float64_t>(rd_num, i, true) = i32_to_f64(vs2);
 },
 {
   require(p->extension_enabled(EXT_ZFH));
@@ -21,4 +21,4 @@ VI_VFP_CVT_SCALE
 {
   require(p->extension_enabled('D'));
 },
-true, (P.VU.vsew >= 8))
+true, (p->VU.vsew >= 8))

--- a/riscv/insns/vfwcvt_f_xu_v.h
+++ b/riscv/insns/vfwcvt_f_xu_v.h
@@ -1,16 +1,16 @@
 // vfwcvt.f.xu.v vd, vs2, vm
 VI_VFP_CVT_SCALE
 ({
-  auto vs2 = P.VU.elt<uint8_t>(rs2_num, i);
-  P.VU.elt<float16_t>(rd_num, i, true) = ui32_to_f16(vs2);
+  auto vs2 = p->VU.elt<uint8_t>(rs2_num, i);
+  p->VU.elt<float16_t>(rd_num, i, true) = ui32_to_f16(vs2);
 },
 {
-  auto vs2 = P.VU.elt<uint16_t>(rs2_num, i);
-  P.VU.elt<float32_t>(rd_num, i, true) = ui32_to_f32(vs2);
+  auto vs2 = p->VU.elt<uint16_t>(rs2_num, i);
+  p->VU.elt<float32_t>(rd_num, i, true) = ui32_to_f32(vs2);
 },
 {
-  auto vs2 = P.VU.elt<uint32_t>(rs2_num, i);
-  P.VU.elt<float64_t>(rd_num, i, true) = ui32_to_f64(vs2);
+  auto vs2 = p->VU.elt<uint32_t>(rs2_num, i);
+  p->VU.elt<float64_t>(rd_num, i, true) = ui32_to_f64(vs2);
 },
 {
   require(p->extension_enabled(EXT_ZFH));
@@ -21,4 +21,4 @@ VI_VFP_CVT_SCALE
 {
   require(p->extension_enabled('D'));
 },
-true, (P.VU.vsew >= 8))
+true, (p->VU.vsew >= 8))

--- a/riscv/insns/vfwcvt_rtz_x_f_v.h
+++ b/riscv/insns/vfwcvt_rtz_x_f_v.h
@@ -4,12 +4,12 @@ VI_VFP_CVT_SCALE
   ;
 },
 {
-  auto vs2 = P.VU.elt<float16_t>(rs2_num, i);
-  P.VU.elt<int32_t>(rd_num, i, true) = f16_to_i32(vs2, softfloat_round_minMag, true);
+  auto vs2 = p->VU.elt<float16_t>(rs2_num, i);
+  p->VU.elt<int32_t>(rd_num, i, true) = f16_to_i32(vs2, softfloat_round_minMag, true);
 },
 {
-  auto vs2 = P.VU.elt<float32_t>(rs2_num, i);
-  P.VU.elt<int64_t>(rd_num, i, true) = f32_to_i64(vs2, softfloat_round_minMag, true);
+  auto vs2 = p->VU.elt<float32_t>(rs2_num, i);
+  p->VU.elt<int64_t>(rd_num, i, true) = f32_to_i64(vs2, softfloat_round_minMag, true);
 },
 {
   ;
@@ -20,4 +20,4 @@ VI_VFP_CVT_SCALE
 {
   require(p->extension_enabled('F'));
 },
-true, (P.VU.vsew >= 16))
+true, (p->VU.vsew >= 16))

--- a/riscv/insns/vfwcvt_rtz_xu_f_v.h
+++ b/riscv/insns/vfwcvt_rtz_xu_f_v.h
@@ -4,12 +4,12 @@ VI_VFP_CVT_SCALE
   ;
 },
 {
-  auto vs2 = P.VU.elt<float16_t>(rs2_num, i);
-  P.VU.elt<uint32_t>(rd_num, i, true) = f16_to_ui32(vs2, softfloat_round_minMag, true);
+  auto vs2 = p->VU.elt<float16_t>(rs2_num, i);
+  p->VU.elt<uint32_t>(rd_num, i, true) = f16_to_ui32(vs2, softfloat_round_minMag, true);
 },
 {
-  auto vs2 = P.VU.elt<float32_t>(rs2_num, i);
-  P.VU.elt<uint64_t>(rd_num, i, true) = f32_to_ui64(vs2, softfloat_round_minMag, true);
+  auto vs2 = p->VU.elt<float32_t>(rs2_num, i);
+  p->VU.elt<uint64_t>(rd_num, i, true) = f32_to_ui64(vs2, softfloat_round_minMag, true);
 },
 {
   ;
@@ -20,4 +20,4 @@ VI_VFP_CVT_SCALE
 {
   require(p->extension_enabled('F'));
 },
-true, (P.VU.vsew >= 16))
+true, (p->VU.vsew >= 16))

--- a/riscv/insns/vfwcvt_x_f_v.h
+++ b/riscv/insns/vfwcvt_x_f_v.h
@@ -4,12 +4,12 @@ VI_VFP_CVT_SCALE
   ;
 },
 {
-  auto vs2 = P.VU.elt<float16_t>(rs2_num, i);
-  P.VU.elt<int32_t>(rd_num, i, true) = f16_to_i32(vs2, STATE.frm->read(), true);
+  auto vs2 = p->VU.elt<float16_t>(rs2_num, i);
+  p->VU.elt<int32_t>(rd_num, i, true) = f16_to_i32(vs2, STATE.frm->read(), true);
 },
 {
-  auto vs2 = P.VU.elt<float32_t>(rs2_num, i);
-  P.VU.elt<int64_t>(rd_num, i, true) = f32_to_i64(vs2, STATE.frm->read(), true);
+  auto vs2 = p->VU.elt<float32_t>(rs2_num, i);
+  p->VU.elt<int64_t>(rd_num, i, true) = f32_to_i64(vs2, STATE.frm->read(), true);
 },
 {
   ;
@@ -20,4 +20,4 @@ VI_VFP_CVT_SCALE
 {
   require(p->extension_enabled('F'));
 },
-true, (P.VU.vsew >= 16))
+true, (p->VU.vsew >= 16))

--- a/riscv/insns/vfwcvt_xu_f_v.h
+++ b/riscv/insns/vfwcvt_xu_f_v.h
@@ -4,12 +4,12 @@ VI_VFP_CVT_SCALE
   ;
 },
 {
-  auto vs2 = P.VU.elt<float16_t>(rs2_num, i);
-  P.VU.elt<uint32_t>(rd_num, i, true) = f16_to_ui32(vs2, STATE.frm->read(), true);
+  auto vs2 = p->VU.elt<float16_t>(rs2_num, i);
+  p->VU.elt<uint32_t>(rd_num, i, true) = f16_to_ui32(vs2, STATE.frm->read(), true);
 },
 {
-  auto vs2 = P.VU.elt<float32_t>(rs2_num, i);
-  P.VU.elt<uint64_t>(rd_num, i, true) = f32_to_ui64(vs2, STATE.frm->read(), true);
+  auto vs2 = p->VU.elt<float32_t>(rs2_num, i);
+  p->VU.elt<uint64_t>(rd_num, i, true) = f32_to_ui64(vs2, STATE.frm->read(), true);
 },
 {
   ;
@@ -20,4 +20,4 @@ VI_VFP_CVT_SCALE
 {
   require(p->extension_enabled('F'));
 },
-true, (P.VU.vsew >= 16))
+true, (p->VU.vsew >= 16))

--- a/riscv/insns/vid_v.h
+++ b/riscv/insns/vid_v.h
@@ -1,31 +1,31 @@
 // vmpopc rd, vs2, vm
-require(P.VU.vsew >= e8 && P.VU.vsew <= e64);
+require(p->VU.vsew >= e8 && p->VU.vsew <= e64);
 require_vector(true);
-reg_t vl = P.VU.vl->read();
-reg_t sew = P.VU.vsew;
+reg_t vl = p->VU.vl->read();
+reg_t sew = p->VU.vsew;
 reg_t rd_num = insn.rd();
 reg_t rs1_num = insn.rs1();
 reg_t rs2_num = insn.rs2();
-require_align(rd_num, P.VU.vflmul);
+require_align(rd_num, p->VU.vflmul);
 require_vm;
 
-for (reg_t i = P.VU.vstart->read() ; i < P.VU.vl->read(); ++i) {
+for (reg_t i = p->VU.vstart->read() ; i < p->VU.vl->read(); ++i) {
   VI_LOOP_ELEMENT_SKIP();
 
   switch (sew) {
   case e8:
-    P.VU.elt<uint8_t>(rd_num, i, true) = i;
+    p->VU.elt<uint8_t>(rd_num, i, true) = i;
     break;
   case e16:
-    P.VU.elt<uint16_t>(rd_num, i, true) = i;
+    p->VU.elt<uint16_t>(rd_num, i, true) = i;
     break;
   case e32:
-    P.VU.elt<uint32_t>(rd_num, i, true) = i;
+    p->VU.elt<uint32_t>(rd_num, i, true) = i;
     break;
   default:
-    P.VU.elt<uint64_t>(rd_num, i, true) = i;
+    p->VU.elt<uint64_t>(rd_num, i, true) = i;
     break;
   }
 }
 
-P.VU.vstart->write(0);
+p->VU.vstart->write(0);

--- a/riscv/insns/viota_m.h
+++ b/riscv/insns/viota_m.h
@@ -1,23 +1,23 @@
 // vmpopc rd, vs2, vm
-require(P.VU.vsew >= e8 && P.VU.vsew <= e64);
+require(p->VU.vsew >= e8 && p->VU.vsew <= e64);
 require_vector(true);
-reg_t vl = P.VU.vl->read();
-reg_t sew = P.VU.vsew;
+reg_t vl = p->VU.vl->read();
+reg_t sew = p->VU.vsew;
 reg_t rd_num = insn.rd();
 reg_t rs1_num = insn.rs1();
 reg_t rs2_num = insn.rs2();
-require(P.VU.vstart->read() == 0);
+require(p->VU.vstart->read() == 0);
 require_vm;
-require_align(rd_num, P.VU.vflmul);
-require_noover(rd_num, P.VU.vflmul, rs2_num, 1);
+require_align(rd_num, p->VU.vflmul);
+require_noover(rd_num, p->VU.vflmul, rs2_num, 1);
 
 int cnt = 0;
 for (reg_t i = 0; i < vl; ++i) {
   const int midx = i / 64;
   const int mpos = i % 64;
 
-  bool vs2_lsb = ((P.VU.elt<uint64_t>(rs2_num, midx) >> mpos) & 0x1) == 1;
-  bool do_mask = (P.VU.elt<uint64_t>(0, midx) >> mpos) & 0x1;
+  bool vs2_lsb = ((p->VU.elt<uint64_t>(rs2_num, midx) >> mpos) & 0x1) == 1;
+  bool do_mask = (p->VU.elt<uint64_t>(0, midx) >> mpos) & 0x1;
 
   bool has_one = false;
   if (insn.v_vm() == 1 || (insn.v_vm() == 0 && do_mask)) {
@@ -29,20 +29,20 @@ for (reg_t i = 0; i < vl; ++i) {
   bool use_ori = (insn.v_vm() == 0) && !do_mask;
   switch (sew) {
   case e8:
-    P.VU.elt<uint8_t>(rd_num, i, true) = use_ori ?
-                                   P.VU.elt<uint8_t>(rd_num, i) : cnt;
+    p->VU.elt<uint8_t>(rd_num, i, true) = use_ori ?
+                                   p->VU.elt<uint8_t>(rd_num, i) : cnt;
     break;
   case e16:
-    P.VU.elt<uint16_t>(rd_num, i, true) = use_ori ?
-                                    P.VU.elt<uint16_t>(rd_num, i) : cnt;
+    p->VU.elt<uint16_t>(rd_num, i, true) = use_ori ?
+                                    p->VU.elt<uint16_t>(rd_num, i) : cnt;
     break;
   case e32:
-    P.VU.elt<uint32_t>(rd_num, i, true) = use_ori ?
-                                    P.VU.elt<uint32_t>(rd_num, i) : cnt;
+    p->VU.elt<uint32_t>(rd_num, i, true) = use_ori ?
+                                    p->VU.elt<uint32_t>(rd_num, i) : cnt;
     break;
   default:
-    P.VU.elt<uint64_t>(rd_num, i, true) = use_ori ?
-                                    P.VU.elt<uint64_t>(rd_num, i) : cnt;
+    p->VU.elt<uint64_t>(rd_num, i, true) = use_ori ?
+                                    p->VU.elt<uint64_t>(rd_num, i) : cnt;
     break;
   }
 

--- a/riscv/insns/vmadc_vim.h
+++ b/riscv/insns/vmadc_vim.h
@@ -1,7 +1,7 @@
 // vmadc.vim vd, vs2, simm5, v0
 VI_XI_LOOP_CARRY
 ({
-  auto v0 = P.VU.elt<uint64_t>(0, midx);
+  auto v0 = p->VU.elt<uint64_t>(0, midx);
   const uint64_t mmask = UINT64_C(1) << mpos; \
   const uint128_t op_mask = (UINT64_MAX >> (64 - sew));
   uint64_t carry = insn.v_vm() == 0 ? (v0 >> mpos) & 0x1 : 0;

--- a/riscv/insns/vmadc_vvm.h
+++ b/riscv/insns/vmadc_vvm.h
@@ -1,7 +1,7 @@
 // vmadc.vvm vd, vs2, rs1, v0
 VI_VV_LOOP_CARRY
 ({
-  auto v0 = P.VU.elt<uint64_t>(0, midx);
+  auto v0 = p->VU.elt<uint64_t>(0, midx);
   const uint64_t mmask = UINT64_C(1) << mpos; \
   const uint128_t op_mask = (UINT64_MAX >> (64 - sew));
   uint64_t carry = insn.v_vm() == 0 ? (v0 >> mpos) & 0x1 : 0;

--- a/riscv/insns/vmadc_vxm.h
+++ b/riscv/insns/vmadc_vxm.h
@@ -1,7 +1,7 @@
 // vadc.vx vd, vs2, rs1, v0
 VI_XI_LOOP_CARRY
 ({
-  auto v0 = P.VU.elt<uint64_t>(0, midx);
+  auto v0 = p->VU.elt<uint64_t>(0, midx);
   const uint64_t mmask = UINT64_C(1) << mpos; \
   const uint128_t op_mask = (UINT64_MAX >> (64 - sew));
   uint64_t carry = insn.v_vm() == 0 ? (v0 >> mpos) & 0x1 : 0;

--- a/riscv/insns/vmerge_vim.h
+++ b/riscv/insns/vmerge_vim.h
@@ -5,7 +5,7 @@ VI_VVXI_MERGE_LOOP
 ({
   int midx = i / 64;
   int mpos = i % 64;
-  bool use_first = (P.VU.elt<uint64_t>(0, midx) >> mpos) & 0x1;
+  bool use_first = (p->VU.elt<uint64_t>(0, midx) >> mpos) & 0x1;
 
   vd = use_first ? simm5 : vs2;
 })

--- a/riscv/insns/vmerge_vvm.h
+++ b/riscv/insns/vmerge_vvm.h
@@ -5,7 +5,7 @@ VI_VVXI_MERGE_LOOP
 ({
   int midx = i / 64;
   int mpos = i % 64;
-  bool use_first = (P.VU.elt<uint64_t>(0, midx) >> mpos) & 0x1;
+  bool use_first = (p->VU.elt<uint64_t>(0, midx) >> mpos) & 0x1;
 
   vd = use_first ? vs1 : vs2;
 })

--- a/riscv/insns/vmerge_vxm.h
+++ b/riscv/insns/vmerge_vxm.h
@@ -5,7 +5,7 @@ VI_VVXI_MERGE_LOOP
 ({
   int midx = i / 64;
   int mpos = i % 64;
-  bool use_first = (P.VU.elt<uint64_t>(0, midx) >> mpos) & 0x1;
+  bool use_first = (p->VU.elt<uint64_t>(0, midx) >> mpos) & 0x1;
 
   vd = use_first ? rs1 : vs2;
 })

--- a/riscv/insns/vmsbc_vvm.h
+++ b/riscv/insns/vmsbc_vvm.h
@@ -1,7 +1,7 @@
 // vmsbc.vvm vd, vs2, rs1, v0
 VI_VV_LOOP_CARRY
 ({
-  auto v0 = P.VU.elt<uint64_t>(0, midx);
+  auto v0 = p->VU.elt<uint64_t>(0, midx);
   const uint64_t mmask = UINT64_C(1) << mpos;
   const uint128_t op_mask = (UINT64_MAX >> (64 - sew));
   uint64_t carry = insn.v_vm() == 0 ? (v0 >> mpos) & 0x1 : 0;

--- a/riscv/insns/vmsbc_vxm.h
+++ b/riscv/insns/vmsbc_vxm.h
@@ -1,7 +1,7 @@
 // vmsbc.vxm vd, vs2, rs1, v0
 VI_XI_LOOP_CARRY
 ({
-  auto &v0 = P.VU.elt<uint64_t>(0, midx);
+  auto &v0 = p->VU.elt<uint64_t>(0, midx);
   const uint64_t mmask = UINT64_C(1) << mpos; \
   const uint128_t op_mask = (UINT64_MAX >> (64 - sew));
   uint64_t carry = insn.v_vm() == 0 ? (v0 >> mpos) & 0x1 : 0;

--- a/riscv/insns/vmsbf_m.h
+++ b/riscv/insns/vmsbf_m.h
@@ -1,26 +1,26 @@
 // vmsbf.m vd, vs2, vm
-require(P.VU.vsew >= e8 && P.VU.vsew <= e64);
+require(p->VU.vsew >= e8 && p->VU.vsew <= e64);
 require_vector(true);
-require(P.VU.vstart->read() == 0);
+require(p->VU.vstart->read() == 0);
 require_vm;
 require(insn.rd() != insn.rs2());
 
-reg_t vl = P.VU.vl->read();
+reg_t vl = p->VU.vl->read();
 reg_t rd_num = insn.rd();
 reg_t rs2_num = insn.rs2();
 
 bool has_one = false;
-for (reg_t i = P.VU.vstart->read(); i < vl; ++i) {
+for (reg_t i = p->VU.vstart->read(); i < vl; ++i) {
   const int midx = i / 64;
   const int mpos = i % 64;
   const uint64_t mmask = UINT64_C(1) << mpos; \
 
-  bool vs2_lsb = ((P.VU.elt<uint64_t>(rs2_num, midx) >> mpos) & 0x1) == 1;
-  bool do_mask = (P.VU.elt<uint64_t>(0, midx) >> mpos) & 0x1;
+  bool vs2_lsb = ((p->VU.elt<uint64_t>(rs2_num, midx) >> mpos) & 0x1) == 1;
+  bool do_mask = (p->VU.elt<uint64_t>(0, midx) >> mpos) & 0x1;
 
 
   if (insn.v_vm() == 1 || (insn.v_vm() == 0 && do_mask)) {
-    auto &vd = P.VU.elt<uint64_t>(rd_num, midx, true);
+    auto &vd = p->VU.elt<uint64_t>(rd_num, midx, true);
     uint64_t res = 0;
     if (!has_one && !vs2_lsb) {
       res = 1;

--- a/riscv/insns/vmsgtu_vi.h
+++ b/riscv/insns/vmsgtu_vi.h
@@ -1,5 +1,5 @@
 // vmsgtu.vi  vd, vd2, simm5
 VI_VI_ULOOP_CMP
 ({
-  res = vs2 > (insn.v_simm5() & (UINT64_MAX >> (64 - P.VU.vsew)));
+  res = vs2 > (insn.v_simm5() & (UINT64_MAX >> (64 - p->VU.vsew)));
 })

--- a/riscv/insns/vmsif_m.h
+++ b/riscv/insns/vmsif_m.h
@@ -1,25 +1,25 @@
 // vmsif.m rd, vs2, vm
-require(P.VU.vsew >= e8 && P.VU.vsew <= e64);
+require(p->VU.vsew >= e8 && p->VU.vsew <= e64);
 require_vector(true);
-require(P.VU.vstart->read() == 0);
+require(p->VU.vstart->read() == 0);
 require_vm;
 require(insn.rd() != insn.rs2());
 
-reg_t vl = P.VU.vl->read();
+reg_t vl = p->VU.vl->read();
 reg_t rd_num = insn.rd();
 reg_t rs2_num = insn.rs2();
 
 bool has_one = false;
-for (reg_t i = P.VU.vstart->read(); i < vl; ++i) {
+for (reg_t i = p->VU.vstart->read(); i < vl; ++i) {
   const int midx = i / 64;
   const int mpos = i % 64;
   const uint64_t mmask = UINT64_C(1) << mpos; \
 
-  bool vs2_lsb = ((P.VU.elt<uint64_t>(rs2_num, midx ) >> mpos) & 0x1) == 1;
-  bool do_mask = (P.VU.elt<uint64_t>(0, midx) >> mpos) & 0x1;
+  bool vs2_lsb = ((p->VU.elt<uint64_t>(rs2_num, midx ) >> mpos) & 0x1) == 1;
+  bool do_mask = (p->VU.elt<uint64_t>(0, midx) >> mpos) & 0x1;
 
   if (insn.v_vm() == 1 || (insn.v_vm() == 0 && do_mask)) {
-    auto &vd = P.VU.elt<uint64_t>(rd_num, midx, true);
+    auto &vd = p->VU.elt<uint64_t>(rd_num, midx, true);
     uint64_t res = 0;
     if (!has_one && !vs2_lsb) {
       res = 1;

--- a/riscv/insns/vmsleu_vi.h
+++ b/riscv/insns/vmsleu_vi.h
@@ -1,5 +1,5 @@
 // vmsleu.vi vd, vs2, simm5
 VI_VI_ULOOP_CMP
 ({
-  res = vs2 <= (insn.v_simm5() & (UINT64_MAX >> (64 - P.VU.vsew)));
+  res = vs2 <= (insn.v_simm5() & (UINT64_MAX >> (64 - p->VU.vsew)));
 })

--- a/riscv/insns/vmsof_m.h
+++ b/riscv/insns/vmsof_m.h
@@ -1,25 +1,25 @@
 // vmsof.m rd, vs2, vm
-require(P.VU.vsew >= e8 && P.VU.vsew <= e64);
+require(p->VU.vsew >= e8 && p->VU.vsew <= e64);
 require_vector(true);
-require(P.VU.vstart->read() == 0);
+require(p->VU.vstart->read() == 0);
 require_vm;
 require(insn.rd() != insn.rs2());
 
-reg_t vl = P.VU.vl->read();
+reg_t vl = p->VU.vl->read();
 reg_t rd_num = insn.rd();
 reg_t rs2_num = insn.rs2();
 
 bool has_one = false;
-for (reg_t i = P.VU.vstart->read() ; i < vl; ++i) {
+for (reg_t i = p->VU.vstart->read() ; i < vl; ++i) {
   const int midx = i / 64;
   const int mpos = i % 64;
   const uint64_t mmask = UINT64_C(1) << mpos; \
 
-  bool vs2_lsb = ((P.VU.elt<uint64_t>(rs2_num, midx ) >> mpos) & 0x1) == 1;
-  bool do_mask = (P.VU.elt<uint64_t>(0, midx) >> mpos) & 0x1;
+  bool vs2_lsb = ((p->VU.elt<uint64_t>(rs2_num, midx ) >> mpos) & 0x1) == 1;
+  bool do_mask = (p->VU.elt<uint64_t>(0, midx) >> mpos) & 0x1;
 
   if (insn.v_vm() == 1 || (insn.v_vm() == 0 && do_mask)) {
-    uint64_t &vd = P.VU.elt<uint64_t>(rd_num, midx, true);
+    uint64_t &vd = p->VU.elt<uint64_t>(rd_num, midx, true);
     uint64_t res = 0;
     if(!has_one && vs2_lsb) {
       has_one = true;

--- a/riscv/insns/vmulhsu_vv.h
+++ b/riscv/insns/vmulhsu_vv.h
@@ -3,33 +3,33 @@ VI_CHECK_SSS(true);
 VI_LOOP_BASE
 switch(sew) {
 case e8: {
-  auto &vd = P.VU.elt<int8_t>(rd_num, i, true);
-  auto vs2 = P.VU.elt<int8_t>(rs2_num, i);
-  auto vs1 = P.VU.elt<uint8_t>(rs1_num, i);
+  auto &vd = p->VU.elt<int8_t>(rd_num, i, true);
+  auto vs2 = p->VU.elt<int8_t>(rs2_num, i);
+  auto vs1 = p->VU.elt<uint8_t>(rs1_num, i);
 
   vd = ((int16_t)vs2 * (uint16_t)vs1) >> sew;
   break;
 }
 case e16: {
-  auto &vd = P.VU.elt<int16_t>(rd_num, i, true);
-  auto vs2 = P.VU.elt<int16_t>(rs2_num, i);
-  auto vs1 = P.VU.elt<uint16_t>(rs1_num, i);
+  auto &vd = p->VU.elt<int16_t>(rd_num, i, true);
+  auto vs2 = p->VU.elt<int16_t>(rs2_num, i);
+  auto vs1 = p->VU.elt<uint16_t>(rs1_num, i);
 
   vd = ((int32_t)vs2 * (uint32_t)vs1) >> sew;
   break;
 }
 case e32: {
-  auto &vd = P.VU.elt<int32_t>(rd_num, i, true);
-  auto vs2 = P.VU.elt<int32_t>(rs2_num, i);
-  auto vs1 = P.VU.elt<uint32_t>(rs1_num, i);
+  auto &vd = p->VU.elt<int32_t>(rd_num, i, true);
+  auto vs2 = p->VU.elt<int32_t>(rs2_num, i);
+  auto vs1 = p->VU.elt<uint32_t>(rs1_num, i);
 
   vd = ((int64_t)vs2 * (uint64_t)vs1) >> sew;
   break;
 }
 default: {
-  auto &vd = P.VU.elt<int64_t>(rd_num, i, true);
-  auto vs2 = P.VU.elt<int64_t>(rs2_num, i);
-  auto vs1 = P.VU.elt<uint64_t>(rs1_num, i);
+  auto &vd = p->VU.elt<int64_t>(rd_num, i, true);
+  auto vs2 = p->VU.elt<int64_t>(rs2_num, i);
+  auto vs1 = p->VU.elt<uint64_t>(rs1_num, i);
 
   vd = ((int128_t)vs2 * (uint128_t)vs1) >> sew;
   break;

--- a/riscv/insns/vmulhsu_vx.h
+++ b/riscv/insns/vmulhsu_vx.h
@@ -3,32 +3,32 @@ VI_CHECK_SSS(false);
 VI_LOOP_BASE
 switch(sew) {
 case e8: {
-  auto &vd = P.VU.elt<int8_t>(rd_num, i, true);
-  auto vs2 = P.VU.elt<int8_t>(rs2_num, i);
+  auto &vd = p->VU.elt<int8_t>(rd_num, i, true);
+  auto vs2 = p->VU.elt<int8_t>(rs2_num, i);
   uint8_t rs1 = RS1;
 
   vd = ((int16_t)vs2 * (uint16_t)rs1) >> sew;
   break;
 }
 case e16: {
-  auto &vd = P.VU.elt<int16_t>(rd_num, i, true);
-  auto vs2 = P.VU.elt<int16_t>(rs2_num, i);
+  auto &vd = p->VU.elt<int16_t>(rd_num, i, true);
+  auto vs2 = p->VU.elt<int16_t>(rs2_num, i);
   uint16_t rs1 = RS1;
 
   vd = ((int32_t)vs2 * (uint32_t)rs1) >> sew;
   break;
 }
 case e32: {
-  auto &vd = P.VU.elt<int32_t>(rd_num, i, true);
-  auto vs2 = P.VU.elt<int32_t>(rs2_num, i);
+  auto &vd = p->VU.elt<int32_t>(rd_num, i, true);
+  auto vs2 = p->VU.elt<int32_t>(rs2_num, i);
   uint32_t rs1 = RS1;
 
   vd = ((int64_t)vs2 * (uint64_t)rs1) >> sew;
   break;
 }
 default: {
-  auto &vd = P.VU.elt<int64_t>(rd_num, i, true);
-  auto vs2 = P.VU.elt<int64_t>(rs2_num, i);
+  auto &vd = p->VU.elt<int64_t>(rd_num, i, true);
+  auto vs2 = p->VU.elt<int64_t>(rs2_num, i);
   uint64_t rs1 = RS1;
 
   vd = ((int128_t)vs2 * (uint128_t)rs1) >> sew;

--- a/riscv/insns/vmv_s_x.h
+++ b/riscv/insns/vmv_s_x.h
@@ -1,29 +1,29 @@
 // vmv_s_x: vd[0] = rs1
 require_vector(true);
 require(insn.v_vm() == 1);
-require(P.VU.vsew >= e8 && P.VU.vsew <= e64);
-reg_t vl = P.VU.vl->read();
+require(p->VU.vsew >= e8 && p->VU.vsew <= e64);
+reg_t vl = p->VU.vl->read();
 
-if (vl > 0 && P.VU.vstart->read() < vl) {
+if (vl > 0 && p->VU.vstart->read() < vl) {
   reg_t rd_num = insn.rd();
-  reg_t sew = P.VU.vsew;
+  reg_t sew = p->VU.vsew;
 
   switch(sew) {
   case e8:
-    P.VU.elt<uint8_t>(rd_num, 0, true) = RS1;
+    p->VU.elt<uint8_t>(rd_num, 0, true) = RS1;
     break;
   case e16:
-    P.VU.elt<uint16_t>(rd_num, 0, true) = RS1;
+    p->VU.elt<uint16_t>(rd_num, 0, true) = RS1;
     break;
   case e32:
-    P.VU.elt<uint32_t>(rd_num, 0, true) = RS1;
+    p->VU.elt<uint32_t>(rd_num, 0, true) = RS1;
     break;
   default:
-    P.VU.elt<uint64_t>(rd_num, 0, true) = RS1;
+    p->VU.elt<uint64_t>(rd_num, 0, true) = RS1;
     break;
   }
 
   vl = 0;
 }
 
-P.VU.vstart->write(0);
+p->VU.vstart->write(0);

--- a/riscv/insns/vmv_x_s.h
+++ b/riscv/insns/vmv_x_s.h
@@ -1,31 +1,31 @@
 // vmv_x_s: rd = vs2[rs1]
 require_vector(true);
 require(insn.v_vm() == 1);
-uint64_t xmask = UINT64_MAX >> (64 - P.get_max_xlen());
+uint64_t xmask = UINT64_MAX >> (64 - p->get_max_xlen());
 reg_t rs1 = RS1;
-reg_t sew = P.VU.vsew;
+reg_t sew = p->VU.vsew;
 reg_t rs2_num = insn.rs2();
 
-if (!(rs1 >= 0 && rs1 < (P.VU.get_vlen() / sew))) {
+if (!(rs1 >= 0 && rs1 < (p->VU.get_vlen() / sew))) {
   WRITE_RD(0);
 } else {
   switch(sew) {
   case e8:
-    WRITE_RD(P.VU.elt<int8_t>(rs2_num, rs1));
+    WRITE_RD(p->VU.elt<int8_t>(rs2_num, rs1));
     break;
   case e16:
-    WRITE_RD(P.VU.elt<int16_t>(rs2_num, rs1));
+    WRITE_RD(p->VU.elt<int16_t>(rs2_num, rs1));
     break;
   case e32:
-    WRITE_RD(P.VU.elt<int32_t>(rs2_num, rs1));
+    WRITE_RD(p->VU.elt<int32_t>(rs2_num, rs1));
     break;
   case e64:
-    if (P.get_max_xlen() <= sew)
-      WRITE_RD(P.VU.elt<uint64_t>(rs2_num, rs1) & xmask);
+    if (p->get_max_xlen() <= sew)
+      WRITE_RD(p->VU.elt<uint64_t>(rs2_num, rs1) & xmask);
     else
-      WRITE_RD(P.VU.elt<uint64_t>(rs2_num, rs1));
+      WRITE_RD(p->VU.elt<uint64_t>(rs2_num, rs1));
     break;
   }
 }
 
-P.VU.vstart->write(0);
+p->VU.vstart->write(0);

--- a/riscv/insns/vmvnfr_v.h
+++ b/riscv/insns/vmvnfr_v.h
@@ -6,22 +6,22 @@ const reg_t vs2 = insn.rs2();
 const reg_t len = insn.rs1() + 1;
 require_align(vd, len);
 require_align(vs2, len);
-const reg_t size = len * P.VU.vlenb;
+const reg_t size = len * p->VU.vlenb;
 
 //register needs one-by-one copy to keep commitlog correct
-if (vd != vs2 && P.VU.vstart->read() < size) {
-  reg_t i = P.VU.vstart->read() / P.VU.vlenb;
-  reg_t off = P.VU.vstart->read() % P.VU.vlenb;
+if (vd != vs2 && p->VU.vstart->read() < size) {
+  reg_t i = p->VU.vstart->read() / p->VU.vlenb;
+  reg_t off = p->VU.vstart->read() % p->VU.vlenb;
   if (off) {
-    memcpy(&P.VU.elt<uint8_t>(vd + i, off, true),
-           &P.VU.elt<uint8_t>(vs2 + i, off), P.VU.vlenb - off);
+    memcpy(&p->VU.elt<uint8_t>(vd + i, off, true),
+           &p->VU.elt<uint8_t>(vs2 + i, off), p->VU.vlenb - off);
     i++;
   }
 
   for (; i < len; ++i) {
-    memcpy(&P.VU.elt<uint8_t>(vd + i, 0, true),
-           &P.VU.elt<uint8_t>(vs2 + i, 0), P.VU.vlenb);
+    memcpy(&p->VU.elt<uint8_t>(vd + i, 0, true),
+           &p->VU.elt<uint8_t>(vs2 + i, 0), p->VU.vlenb);
   }
 }
 
-P.VU.vstart->write(0);
+p->VU.vstart->write(0);

--- a/riscv/insns/vnclip_wi.h
+++ b/riscv/insns/vnclip_wi.h
@@ -1,7 +1,7 @@
 // vnclip: vd[i] = clip(round(vs2[i] + rnd) >> simm)
-VRM xrm = P.VU.get_vround_mode();
-int64_t int_max = INT64_MAX >> (64 - P.VU.vsew);
-int64_t int_min = INT64_MIN >> (64 - P.VU.vsew);
+VRM xrm = p->VU.get_vround_mode();
+int64_t int_max = INT64_MAX >> (64 - p->VU.vsew);
+int64_t int_min = INT64_MIN >> (64 - p->VU.vsew);
 VI_VVXI_LOOP_NARROW
 ({
   int128_t result = vs2;

--- a/riscv/insns/vnclip_wv.h
+++ b/riscv/insns/vnclip_wv.h
@@ -1,7 +1,7 @@
 // vnclip: vd[i] = clip(round(vs2[i] + rnd) >> vs1[i])
-VRM xrm = P.VU.get_vround_mode();
-int64_t int_max = INT64_MAX >> (64 - P.VU.vsew);
-int64_t int_min = INT64_MIN >> (64 - P.VU.vsew);
+VRM xrm = p->VU.get_vround_mode();
+int64_t int_max = INT64_MAX >> (64 - p->VU.vsew);
+int64_t int_min = INT64_MIN >> (64 - p->VU.vsew);
 VI_VVXI_LOOP_NARROW
 ({
   int128_t result = vs2;

--- a/riscv/insns/vnclip_wx.h
+++ b/riscv/insns/vnclip_wx.h
@@ -1,7 +1,7 @@
 // vnclip: vd[i] = clip(round(vs2[i] + rnd) >> rs1[i])
-VRM xrm = P.VU.get_vround_mode();
-int64_t int_max = INT64_MAX >> (64 - P.VU.vsew);
-int64_t int_min = INT64_MIN >> (64 - P.VU.vsew);
+VRM xrm = p->VU.get_vround_mode();
+int64_t int_max = INT64_MAX >> (64 - p->VU.vsew);
+int64_t int_min = INT64_MIN >> (64 - p->VU.vsew);
 VI_VVXI_LOOP_NARROW
 ({
   int128_t result = vs2;

--- a/riscv/insns/vnclipu_wi.h
+++ b/riscv/insns/vnclipu_wi.h
@@ -1,7 +1,7 @@
 // vnclipu: vd[i] = clip(round(vs2[i] + rnd) >> simm)
-VRM xrm = P.VU.get_vround_mode();
-uint64_t uint_max = UINT64_MAX >> (64 - P.VU.vsew);
-uint64_t sign_mask = UINT64_MAX << P.VU.vsew;
+VRM xrm = p->VU.get_vround_mode();
+uint64_t uint_max = UINT64_MAX >> (64 - p->VU.vsew);
+uint64_t sign_mask = UINT64_MAX << p->VU.vsew;
 VI_VVXI_LOOP_NARROW
 ({
   uint128_t result = vs2_u;

--- a/riscv/insns/vnclipu_wv.h
+++ b/riscv/insns/vnclipu_wv.h
@@ -1,7 +1,7 @@
 // vnclipu: vd[i] = clip(round(vs2[i] + rnd) >> vs1[i])
-VRM xrm = P.VU.get_vround_mode();
-uint64_t uint_max = UINT64_MAX >> (64 - P.VU.vsew);
-uint64_t sign_mask = UINT64_MAX << P.VU.vsew;
+VRM xrm = p->VU.get_vround_mode();
+uint64_t uint_max = UINT64_MAX >> (64 - p->VU.vsew);
+uint64_t sign_mask = UINT64_MAX << p->VU.vsew;
 VI_VVXI_LOOP_NARROW
 ({
   uint128_t result = vs2_u;

--- a/riscv/insns/vnclipu_wx.h
+++ b/riscv/insns/vnclipu_wx.h
@@ -1,7 +1,7 @@
 // vnclipu: vd[i] = clip(round(vs2[i] + rnd) >> rs1[i])
-VRM xrm = P.VU.get_vround_mode();
-uint64_t uint_max = UINT64_MAX >> (64 - P.VU.vsew);
-uint64_t sign_mask = UINT64_MAX << P.VU.vsew;
+VRM xrm = p->VU.get_vround_mode();
+uint64_t uint_max = UINT64_MAX >> (64 - p->VU.vsew);
+uint64_t sign_mask = UINT64_MAX << p->VU.vsew;
 VI_VVXI_LOOP_NARROW
 ({
   uint128_t result = vs2_u;

--- a/riscv/insns/vrgather_vi.h
+++ b/riscv/insns/vrgather_vi.h
@@ -1,6 +1,6 @@
 // vrgather.vi vd, vs2, zimm5 vm # vd[i] = (zimm5 >= VLMAX) ? 0 : vs2[zimm5];
-require_align(insn.rd(), P.VU.vflmul);
-require_align(insn.rs2(), P.VU.vflmul);
+require_align(insn.rd(), p->VU.vflmul);
+require_align(insn.rs2(), p->VU.vflmul);
 require(insn.rd() != insn.rs2());
 require_vm;
 
@@ -8,21 +8,21 @@ reg_t zimm5 = insn.v_zimm5();
 
 VI_LOOP_BASE
 
-for (reg_t i = P.VU.vstart->read(); i < vl; ++i) {
+for (reg_t i = p->VU.vstart->read(); i < vl; ++i) {
   VI_LOOP_ELEMENT_SKIP();
 
   switch (sew) {
   case e8:
-    P.VU.elt<uint8_t>(rd_num, i, true) = zimm5 >= P.VU.vlmax ? 0 : P.VU.elt<uint8_t>(rs2_num, zimm5);
+    p->VU.elt<uint8_t>(rd_num, i, true) = zimm5 >= p->VU.vlmax ? 0 : p->VU.elt<uint8_t>(rs2_num, zimm5);
     break;
   case e16:
-    P.VU.elt<uint16_t>(rd_num, i, true) = zimm5 >= P.VU.vlmax ? 0 : P.VU.elt<uint16_t>(rs2_num, zimm5);
+    p->VU.elt<uint16_t>(rd_num, i, true) = zimm5 >= p->VU.vlmax ? 0 : p->VU.elt<uint16_t>(rs2_num, zimm5);
     break;
   case e32:
-    P.VU.elt<uint32_t>(rd_num, i, true) = zimm5 >= P.VU.vlmax ? 0 : P.VU.elt<uint32_t>(rs2_num, zimm5);
+    p->VU.elt<uint32_t>(rd_num, i, true) = zimm5 >= p->VU.vlmax ? 0 : p->VU.elt<uint32_t>(rs2_num, zimm5);
     break;
   default:
-    P.VU.elt<uint64_t>(rd_num, i, true) = zimm5 >= P.VU.vlmax ? 0 : P.VU.elt<uint64_t>(rs2_num, zimm5);
+    p->VU.elt<uint64_t>(rd_num, i, true) = zimm5 >= p->VU.vlmax ? 0 : p->VU.elt<uint64_t>(rs2_num, zimm5);
     break;
   }
 }

--- a/riscv/insns/vrgather_vv.h
+++ b/riscv/insns/vrgather_vv.h
@@ -1,31 +1,31 @@
 // vrgather.vv vd, vs2, vs1, vm # vd[i] = (vs1[i] >= VLMAX) ? 0 : vs2[vs1[i]];
-require_align(insn.rd(), P.VU.vflmul);
-require_align(insn.rs2(), P.VU.vflmul);
-require_align(insn.rs1(), P.VU.vflmul);
+require_align(insn.rd(), p->VU.vflmul);
+require_align(insn.rs2(), p->VU.vflmul);
+require_align(insn.rs1(), p->VU.vflmul);
 require(insn.rd() != insn.rs2() && insn.rd() != insn.rs1());
 require_vm;
 
 VI_LOOP_BASE
   switch (sew) {
   case e8: {
-    auto vs1 = P.VU.elt<uint8_t>(rs1_num, i);
+    auto vs1 = p->VU.elt<uint8_t>(rs1_num, i);
     //if (i > 255) continue;
-    P.VU.elt<uint8_t>(rd_num, i, true) = vs1 >= P.VU.vlmax ? 0 : P.VU.elt<uint8_t>(rs2_num, vs1);
+    p->VU.elt<uint8_t>(rd_num, i, true) = vs1 >= p->VU.vlmax ? 0 : p->VU.elt<uint8_t>(rs2_num, vs1);
     break;
   }
   case e16: {
-    auto vs1 = P.VU.elt<uint16_t>(rs1_num, i);
-    P.VU.elt<uint16_t>(rd_num, i, true) = vs1 >= P.VU.vlmax ? 0 : P.VU.elt<uint16_t>(rs2_num, vs1);
+    auto vs1 = p->VU.elt<uint16_t>(rs1_num, i);
+    p->VU.elt<uint16_t>(rd_num, i, true) = vs1 >= p->VU.vlmax ? 0 : p->VU.elt<uint16_t>(rs2_num, vs1);
     break;
   }
   case e32: {
-    auto vs1 = P.VU.elt<uint32_t>(rs1_num, i);
-    P.VU.elt<uint32_t>(rd_num, i, true) = vs1 >= P.VU.vlmax ? 0 : P.VU.elt<uint32_t>(rs2_num, vs1);
+    auto vs1 = p->VU.elt<uint32_t>(rs1_num, i);
+    p->VU.elt<uint32_t>(rd_num, i, true) = vs1 >= p->VU.vlmax ? 0 : p->VU.elt<uint32_t>(rs2_num, vs1);
     break;
   }
   default: {
-    auto vs1 = P.VU.elt<uint64_t>(rs1_num, i);
-    P.VU.elt<uint64_t>(rd_num, i, true) = vs1 >= P.VU.vlmax ? 0 : P.VU.elt<uint64_t>(rs2_num, vs1);
+    auto vs1 = p->VU.elt<uint64_t>(rs1_num, i);
+    p->VU.elt<uint64_t>(rd_num, i, true) = vs1 >= p->VU.vlmax ? 0 : p->VU.elt<uint64_t>(rs2_num, vs1);
     break;
   }
   }

--- a/riscv/insns/vrgather_vx.h
+++ b/riscv/insns/vrgather_vx.h
@@ -1,6 +1,6 @@
 // vrgather.vx vd, vs2, rs1, vm # vd[i] = (rs1 >= VLMAX) ? 0 : vs2[rs1];
-require_align(insn.rd(), P.VU.vflmul);
-require_align(insn.rs2(), P.VU.vflmul);
+require_align(insn.rd(), p->VU.vflmul);
+require_align(insn.rs2(), p->VU.vflmul);
 require(insn.rd() != insn.rs2());
 require_vm;
 
@@ -9,16 +9,16 @@ reg_t rs1 = RS1;
 VI_LOOP_BASE
   switch (sew) {
   case e8:
-    P.VU.elt<uint8_t>(rd_num, i, true) = rs1 >= P.VU.vlmax ? 0 : P.VU.elt<uint8_t>(rs2_num, rs1);
+    p->VU.elt<uint8_t>(rd_num, i, true) = rs1 >= p->VU.vlmax ? 0 : p->VU.elt<uint8_t>(rs2_num, rs1);
     break;
   case e16:
-    P.VU.elt<uint16_t>(rd_num, i, true) = rs1 >= P.VU.vlmax ? 0 : P.VU.elt<uint16_t>(rs2_num, rs1);
+    p->VU.elt<uint16_t>(rd_num, i, true) = rs1 >= p->VU.vlmax ? 0 : p->VU.elt<uint16_t>(rs2_num, rs1);
     break;
   case e32:
-    P.VU.elt<uint32_t>(rd_num, i, true) = rs1 >= P.VU.vlmax ? 0 : P.VU.elt<uint32_t>(rs2_num, rs1);
+    p->VU.elt<uint32_t>(rd_num, i, true) = rs1 >= p->VU.vlmax ? 0 : p->VU.elt<uint32_t>(rs2_num, rs1);
     break;
   default:
-    P.VU.elt<uint64_t>(rd_num, i, true) = rs1 >= P.VU.vlmax ? 0 : P.VU.elt<uint64_t>(rs2_num, rs1);
+    p->VU.elt<uint64_t>(rd_num, i, true) = rs1 >= p->VU.vlmax ? 0 : p->VU.elt<uint64_t>(rs2_num, rs1);
     break;
   }
 VI_LOOP_END;

--- a/riscv/insns/vrgatherei16_vv.h
+++ b/riscv/insns/vrgatherei16_vv.h
@@ -1,33 +1,33 @@
 // vrgatherei16.vv vd, vs2, vs1, vm # vd[i] = (vs1[i] >= VLMAX) ? 0 : vs2[vs1[i]];
-float vemul = (16.0 / P.VU.vsew * P.VU.vflmul);
+float vemul = (16.0 / p->VU.vsew * p->VU.vflmul);
 require(vemul >= 0.125 && vemul <= 8);
-require_align(insn.rd(), P.VU.vflmul);
-require_align(insn.rs2(), P.VU.vflmul);
+require_align(insn.rd(), p->VU.vflmul);
+require_align(insn.rs2(), p->VU.vflmul);
 require_align(insn.rs1(), vemul);
-require_noover(insn.rd(), P.VU.vflmul, insn.rs1(), vemul);
+require_noover(insn.rd(), p->VU.vflmul, insn.rs1(), vemul);
 require(insn.rd() != insn.rs2());
 require_vm;
 
 VI_LOOP_BASE
   switch (sew) {
   case e8: {
-    auto vs1 = P.VU.elt<uint16_t>(rs1_num, i);
-    P.VU.elt<uint8_t>(rd_num, i, true) = vs1 >= P.VU.vlmax ? 0 : P.VU.elt<uint8_t>(rs2_num, vs1);
+    auto vs1 = p->VU.elt<uint16_t>(rs1_num, i);
+    p->VU.elt<uint8_t>(rd_num, i, true) = vs1 >= p->VU.vlmax ? 0 : p->VU.elt<uint8_t>(rs2_num, vs1);
     break;
   }
   case e16: {
-    auto vs1 = P.VU.elt<uint16_t>(rs1_num, i);
-    P.VU.elt<uint16_t>(rd_num, i, true) = vs1 >= P.VU.vlmax ? 0 : P.VU.elt<uint16_t>(rs2_num, vs1);
+    auto vs1 = p->VU.elt<uint16_t>(rs1_num, i);
+    p->VU.elt<uint16_t>(rd_num, i, true) = vs1 >= p->VU.vlmax ? 0 : p->VU.elt<uint16_t>(rs2_num, vs1);
     break;
   }
   case e32: {
-    auto vs1 = P.VU.elt<uint16_t>(rs1_num, i);
-    P.VU.elt<uint32_t>(rd_num, i, true) = vs1 >= P.VU.vlmax ? 0 : P.VU.elt<uint32_t>(rs2_num, vs1);
+    auto vs1 = p->VU.elt<uint16_t>(rs1_num, i);
+    p->VU.elt<uint32_t>(rd_num, i, true) = vs1 >= p->VU.vlmax ? 0 : p->VU.elt<uint32_t>(rs2_num, vs1);
     break;
   }
   default: {
-    auto vs1 = P.VU.elt<uint16_t>(rs1_num, i);
-    P.VU.elt<uint64_t>(rd_num, i, true) = vs1 >= P.VU.vlmax ? 0 : P.VU.elt<uint64_t>(rs2_num, vs1);
+    auto vs1 = p->VU.elt<uint16_t>(rs1_num, i);
+    p->VU.elt<uint64_t>(rd_num, i, true) = vs1 >= p->VU.vlmax ? 0 : p->VU.elt<uint64_t>(rs2_num, vs1);
     break;
   }
   }

--- a/riscv/insns/vsaddu_vi.h
+++ b/riscv/insns/vsaddu_vi.h
@@ -2,7 +2,7 @@
 VI_VI_ULOOP
 ({
   bool sat = false;
-  vd = vs2 + (insn.v_simm5() & (UINT64_MAX >> (64 - P.VU.vsew)));
+  vd = vs2 + (insn.v_simm5() & (UINT64_MAX >> (64 - p->VU.vsew)));
 
   sat = vd < vs2;
   vd |= -(vd < vs2);

--- a/riscv/insns/vsbc_vvm.h
+++ b/riscv/insns/vsbc_vvm.h
@@ -1,7 +1,7 @@
 // vsbc.vvm vd, vs2, rs1, v0
 VI_VV_LOOP_WITH_CARRY
 ({
-  auto &v0 = P.VU.elt<uint64_t>(0, midx);
+  auto &v0 = p->VU.elt<uint64_t>(0, midx);
   const uint128_t op_mask = (UINT64_MAX >> (64 - sew));
   uint64_t carry = (v0 >> mpos) & 0x1;
 

--- a/riscv/insns/vsbc_vxm.h
+++ b/riscv/insns/vsbc_vxm.h
@@ -1,7 +1,7 @@
 // vsbc.vxm vd, vs2, rs1, v0
 VI_XI_LOOP_WITH_CARRY
 ({
-  auto &v0 = P.VU.elt<uint64_t>(0, midx);
+  auto &v0 = p->VU.elt<uint64_t>(0, midx);
   const uint128_t op_mask = (UINT64_MAX >> (64 - sew));
   uint64_t carry = (v0 >> mpos) & 0x1;
 

--- a/riscv/insns/vsetivli.h
+++ b/riscv/insns/vsetivli.h
@@ -1,2 +1,2 @@
 require_vector_novtype(false, false);
-WRITE_RD(P.VU.set_vl(insn.rd(), -1, insn.rs1(), insn.v_zimm10()));
+WRITE_RD(p->VU.set_vl(insn.rd(), -1, insn.rs1(), insn.v_zimm10()));

--- a/riscv/insns/vsetvl.h
+++ b/riscv/insns/vsetvl.h
@@ -1,2 +1,2 @@
 require_vector_novtype(false, false);
-WRITE_RD(P.VU.set_vl(insn.rd(), insn.rs1(), RS1, RS2));
+WRITE_RD(p->VU.set_vl(insn.rd(), insn.rs1(), RS1, RS2));

--- a/riscv/insns/vsetvli.h
+++ b/riscv/insns/vsetvli.h
@@ -1,2 +1,2 @@
 require_vector_novtype(false, false);
-WRITE_RD(P.VU.set_vl(insn.rd(), insn.rs1(), RS1, insn.v_zimm11()));
+WRITE_RD(p->VU.set_vl(insn.rd(), insn.rs1(), RS1, insn.v_zimm11()));

--- a/riscv/insns/vslide1down_vx.h
+++ b/riscv/insns/vslide1down_vx.h
@@ -28,16 +28,16 @@ if (i != vl - 1) {
 } else {
   switch (sew) {
   case e8:
-    P.VU.elt<uint8_t>(rd_num, vl - 1, true) = RS1;
+    p->VU.elt<uint8_t>(rd_num, vl - 1, true) = RS1;
     break;
   case e16:
-    P.VU.elt<uint16_t>(rd_num, vl - 1, true) = RS1;
+    p->VU.elt<uint16_t>(rd_num, vl - 1, true) = RS1;
     break;
   case e32:
-    P.VU.elt<uint32_t>(rd_num, vl - 1, true) = RS1;
+    p->VU.elt<uint32_t>(rd_num, vl - 1, true) = RS1;
     break;
   default:
-    P.VU.elt<uint64_t>(rd_num, vl - 1, true) = RS1;
+    p->VU.elt<uint64_t>(rd_num, vl - 1, true) = RS1;
     break;
   }
 }

--- a/riscv/insns/vslide1up_vx.h
+++ b/riscv/insns/vslide1up_vx.h
@@ -18,13 +18,13 @@ if (i != 0) {
   }
 } else {
   if (sew == e8) {
-    P.VU.elt<uint8_t>(rd_num, 0, true) = RS1;
+    p->VU.elt<uint8_t>(rd_num, 0, true) = RS1;
   } else if(sew == e16) {
-    P.VU.elt<uint16_t>(rd_num, 0, true) = RS1;
+    p->VU.elt<uint16_t>(rd_num, 0, true) = RS1;
   } else if(sew == e32) {
-    P.VU.elt<uint32_t>(rd_num, 0, true) = RS1;
+    p->VU.elt<uint32_t>(rd_num, 0, true) = RS1;
   } else if(sew == e64) {
-    P.VU.elt<uint64_t>(rd_num, 0, true) = RS1;
+    p->VU.elt<uint64_t>(rd_num, 0, true) = RS1;
   }
 }
 VI_LOOP_END

--- a/riscv/insns/vslidedown_vi.h
+++ b/riscv/insns/vslidedown_vi.h
@@ -5,7 +5,7 @@ const reg_t sh = insn.v_zimm5();
 VI_LOOP_BASE
 
 reg_t offset = 0;
-bool is_valid = (i + sh) < P.VU.vlmax;
+bool is_valid = (i + sh) < p->VU.vlmax;
 
 if (is_valid) {
   offset = sh;

--- a/riscv/insns/vslidedown_vx.h
+++ b/riscv/insns/vslidedown_vx.h
@@ -5,7 +5,7 @@ const uint128_t sh = RS1;
 VI_LOOP_BASE
 
 reg_t offset = 0;
-bool is_valid = (i + sh) < P.VU.vlmax;
+bool is_valid = (i + sh) < p->VU.vlmax;
 
 if (is_valid) {
   offset = sh;

--- a/riscv/insns/vslideup_vi.h
+++ b/riscv/insns/vslideup_vi.h
@@ -3,7 +3,7 @@ VI_CHECK_SLIDE(true);
 
 const reg_t offset = insn.v_zimm5();
 VI_LOOP_BASE
-if (P.VU.vstart->read() < offset && i < offset)
+if (p->VU.vstart->read() < offset && i < offset)
   continue;
 
 switch (sew) {

--- a/riscv/insns/vslideup_vx.h
+++ b/riscv/insns/vslideup_vx.h
@@ -3,7 +3,7 @@ VI_CHECK_SLIDE(true);
 
 const reg_t offset = RS1;
 VI_LOOP_BASE
-if (P.VU.vstart->read() < offset && i < offset)
+if (p->VU.vstart->read() < offset && i < offset)
   continue;
 
 switch (sew) {

--- a/riscv/insns/vsmul_vv.h
+++ b/riscv/insns/vsmul_vv.h
@@ -1,8 +1,8 @@
 // vsmul.vv vd, vs2, vs1
-VRM xrm = P.VU.get_vround_mode();
-int64_t int_max = INT64_MAX >> (64 - P.VU.vsew);
-int64_t int_min = INT64_MIN >> (64 - P.VU.vsew);
-int64_t sign_mask = uint64_t(1) << (P.VU.vsew - 1);
+VRM xrm = p->VU.get_vround_mode();
+int64_t int_max = INT64_MAX >> (64 - p->VU.vsew);
+int64_t int_min = INT64_MIN >> (64 - p->VU.vsew);
+int64_t sign_mask = uint64_t(1) << (p->VU.vsew - 1);
 
 VI_VV_LOOP
 ({

--- a/riscv/insns/vsmul_vx.h
+++ b/riscv/insns/vsmul_vx.h
@@ -1,8 +1,8 @@
 // vsmul.vx vd, vs2, rs1
-VRM xrm = P.VU.get_vround_mode();
-int64_t int_max = INT64_MAX >> (64 - P.VU.vsew);
-int64_t int_min = INT64_MIN >> (64 - P.VU.vsew);
-int64_t sign_mask = uint64_t(1) << (P.VU.vsew - 1);
+VRM xrm = p->VU.get_vround_mode();
+int64_t int_max = INT64_MAX >> (64 - p->VU.vsew);
+int64_t int_min = INT64_MIN >> (64 - p->VU.vsew);
+int64_t sign_mask = uint64_t(1) << (p->VU.vsew - 1);
 
 VI_VX_LOOP
 ({

--- a/riscv/insns/vssra_vi.h
+++ b/riscv/insns/vssra_vi.h
@@ -1,5 +1,5 @@
 // vssra.vi vd, vs2, simm5
-VRM xrm = P.VU.get_vround_mode();
+VRM xrm = p->VU.get_vround_mode();
 VI_VI_LOOP
 ({
   int sh = simm5 & (sew - 1) & 0x1f;

--- a/riscv/insns/vssra_vv.h
+++ b/riscv/insns/vssra_vv.h
@@ -1,5 +1,5 @@
 // vssra.vv vd, vs2, vs1
-VRM xrm = P.VU.get_vround_mode();
+VRM xrm = p->VU.get_vround_mode();
 VI_VV_LOOP
 ({
   int sh = vs1 & (sew - 1);

--- a/riscv/insns/vssra_vx.h
+++ b/riscv/insns/vssra_vx.h
@@ -1,5 +1,5 @@
 // vssra.vx vd, vs2, rs1
-VRM xrm = P.VU.get_vround_mode();
+VRM xrm = p->VU.get_vround_mode();
 VI_VX_LOOP
 ({
   int sh = rs1 & (sew - 1);

--- a/riscv/insns/vssrl_vi.h
+++ b/riscv/insns/vssrl_vi.h
@@ -1,5 +1,5 @@
 // vssra.vi vd, vs2, simm5
-VRM xrm = P.VU.get_vround_mode();
+VRM xrm = p->VU.get_vround_mode();
 VI_VI_ULOOP
 ({
   int sh = zimm5 & (sew - 1) & 0x1f;

--- a/riscv/insns/vssrl_vv.h
+++ b/riscv/insns/vssrl_vv.h
@@ -1,5 +1,5 @@
 // vssrl.vv vd, vs2, vs1
-VRM xrm = P.VU.get_vround_mode();
+VRM xrm = p->VU.get_vround_mode();
 VI_VV_ULOOP
 ({
   int sh = vs1 & (sew - 1);

--- a/riscv/insns/vssrl_vx.h
+++ b/riscv/insns/vssrl_vx.h
@@ -1,5 +1,5 @@
 // vssrl.vx vd, vs2, rs1
-VRM xrm = P.VU.get_vround_mode();
+VRM xrm = p->VU.get_vround_mode();
 VI_VX_ULOOP
 ({
   int sh = rs1 & (sew - 1);

--- a/riscv/insns/vwmulsu_vv.h
+++ b/riscv/insns/vwmulsu_vv.h
@@ -2,15 +2,15 @@
 VI_CHECK_DSS(true);
 VI_VV_LOOP_WIDEN
 ({
-  switch(P.VU.vsew) {
+  switch(p->VU.vsew) {
   case e8:
-    P.VU.elt<uint16_t>(rd_num, i, true) = (int16_t)(int8_t)vs2 * (int16_t)(uint8_t)vs1;
+    p->VU.elt<uint16_t>(rd_num, i, true) = (int16_t)(int8_t)vs2 * (int16_t)(uint8_t)vs1;
     break;
   case e16:
-    P.VU.elt<uint32_t>(rd_num, i, true) = (int32_t)(int16_t)vs2 * (int32_t)(uint16_t)vs1;
+    p->VU.elt<uint32_t>(rd_num, i, true) = (int32_t)(int16_t)vs2 * (int32_t)(uint16_t)vs1;
     break;
   default:
-    P.VU.elt<uint64_t>(rd_num, i, true) = (int64_t)(int32_t)vs2 * (int64_t)(uint32_t)vs1;
+    p->VU.elt<uint64_t>(rd_num, i, true) = (int64_t)(int32_t)vs2 * (int64_t)(uint32_t)vs1;
     break;
   }
 })

--- a/riscv/insns/vwmulsu_vx.h
+++ b/riscv/insns/vwmulsu_vx.h
@@ -2,15 +2,15 @@
 VI_CHECK_DSS(false);
 VI_VX_LOOP_WIDEN
 ({
-  switch(P.VU.vsew) {
+  switch(p->VU.vsew) {
   case e8:
-    P.VU.elt<uint16_t>(rd_num, i, true) = (int16_t)(int8_t)vs2 * (int16_t)(uint8_t)rs1;
+    p->VU.elt<uint16_t>(rd_num, i, true) = (int16_t)(int8_t)vs2 * (int16_t)(uint8_t)rs1;
     break;
   case e16:
-    P.VU.elt<uint32_t>(rd_num, i, true) = (int32_t)(int16_t)vs2 * (int32_t)(uint16_t)rs1;
+    p->VU.elt<uint32_t>(rd_num, i, true) = (int32_t)(int16_t)vs2 * (int32_t)(uint16_t)rs1;
     break;
   default:
-    P.VU.elt<uint64_t>(rd_num, i, true) = (int64_t)(int32_t)vs2 * (int64_t)(uint32_t)rs1;
+    p->VU.elt<uint64_t>(rd_num, i, true) = (int64_t)(int32_t)vs2 * (int64_t)(uint32_t)rs1;
     break;
   }
 })


### PR DESCRIPTION
This PR improves coding style.

In the files `decode.h` in the `riscv/` directory
and in the files `v*.h` in the `riscv/insns/` directory
there was an inconsistent use of `p->` and `(*p).`, being that
`(*p).` was used by means of a macro definition as `P.`.
For example, one could find the expression `P.get_max_xlen()`
as well as the expression `p->get_max_xlen()`.

This PR proposes to eliminate all ocurrences of `P.`,
replacing them by `p->`.

As a side effect, the macro definition of `P` becomes
unnecessary and is also eliminated.
Eliminating the macro named `P` has the beneficial
side effect that a foreign library header file
which happens to use `P` as a template definition type
placeholder (for example boost) can be used without problem.

To guarantee that funcionality is preserved, a static
verification approach was used. This approach is based
on the assumption that all C source code, without exception,
gets compiled to an object file in the `build/` directory.

Using the command `objdump -d *.o` before any modification
and comparing its output with the output of the same
command after `make` with the modifications proposed in this PR,
no difference is reported. This proves that the modifications
do not affect the funtion of the code in any way.

The verification was done on CentOS7 (gcc 4.8.5),
Ubuntu 21.10 (gcc 11.2.0), and MacOS Monterey (clang 13.0.0).
