### PR TITLE
P-ext v.0.9.11. update

### DIFF
--- a/riscv/insns/kaddh.h
+++ b/riscv/insns/kaddh.h
@@ -1,5 +1,5 @@
 require_vector_vs;
 require_extension(EXT_ZPN);
-sreg_t res = (sreg_t)P_SW(RS1, 0) + (sreg_t)P_SW(RS2, 0);
+sreg_t res = (sreg_t)P_SH(RS1, 0) + (sreg_t)P_SH(RS2, 0);
 P_SAT(res, 16);
 WRITE_RD(sext_xlen((int16_t)res));

--- a/riscv/insns/ksubh.h
+++ b/riscv/insns/ksubh.h
@@ -1,5 +1,5 @@
 require_vector_vs;
 require_extension(EXT_ZPN);
-sreg_t res = (sreg_t)P_SW(RS1, 0) - (sreg_t)P_SW(RS2, 0);
+sreg_t res = (sreg_t)P_SH(RS1, 0) - (sreg_t)P_SH(RS2, 0);
 P_SAT(res, 16);
 WRITE_RD(sext_xlen((int16_t)res));

--- a/riscv/insns/ukaddh.h
+++ b/riscv/insns/ukaddh.h
@@ -1,5 +1,5 @@
 require_vector_vs;
 require_extension(EXT_ZPN);
-sreg_t res = (sreg_t)P_W(RS1, 0) + (sreg_t)P_W(RS2, 0);
+sreg_t res = (sreg_t)P_H(RS1, 0) + (sreg_t)P_H(RS2, 0);
 P_SATU(res, 16);
 WRITE_RD(sext_xlen((int16_t)res));

--- a/riscv/insns/uksubh.h
+++ b/riscv/insns/uksubh.h
@@ -1,5 +1,5 @@
 require_vector_vs;
 require_extension(EXT_ZPN);
-sreg_t res = (sreg_t)P_W(RS1, 0) - (sreg_t)P_W(RS2, 0);
+sreg_t res = (sreg_t)P_H(RS1, 0) - (sreg_t)P_H(RS2, 0);
 P_SATU(res, 16);
 WRITE_RD(sext_xlen((int16_t)res));


### PR DESCRIPTION
[u]k(add|sub)h insns now operate half-word data (not word as 0.9.10 and earlier).