### PR TITLE
Simplify mulhsu

### DIFF
--- a/riscv/decode.h
+++ b/riscv/decode.h
@@ -738,6 +738,16 @@ static inline bool is_aligned(const unsigned val, const unsigned pos)
   type_sew_t<x>::type &vd = P.VU.elt<type_sew_t<x>::type>(rd_num, i, true); \
   type_usew_t<x>::type vs2 = P.VU.elt<type_usew_t<x>::type>(rs2_num, RS1);
 
+#define VV_SU_PARAMS(x) \
+  type_sew_t<x>::type &vd = P.VU.elt<type_sew_t<x>::type>(rd_num, i, true); \
+  type_usew_t<x>::type vs1 = P.VU.elt<type_usew_t<x>::type>(rs1_num, i); \
+  type_sew_t<x>::type vs2 = P.VU.elt<type_sew_t<x>::type>(rs2_num, i);
+
+#define VX_SU_PARAMS(x) \
+  type_sew_t<x>::type &vd = P.VU.elt<type_sew_t<x>::type>(rd_num, i, true); \
+  type_usew_t<x>::type rs1 = (type_usew_t<x>::type)RS1; \
+  type_sew_t<x>::type vs2 = P.VU.elt<type_sew_t<x>::type>(rs2_num, i);
+
 #define VV_UCMP_PARAMS(x) \
   type_usew_t<x>::type vs1 = P.VU.elt<type_usew_t<x>::type>(rs1_num, i); \
   type_usew_t<x>::type vs2 = P.VU.elt<type_usew_t<x>::type>(rs2_num, i);
@@ -1108,6 +1118,43 @@ static inline bool is_aligned(const unsigned val, const unsigned pos)
     BODY; \
   }else if(sew == e64){ \
     VI_PARAMS(e64); \
+    BODY; \
+  } \
+  VI_LOOP_END 
+
+// signed unsigned operation loop (e.g. mulhsu)
+#define VI_VV_SU_LOOP(BODY) \
+  VI_CHECK_SSS(true) \
+  VI_LOOP_BASE \
+  if (sew == e8){ \
+    VV_SU_PARAMS(e8); \
+    BODY; \
+  }else if(sew == e16){ \
+    VV_SU_PARAMS(e16); \
+    BODY; \
+  }else if(sew == e32){ \
+    VV_SU_PARAMS(e32); \
+    BODY; \
+  }else if(sew == e64){ \
+    VV_SU_PARAMS(e64); \
+    BODY; \
+  } \
+  VI_LOOP_END 
+
+#define VI_VX_SU_LOOP(BODY) \
+  VI_CHECK_SSS(false) \
+  VI_LOOP_BASE \
+  if (sew == e8){ \
+    VX_SU_PARAMS(e8); \
+    BODY; \
+  }else if(sew == e16){ \
+    VX_SU_PARAMS(e16); \
+    BODY; \
+  }else if(sew == e32){ \
+    VX_SU_PARAMS(e32); \
+    BODY; \
+  }else if(sew == e64){ \
+    VX_SU_PARAMS(e64); \
     BODY; \
   } \
   VI_LOOP_END 

--- a/riscv/insns/vmulhsu_vv.h
+++ b/riscv/insns/vmulhsu_vv.h
@@ -1,38 +1,4 @@
 // vmulhsu.vv vd, vs2, vs1
-VI_CHECK_SSS(true);
-VI_LOOP_BASE
-switch(sew) {
-case e8: {
-  auto &vd = P.VU.elt<int8_t>(rd_num, i, true);
-  auto vs2 = P.VU.elt<int8_t>(rs2_num, i);
-  auto vs1 = P.VU.elt<uint8_t>(rs1_num, i);
-
-  vd = ((int16_t)vs2 * (uint16_t)vs1) >> sew;
-  break;
-}
-case e16: {
-  auto &vd = P.VU.elt<int16_t>(rd_num, i, true);
-  auto vs2 = P.VU.elt<int16_t>(rs2_num, i);
-  auto vs1 = P.VU.elt<uint16_t>(rs1_num, i);
-
-  vd = ((int32_t)vs2 * (uint32_t)vs1) >> sew;
-  break;
-}
-case e32: {
-  auto &vd = P.VU.elt<int32_t>(rd_num, i, true);
-  auto vs2 = P.VU.elt<int32_t>(rs2_num, i);
-  auto vs1 = P.VU.elt<uint32_t>(rs1_num, i);
-
-  vd = ((int64_t)vs2 * (uint64_t)vs1) >> sew;
-  break;
-}
-default: {
-  auto &vd = P.VU.elt<int64_t>(rd_num, i, true);
-  auto vs2 = P.VU.elt<int64_t>(rs2_num, i);
-  auto vs1 = P.VU.elt<uint64_t>(rs1_num, i);
-
+VI_VV_SU_LOOP({
   vd = ((int128_t)vs2 * (uint128_t)vs1) >> sew;
-  break;
-}
-}
-VI_LOOP_END
+})

--- a/riscv/insns/vmulhsu_vx.h
+++ b/riscv/insns/vmulhsu_vx.h
@@ -1,38 +1,4 @@
 // vmulhsu.vx vd, vs2, rs1
-VI_CHECK_SSS(false);
-VI_LOOP_BASE
-switch(sew) {
-case e8: {
-  auto &vd = P.VU.elt<int8_t>(rd_num, i, true);
-  auto vs2 = P.VU.elt<int8_t>(rs2_num, i);
-  uint8_t rs1 = RS1;
-
-  vd = ((int16_t)vs2 * (uint16_t)rs1) >> sew;
-  break;
-}
-case e16: {
-  auto &vd = P.VU.elt<int16_t>(rd_num, i, true);
-  auto vs2 = P.VU.elt<int16_t>(rs2_num, i);
-  uint16_t rs1 = RS1;
-
-  vd = ((int32_t)vs2 * (uint32_t)rs1) >> sew;
-  break;
-}
-case e32: {
-  auto &vd = P.VU.elt<int32_t>(rd_num, i, true);
-  auto vs2 = P.VU.elt<int32_t>(rs2_num, i);
-  uint32_t rs1 = RS1;
-
-  vd = ((int64_t)vs2 * (uint64_t)rs1) >> sew;
-  break;
-}
-default: {
-  auto &vd = P.VU.elt<int64_t>(rd_num, i, true);
-  auto vs2 = P.VU.elt<int64_t>(rs2_num, i);
-  uint64_t rs1 = RS1;
-
+VI_VX_SU_LOOP({
   vd = ((int128_t)vs2 * (uint128_t)rs1) >> sew;
-  break;
-}
-}
-VI_LOOP_END
+})


### PR DESCRIPTION
The last PR is bugged, as Andrew had pointed out.

> the vs1 argument is being sign-extended before it's being zero-extended. I'll revert this right now. Not sure if there's a more elegant way to handle this that's also correct.

This PR will have `vs1` not being sign-extended before an unsigned-extend.