### PR TITLE
The pmpcfg csr should be WARL other than WIRI

### DIFF
--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -218,7 +218,7 @@ bool pmpcfg_csr_t::unlogged_write(const reg_t val) noexcept {
   for (size_t i0 = (address - CSR_PMPCFG0) * 4, i = i0; i < i0 + proc->get_xlen() / 8; i++) {
     if (i < proc->n_pmp) {
       if (!(state->pmpaddr[i]->cfg & PMP_L)) {
-        uint8_t cfg = (val >> (8 * (i - i0))) & (PMP_R | PMP_W | PMP_X | PMP_A | PMP_L);
+        uint8_t cfg = (val >> (8 * (i - i0)));
         cfg &= ~PMP_W | ((cfg & PMP_R) ? PMP_W : 0); // Disallow R=0 W=1
         if (proc->lg_pmp_granularity != PMP_SHIFT && (cfg & PMP_A) == PMP_NA4)
           cfg |= PMP_NAPOT; // Disallow A=NA4 when granularity > 4


### PR DESCRIPTION
The riscv-privileged version1.11 has revised the pmpcfg csr fields: "Made the unused pmpaddr and pmpcfg fields WARL, rather than WIRI."