### PR TITLE
Simplify vmadc and vmsbc

### DIFF
--- a/riscv/insns/vmadc_vim.h
+++ b/riscv/insns/vmadc_vim.h
@@ -1,13 +1,5 @@
 // vmadc.vim vd, vs2, simm5, v0
 VI_XI_LOOP_CARRY
 ({
-  auto v0 = P.VU.elt<uint64_t>(0, midx);
-  const uint64_t mmask = UINT64_C(1) << mpos; \
-  const uint128_t op_mask = (UINT64_MAX >> (64 - sew));
-  uint64_t carry = insn.v_vm() == 0 ? (v0 >> mpos) & 0x1 : 0;
-
-  uint128_t res = (op_mask & simm5) + (op_mask & vs2) + carry;
-
-  carry = (res >> sew) & 0x1u;
-  vd = (vd & ~mmask) | ((carry << mpos) & mmask);
+  res = (((op_mask & simm5) + (op_mask & vs2) + carry) >> sew) & 0x1u;
 })

--- a/riscv/insns/vmadc_vvm.h
+++ b/riscv/insns/vmadc_vvm.h
@@ -1,13 +1,5 @@
 // vmadc.vvm vd, vs2, rs1, v0
 VI_VV_LOOP_CARRY
 ({
-  auto v0 = P.VU.elt<uint64_t>(0, midx);
-  const uint64_t mmask = UINT64_C(1) << mpos; \
-  const uint128_t op_mask = (UINT64_MAX >> (64 - sew));
-  uint64_t carry = insn.v_vm() == 0 ? (v0 >> mpos) & 0x1 : 0;
-
-  uint128_t res = (op_mask & vs1) + (op_mask & vs2) + carry;
-
-  carry = (res >> sew) & 0x1u;
-  vd = (vd & ~mmask) | ((carry << mpos) & mmask);
+  res = (((op_mask & vs1) + (op_mask & vs2) + carry) >> sew) & 0x1u;
 })

--- a/riscv/insns/vmadc_vxm.h
+++ b/riscv/insns/vmadc_vxm.h
@@ -1,13 +1,5 @@
 // vadc.vx vd, vs2, rs1, v0
 VI_XI_LOOP_CARRY
 ({
-  auto v0 = P.VU.elt<uint64_t>(0, midx);
-  const uint64_t mmask = UINT64_C(1) << mpos; \
-  const uint128_t op_mask = (UINT64_MAX >> (64 - sew));
-  uint64_t carry = insn.v_vm() == 0 ? (v0 >> mpos) & 0x1 : 0;
-
-  uint128_t res = (op_mask & rs1) + (op_mask & vs2) + carry;
-
-  carry = (res >> sew) & 0x1u;
-  vd = (vd & ~mmask) | ((carry << mpos) & mmask);
+  res = (((op_mask & rs1) + (op_mask & vs2) + carry) >> sew) & 0x1u;
 })

--- a/riscv/insns/vmsbc_vvm.h
+++ b/riscv/insns/vmsbc_vvm.h
@@ -1,13 +1,5 @@
 // vmsbc.vvm vd, vs2, rs1, v0
 VI_VV_LOOP_CARRY
 ({
-  auto v0 = P.VU.elt<uint64_t>(0, midx);
-  const uint64_t mmask = UINT64_C(1) << mpos;
-  const uint128_t op_mask = (UINT64_MAX >> (64 - sew));
-  uint64_t carry = insn.v_vm() == 0 ? (v0 >> mpos) & 0x1 : 0;
-
-  uint128_t res = (op_mask & vs2) - (op_mask & vs1) - carry;
-
-  carry = (res >> sew) & 0x1u;
-  vd = (vd & ~mmask) | ((carry << mpos) & mmask);
+  res = (((op_mask & vs2) - (op_mask & vs1) - carry) >> sew) & 0x1u;
 })

--- a/riscv/insns/vmsbc_vxm.h
+++ b/riscv/insns/vmsbc_vxm.h
@@ -1,13 +1,5 @@
 // vmsbc.vxm vd, vs2, rs1, v0
 VI_XI_LOOP_CARRY
 ({
-  auto &v0 = P.VU.elt<uint64_t>(0, midx);
-  const uint64_t mmask = UINT64_C(1) << mpos; \
-  const uint128_t op_mask = (UINT64_MAX >> (64 - sew));
-  uint64_t carry = insn.v_vm() == 0 ? (v0 >> mpos) & 0x1 : 0;
-
-  uint128_t res = (op_mask & vs2) - (op_mask & rs1) - carry;
-
-  carry = (res >> sew) & 0x1u;
-  vd = (vd & ~mmask) | ((carry << mpos) & mmask);
+  res = (((op_mask & vs2) - (op_mask & rs1) - carry) >> sew) & 0x1u;
 })


### PR DESCRIPTION
Extract prefix and suffix as macro, leaving only main logic in header.
```cpp
#define VI_LOOP_CARRY_BASE \
  VI_GENERAL_LOOP_BASE \
  VI_MASK_VARS \
  auto v0 = P.VU.elt<uint64_t>(0, midx); \
  const uint64_t mmask = UINT64_C(1) << mpos; \
  const uint128_t op_mask = (UINT64_MAX >> (64 - sew)); \
  uint64_t carry = insn.v_vm() == 0 ? (v0 >> mpos) & 0x1 : 0; \
  uint128_t res = 0; \
  auto &vd = P.VU.elt<uint64_t>(rd_num, midx, true);

#define VI_LOOP_CARRY_END \
    vd = (vd & ~mmask) | (((res) << mpos) & mmask); \
  } \
  P.VU.vstart->write(0);
```
