### PR TITLE
Simplify narrowing instruction

### DIFF
--- a/riscv/decode.h
+++ b/riscv/decode.h
@@ -1151,8 +1151,8 @@ VI_LOOP_END
   } \
   VI_LOOP_END
 
-#define VI_VI_LOOP_NSHIFT(BODY, is_vs1) \
-  VI_CHECK_SDS(is_vs1); \
+#define VI_VI_LOOP_NSHIFT(BODY) \
+  VI_CHECK_SDS(false); \
   VI_LOOP_NSHIFT_BASE \
   if (sew == e8){ \
     VI_NSHIFT_PARAMS(e8, e16) \
@@ -1166,8 +1166,8 @@ VI_LOOP_END
   } \
   VI_LOOP_END
 
-#define VI_VX_LOOP_NSHIFT(BODY, is_vs1) \
-  VI_CHECK_SDS(is_vs1); \
+#define VI_VX_LOOP_NSHIFT(BODY) \
+  VI_CHECK_SDS(false); \
   VI_LOOP_NSHIFT_BASE \
   if (sew == e8){ \
     VX_NSHIFT_PARAMS(e8, e16) \
@@ -1181,8 +1181,8 @@ VI_LOOP_END
   } \
   VI_LOOP_END
 
-#define VI_VV_LOOP_NSHIFT(BODY, is_vs1) \
-  VI_CHECK_SDS(is_vs1); \
+#define VI_VV_LOOP_NSHIFT(BODY) \
+  VI_CHECK_SDS(true); \
   VI_LOOP_NSHIFT_BASE \
   if (sew == e8){ \
     VV_NSHIFT_PARAMS(e8, e16) \

--- a/riscv/insns/vnclip_wi.h
+++ b/riscv/insns/vnclip_wi.h
@@ -2,7 +2,7 @@
 VRM xrm = P.VU.get_vround_mode();
 int64_t int_max = INT64_MAX >> (64 - P.VU.vsew);
 int64_t int_min = INT64_MIN >> (64 - P.VU.vsew);
-VI_VVXI_LOOP_NARROW
+VI_VI_LOOP_NARROW
 ({
   int128_t result = vs2;
   unsigned shift = zimm5 & ((sew * 2) - 1);
@@ -22,4 +22,4 @@ VI_VVXI_LOOP_NARROW
   }
 
   vd = result;
-}, false)
+})

--- a/riscv/insns/vnclip_wv.h
+++ b/riscv/insns/vnclip_wv.h
@@ -2,7 +2,7 @@
 VRM xrm = P.VU.get_vround_mode();
 int64_t int_max = INT64_MAX >> (64 - P.VU.vsew);
 int64_t int_min = INT64_MIN >> (64 - P.VU.vsew);
-VI_VVXI_LOOP_NARROW
+VI_VV_LOOP_NARROW
 ({
   int128_t result = vs2;
   unsigned shift = vs1 & ((sew * 2) - 1);
@@ -22,4 +22,4 @@ VI_VVXI_LOOP_NARROW
   }
 
   vd = result;
-}, true)
+})

--- a/riscv/insns/vnclip_wx.h
+++ b/riscv/insns/vnclip_wx.h
@@ -2,7 +2,7 @@
 VRM xrm = P.VU.get_vround_mode();
 int64_t int_max = INT64_MAX >> (64 - P.VU.vsew);
 int64_t int_min = INT64_MIN >> (64 - P.VU.vsew);
-VI_VVXI_LOOP_NARROW
+VI_VX_LOOP_NARROW
 ({
   int128_t result = vs2;
   unsigned shift = rs1 & ((sew * 2) - 1);
@@ -22,4 +22,4 @@ VI_VVXI_LOOP_NARROW
   }
 
   vd = result;
-}, false)
+})

--- a/riscv/insns/vnclipu_wi.h
+++ b/riscv/insns/vnclipu_wi.h
@@ -2,7 +2,7 @@
 VRM xrm = P.VU.get_vround_mode();
 uint64_t uint_max = UINT64_MAX >> (64 - P.VU.vsew);
 uint64_t sign_mask = UINT64_MAX << P.VU.vsew;
-VI_VVXI_LOOP_NARROW
+VI_VI_LOOP_NARROW
 ({
   uint128_t result = vs2_u;
   unsigned shift = zimm5 & ((sew * 2) - 1);
@@ -20,4 +20,4 @@ VI_VVXI_LOOP_NARROW
   }
 
   vd = result;
-}, false)
+})

--- a/riscv/insns/vnclipu_wv.h
+++ b/riscv/insns/vnclipu_wv.h
@@ -2,7 +2,7 @@
 VRM xrm = P.VU.get_vround_mode();
 uint64_t uint_max = UINT64_MAX >> (64 - P.VU.vsew);
 uint64_t sign_mask = UINT64_MAX << P.VU.vsew;
-VI_VVXI_LOOP_NARROW
+VI_VV_LOOP_NARROW
 ({
   uint128_t result = vs2_u;
   unsigned shift = vs1 & ((sew * 2) - 1);
@@ -19,4 +19,4 @@ VI_VVXI_LOOP_NARROW
   }
 
   vd = result;
-}, true)
+})

--- a/riscv/insns/vnclipu_wx.h
+++ b/riscv/insns/vnclipu_wx.h
@@ -2,7 +2,7 @@
 VRM xrm = P.VU.get_vround_mode();
 uint64_t uint_max = UINT64_MAX >> (64 - P.VU.vsew);
 uint64_t sign_mask = UINT64_MAX << P.VU.vsew;
-VI_VVXI_LOOP_NARROW
+VI_VX_LOOP_NARROW
 ({
   uint128_t result = vs2_u;
   unsigned shift = rs1 & ((sew * 2) - 1);
@@ -19,4 +19,4 @@ VI_VVXI_LOOP_NARROW
   }
 
   vd = result;
-}, false)
+})

--- a/riscv/insns/vnsra_wi.h
+++ b/riscv/insns/vnsra_wi.h
@@ -2,4 +2,4 @@
 VI_VI_LOOP_NSHIFT
 ({
   vd = vs2 >> (zimm5 & (sew * 2 - 1) & 0x1f);
-}, false)
+})

--- a/riscv/insns/vnsra_wv.h
+++ b/riscv/insns/vnsra_wv.h
@@ -2,4 +2,4 @@
 VI_VV_LOOP_NSHIFT
 ({
   vd = vs2 >> (vs1 & (sew * 2 - 1));
-}, true)
+})

--- a/riscv/insns/vnsra_wx.h
+++ b/riscv/insns/vnsra_wx.h
@@ -2,4 +2,4 @@
 VI_VX_LOOP_NSHIFT
 ({
   vd = vs2 >> (rs1 & (sew * 2 - 1));
-}, false)
+})

--- a/riscv/insns/vnsrl_wi.h
+++ b/riscv/insns/vnsrl_wi.h
@@ -2,4 +2,4 @@
 VI_VI_LOOP_NSHIFT
 ({
   vd = vs2_u >> (zimm5 & (sew * 2 - 1));
-}, false)
+})

--- a/riscv/insns/vnsrl_wv.h
+++ b/riscv/insns/vnsrl_wv.h
@@ -2,4 +2,4 @@
 VI_VV_LOOP_NSHIFT
 ({
   vd = vs2_u >> (vs1 & (sew * 2 - 1));
-}, true)
+})

--- a/riscv/insns/vnsrl_wx.h
+++ b/riscv/insns/vnsrl_wx.h
@@ -2,4 +2,4 @@
 VI_VX_LOOP_NSHIFT
 ({
   vd = vs2_u >> (rs1 & (sew * 2 - 1));
-}, false)
+})


### PR DESCRIPTION
Eliminate redundant parameters and reuse parameter macros.