### PR TITLE
page fault when PTE_N bit set and not EXT_SVNAPOT

### DIFF
--- a/riscv/mmu.cc
+++ b/riscv/mmu.cc
@@ -291,6 +291,8 @@ reg_t mmu_t::s2xlate(reg_t gva, reg_t gpa, access_type type, access_type trap_ty
 
       if (pte & PTE_RSVD) {
         break;
+      } else if (!proc->extension_enabled(EXT_SVNAPOT) && (pte & PTE_N)) {
+        break;
       } else if (!proc->extension_enabled(EXT_SVPBMT) && (pte & PTE_PBMT)) {
         break;
       } else if (PTE_TABLE(pte)) { // next level of page table
@@ -378,6 +380,8 @@ reg_t mmu_t::walk(reg_t addr, access_type type, reg_t mode, bool virt, bool hlvx
     reg_t ppn = (pte & ~reg_t(PTE_ATTR)) >> PTE_PPN_SHIFT;
 
     if (pte & PTE_RSVD) {
+      break;
+    } else if (!proc->extension_enabled(EXT_SVNAPOT) && (pte & PTE_N)) {
       break;
     } else if (!proc->extension_enabled(EXT_SVPBMT) && (pte & PTE_PBMT)) {
       break;


### PR DESCRIPTION
when Svnapot extension for NAPOT Translation Contiguity is **not** enabled, the `PTE_N` bit should be behave as `PTE_RSVD` bits and page fault when set

follow-up to https://github.com/riscv-software-src/riscv-isa-sim/pull/874#issuecomment-986267199 from @scottj97 cc @daniellustig 