### PR TITLE
Add 'Zfhmin' extension

### DIFF
--- a/riscv/insns/fcvt_d_h.h
+++ b/riscv/insns/fcvt_d_h.h
@@ -1,4 +1,4 @@
-require_extension(EXT_ZFH);
+require_extension(EXT_ZFHMIN);
 require_extension('D');
 require_fp;
 softfloat_roundingMode = RM;

--- a/riscv/insns/fcvt_h_d.h
+++ b/riscv/insns/fcvt_h_d.h
@@ -1,4 +1,4 @@
-require_extension(EXT_ZFH);
+require_extension(EXT_ZFHMIN);
 require_extension('D');
 require_fp;
 softfloat_roundingMode = RM;

--- a/riscv/insns/fcvt_h_q.h
+++ b/riscv/insns/fcvt_h_q.h
@@ -1,4 +1,4 @@
-require_extension(EXT_ZFH);
+require_extension(EXT_ZFHMIN);
 require_extension('Q');
 require_fp;
 softfloat_roundingMode = RM;

--- a/riscv/insns/fcvt_h_s.h
+++ b/riscv/insns/fcvt_h_s.h
@@ -1,4 +1,4 @@
-require_extension(EXT_ZFH);
+require_extension(EXT_ZFHMIN);
 require_fp;
 softfloat_roundingMode = RM;
 WRITE_FRD(f32_to_f16(f32(FRS1)));

--- a/riscv/insns/fcvt_q_h.h
+++ b/riscv/insns/fcvt_q_h.h
@@ -1,4 +1,4 @@
-require_extension(EXT_ZFH);
+require_extension(EXT_ZFHMIN);
 require_extension('Q');
 require_fp;
 softfloat_roundingMode = RM;

--- a/riscv/insns/fcvt_s_h.h
+++ b/riscv/insns/fcvt_s_h.h
@@ -1,4 +1,4 @@
-require_extension(EXT_ZFH);
+require_extension(EXT_ZFHMIN);
 require_fp;
 softfloat_roundingMode = RM;
 WRITE_FRD(f16_to_f32(f16(FRS1)));

--- a/riscv/insns/flh.h
+++ b/riscv/insns/flh.h
@@ -1,3 +1,3 @@
-require_extension(EXT_ZFH);
+require_extension(EXT_ZFHMIN);
 require_fp;
 WRITE_FRD(f16(MMU.load_uint16(RS1 + insn.i_imm())));

--- a/riscv/insns/fmv_h_x.h
+++ b/riscv/insns/fmv_h_x.h
@@ -1,3 +1,3 @@
-require_extension(EXT_ZFH);
+require_extension(EXT_ZFHMIN);
 require_fp;
 WRITE_FRD(f16(RS1));

--- a/riscv/insns/fmv_x_h.h
+++ b/riscv/insns/fmv_x_h.h
@@ -1,3 +1,3 @@
-require_extension(EXT_ZFH);
+require_extension(EXT_ZFHMIN);
 require_fp;
 WRITE_RD(sext32((int16_t)(FRS1.v[0])));

--- a/riscv/insns/fsh.h
+++ b/riscv/insns/fsh.h
@@ -1,3 +1,3 @@
-require_extension(EXT_ZFH);
+require_extension(EXT_ZFHMIN);
 require_fp;
 MMU.store_uint16(RS1 + insn.s_imm(), FRS2.v[0]);

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -250,10 +250,12 @@ void processor_t::parse_isa_string(const char* str)
     auto end = p;
     do ++end; while (*end && *end != '_');
     auto ext_str = std::string(p, end);
-    if (ext_str == "zfh") {
+    if (ext_str == "zfh" || ext_str == "zfhmin") {
       if (!((max_isa >> ('f' - 'a')) & 1))
-        bad_isa_string(str, "'Zfh' extension requires 'F'");
-      extension_table[EXT_ZFH] = true;
+        bad_isa_string(str, ("'" + ext_str + "' extension requires 'F'").c_str());
+      extension_table[EXT_ZFHMIN] = true;
+      if (ext_str == "zfh")
+        extension_table[EXT_ZFH] = true;
     } else if (ext_str == "zicsr") {
       // Spike necessarily has Zicsr, because
       // Zicsr is implied by the privileged architecture

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -230,6 +230,7 @@ typedef enum {
 typedef enum {
   // 65('A') ~ 90('Z') is reserved for standard isa in misa
   EXT_ZFH,
+  EXT_ZFHMIN,
   EXT_ZBA,
   EXT_ZBB,
   EXT_ZBC,


### PR DESCRIPTION
'Zfhmin' is a subset of 'Zfh' extension (which is implemented in Spike).
Because 'Zfhmin' is ratified along with 'Zfh', it should be good to implement this extension in Spike.