### PR TITLE
Mask hideleg/hip/hie according to recent spec clarification

### DIFF
--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -956,6 +956,16 @@ void hypervisor_csr_t::verify_permissions(insn_t insn, bool write) const {
 }
 
 
+hideleg_csr_t::hideleg_csr_t(processor_t* const proc, const reg_t addr, csr_t_p mideleg):
+  masked_csr_t(proc, addr, MIP_VS_MASK, 0),
+  mideleg(mideleg) {
+}
+
+reg_t hideleg_csr_t::read() const noexcept {
+  return masked_csr_t::read() & mideleg->read();
+};
+
+
 hgatp_csr_t::hgatp_csr_t(processor_t* const proc, const reg_t addr):
   basic_csr_t(proc, addr, 0) {
 }

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -616,15 +616,14 @@ generic_int_accessor_t::generic_int_accessor_t(state_t* const state,
                                                const reg_t read_mask,
                                                const reg_t ip_write_mask,
                                                const reg_t ie_write_mask,
-                                               const bool mask_mideleg,
-                                               const bool mask_hideleg,
+                                               const mask_mode_t mask_mode,
                                                const int shiftamt):
   state(state),
   read_mask(read_mask),
   ip_write_mask(ip_write_mask),
   ie_write_mask(ie_write_mask),
-  mask_mideleg(mask_mideleg),
-  mask_hideleg(mask_hideleg),
+  mask_mideleg(mask_mode == MIDELEG),
+  mask_hideleg(mask_mode == HIDELEG),
   shiftamt(shiftamt) {
 }
 

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -323,12 +323,13 @@ typedef std::shared_ptr<mie_csr_t> mie_csr_t_p;
 // etc.
 class generic_int_accessor_t {
  public:
+  enum mask_mode_t { NONE, MIDELEG, HIDELEG };
+
   generic_int_accessor_t(state_t* const state,
                          const reg_t read_mask,
                          const reg_t ip_write_mask,
                          const reg_t ie_write_mask,
-                         const bool mask_mideleg,
-                         const bool mask_hideleg,
+                         const mask_mode_t mask_mode,
                          const int shiftamt);
   reg_t ip_read() const noexcept;
   void ip_write(const reg_t val) noexcept;

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -511,6 +511,15 @@ class hypervisor_csr_t: public basic_csr_t {
 };
 
 
+class hideleg_csr_t: public masked_csr_t {
+ public:
+  hideleg_csr_t(processor_t* const proc, const reg_t addr, csr_t_p mideleg);
+  virtual reg_t read() const noexcept override;
+ private:
+  csr_t_p mideleg;
+};
+
+
 class hgatp_csr_t: public basic_csr_t {
  public:
   hgatp_csr_t(processor_t* const proc, const reg_t addr);

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -736,7 +736,7 @@ void processor_t::take_interrupt(reg_t pending_interrupts)
     enabled_interrupts = pending_interrupts & deleg_to_hs & -hs_enabled;
     if (state.v && enabled_interrupts == 0) {
       // VS-ints have least priority and can only be taken with virt enabled
-      const reg_t deleg_to_vs = state.mideleg->read() & state.hideleg->read();
+      const reg_t deleg_to_vs = state.hideleg->read();
       const reg_t vs_enabled = state.prv < PRV_S || (state.prv == PRV_S && sie);
       enabled_interrupts = pending_interrupts & deleg_to_vs & -vs_enabled;
     }
@@ -867,7 +867,7 @@ void processor_t::take_trap(trap_t& t, reg_t epc)
   bool curr_virt = state.v;
   bool interrupt = (bit & ((reg_t)1 << (max_xlen-1))) != 0;
   if (interrupt) {
-    vsdeleg = (curr_virt && state.prv <= PRV_S) ? (state.mideleg->read() & state.hideleg->read()) : 0;
+    vsdeleg = (curr_virt && state.prv <= PRV_S) ? state.hideleg->read() : 0;
     hsdeleg = (state.prv <= PRV_S) ? state.mideleg->read() : 0;
     bit &= ~((reg_t)1 << (max_xlen-1));
   } else {

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -394,37 +394,45 @@ void state_t::reset(processor_t* const proc, reg_t max_isa)
   csrmap[CSR_MCOUNTINHIBIT] = std::make_shared<const_csr_t>(proc, CSR_MCOUNTINHIBIT, 0);
   csrmap[CSR_MIE] = mie = std::make_shared<mie_csr_t>(proc, CSR_MIE);
   csrmap[CSR_MIP] = mip = std::make_shared<mip_csr_t>(proc, CSR_MIP);
-  auto sip_sie_accr = std::make_shared<generic_int_accessor_t>(this,
-                                                               ~MIP_HS_MASK,  // read_mask
-                                                               MIP_SSIP,      // ip_write_mask
-                                                               ~MIP_HS_MASK,  // ie_write_mask
-                                                               true,          // mask_mideleg
-                                                               false,         // mask_hideleg
-                                                               0);            // shiftamt
+  auto sip_sie_accr = std::make_shared<generic_int_accessor_t>(
+    this,
+    ~MIP_HS_MASK,  // read_mask
+    MIP_SSIP,      // ip_write_mask
+    ~MIP_HS_MASK,  // ie_write_mask
+    true,          // mask_mideleg
+    false,         // mask_hideleg
+    0              // shiftamt
+  );
 
-  auto hip_hie_accr = std::make_shared<generic_int_accessor_t>(this,
-                                                               MIP_HS_MASK,   // read_mask
-                                                               MIP_VSSIP,     // ip_write_mask
-                                                               MIP_HS_MASK,   // ie_write_mask
-                                                               true,          // mask_mideleg
-                                                               false,         // mask_hideleg
-                                                               0);
+  auto hip_hie_accr = std::make_shared<generic_int_accessor_t>(
+    this,
+    MIP_HS_MASK,   // read_mask
+    MIP_VSSIP,     // ip_write_mask
+    MIP_HS_MASK,   // ie_write_mask
+    true,          // mask_mideleg
+    false,         // mask_hideleg
+    0              // shiftamt
+  );
 
-  auto hvip_accr = std::make_shared<generic_int_accessor_t>(this,
-                                                            MIP_VS_MASK,   // read_mask
-                                                            MIP_VS_MASK,   // ip_write_mask
-                                                            MIP_VS_MASK,   // ie_write_mask
-                                                            false,         // mask_mideleg
-                                                            false,         // mask_hideleg
-                                                            0);            // shiftamt
+  auto hvip_accr = std::make_shared<generic_int_accessor_t>(
+    this,
+    MIP_VS_MASK,   // read_mask
+    MIP_VS_MASK,   // ip_write_mask
+    MIP_VS_MASK,   // ie_write_mask
+    false,         // mask_mideleg
+    false,         // mask_hideleg
+    0              // shiftamt
+  );
 
-  auto vsip_vsie_accr = std::make_shared<generic_int_accessor_t>(this,
-                                                                 MIP_VS_MASK,   // read_mask
-                                                                 MIP_VSSIP,     // ip_write_mask
-                                                                 MIP_VS_MASK,   // ie_write_mask
-                                                                 false,         // mask_mideleg
-                                                                 true,          // mask_hideleg
-                                                                 1);            // shiftamt
+  auto vsip_vsie_accr = std::make_shared<generic_int_accessor_t>(
+    this,
+    MIP_VS_MASK,   // read_mask
+    MIP_VSSIP,     // ip_write_mask
+    MIP_VS_MASK,   // ie_write_mask
+    false,         // mask_mideleg
+    true,          // mask_hideleg
+    1              // shiftamt
+  );
 
   auto nonvirtual_sip = std::make_shared<mip_proxy_csr_t>(proc, CSR_SIP, sip_sie_accr);
   auto vsip = std::make_shared<mip_proxy_csr_t>(proc, CSR_VSIP, vsip_vsie_accr);

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -399,8 +399,7 @@ void state_t::reset(processor_t* const proc, reg_t max_isa)
     ~MIP_HS_MASK,  // read_mask
     MIP_SSIP,      // ip_write_mask
     ~MIP_HS_MASK,  // ie_write_mask
-    true,          // mask_mideleg
-    false,         // mask_hideleg
+    generic_int_accessor_t::mask_mode_t::MIDELEG,
     0              // shiftamt
   );
 
@@ -409,8 +408,7 @@ void state_t::reset(processor_t* const proc, reg_t max_isa)
     MIP_HS_MASK,   // read_mask
     MIP_VSSIP,     // ip_write_mask
     MIP_HS_MASK,   // ie_write_mask
-    true,          // mask_mideleg
-    false,         // mask_hideleg
+    generic_int_accessor_t::mask_mode_t::MIDELEG,
     0              // shiftamt
   );
 
@@ -419,8 +417,7 @@ void state_t::reset(processor_t* const proc, reg_t max_isa)
     MIP_VS_MASK,   // read_mask
     MIP_VS_MASK,   // ip_write_mask
     MIP_VS_MASK,   // ie_write_mask
-    false,         // mask_mideleg
-    false,         // mask_hideleg
+    generic_int_accessor_t::mask_mode_t::NONE,
     0              // shiftamt
   );
 
@@ -429,8 +426,7 @@ void state_t::reset(processor_t* const proc, reg_t max_isa)
     MIP_VS_MASK,   // read_mask
     MIP_VSSIP,     // ip_write_mask
     MIP_VS_MASK,   // ie_write_mask
-    false,         // mask_mideleg
-    true,          // mask_hideleg
+    generic_int_accessor_t::mask_mode_t::HIDELEG,
     1              // shiftamt
   );
 

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -474,7 +474,7 @@ void state_t::reset(processor_t* const proc, reg_t max_isa)
   csrmap[CSR_HSTATUS] = hstatus = std::make_shared<masked_csr_t>(proc, CSR_HSTATUS, hstatus_mask, hstatus_init);
   csrmap[CSR_HGEIE] = std::make_shared<const_csr_t>(proc, CSR_HGEIE, 0);
   csrmap[CSR_HGEIP] = std::make_shared<const_csr_t>(proc, CSR_HGEIP, 0);
-  csrmap[CSR_HIDELEG] = hideleg = std::make_shared<masked_csr_t>(proc, CSR_HIDELEG, MIP_VS_MASK, 0);
+  csrmap[CSR_HIDELEG] = hideleg = std::make_shared<hideleg_csr_t>(proc, CSR_HIDELEG, mideleg);
   const reg_t hedeleg_mask =
     (1 << CAUSE_MISALIGNED_FETCH) |
     (1 << CAUSE_FETCH_ACCESS) |

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -406,7 +406,7 @@ void state_t::reset(processor_t* const proc, reg_t max_isa)
                                                                MIP_HS_MASK,   // read_mask
                                                                MIP_VSSIP,     // ip_write_mask
                                                                MIP_HS_MASK,   // ie_write_mask
-                                                               false,         // mask_mideleg
+                                                               true,          // mask_mideleg
                                                                false,         // mask_hideleg
                                                                0);
 


### PR DESCRIPTION
This [spec clarification](https://github.com/riscv/riscv-isa-manual/pull/771) says that these three CSRs should be masked by `mideleg`:
* `hideleg`
* `hip`
* `hie`

This has no functional effect today, since the only active bits in these three CSRs are all [tied to 1 in `mideleg`](https://github.com/riscv-software-src/riscv-isa-sim/blob/f1bc56264ed214ee941b3a601a693ab655724f52/riscv/csrs.cc#L694) when hypervisor is enabled. But it [might affect](https://github.com/riscv/riscv-isa-manual/pull/771#issuecomment-967724784) future features, so let's explicitly do what the spec requires so there's no subtle bugs in the future.