### PR TITLE
Simplify vadc and vsbc

### DIFF
--- a/riscv/decode.h
+++ b/riscv/decode.h
@@ -644,6 +644,12 @@ static inline bool is_aligned(const unsigned val, const unsigned pos)
     vd = (vd & ~mmask) | (((res) << mpos) & mmask); \
   } \
   P.VU.vstart->write(0);
+#define VI_LOOP_WITH_CARRY_BASE \
+  VI_GENERAL_LOOP_BASE \
+  VI_MASK_VARS \
+  auto &v0 = P.VU.elt<uint64_t>(0, midx); \
+  const uint128_t op_mask = (UINT64_MAX >> (64 - sew)); \
+  uint64_t carry = (v0 >> mpos) & 0x1;
 
 #define VI_LOOP_CMP_BASE \
   require(P.VU.vsew >= e8 && P.VU.vsew <= e64); \
@@ -1445,10 +1451,9 @@ VI_LOOP_END
   VI_LOOP_CARRY_END
 
 #define VI_VV_LOOP_WITH_CARRY(BODY) \
-  require(insn.rd() != 0); \
+  require_vm; \
   VI_CHECK_SSS(true); \
-  VI_GENERAL_LOOP_BASE \
-  VI_MASK_VARS \
+  VI_LOOP_WITH_CARRY_BASE \
     if (sew == e8){ \
       VV_WITH_CARRY_PARAMS(e8) \
       BODY; \
@@ -1465,10 +1470,9 @@ VI_LOOP_END
   VI_LOOP_END
 
 #define VI_XI_LOOP_WITH_CARRY(BODY) \
-  require(insn.rd() != 0); \
+  require_vm; \
   VI_CHECK_SSS(false); \
-  VI_GENERAL_LOOP_BASE \
-  VI_MASK_VARS \
+  VI_LOOP_WITH_CARRY_BASE \
     if (sew == e8){ \
       XI_WITH_CARRY_PARAMS(e8) \
       BODY; \

--- a/riscv/insns/vadc_vim.h
+++ b/riscv/insns/vadc_vim.h
@@ -1,10 +1,5 @@
 // vadc.vim vd, vs2, simm5, v0
 VI_XI_LOOP_WITH_CARRY
 ({
-  auto &v0 = P.VU.elt<uint64_t>(0, midx);
-  const uint128_t op_mask = (UINT64_MAX >> (64 - sew));
-  uint64_t carry = (v0 >> mpos) & 0x1;
-
-  uint128_t res = (op_mask & simm5) + (op_mask & vs2) + carry;
-  vd = res;
+  vd = (uint128_t)((op_mask & simm5) + (op_mask & vs2) + carry);
 })

--- a/riscv/insns/vadc_vvm.h
+++ b/riscv/insns/vadc_vvm.h
@@ -1,10 +1,5 @@
 // vadc.vvm vd, vs2, rs1, v0
 VI_VV_LOOP_WITH_CARRY
 ({
-  auto &v0 = P.VU.elt<uint64_t>(0, midx);
-  const uint128_t op_mask = (UINT64_MAX >> (64 - sew));
-  uint64_t carry = (v0 >> mpos) & 0x1;
-
-  uint128_t res = (op_mask & vs1) + (op_mask & vs2) + carry;
-  vd = res;
+  vd = (uint128_t)((op_mask & vs1) + (op_mask & vs2) + carry);
 })

--- a/riscv/insns/vadc_vxm.h
+++ b/riscv/insns/vadc_vxm.h
@@ -1,10 +1,5 @@
 // vadc.vxm vd, vs2, rs1, v0
 VI_XI_LOOP_WITH_CARRY
 ({
-  auto &v0 = P.VU.elt<uint64_t>(0, midx);
-  const uint128_t op_mask = (UINT64_MAX >> (64 - sew));
-  uint64_t carry = (v0 >> mpos) & 0x1;
-
-  uint128_t res = (op_mask & rs1) + (op_mask & vs2) + carry;
-  vd = res;
+  vd = (uint128_t)((op_mask & rs1) + (op_mask & vs2) + carry);
 })

--- a/riscv/insns/vsbc_vvm.h
+++ b/riscv/insns/vsbc_vvm.h
@@ -1,10 +1,5 @@
 // vsbc.vvm vd, vs2, rs1, v0
 VI_VV_LOOP_WITH_CARRY
 ({
-  auto &v0 = P.VU.elt<uint64_t>(0, midx);
-  const uint128_t op_mask = (UINT64_MAX >> (64 - sew));
-  uint64_t carry = (v0 >> mpos) & 0x1;
-
-  uint128_t res = (op_mask & vs2) - (op_mask & vs1) - carry;
-  vd = res;
+  vd = (uint128_t)((op_mask & vs2) - (op_mask & vs1) - carry);
 })

--- a/riscv/insns/vsbc_vxm.h
+++ b/riscv/insns/vsbc_vxm.h
@@ -1,10 +1,5 @@
 // vsbc.vxm vd, vs2, rs1, v0
 VI_XI_LOOP_WITH_CARRY
 ({
-  auto &v0 = P.VU.elt<uint64_t>(0, midx);
-  const uint128_t op_mask = (UINT64_MAX >> (64 - sew));
-  uint64_t carry = (v0 >> mpos) & 0x1;
-
-  uint128_t res = (op_mask & vs2) - (op_mask & rs1) - carry;
-  vd = res;
+  vd = (uint128_t)((op_mask & vs2) - (op_mask & rs1) - carry);
 })


### PR DESCRIPTION
- Extract common lines as macro
```cpp
#define VI_LOOP_WITH_CARRY_BASE \
  VI_GENERAL_LOOP_BASE \
  VI_MASK_VARS \
  auto &v0 = P.VU.elt<uint64_t>(0, midx); \
  const uint128_t op_mask = (UINT64_MAX >> (64 - sew)); \
  uint64_t carry = (v0 >> mpos) & 0x1;
```
- Leverage existing macro (`require_vm`)