### PR TITLE
Add disassembler support for `unimp'

### DIFF
--- a/disasm/disasm.cc
+++ b/disasm/disasm.cc
@@ -676,6 +676,9 @@ disassembler_t::disassembler_t(int xlen)
   #define DEFINE_XFTYPE(code) add_xftype_insn(this, #code, match_##code, mask_##code);
   #define DEFINE_SFENCE_TYPE(code) add_sfence_insn(this, #code, match_##code, mask_##code);
 
+  add_insn(new disasm_insn_t("unimp", match_csrrw|(CSR_CYCLE<<20), 0xffffffff, {}));
+  add_insn(new disasm_insn_t("c.unimp", 0, 0xffff, {}));
+
   DEFINE_XLOAD(lb)
   DEFINE_XLOAD(lbu)
   DEFINE_XLOAD(lh)


### PR DESCRIPTION
Now it disassembles 0x0000 (invalid encoding of `c.addi4spn`) as `c.unimp` (RVC).
Non-RVC variant of `unimp` pseudoinstruction (0xc0001073) is also implemented.

It resolves #49 but... is there any good reason *not* to do that? I think `c.unimp` (RVC variant) should be handled (at least).
cf. https://github.com/riscv-non-isa/riscv-asm-manual/blob/b01f83328a8176a7351402414b14a0ac9bd1802f/riscv-asm.md