### PR TITLE
TSR is read-only 0 when S-mode is not supported.

### DIFF
--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -439,7 +439,8 @@ bool mstatus_csr_t::unlogged_write(const reg_t val) noexcept {
 
   const reg_t mask = sstatus_write_mask
                    | MSTATUS_MIE | MSTATUS_MPIE | MSTATUS_MPRV
-                   | MSTATUS_MPP | MSTATUS_TW | MSTATUS_TSR
+                   | MSTATUS_MPP | MSTATUS_TW
+                   | (proc->extension_enabled('S') ? MSTATUS_TSR : 0)
                    | (has_page ? MSTATUS_TVM : 0)
                    | (has_gva ? MSTATUS_GVA : 0)
                    | (has_mpv ? MSTATUS_MPV : 0);


### PR DESCRIPTION
According the privileged spec, TSR is read-only 0 when S-mode is not supported. (https://github.com/riscv/riscv-isa-manual/blob/56515289e5999512fe578cdddf861b730d790018/src/machine.tex#L860-L861)