### PR TITLE
Add RV32E/RV64E base ISA support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ completion of the US transcontinental railway.
 
 Spike supports the following RISC-V ISA features:
   - RV32I and RV64I base ISAs, v2.1
+  - RV32E and RV64E base ISAs, v1.9
   - Zifencei extension, v2.0
   - Zicsr extension, v2.0
   - M extension, v2.0

--- a/riscv/decode.h
+++ b/riscv/decode.h
@@ -175,7 +175,8 @@ private:
 #define MMU (*p->get_mmu())
 #define STATE (*p->get_state())
 #define FLEN (p->get_flen())
-#define READ_REG(reg) STATE.XPR[reg]
+#define CHECK_REG(reg) ((void) 0)
+#define READ_REG(reg) ({ CHECK_REG(reg); STATE.XPR[reg]; })
 #define READ_FREG(reg) STATE.FPR[reg]
 #define RD READ_REG(insn.rd())
 #define RS1 READ_REG(insn.rs1())
@@ -184,7 +185,7 @@ private:
 #define WRITE_RD(value) WRITE_REG(insn.rd(), value)
 
 #ifndef RISCV_ENABLE_COMMITLOG
-# define WRITE_REG(reg, value) STATE.XPR.write(reg, value)
+# define WRITE_REG(reg, value) ({ CHECK_REG(reg); STATE.XPR.write(reg, value); })
 # define WRITE_FREG(reg, value) DO_WRITE_FREG(reg, freg(value))
 # define WRITE_VSTATUS
 #else
@@ -197,6 +198,7 @@ private:
 # define WRITE_REG(reg, value) ({ \
     reg_t wdata = (value); /* value may have side effects */ \
     STATE.log_reg_write[(reg) << 4] = {wdata, 0}; \
+    CHECK_REG(reg); \
     STATE.XPR.write(reg, wdata); \
   })
 # define WRITE_FREG(reg, value) ({ \

--- a/riscv/insn_template.cc
+++ b/riscv/insn_template.cc
@@ -3,7 +3,7 @@
 #include "insn_template.h"
 #include "insn_macros.h"
 
-reg_t rv32_NAME(processor_t* p, insn_t insn, reg_t pc)
+reg_t rv32i_NAME(processor_t* p, insn_t insn, reg_t pc)
 {
   #define xlen 32
   reg_t npc = sext_xlen(pc + insn_length(OPCODE));
@@ -13,7 +13,30 @@ reg_t rv32_NAME(processor_t* p, insn_t insn, reg_t pc)
   return npc;
 }
 
-reg_t rv64_NAME(processor_t* p, insn_t insn, reg_t pc)
+reg_t rv64i_NAME(processor_t* p, insn_t insn, reg_t pc)
+{
+  #define xlen 64
+  reg_t npc = sext_xlen(pc + insn_length(OPCODE));
+  #include "insns/NAME.h"
+  trace_opcode(p, OPCODE, insn);
+  #undef xlen
+  return npc;
+}
+
+#undef CHECK_REG
+#define CHECK_REG(reg) require((reg) < 16)
+
+reg_t rv32e_NAME(processor_t* p, insn_t insn, reg_t pc)
+{
+  #define xlen 32
+  reg_t npc = sext_xlen(pc + insn_length(OPCODE));
+  #include "insns/NAME.h"
+  trace_opcode(p, OPCODE, insn);
+  #undef xlen
+  return npc;
+}
+
+reg_t rv64e_NAME(processor_t* p, insn_t insn, reg_t pc)
 {
   #define xlen 64
   reg_t npc = sext_xlen(pc + insn_length(OPCODE));

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -1068,7 +1068,7 @@ void processor_t::build_opcode_map()
   std::sort(instructions.begin(), instructions.end(), cmp());
 
   for (size_t i = 0; i < OPCODE_CACHE_SIZE; i++)
-    opcode_cache[i] = {0, 0, &illegal_instruction, &illegal_instruction};
+    opcode_cache[i] = insn_desc_t::illegal();
 }
 
 void processor_t::register_extension(extension_t* x)
@@ -1107,7 +1107,9 @@ void processor_t::register_base_instructions()
   #include "insn_list.h"
   #undef DEFINE_INSN
 
-  register_insn({0, 0, &illegal_instruction, &illegal_instruction});
+  // terminate instruction list with a catch-all
+  register_insn(insn_desc_t::illegal());
+
   build_opcode_map();
 }
 

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -1027,11 +1027,11 @@ insn_func_t processor_t::decode_insn(insn_t insn)
   size_t idx = insn.bits() % OPCODE_CACHE_SIZE;
   insn_desc_t desc = opcode_cache[idx];
 
-  if (unlikely(insn.bits() != desc.match || !(xlen == 64 ? desc.rv64 : desc.rv32))) {
+  if (unlikely(insn.bits() != desc.match || !desc.func(xlen))) {
     // fall back to linear search
     int cnt = 0;
     insn_desc_t* p = &instructions[0];
-    while ((insn.bits() & p->mask) != p->match || !(xlen == 64 ? p->rv64 : p->rv32))
+    while ((insn.bits() & p->mask) != p->match || !desc.func(xlen))
       p++, cnt++;
     desc = *p;
 
@@ -1048,7 +1048,7 @@ insn_func_t processor_t::decode_insn(insn_t insn)
     opcode_cache[idx].match = insn.bits();
   }
 
-  return xlen == 64 ? desc.rv64 : desc.rv32;
+  return desc.func(xlen);
 }
 
 void processor_t::register_insn(insn_desc_t desc)

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -29,6 +29,8 @@ struct insn_desc_t
   insn_bits_t mask;
   insn_func_t rv32;
   insn_func_t rv64;
+
+  insn_func_t func(int xlen) { return xlen == 64 ? rv64 : rv32; }
 };
 
 // regnum, data

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -23,6 +23,8 @@ class trap_t;
 class extension_t;
 class disassembler_t;
 
+reg_t illegal_instruction(processor_t* p, insn_t insn, reg_t pc);
+
 struct insn_desc_t
 {
   insn_bits_t match;
@@ -31,6 +33,11 @@ struct insn_desc_t
   insn_func_t rv64;
 
   insn_func_t func(int xlen) { return xlen == 64 ? rv64 : rv32; }
+
+  static insn_desc_t illegal()
+  {
+    return {0, 0, &illegal_instruction, &illegal_instruction};
+  }
 };
 
 // regnum, data
@@ -595,8 +602,6 @@ public:
 
   vectorUnit_t VU;
 };
-
-reg_t illegal_instruction(processor_t* p, insn_t insn, reg_t pc);
 
 #define REGISTER_INSN(proc, name, match, mask, archen) \
   extern reg_t rv32_##name(processor_t*, insn_t, reg_t); \

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -29,14 +29,22 @@ struct insn_desc_t
 {
   insn_bits_t match;
   insn_bits_t mask;
-  insn_func_t rv32;
-  insn_func_t rv64;
+  insn_func_t rv32i;
+  insn_func_t rv64i;
+  insn_func_t rv32e;
+  insn_func_t rv64e;
 
-  insn_func_t func(int xlen) { return xlen == 64 ? rv64 : rv32; }
+  insn_func_t func(int xlen, bool rve)
+  {
+    if (rve)
+      return xlen == 64 ? rv64e : rv32e;
+    else
+      return xlen == 64 ? rv64i : rv32i;
+  }
 
   static insn_desc_t illegal()
   {
-    return {0, 0, &illegal_instruction, &illegal_instruction};
+    return {0, 0, &illegal_instruction, &illegal_instruction, &illegal_instruction, &illegal_instruction};
   }
 };
 
@@ -602,10 +610,5 @@ public:
 
   vectorUnit_t VU;
 };
-
-#define REGISTER_INSN(proc, name, match, mask, archen) \
-  extern reg_t rv32_##name(processor_t*, insn_t, reg_t); \
-  extern reg_t rv64_##name(processor_t*, insn_t, reg_t); \
-  proc->register_insn((insn_desc_t){match, mask, rv32_##name, rv64_##name,archen});
 
 #endif


### PR DESCRIPTION
The basic approach is to hook into the RS1/RS2/WRITE_RD accessors to check for valid register specifiers and possibly throw illegal-instruction exceptions as a side effect.