### PR TITLE
[RFC] Accept dummy extensions ("Zifencei" and "ZiHintPause")

### DIFF
--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -215,7 +215,7 @@ void processor_t::parse_isa_string(const char* str)
   else
     bad_isa_string(str, "Spike supports either RV32I or RV64I");
   if (isa_string[4] == 'g')
-    isa_string = isa_string.substr(0, 4) + "imafd" + isa_string.substr(5);
+    isa_string = isa_string.substr(0, 4) + "imafd" + isa_string.substr(5) + "_zicsr_zifencei";
   if (isa_string[4] != 'i')
     bad_isa_string(str, "'I' extension is required");
 

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -256,6 +256,8 @@ void processor_t::parse_isa_string(const char* str)
       // Zicsr is implied by the privileged architecture
     } else if (ext_str == "zifencei") {
       // Zifencei is ignored and implied
+    } else if (ext_str == "zihintpause") {
+      // ZiHintPause is ignored (only a hint)
     } else if (ext_str == "zmmul") {
       extension_table[EXT_ZMMUL] = true;
     } else if (ext_str == "zba") {

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -254,6 +254,8 @@ void processor_t::parse_isa_string(const char* str)
     } else if (ext_str == "zicsr") {
       // Spike necessarily has Zicsr, because
       // Zicsr is implied by the privileged architecture
+    } else if (ext_str == "zifencei") {
+      // Zifencei is ignored and implied
     } else if (ext_str == "zmmul") {
       extension_table[EXT_ZMMUL] = true;
     } else if (ext_str == "zba") {


### PR DESCRIPTION
# Patch 1, 2: Accept Dummy Extensions

To prevent "unsupported extension" error, this pull request adds two valid extensions (valid but does nothing in the simulator) to `processor_t::parse_isa_string`.

*   "Zifencei" (`fence.i` instruction)
*   "ZiHintPause" (`pause` instruction - a special encoding of `fence` instruction)

# RFC Patch 3: Expand "G" to full extension name

In addition, third commit expands "G" extension to "IMAFDZicsr_Zifencei" (because "Zifencei" is now a valid extension name).
This commit would not meet your requirements because...

*   It may confuse some operating systems such as Linux, which does not correctly parse (or ignore) multi-letter extensions for now  
    Recently, I submitted RFC PATCH to linux-riscv ([v1 with background](http://lists.infradead.org/pipermail/linux-riscv/2021-November/010252.html) and [v2](http://lists.infradead.org/pipermail/linux-riscv/2021-November/010350.html)) to fix this
*   Extension name ordering is not respected  
    Putting some extensions with `--isa` argument (e.g. `Xhwacha`) may make full set of extensions invalid (because `Z` multi-letter extensions cannot come after `X` ones).
    Current `processor_t::parse_isa_string` does not respect multi-letter ordering but still, applying patch 3 may not be a good idea as first two patches.

So, third commit is not a requirement (just a proposal). I just want to hear your thoughts.