### PR TITLE
Add more assertion for fcvt

### DIFF
--- a/riscv/decode.h
+++ b/riscv/decode.h
@@ -2392,6 +2392,7 @@ reg_t index[P.VU.vlmax]; \
 
 #define VI_VFP_CVT_INT_TO_FP(BODY16, BODY32, BODY64, sign) \
   VI_CHECK_SSS(false); \
+  VI_VFP_COMMON \
   switch(P.VU.vsew) { \
     case e16: \
       { VI_VFP_CVT_LOOP(CVT_INT_TO_FP_PARAMS(16, 16, sign), \
@@ -2415,6 +2416,7 @@ reg_t index[P.VU.vlmax]; \
 
 #define VI_VFP_CVT_FP_TO_INT(BODY16, BODY32, BODY64, sign) \
   VI_CHECK_SSS(false); \
+  VI_VFP_COMMON \
   switch(P.VU.vsew) { \
     case e16: \
       { VI_VFP_CVT_LOOP(CVT_FP_TO_INT_PARAMS(16, 16, sign), \


### PR DESCRIPTION
I personally think this is not a bug fix, but I received email that my refactoring caused some test suite failures. Here is a brief of what happened...

Before my refactoring in #881, the assertions for vector fp. conversion instructions looks like

```
if (no legal {eew, extension_enabled} exist)
  throw exception
for (...) // starts to look at elements in vector register and do computation
  /* do something */
```

After my refactoring, the logic looks like

```
for (...) // starts to look at elements in vector register and do computation
  if (no legal {eew, extension_enabled} exist)
    throw exception
  /* do something */
```

Overall the exception is still thrown, but I think registers and variables may not be the same, which caused the test suite failures.

This PR adds the checks back in the loop pre-header and resolves the test fail.