### PR TITLE
bind disas support with isa

### DIFF
--- a/disasm/disasm.cc
+++ b/disasm/disasm.cc
@@ -931,6 +931,38 @@ disassembler_t::disassembler_t(isa_parser_t* isa)
     DEFINE_FX2TYPE(fle_s);
   }
 
+  if (isa->extension_enabled(EXT_ZFINX)) {
+    DEFINE_RTYPE(fadd_s);
+    DEFINE_RTYPE(fsub_s);
+    DEFINE_RTYPE(fmul_s);
+    DEFINE_RTYPE(fdiv_s);
+    DEFINE_R1TYPE(fsqrt_s);
+    DEFINE_RTYPE(fmin_s);
+    DEFINE_RTYPE(fmax_s);
+    DEFINE_R3TYPE(fmadd_s);
+    DEFINE_R3TYPE(fmsub_s);
+    DEFINE_R3TYPE(fnmadd_s);
+    DEFINE_R3TYPE(fnmsub_s);
+    DEFINE_RTYPE(fsgnj_s);
+    DEFINE_RTYPE(fsgnjn_s);
+    DEFINE_RTYPE(fsgnjx_s);
+    DEFINE_R1TYPE(fcvt_s_d);
+    //DEFINE_R1TYPE(fcvt_s_q);
+    DEFINE_R1TYPE(fcvt_s_l);
+    DEFINE_R1TYPE(fcvt_s_lu);
+    DEFINE_R1TYPE(fcvt_s_w);
+    DEFINE_R1TYPE(fcvt_s_wu);
+    DEFINE_R1TYPE(fcvt_s_wu);
+    DEFINE_R1TYPE(fcvt_l_s);
+    DEFINE_R1TYPE(fcvt_lu_s);
+    DEFINE_R1TYPE(fcvt_w_s);
+    DEFINE_R1TYPE(fcvt_wu_s);
+    DEFINE_R1TYPE(fclass_s);
+    DEFINE_RTYPE(feq_s);
+    DEFINE_RTYPE(flt_s);
+    DEFINE_RTYPE(fle_s);
+  }
+
   if (isa->extension_enabled('D')) {
     DEFINE_FLOAD(fld)
     DEFINE_FSTORE(fsd)
@@ -967,6 +999,38 @@ disassembler_t::disassembler_t(isa_parser_t* isa)
     DEFINE_FX2TYPE(fle_d);
   }
 
+  if (isa->extension_enabled(EXT_ZDINX)) {
+    DEFINE_RTYPE(fadd_d);
+    DEFINE_RTYPE(fsub_d);
+    DEFINE_RTYPE(fmul_d);
+    DEFINE_RTYPE(fdiv_d);
+    DEFINE_R1TYPE(fsqrt_d);
+    DEFINE_RTYPE(fmin_d);
+    DEFINE_RTYPE(fmax_d);
+    DEFINE_R3TYPE(fmadd_d);
+    DEFINE_R3TYPE(fmsub_d);
+    DEFINE_R3TYPE(fnmadd_d);
+    DEFINE_R3TYPE(fnmsub_d);
+    DEFINE_RTYPE(fsgnj_d);
+    DEFINE_RTYPE(fsgnjn_d);
+    DEFINE_RTYPE(fsgnjx_d);
+    DEFINE_R1TYPE(fcvt_d_s);
+    //DEFINE_R1TYPE(fcvt_d_q);
+    DEFINE_R1TYPE(fcvt_d_l);
+    DEFINE_R1TYPE(fcvt_d_lu);
+    DEFINE_R1TYPE(fcvt_d_w);
+    DEFINE_R1TYPE(fcvt_d_wu);
+    DEFINE_R1TYPE(fcvt_d_wu);
+    DEFINE_R1TYPE(fcvt_l_d);
+    DEFINE_R1TYPE(fcvt_lu_d);
+    DEFINE_R1TYPE(fcvt_w_d);
+    DEFINE_R1TYPE(fcvt_wu_d);
+    DEFINE_R1TYPE(fclass_d);
+    DEFINE_RTYPE(feq_d);
+    DEFINE_RTYPE(flt_d);
+    DEFINE_RTYPE(fle_d);
+  }
+
   if (isa->extension_enabled(EXT_ZFH)) { 
     DEFINE_FRTYPE(fadd_h);
     DEFINE_FRTYPE(fsub_h);
@@ -997,6 +1061,36 @@ disassembler_t::disassembler_t(isa_parser_t* isa)
     DEFINE_FX2TYPE(fle_h);
   }
 
+  if (isa->extension_enabled(EXT_ZHINX)) {
+    DEFINE_RTYPE(fadd_h);
+    DEFINE_RTYPE(fsub_h);
+    DEFINE_RTYPE(fmul_h);
+    DEFINE_RTYPE(fdiv_h);
+    DEFINE_R1TYPE(fsqrt_h);
+    DEFINE_RTYPE(fmin_h);
+    DEFINE_RTYPE(fmax_h);
+    DEFINE_R3TYPE(fmadd_h);
+    DEFINE_R3TYPE(fmsub_h);
+    DEFINE_R3TYPE(fnmadd_h);
+    DEFINE_R3TYPE(fnmsub_h);
+    DEFINE_RTYPE(fsgnj_h);
+    DEFINE_RTYPE(fsgnjn_h);
+    DEFINE_RTYPE(fsgnjx_h);
+    DEFINE_R1TYPE(fcvt_h_l);
+    DEFINE_R1TYPE(fcvt_h_lu);
+    DEFINE_R1TYPE(fcvt_h_w);
+    DEFINE_R1TYPE(fcvt_h_wu);
+    DEFINE_R1TYPE(fcvt_h_wu);
+    DEFINE_R1TYPE(fcvt_l_h);
+    DEFINE_R1TYPE(fcvt_lu_h);
+    DEFINE_R1TYPE(fcvt_w_h);
+    DEFINE_R1TYPE(fcvt_wu_h);
+    DEFINE_R1TYPE(fclass_h);
+    DEFINE_RTYPE(feq_h);
+    DEFINE_RTYPE(flt_h);
+    DEFINE_RTYPE(fle_h);
+  }
+
   if (isa->extension_enabled(EXT_ZFHMIN)) {
     DEFINE_FLOAD(flh)
     DEFINE_FSTORE(fsh)
@@ -1008,6 +1102,15 @@ disassembler_t::disassembler_t(isa_parser_t* isa)
     DEFINE_FR1TYPE(fcvt_q_h);
     DEFINE_XFTYPE(fmv_h_x);
     DEFINE_FXTYPE(fmv_x_h);
+  }
+
+  if (isa->extension_enabled(EXT_ZHINXMIN)) {
+    DEFINE_R1TYPE(fcvt_h_s);
+    DEFINE_R1TYPE(fcvt_h_d);
+    //DEFINE_R1TYPE(fcvt_h_q);
+    DEFINE_R1TYPE(fcvt_s_h);
+    DEFINE_R1TYPE(fcvt_d_h);
+    //DEFINE_R1TYPE(fcvt_q_h);
   }
 
   if (isa->extension_enabled('Q')) {

--- a/disasm/disasm.cc
+++ b/disasm/disasm.cc
@@ -622,7 +622,7 @@ static void NOINLINE add_unknown_insns(disassembler_t* d)
   #undef DECLARE_INSN
 }
 
-disassembler_t::disassembler_t(int xlen)
+disassembler_t::disassembler_t(isa_parser_t* isa)
 {
   const uint32_t mask_rd = 0x1fUL << 7;
   const uint32_t match_rd_ra = 1UL << 7;
@@ -692,39 +692,30 @@ disassembler_t::disassembler_t(int xlen)
   DEFINE_XSTORE(sw)
   DEFINE_XSTORE(sd)
 
-  DEFINE_XAMO(amoadd_w)
-  DEFINE_XAMO(amoswap_w)
-  DEFINE_XAMO(amoand_w)
-  DEFINE_XAMO(amoor_w)
-  DEFINE_XAMO(amoxor_w)
-  DEFINE_XAMO(amomin_w)
-  DEFINE_XAMO(amomax_w)
-  DEFINE_XAMO(amominu_w)
-  DEFINE_XAMO(amomaxu_w)
-  DEFINE_XAMO(amoadd_d)
-  DEFINE_XAMO(amoswap_d)
-  DEFINE_XAMO(amoand_d)
-  DEFINE_XAMO(amoor_d)
-  DEFINE_XAMO(amoxor_d)
-  DEFINE_XAMO(amomin_d)
-  DEFINE_XAMO(amomax_d)
-  DEFINE_XAMO(amominu_d)
-  DEFINE_XAMO(amomaxu_d)
-
-  DEFINE_XLOAD_BASE(lr_w)
-  DEFINE_XAMO(sc_w)
-  DEFINE_XLOAD_BASE(lr_d)
-  DEFINE_XAMO(sc_d)
-
-  DEFINE_FLOAD(flw)
-  DEFINE_FLOAD(fld)
-  DEFINE_FLOAD(flh)
-  DEFINE_FLOAD(flq)
-
-  DEFINE_FSTORE(fsw)
-  DEFINE_FSTORE(fsd)
-  DEFINE_FSTORE(fsh)
-  DEFINE_FSTORE(fsq)
+  if (isa->extension_enabled('A')) {
+    DEFINE_XAMO(amoadd_w)
+    DEFINE_XAMO(amoswap_w)
+    DEFINE_XAMO(amoand_w)
+    DEFINE_XAMO(amoor_w)
+    DEFINE_XAMO(amoxor_w)
+    DEFINE_XAMO(amomin_w)
+    DEFINE_XAMO(amomax_w)
+    DEFINE_XAMO(amominu_w)
+    DEFINE_XAMO(amomaxu_w)
+    DEFINE_XAMO(amoadd_d)
+    DEFINE_XAMO(amoswap_d)
+    DEFINE_XAMO(amoand_d)
+    DEFINE_XAMO(amoor_d)
+    DEFINE_XAMO(amoxor_d)
+    DEFINE_XAMO(amomin_d)
+    DEFINE_XAMO(amomax_d)
+    DEFINE_XAMO(amominu_d)
+    DEFINE_XAMO(amomaxu_d)
+    DEFINE_XLOAD_BASE(lr_w)
+    DEFINE_XAMO(sc_w)
+    DEFINE_XLOAD_BASE(lr_d)
+    DEFINE_XAMO(sc_d)
+  }
 
   add_insn(new disasm_insn_t("j", match_jal, mask_jal | mask_rd, {&jump_target}));
   add_insn(new disasm_insn_t("jal", match_jal | match_rd_ra, mask_jal | mask_rd, {&jump_target}));
@@ -783,102 +774,19 @@ disassembler_t::disassembler_t(int xlen)
   DEFINE_RTYPE(sra);
   DEFINE_RTYPE(or);
   DEFINE_RTYPE(and);
-  DEFINE_RTYPE(mul);
-  DEFINE_RTYPE(mulh);
-  DEFINE_RTYPE(mulhu);
-  DEFINE_RTYPE(mulhsu);
-  DEFINE_RTYPE(div);
-  DEFINE_RTYPE(divu);
-  DEFINE_RTYPE(rem);
-  DEFINE_RTYPE(remu);
   DEFINE_RTYPE(addw);
   DEFINE_RTYPE(subw);
   DEFINE_RTYPE(sllw);
   DEFINE_RTYPE(srlw);
   DEFINE_RTYPE(sraw);
-  DEFINE_RTYPE(mulw);
-  DEFINE_RTYPE(divw);
-  DEFINE_RTYPE(divuw);
-  DEFINE_RTYPE(remw);
-  DEFINE_RTYPE(remuw);
-
-  DEFINE_ITYPE_SHIFT(slli_uw);
-  add_insn(new disasm_insn_t("zext.w", match_add_uw, mask_add_uw | mask_rs2, {&xrd, &xrs1}));
-  DEFINE_RTYPE(add_uw);
-  DEFINE_RTYPE(sh1add);
-  DEFINE_RTYPE(sh2add);
-  DEFINE_RTYPE(sh3add);
-  DEFINE_RTYPE(sh1add_uw);
-  DEFINE_RTYPE(sh2add_uw);
-  DEFINE_RTYPE(sh3add_uw);
-  DEFINE_RTYPE(ror);
-  DEFINE_RTYPE(rorw);
-  DEFINE_RTYPE(rol);
-  DEFINE_RTYPE(rolw);
-  DEFINE_ITYPE_SHIFT(rori);
-  DEFINE_ITYPE_SHIFT(roriw);
-  DEFINE_R1TYPE(ctz);
-  DEFINE_R1TYPE(ctzw);
-  DEFINE_R1TYPE(clz);
-  DEFINE_R1TYPE(clzw);
-  DEFINE_R1TYPE(cpop);
-  DEFINE_R1TYPE(cpopw);
-  DEFINE_RTYPE(min);
-  DEFINE_RTYPE(minu);
-  DEFINE_RTYPE(max);
-  DEFINE_RTYPE(maxu);
-  DEFINE_RTYPE(andn);
-  DEFINE_RTYPE(orn);
-  DEFINE_RTYPE(xnor);
-  DEFINE_R1TYPE(sext_b);
-  DEFINE_R1TYPE(sext_h);
-  add_insn(new disasm_insn_t("zext.h", (xlen == 32 ? match_pack : match_packw), mask_pack | mask_rs2, {&xrd, &xrs1}));
-  DEFINE_RTYPE(pack);
-  DEFINE_RTYPE(packu);
-  DEFINE_RTYPE(packw);
-  DEFINE_RTYPE(grev);
-  add_insn(new disasm_insn_t("rev", match_grevi | ((xlen - 1) << imm_shift), mask_grevi | mask_imm, {&xrd, &xrs1}));
-  add_insn(new disasm_insn_t("rev8", match_grevi | ((xlen - 8) << imm_shift), mask_grevi | mask_imm, {&xrd, &xrs1}));
-  add_insn(new disasm_insn_t("brev8", match_grevi | (0x7 << imm_shift), mask_grevi | mask_imm, {&xrd, &xrs1})); // brev8
-  add_insn(new disasm_insn_t("rev8.h", match_grevi | (0x8 << imm_shift), mask_grevi | mask_imm, {&xrd, &xrs1})); // swap16
-  DEFINE_ITYPE_SHIFT(grevi);
-  DEFINE_RTYPE(gorc);
-  add_insn(new disasm_insn_t("orc.b", match_gorci | (0x7 << imm_shift), mask_grevi | mask_imm, {&xrd, &xrs1}));
-  DEFINE_ITYPE_SHIFT(gorci);
-  DEFINE_RTYPE(xperm4);
-  DEFINE_RTYPE(xperm8);
-  DEFINE_RTYPE(xperm16);
-  DEFINE_RTYPE(xperm32);
-
-  DEFINE_RTYPE(bclr);
-  DEFINE_RTYPE(binv);
-  DEFINE_RTYPE(bset);
-  DEFINE_RTYPE(bext);
-  DEFINE_ITYPE_SHIFT(bclri);
-  DEFINE_ITYPE_SHIFT(binvi);
-  DEFINE_ITYPE_SHIFT(bseti);
-  DEFINE_ITYPE_SHIFT(bexti);
-
-  DEFINE_R3TYPE(cmix);
-  DEFINE_R3TYPE(fsr);
-  DEFINE_R3TYPE(fsri);
-  DEFINE_R3TYPE(fsriw);
-  DEFINE_R3TYPE(fsrw);
 
   DEFINE_NOARG(ecall);
   DEFINE_NOARG(ebreak);
-  DEFINE_NOARG(sret);
   DEFINE_NOARG(mret);
   DEFINE_NOARG(dret);
   DEFINE_NOARG(wfi);
   add_insn(new disasm_insn_t("fence", match_fence, mask_fence, {&iorw}));
   DEFINE_NOARG(fence_i);
-  DEFINE_SFENCE_TYPE(sfence_vma);
-  DEFINE_NOARG(sfence_w_inval);
-  DEFINE_NOARG(sfence_inval_ir);
-  DEFINE_SFENCE_TYPE(sinval_vma);
-  DEFINE_SFENCE_TYPE(hinval_vvma);
-  DEFINE_SFENCE_TYPE(hinval_gvma);
 
   add_insn(new disasm_insn_t("csrr", match_csrrs, mask_csrrs | mask_rs1, {&xrd, &csr}));
   add_insn(new disasm_insn_t("csrw", match_csrrw, mask_csrrw | mask_rd, {&csr, &xrs1}));
@@ -894,625 +802,753 @@ disassembler_t::disassembler_t(int xlen)
   add_insn(new disasm_insn_t("csrrsi", match_csrrsi, mask_csrrsi, {&xrd, &csr, &zimm5}));
   add_insn(new disasm_insn_t("csrrci", match_csrrci, mask_csrrci, {&xrd, &csr, &zimm5}));
 
-  DEFINE_FRTYPE(fadd_s);
-  DEFINE_FRTYPE(fsub_s);
-  DEFINE_FRTYPE(fmul_s);
-  DEFINE_FRTYPE(fdiv_s);
-  DEFINE_FR1TYPE(fsqrt_s);
-  DEFINE_FRTYPE(fmin_s);
-  DEFINE_FRTYPE(fmax_s);
-  DEFINE_FR3TYPE(fmadd_s);
-  DEFINE_FR3TYPE(fmsub_s);
-  DEFINE_FR3TYPE(fnmadd_s);
-  DEFINE_FR3TYPE(fnmsub_s);
-  DEFINE_FRTYPE(fsgnj_s);
-  DEFINE_FRTYPE(fsgnjn_s);
-  DEFINE_FRTYPE(fsgnjx_s);
-  DEFINE_FR1TYPE(fcvt_s_d);
-  DEFINE_FR1TYPE(fcvt_s_q);
-  DEFINE_XFTYPE(fcvt_s_l);
-  DEFINE_XFTYPE(fcvt_s_lu);
-  DEFINE_XFTYPE(fcvt_s_w);
-  DEFINE_XFTYPE(fcvt_s_wu);
-  DEFINE_XFTYPE(fcvt_s_wu);
-  DEFINE_XFTYPE(fmv_w_x);
-  DEFINE_FXTYPE(fcvt_l_s);
-  DEFINE_FXTYPE(fcvt_lu_s);
-  DEFINE_FXTYPE(fcvt_w_s);
-  DEFINE_FXTYPE(fcvt_wu_s);
-  DEFINE_FXTYPE(fclass_s);
-  DEFINE_FXTYPE(fmv_x_w);
-  DEFINE_FX2TYPE(feq_s);
-  DEFINE_FX2TYPE(flt_s);
-  DEFINE_FX2TYPE(fle_s);
+  if (isa->extension_enabled('S')) {
+    DEFINE_NOARG(sret);
+    DEFINE_SFENCE_TYPE(sfence_vma);
+  }
 
-  DEFINE_FRTYPE(fadd_d);
-  DEFINE_FRTYPE(fsub_d);
-  DEFINE_FRTYPE(fmul_d);
-  DEFINE_FRTYPE(fdiv_d);
-  DEFINE_FR1TYPE(fsqrt_d);
-  DEFINE_FRTYPE(fmin_d);
-  DEFINE_FRTYPE(fmax_d);
-  DEFINE_FR3TYPE(fmadd_d);
-  DEFINE_FR3TYPE(fmsub_d);
-  DEFINE_FR3TYPE(fnmadd_d);
-  DEFINE_FR3TYPE(fnmsub_d);
-  DEFINE_FRTYPE(fsgnj_d);
-  DEFINE_FRTYPE(fsgnjn_d);
-  DEFINE_FRTYPE(fsgnjx_d);
-  DEFINE_FR1TYPE(fcvt_d_s);
-  DEFINE_FR1TYPE(fcvt_d_q);
-  DEFINE_XFTYPE(fcvt_d_l);
-  DEFINE_XFTYPE(fcvt_d_lu);
-  DEFINE_XFTYPE(fcvt_d_w);
-  DEFINE_XFTYPE(fcvt_d_wu);
-  DEFINE_XFTYPE(fcvt_d_wu);
-  DEFINE_XFTYPE(fmv_d_x);
-  DEFINE_FXTYPE(fcvt_l_d);
-  DEFINE_FXTYPE(fcvt_lu_d);
-  DEFINE_FXTYPE(fcvt_w_d);
-  DEFINE_FXTYPE(fcvt_wu_d);
-  DEFINE_FXTYPE(fclass_d);
-  DEFINE_FXTYPE(fmv_x_d);
-  DEFINE_FX2TYPE(feq_d);
-  DEFINE_FX2TYPE(flt_d);
-  DEFINE_FX2TYPE(fle_d);
+  if (isa->extension_enabled('M')) {
+    DEFINE_RTYPE(mul);
+    DEFINE_RTYPE(mulh);
+    DEFINE_RTYPE(mulhu);
+    DEFINE_RTYPE(mulhsu);
+    DEFINE_RTYPE(mulw);
+    DEFINE_RTYPE(div);
+    DEFINE_RTYPE(divu);
+    DEFINE_RTYPE(rem);
+    DEFINE_RTYPE(remu);
+    DEFINE_RTYPE(divw);
+    DEFINE_RTYPE(divuw);
+    DEFINE_RTYPE(remw);
+    DEFINE_RTYPE(remuw);
+  }
 
-  DEFINE_FRTYPE(fadd_h);
-  DEFINE_FRTYPE(fsub_h);
-  DEFINE_FRTYPE(fmul_h);
-  DEFINE_FRTYPE(fdiv_h);
-  DEFINE_FR1TYPE(fsqrt_h);
-  DEFINE_FRTYPE(fmin_h);
-  DEFINE_FRTYPE(fmax_h);
-  DEFINE_FR3TYPE(fmadd_h);
-  DEFINE_FR3TYPE(fmsub_h);
-  DEFINE_FR3TYPE(fnmadd_h);
-  DEFINE_FR3TYPE(fnmsub_h);
-  DEFINE_FRTYPE(fsgnj_h);
-  DEFINE_FRTYPE(fsgnjn_h);
-  DEFINE_FRTYPE(fsgnjx_h);
-  DEFINE_FR1TYPE(fcvt_h_s);
-  DEFINE_FR1TYPE(fcvt_h_d);
-  DEFINE_FR1TYPE(fcvt_h_q);
-  DEFINE_FR1TYPE(fcvt_s_h);
-  DEFINE_FR1TYPE(fcvt_d_h);
-  DEFINE_FR1TYPE(fcvt_q_h);
-  DEFINE_XFTYPE(fcvt_h_l);
-  DEFINE_XFTYPE(fcvt_h_lu);
-  DEFINE_XFTYPE(fcvt_h_w);
-  DEFINE_XFTYPE(fcvt_h_wu);
-  DEFINE_XFTYPE(fcvt_h_wu);
-  DEFINE_XFTYPE(fmv_h_x);
-  DEFINE_FXTYPE(fcvt_l_h);
-  DEFINE_FXTYPE(fcvt_lu_h);
-  DEFINE_FXTYPE(fcvt_w_h);
-  DEFINE_FXTYPE(fcvt_wu_h);
-  DEFINE_FXTYPE(fclass_h);
-  DEFINE_FXTYPE(fmv_x_h);
-  DEFINE_FX2TYPE(feq_h);
-  DEFINE_FX2TYPE(flt_h);
-  DEFINE_FX2TYPE(fle_h);
-
-  DEFINE_FRTYPE(fadd_q);
-  DEFINE_FRTYPE(fsub_q);
-  DEFINE_FRTYPE(fmul_q);
-  DEFINE_FRTYPE(fdiv_q);
-  DEFINE_FR1TYPE(fsqrt_q);
-  DEFINE_FRTYPE(fmin_q);
-  DEFINE_FRTYPE(fmax_q);
-  DEFINE_FR3TYPE(fmadd_q);
-  DEFINE_FR3TYPE(fmsub_q);
-  DEFINE_FR3TYPE(fnmadd_q);
-  DEFINE_FR3TYPE(fnmsub_q);
-  DEFINE_FRTYPE(fsgnj_q);
-  DEFINE_FRTYPE(fsgnjn_q);
-  DEFINE_FRTYPE(fsgnjx_q);
-  DEFINE_FR1TYPE(fcvt_q_s);
-  DEFINE_FR1TYPE(fcvt_q_d);
-  DEFINE_XFTYPE(fcvt_q_l);
-  DEFINE_XFTYPE(fcvt_q_lu);
-  DEFINE_XFTYPE(fcvt_q_w);
-  DEFINE_XFTYPE(fcvt_q_wu);
-  DEFINE_XFTYPE(fcvt_q_wu);
-  DEFINE_FXTYPE(fcvt_l_q);
-  DEFINE_FXTYPE(fcvt_lu_q);
-  DEFINE_FXTYPE(fcvt_w_q);
-  DEFINE_FXTYPE(fcvt_wu_q);
-  DEFINE_FXTYPE(fclass_q);
-  DEFINE_FX2TYPE(feq_q);
-  DEFINE_FX2TYPE(flt_q);
-  DEFINE_FX2TYPE(fle_q);
-
-
-  // ext-h
-  DEFINE_XLOAD_BASE(hlv_b)
-  DEFINE_XLOAD_BASE(hlv_bu)
-  DEFINE_XLOAD_BASE(hlv_h)
-  DEFINE_XLOAD_BASE(hlv_hu)
-  DEFINE_XLOAD_BASE(hlv_w)
-  DEFINE_XLOAD_BASE(hlv_wu)
-  DEFINE_XLOAD_BASE(hlv_d)
-
-  DEFINE_XLOAD_BASE(hlvx_hu)
-  DEFINE_XLOAD_BASE(hlvx_wu)
-
-  DEFINE_XSTORE_BASE(hsv_b)
-  DEFINE_XSTORE_BASE(hsv_h)
-  DEFINE_XSTORE_BASE(hsv_w)
-  DEFINE_XSTORE_BASE(hsv_d)
-
-  DEFINE_SFENCE_TYPE(hfence_gvma);
-  DEFINE_SFENCE_TYPE(hfence_vvma);
-
-
-  // ext-c
-  DISASM_INSN("c.ebreak", c_add, mask_rd | mask_rvc_rs2, {});
-  add_insn(new disasm_insn_t("ret", match_c_jr | match_rd_ra, mask_c_jr | mask_rd | mask_rvc_imm, {}));
-  DISASM_INSN("c.jr", c_jr, mask_rvc_imm, {&rvc_rs1});
-  DISASM_INSN("c.jalr", c_jalr, mask_rvc_imm, {&rvc_rs1});
-  DISASM_INSN("c.nop", c_addi, mask_rd | mask_rvc_imm, {});
-  DISASM_INSN("c.addi16sp", c_addi16sp, mask_rd, {&rvc_sp, &rvc_addi16sp_imm});
-  DISASM_INSN("c.addi4spn", c_addi4spn, 0, {&rvc_rs2s, &rvc_sp, &rvc_addi4spn_imm});
-  DISASM_INSN("c.li", c_li, 0, {&xrd, &rvc_imm});
-  DISASM_INSN("c.lui", c_lui, 0, {&xrd, &rvc_uimm});
-  DISASM_INSN("c.addi", c_addi, 0, {&xrd, &rvc_imm});
-  DISASM_INSN("c.slli", c_slli, 0, {&rvc_rs1, &rvc_shamt});
-  DISASM_INSN("c.srli", c_srli, 0, {&rvc_rs1s, &rvc_shamt});
-  DISASM_INSN("c.srai", c_srai, 0, {&rvc_rs1s, &rvc_shamt});
-  DISASM_INSN("c.andi", c_andi, 0, {&rvc_rs1s, &rvc_imm});
-  DISASM_INSN("c.mv", c_mv, 0, {&xrd, &rvc_rs2});
-  DISASM_INSN("c.add", c_add, 0, {&xrd, &rvc_rs2});
-  DISASM_INSN("c.addw", c_addw, 0, {&rvc_rs1s, &rvc_rs2s});
-  DISASM_INSN("c.sub", c_sub, 0, {&rvc_rs1s, &rvc_rs2s});
-  DISASM_INSN("c.subw", c_subw, 0, {&rvc_rs1s, &rvc_rs2s});
-  DISASM_INSN("c.and", c_and, 0, {&rvc_rs1s, &rvc_rs2s});
-  DISASM_INSN("c.or", c_or, 0, {&rvc_rs1s, &rvc_rs2s});
-  DISASM_INSN("c.xor", c_xor, 0, {&rvc_rs1s, &rvc_rs2s});
-  DISASM_INSN("c.lwsp", c_lwsp, 0, {&xrd, &rvc_lwsp_address});
-  DISASM_INSN("c.fld", c_fld, 0, {&rvc_fp_rs2s, &rvc_ld_address});
-  DISASM_INSN("c.swsp", c_swsp, 0, {&rvc_rs2, &rvc_swsp_address});
-  DISASM_INSN("c.lw", c_lw, 0, {&rvc_rs2s, &rvc_lw_address});
-  DISASM_INSN("c.sw", c_sw, 0, {&rvc_rs2s, &rvc_lw_address});
-  DISASM_INSN("c.beqz", c_beqz, 0, {&rvc_rs1s, &rvc_branch_target});
-  DISASM_INSN("c.bnez", c_bnez, 0, {&rvc_rs1s, &rvc_branch_target});
-  DISASM_INSN("c.j", c_j, 0, {&rvc_jump_target});
-  DISASM_INSN("c.fldsp", c_fldsp, 0, {&frd, &rvc_ldsp_address});
-  DISASM_INSN("c.fsd", c_fsd, 0, {&rvc_fp_rs2s, &rvc_ld_address});
-  DISASM_INSN("c.fsdsp", c_fsdsp, 0, {&rvc_fp_rs2, &rvc_sdsp_address});
-
-  DISASM_INSN("vsetivli", vsetivli, 0, {&xrd, &zimm5, &v_vtype});
-  DISASM_INSN("vsetvli", vsetvli, 0, {&xrd, &xrs1, &v_vtype});
-  DEFINE_RTYPE(vsetvl);
-
-  std::vector<const arg_t *> v_ld_unit = {&vd, &v_address, opt, &vm};
-  std::vector<const arg_t *> v_st_unit = {&vs3, &v_address, opt, &vm};
-  std::vector<const arg_t *> v_ld_stride = {&vd, &v_address, &xrs2, opt, &vm};
-  std::vector<const arg_t *> v_st_stride = {&vs3, &v_address, &xrs2, opt, &vm};
-  std::vector<const arg_t *> v_ld_index = {&vd, &v_address, &vs2, opt, &vm};
-  std::vector<const arg_t *> v_st_index = {&vs3, &v_address, &vs2, opt, &vm};
-
-  add_insn(new disasm_insn_t("vlm.v",  match_vlm_v,     mask_vlm_v, v_ld_unit));
-  add_insn(new disasm_insn_t("vsm.v",  match_vsm_v,     mask_vsm_v, v_st_unit));
-
-  // handle vector segment load/store
-  for (size_t elt = 0; elt <= 7; ++elt) {
-    const custom_fmt_t template_insn[] = {
-      {match_vle8_v,   mask_vle8_v,   "vl%se%d.v",   v_ld_unit},
-      {match_vse8_v,   mask_vse8_v,   "vs%se%d.v",   v_st_unit},
-
-      {match_vluxei8_v, mask_vluxei8_v, "vlux%sei%d.v", v_ld_index},
-      {match_vsuxei8_v, mask_vsuxei8_v, "vsux%sei%d.v", v_st_index},
-
-      {match_vlse8_v,  mask_vlse8_v,  "vls%se%d.v",  v_ld_stride},
-      {match_vsse8_v,  mask_vsse8_v,  "vss%se%d.v",  v_st_stride},
-
-      {match_vloxei8_v, mask_vloxei8_v, "vlox%sei%d.v", v_ld_index},
-      {match_vsoxei8_v, mask_vsoxei8_v, "vsox%sei%d.v", v_st_index},
-
-      {match_vle8ff_v, mask_vle8ff_v, "vl%se%dff.v", v_ld_unit}
-    };
-
-    reg_t elt_map[] = {0x00000000, 0x00005000, 0x00006000, 0x00007000,
-                       0x10000000, 0x10005000, 0x10006000, 0x10007000};
-
-    for (unsigned nf = 0; nf <= 7; ++nf) {
-      char seg_str[8] = "";
-      if (nf)
-        sprintf(seg_str, "seg%u", nf + 1);
-
-      for (auto item : template_insn) {
-        const reg_t match_nf = nf << 29;
-        char buf[128];
-        sprintf(buf, item.fmt, seg_str, 8 << elt);
-        add_insn(new disasm_insn_t(
-          buf,
-          ((item.match | match_nf) & ~mask_vldst) | elt_map[elt],
-          item.mask | mask_nf,
-          item.arg
-          ));
-      }
-    }
-
-    const custom_fmt_t template_insn2[] = {
-      {match_vl1re8_v,   mask_vl1re8_v,   "vl%dre%d.v",   v_ld_unit},
-    };
-
-    for (reg_t i = 0, nf = 7; i < 4; i++, nf >>= 1) {
-      for (auto item : template_insn2) {
-        const reg_t match_nf = nf << 29;
-        char buf[128];
-        sprintf(buf, item.fmt, nf + 1, 8 << elt);
-        add_insn(new disasm_insn_t(
-          buf,
-          item.match | match_nf | elt_map[elt],
-          item.mask | mask_nf,
-          item.arg
-        ));
-      }
+  if (isa->extension_enabled(EXT_ZBA)) { 
+    DEFINE_RTYPE(sh1add);
+    DEFINE_RTYPE(sh2add);
+    DEFINE_RTYPE(sh3add);
+    if (isa->get_max_xlen() == 64) {
+      DEFINE_ITYPE_SHIFT(slli_uw);
+      add_insn(new disasm_insn_t("zext.w", match_add_uw, mask_add_uw | mask_rs2, {&xrd, &xrs1}));
+      DEFINE_RTYPE(add_uw);
+      DEFINE_RTYPE(sh1add_uw);
+      DEFINE_RTYPE(sh2add_uw);
+      DEFINE_RTYPE(sh3add_uw);
     }
   }
 
-  #define DISASM_ST_WHOLE_INSN(name, nf) \
-    add_insn(new disasm_insn_t(#name, match_vs1r_v | (nf << 29), \
-                                      mask_vs1r_v | mask_nf, \
-                                      {&vs3, &v_address}));
-  DISASM_ST_WHOLE_INSN(vs1r.v, 0);
-  DISASM_ST_WHOLE_INSN(vs2r.v, 1);
-  DISASM_ST_WHOLE_INSN(vs4r.v, 3);
-  DISASM_ST_WHOLE_INSN(vs8r.v, 7);
+  if (isa->extension_enabled(EXT_ZBB)) { 
+    DEFINE_RTYPE(ror);
+    DEFINE_RTYPE(rol);
+    DEFINE_ITYPE_SHIFT(rori);
+    DEFINE_R1TYPE(ctz);
+    DEFINE_R1TYPE(clz);
+    DEFINE_R1TYPE(cpop);
+    DEFINE_RTYPE(min);
+    DEFINE_RTYPE(minu);
+    DEFINE_RTYPE(max);
+    DEFINE_RTYPE(maxu);
+    DEFINE_RTYPE(andn);
+    DEFINE_RTYPE(orn);
+    DEFINE_RTYPE(xnor);
+    DEFINE_R1TYPE(sext_b);
+    DEFINE_R1TYPE(sext_h);
+    add_insn(new disasm_insn_t("rev8", match_grevi | ((isa->get_max_xlen() - 8) << imm_shift), mask_grevi | mask_imm, {&xrd, &xrs1}));
+    add_insn(new disasm_insn_t("orc.b", match_gorci | (0x7 << imm_shift), mask_grevi | mask_imm, {&xrd, &xrs1}));
+    add_insn(new disasm_insn_t("zext.h", (isa->get_max_xlen() == 32 ? match_pack : match_packw), mask_pack | mask_rs2, {&xrd, &xrs1}));
+    if (isa->get_max_xlen() == 64) {
+      DEFINE_RTYPE(rorw);
+      DEFINE_RTYPE(rolw);
+      DEFINE_ITYPE_SHIFT(roriw);
+      DEFINE_R1TYPE(ctzw);
+      DEFINE_R1TYPE(clzw);
+      DEFINE_R1TYPE(cpopw);
+    }
+  }
 
-  #undef DISASM_ST_WHOLE_INSN
+  if (isa->extension_enabled(EXT_ZBS)) { 
+    DEFINE_RTYPE(bclr);
+    DEFINE_RTYPE(binv);
+    DEFINE_RTYPE(bset);
+    DEFINE_RTYPE(bext);
+    DEFINE_ITYPE_SHIFT(bclri);
+    DEFINE_ITYPE_SHIFT(binvi);
+    DEFINE_ITYPE_SHIFT(bseti);
+    DEFINE_ITYPE_SHIFT(bexti);
+  }
 
-  #define DEFINE_VECTOR_V(code) add_vector_v_insn(this, #code, match_##code, mask_##code)
-  #define DEFINE_VECTOR_VV(code) add_vector_vv_insn(this, #code, match_##code, mask_##code)
-  #define DEFINE_VECTOR_VX(code) add_vector_vx_insn(this, #code, match_##code, mask_##code)
-  #define DEFINE_VECTOR_VF(code) add_vector_vf_insn(this, #code, match_##code, mask_##code)
-  #define DEFINE_VECTOR_VI(code) add_vector_vi_insn(this, #code, match_##code, mask_##code)
-  #define DEFINE_VECTOR_VIU(code) add_vector_viu_insn(this, #code, match_##code, mask_##code)
+  if (isa->extension_enabled(EXT_ZBKB)) {
+    add_insn(new disasm_insn_t("brev8", match_grevi | (0x7 << imm_shift), mask_grevi | mask_imm, {&xrd, &xrs1})); // brev8
+    add_insn(new disasm_insn_t("rev8", match_grevi | ((isa->get_max_xlen() - 8) << imm_shift), mask_grevi | mask_imm, {&xrd, &xrs1}));
+    DEFINE_RTYPE(pack);
+    DEFINE_RTYPE(packh);
+    if (isa->get_max_xlen() == 64) {
+      DEFINE_RTYPE(packw);
+    }
+  }
 
-  #define DISASM_OPIV_VXI_INSN(name, sign, suf) \
-    DEFINE_VECTOR_VV(name##_##suf##v); \
-    DEFINE_VECTOR_VX(name##_##suf##x); \
-    if (sign) \
-      DEFINE_VECTOR_VI(name##_##suf##i); \
-    else \
-      DEFINE_VECTOR_VIU(name##_##suf##i)
+  if (isa->extension_enabled(EXT_SVINVAL)) {
+    DEFINE_NOARG(sfence_w_inval);
+    DEFINE_NOARG(sfence_inval_ir);
+    DEFINE_SFENCE_TYPE(sinval_vma);
+    DEFINE_SFENCE_TYPE(hinval_vvma);
+    DEFINE_SFENCE_TYPE(hinval_gvma);
+  }
 
-  #define DISASM_OPIV_VX__INSN(name, sign) \
-    DEFINE_VECTOR_VV(name##_vv); \
-    DEFINE_VECTOR_VX(name##_vx)
+  if (isa->extension_enabled('F')) {
+    DEFINE_FLOAD(flw)
+    DEFINE_FSTORE(fsw)
+    DEFINE_FRTYPE(fadd_s);
+    DEFINE_FRTYPE(fsub_s);
+    DEFINE_FRTYPE(fmul_s);
+    DEFINE_FRTYPE(fdiv_s);
+    DEFINE_FR1TYPE(fsqrt_s);
+    DEFINE_FRTYPE(fmin_s);
+    DEFINE_FRTYPE(fmax_s);
+    DEFINE_FR3TYPE(fmadd_s);
+    DEFINE_FR3TYPE(fmsub_s);
+    DEFINE_FR3TYPE(fnmadd_s);
+    DEFINE_FR3TYPE(fnmsub_s);
+    DEFINE_FRTYPE(fsgnj_s);
+    DEFINE_FRTYPE(fsgnjn_s);
+    DEFINE_FRTYPE(fsgnjx_s);
+    DEFINE_FR1TYPE(fcvt_s_d);
+    DEFINE_FR1TYPE(fcvt_s_q);
+    DEFINE_XFTYPE(fcvt_s_l);
+    DEFINE_XFTYPE(fcvt_s_lu);
+    DEFINE_XFTYPE(fcvt_s_w);
+    DEFINE_XFTYPE(fcvt_s_wu);
+    DEFINE_XFTYPE(fcvt_s_wu);
+    DEFINE_XFTYPE(fmv_w_x);
+    DEFINE_FXTYPE(fcvt_l_s);
+    DEFINE_FXTYPE(fcvt_lu_s);
+    DEFINE_FXTYPE(fcvt_w_s);
+    DEFINE_FXTYPE(fcvt_wu_s);
+    DEFINE_FXTYPE(fclass_s);
+    DEFINE_FXTYPE(fmv_x_w);
+    DEFINE_FX2TYPE(feq_s);
+    DEFINE_FX2TYPE(flt_s);
+    DEFINE_FX2TYPE(fle_s);
+  }
 
-  #define DISASM_OPIV__XI_INSN(name, sign) \
-    DEFINE_VECTOR_VX(name##_vx); \
-    if (sign) \
-      DEFINE_VECTOR_VI(name##_vi); \
-    else \
-      DEFINE_VECTOR_VIU(name##_vi)
+  if (isa->extension_enabled('D')) {
+    DEFINE_FLOAD(fld)
+    DEFINE_FSTORE(fsd)
+    DEFINE_FRTYPE(fadd_d);
+    DEFINE_FRTYPE(fsub_d);
+    DEFINE_FRTYPE(fmul_d);
+    DEFINE_FRTYPE(fdiv_d);
+    DEFINE_FR1TYPE(fsqrt_d);
+    DEFINE_FRTYPE(fmin_d);
+    DEFINE_FRTYPE(fmax_d);
+    DEFINE_FR3TYPE(fmadd_d);
+    DEFINE_FR3TYPE(fmsub_d);
+    DEFINE_FR3TYPE(fnmadd_d);
+    DEFINE_FR3TYPE(fnmsub_d);
+    DEFINE_FRTYPE(fsgnj_d);
+    DEFINE_FRTYPE(fsgnjn_d);
+    DEFINE_FRTYPE(fsgnjx_d);
+    DEFINE_FR1TYPE(fcvt_d_s);
+    DEFINE_FR1TYPE(fcvt_d_q);
+    DEFINE_XFTYPE(fcvt_d_l);
+    DEFINE_XFTYPE(fcvt_d_lu);
+    DEFINE_XFTYPE(fcvt_d_w);
+    DEFINE_XFTYPE(fcvt_d_wu);
+    DEFINE_XFTYPE(fcvt_d_wu);
+    DEFINE_XFTYPE(fmv_d_x);
+    DEFINE_FXTYPE(fcvt_l_d);
+    DEFINE_FXTYPE(fcvt_lu_d);
+    DEFINE_FXTYPE(fcvt_w_d);
+    DEFINE_FXTYPE(fcvt_wu_d);
+    DEFINE_FXTYPE(fclass_d);
+    DEFINE_FXTYPE(fmv_x_d);
+    DEFINE_FX2TYPE(feq_d);
+    DEFINE_FX2TYPE(flt_d);
+    DEFINE_FX2TYPE(fle_d);
+  }
 
-  #define DISASM_OPIV_V___INSN(name, sign) DEFINE_VECTOR_VV(name##_vv)
+  if (isa->extension_enabled(EXT_ZFH)) { 
+    DEFINE_FRTYPE(fadd_h);
+    DEFINE_FRTYPE(fsub_h);
+    DEFINE_FRTYPE(fmul_h);
+    DEFINE_FRTYPE(fdiv_h);
+    DEFINE_FR1TYPE(fsqrt_h);
+    DEFINE_FRTYPE(fmin_h);
+    DEFINE_FRTYPE(fmax_h);
+    DEFINE_FR3TYPE(fmadd_h);
+    DEFINE_FR3TYPE(fmsub_h);
+    DEFINE_FR3TYPE(fnmadd_h);
+    DEFINE_FR3TYPE(fnmsub_h);
+    DEFINE_FRTYPE(fsgnj_h);
+    DEFINE_FRTYPE(fsgnjn_h);
+    DEFINE_FRTYPE(fsgnjx_h);
+    DEFINE_XFTYPE(fcvt_h_l);
+    DEFINE_XFTYPE(fcvt_h_lu);
+    DEFINE_XFTYPE(fcvt_h_w);
+    DEFINE_XFTYPE(fcvt_h_wu);
+    DEFINE_XFTYPE(fcvt_h_wu);
+    DEFINE_FXTYPE(fcvt_l_h);
+    DEFINE_FXTYPE(fcvt_lu_h);
+    DEFINE_FXTYPE(fcvt_w_h);
+    DEFINE_FXTYPE(fcvt_wu_h);
+    DEFINE_FXTYPE(fclass_h);
+    DEFINE_FX2TYPE(feq_h);
+    DEFINE_FX2TYPE(flt_h);
+    DEFINE_FX2TYPE(fle_h);
+  }
 
-  #define DISASM_OPIV_S___INSN(name, sign) DEFINE_VECTOR_VV(name##_vs)
+  if (isa->extension_enabled(EXT_ZFHMIN)) {
+    DEFINE_FLOAD(flh)
+    DEFINE_FSTORE(fsh)
+    DEFINE_FR1TYPE(fcvt_h_s);
+    DEFINE_FR1TYPE(fcvt_h_d);
+    DEFINE_FR1TYPE(fcvt_h_q);
+    DEFINE_FR1TYPE(fcvt_s_h);
+    DEFINE_FR1TYPE(fcvt_d_h);
+    DEFINE_FR1TYPE(fcvt_q_h);
+    DEFINE_XFTYPE(fmv_h_x);
+    DEFINE_FXTYPE(fmv_x_h);
+  }
 
-  #define DISASM_OPIV_W___INSN(name, sign) \
-    DEFINE_VECTOR_VV(name##_wv); \
-    DEFINE_VECTOR_VX(name##_wx)
+  if (isa->extension_enabled('Q')) {
+    DEFINE_FLOAD(flq)
+    DEFINE_FSTORE(fsq)
+    DEFINE_FRTYPE(fadd_q);
+    DEFINE_FRTYPE(fsub_q);
+    DEFINE_FRTYPE(fmul_q);
+    DEFINE_FRTYPE(fdiv_q);
+    DEFINE_FR1TYPE(fsqrt_q);
+    DEFINE_FRTYPE(fmin_q);
+    DEFINE_FRTYPE(fmax_q);
+    DEFINE_FR3TYPE(fmadd_q);
+    DEFINE_FR3TYPE(fmsub_q);
+    DEFINE_FR3TYPE(fnmadd_q);
+    DEFINE_FR3TYPE(fnmsub_q);
+    DEFINE_FRTYPE(fsgnj_q);
+    DEFINE_FRTYPE(fsgnjn_q);
+    DEFINE_FRTYPE(fsgnjx_q);
+    DEFINE_FR1TYPE(fcvt_q_s);
+    DEFINE_FR1TYPE(fcvt_q_d);
+    DEFINE_XFTYPE(fcvt_q_l);
+    DEFINE_XFTYPE(fcvt_q_lu);
+    DEFINE_XFTYPE(fcvt_q_w);
+    DEFINE_XFTYPE(fcvt_q_wu);
+    DEFINE_XFTYPE(fcvt_q_wu);
+    DEFINE_FXTYPE(fcvt_l_q);
+    DEFINE_FXTYPE(fcvt_lu_q);
+    DEFINE_FXTYPE(fcvt_w_q);
+    DEFINE_FXTYPE(fcvt_wu_q);
+    DEFINE_FXTYPE(fclass_q);
+    DEFINE_FX2TYPE(feq_q);
+    DEFINE_FX2TYPE(flt_q);
+    DEFINE_FX2TYPE(fle_q);
+  }
 
-  #define DISASM_OPIV_M___INSN(name, sign) DEFINE_VECTOR_VV(name##_mm)
+  // ext-h
+  if (isa->extension_enabled('H')) {
+    DEFINE_XLOAD_BASE(hlv_b)
+    DEFINE_XLOAD_BASE(hlv_bu)
+    DEFINE_XLOAD_BASE(hlv_h)
+    DEFINE_XLOAD_BASE(hlv_hu)
+    DEFINE_XLOAD_BASE(hlv_w)
+    DEFINE_XLOAD_BASE(hlv_wu)
+    DEFINE_XLOAD_BASE(hlv_d)
 
-  #define DISASM_OPIV__X__INSN(name, sign) DEFINE_VECTOR_VX(name##_vx)
+    DEFINE_XLOAD_BASE(hlvx_hu)
+    DEFINE_XLOAD_BASE(hlvx_wu)
 
-  #define DEFINE_VECTOR_VVM(name, has_vm) \
-    add_vector_vvm_insn(this, #name, match_##name, mask_##name | mask_vm); \
-    if (has_vm) \
-      add_vector_vv_insn(this, #name, match_##name, mask_##name | mask_vm)
+    DEFINE_XSTORE_BASE(hsv_b)
+    DEFINE_XSTORE_BASE(hsv_h)
+    DEFINE_XSTORE_BASE(hsv_w)
+    DEFINE_XSTORE_BASE(hsv_d)
 
-  #define DEFINE_VECTOR_VXM(name, has_vm) \
-    add_vector_vxm_insn(this, #name, match_##name, mask_##name | mask_vm); \
-    if (has_vm) \
-      add_vector_vx_insn(this, #name, match_##name, mask_##name | mask_vm)
+    DEFINE_SFENCE_TYPE(hfence_gvma);
+    DEFINE_SFENCE_TYPE(hfence_vvma);
+  }
 
-  #define DEFINE_VECTOR_VIM(name, has_vm) \
-    add_vector_vim_insn(this, #name, match_##name, mask_##name | mask_vm); \
-    if (has_vm) \
-      add_vector_vi_insn(this, #name, match_##name, mask_##name | mask_vm)
+  // ext-c
+  if (isa->extension_enabled('C')) {
+    DISASM_INSN("c.ebreak", c_add, mask_rd | mask_rvc_rs2, {});
+    add_insn(new disasm_insn_t("ret", match_c_jr | match_rd_ra, mask_c_jr | mask_rd | mask_rvc_imm, {}));
+    DISASM_INSN("c.jr", c_jr, mask_rvc_imm, {&rvc_rs1});
+    DISASM_INSN("c.jalr", c_jalr, mask_rvc_imm, {&rvc_rs1});
+    DISASM_INSN("c.nop", c_addi, mask_rd | mask_rvc_imm, {});
+    DISASM_INSN("c.addi16sp", c_addi16sp, mask_rd, {&rvc_sp, &rvc_addi16sp_imm});
+    DISASM_INSN("c.addi4spn", c_addi4spn, 0, {&rvc_rs2s, &rvc_sp, &rvc_addi4spn_imm});
+    DISASM_INSN("c.li", c_li, 0, {&xrd, &rvc_imm});
+    DISASM_INSN("c.lui", c_lui, 0, {&xrd, &rvc_uimm});
+    DISASM_INSN("c.addi", c_addi, 0, {&xrd, &rvc_imm});
+    DISASM_INSN("c.slli", c_slli, 0, {&rvc_rs1, &rvc_shamt});
+    DISASM_INSN("c.srli", c_srli, 0, {&rvc_rs1s, &rvc_shamt});
+    DISASM_INSN("c.srai", c_srai, 0, {&rvc_rs1s, &rvc_shamt});
+    DISASM_INSN("c.andi", c_andi, 0, {&rvc_rs1s, &rvc_imm});
+    DISASM_INSN("c.mv", c_mv, 0, {&xrd, &rvc_rs2});
+    DISASM_INSN("c.add", c_add, 0, {&xrd, &rvc_rs2});
+    DISASM_INSN("c.addw", c_addw, 0, {&rvc_rs1s, &rvc_rs2s});
+    DISASM_INSN("c.sub", c_sub, 0, {&rvc_rs1s, &rvc_rs2s});
+    DISASM_INSN("c.subw", c_subw, 0, {&rvc_rs1s, &rvc_rs2s});
+    DISASM_INSN("c.and", c_and, 0, {&rvc_rs1s, &rvc_rs2s});
+    DISASM_INSN("c.or", c_or, 0, {&rvc_rs1s, &rvc_rs2s});
+    DISASM_INSN("c.xor", c_xor, 0, {&rvc_rs1s, &rvc_rs2s});
+    DISASM_INSN("c.lwsp", c_lwsp, 0, {&xrd, &rvc_lwsp_address});
+    DISASM_INSN("c.fld", c_fld, 0, {&rvc_fp_rs2s, &rvc_ld_address});
+    DISASM_INSN("c.swsp", c_swsp, 0, {&rvc_rs2, &rvc_swsp_address});
+    DISASM_INSN("c.lw", c_lw, 0, {&rvc_rs2s, &rvc_lw_address});
+    DISASM_INSN("c.sw", c_sw, 0, {&rvc_rs2s, &rvc_lw_address});
+    DISASM_INSN("c.beqz", c_beqz, 0, {&rvc_rs1s, &rvc_branch_target});
+    DISASM_INSN("c.bnez", c_bnez, 0, {&rvc_rs1s, &rvc_branch_target});
+    DISASM_INSN("c.j", c_j, 0, {&rvc_jump_target});
+    DISASM_INSN("c.fldsp", c_fldsp, 0, {&frd, &rvc_ldsp_address});
+    DISASM_INSN("c.fsd", c_fsd, 0, {&rvc_fp_rs2s, &rvc_ld_address});
+    DISASM_INSN("c.fsdsp", c_fsdsp, 0, {&rvc_fp_rs2, &rvc_sdsp_address});
+    if (isa->get_max_xlen() == 32) {
+      DISASM_INSN("c.flw", c_flw, 0, {&rvc_fp_rs2s, &rvc_lw_address});
+      DISASM_INSN("c.flwsp", c_flwsp, 0, {&frd, &rvc_lwsp_address});
+      DISASM_INSN("c.fsw", c_fsw, 0, {&rvc_fp_rs2s, &rvc_lw_address});
+      DISASM_INSN("c.fswsp", c_fswsp, 0, {&rvc_fp_rs2, &rvc_swsp_address});
+      DISASM_INSN("c.jal", c_jal, 0, {&rvc_jump_target});
+    } else {
+      DISASM_INSN("c.ld", c_ld, 0, {&rvc_rs2s, &rvc_ld_address});
+      DISASM_INSN("c.ldsp", c_ldsp, 0, {&xrd, &rvc_ldsp_address});
+      DISASM_INSN("c.sd", c_sd, 0, {&rvc_rs2s, &rvc_ld_address});
+      DISASM_INSN("c.sdsp", c_sdsp, 0, {&rvc_rs2, &rvc_sdsp_address});
+      DISASM_INSN("c.addiw", c_addiw, 0, {&xrd, &rvc_imm});
+    }
+  }
 
-  #define DISASM_OPIV_VXIM_INSN(name, sign, has_vm) \
-    DEFINE_VECTOR_VVM(name##_vvm, has_vm); \
-    DEFINE_VECTOR_VXM(name##_vxm, has_vm); \
-    DEFINE_VECTOR_VIM(name##_vim, has_vm)
+  if (isa->extension_enabled('V')) {
+    DISASM_INSN("vsetivli", vsetivli, 0, {&xrd, &zimm5, &v_vtype});
+    DISASM_INSN("vsetvli", vsetvli, 0, {&xrd, &xrs1, &v_vtype});
+    DEFINE_RTYPE(vsetvl);
 
-  #define DISASM_OPIV_VX_M_INSN(name, sign, has_vm) \
-    DEFINE_VECTOR_VVM(name##_vvm, has_vm); \
-    DEFINE_VECTOR_VXM(name##_vxm, has_vm)
+    std::vector<const arg_t *> v_ld_unit = {&vd, &v_address, opt, &vm};
+    std::vector<const arg_t *> v_st_unit = {&vs3, &v_address, opt, &vm};
+    std::vector<const arg_t *> v_ld_stride = {&vd, &v_address, &xrs2, opt, &vm};
+    std::vector<const arg_t *> v_st_stride = {&vs3, &v_address, &xrs2, opt, &vm};
+    std::vector<const arg_t *> v_ld_index = {&vd, &v_address, &vs2, opt, &vm};
+    std::vector<const arg_t *> v_st_index = {&vs3, &v_address, &vs2, opt, &vm};
 
-  //OPFVV/OPFVF
-  //0b00_0000
-  DISASM_OPIV_VXI_INSN(vadd,         1, v);
-  DISASM_OPIV_VX__INSN(vsub,         1);
-  DISASM_OPIV__XI_INSN(vrsub,        1);
-  DISASM_OPIV_VX__INSN(vminu,        0);
-  DISASM_OPIV_VX__INSN(vmin,         1);
-  DISASM_OPIV_VX__INSN(vmaxu,        1);
-  DISASM_OPIV_VX__INSN(vmax,         0);
-  DISASM_OPIV_VXI_INSN(vand,         1, v);
-  DISASM_OPIV_VXI_INSN(vor,          1, v);
-  DISASM_OPIV_VXI_INSN(vxor,         1, v);
-  DISASM_OPIV_VXI_INSN(vrgather,     0, v);
-  DISASM_OPIV_V___INSN(vrgatherei16, 0);
-  DISASM_OPIV__XI_INSN(vslideup,     0);
-  DISASM_OPIV__XI_INSN(vslidedown,   0);
+    add_insn(new disasm_insn_t("vlm.v",  match_vlm_v,     mask_vlm_v, v_ld_unit));
+    add_insn(new disasm_insn_t("vsm.v",  match_vsm_v,     mask_vsm_v, v_st_unit));
 
-  //0b01_0000
-  DISASM_OPIV_VXIM_INSN(vadc,    1, 0);
-  DISASM_OPIV_VXIM_INSN(vmadc,   1, 1);
-  DISASM_OPIV_VX_M_INSN(vsbc,    1, 0);
-  DISASM_OPIV_VX_M_INSN(vmsbc,   1, 1);
-  DISASM_OPIV_VXIM_INSN(vmerge,  1, 0);
-  DISASM_INSN("vmv.v.i", vmv_v_i, 0, {&vd, &v_simm5});
-  DISASM_INSN("vmv.v.v", vmv_v_v, 0, {&vd, &vs1});
-  DISASM_INSN("vmv.v.x", vmv_v_x, 0, {&vd, &xrs1});
-  DISASM_OPIV_VXI_INSN(vmseq,     1, v);
-  DISASM_OPIV_VXI_INSN(vmsne,     1, v);
-  DISASM_OPIV_VX__INSN(vmsltu,    0);
-  DISASM_OPIV_VX__INSN(vmslt,     1);
-  DISASM_OPIV_VXI_INSN(vmsleu,    0, v);
-  DISASM_OPIV_VXI_INSN(vmsle,     1, v);
-  DISASM_OPIV__XI_INSN(vmsgtu,    0);
-  DISASM_OPIV__XI_INSN(vmsgt,     1);
+    // handle vector segment load/store
+    for (size_t elt = 0; elt <= 7; ++elt) {
+      const custom_fmt_t template_insn[] = {
+        {match_vle8_v,   mask_vle8_v,   "vl%se%d.v",   v_ld_unit},
+        {match_vse8_v,   mask_vse8_v,   "vs%se%d.v",   v_st_unit},
 
-  //0b10_0000
-  DISASM_OPIV_VXI_INSN(vsaddu,    0, v);
-  DISASM_OPIV_VXI_INSN(vsadd,     1, v);
-  DISASM_OPIV_VX__INSN(vssubu,    0);
-  DISASM_OPIV_VX__INSN(vssub,     1);
-  DISASM_OPIV_VXI_INSN(vsll,      1, v);
-  DISASM_INSN("vmv1r.v", vmv1r_v, 0, {&vd, &vs2});
-  DISASM_INSN("vmv2r.v", vmv2r_v, 0, {&vd, &vs2});
-  DISASM_INSN("vmv4r.v", vmv4r_v, 0, {&vd, &vs2});
-  DISASM_INSN("vmv8r.v", vmv8r_v, 0, {&vd, &vs2});
-  DISASM_OPIV_VX__INSN(vsmul,     1);
-  DISASM_OPIV_VXI_INSN(vsrl,      0, v);
-  DISASM_OPIV_VXI_INSN(vsra,      0, v);
-  DISASM_OPIV_VXI_INSN(vssrl,     0, v);
-  DISASM_OPIV_VXI_INSN(vssra,     0, v);
-  DISASM_OPIV_VXI_INSN(vnsrl,     0, w);
-  DISASM_OPIV_VXI_INSN(vnsra,     0, w);
-  DISASM_OPIV_VXI_INSN(vnclipu,   0, w);
-  DISASM_OPIV_VXI_INSN(vnclip,    0, w);
+        {match_vluxei8_v, mask_vluxei8_v, "vlux%sei%d.v", v_ld_index},
+        {match_vsuxei8_v, mask_vsuxei8_v, "vsux%sei%d.v", v_st_index},
 
-  //0b11_0000
-  DISASM_OPIV_S___INSN(vwredsumu, 0);
-  DISASM_OPIV_S___INSN(vwredsum,  1);
+        {match_vlse8_v,  mask_vlse8_v,  "vls%se%d.v",  v_ld_stride},
+        {match_vsse8_v,  mask_vsse8_v,  "vss%se%d.v",  v_st_stride},
 
-  //OPMVV/OPMVX
-  //0b00_0000
-  DISASM_OPIV_VX__INSN(vaaddu,    0);
-  DISASM_OPIV_VX__INSN(vaadd,     0);
-  DISASM_OPIV_VX__INSN(vasubu,    0);
-  DISASM_OPIV_VX__INSN(vasub,     0);
+        {match_vloxei8_v, mask_vloxei8_v, "vlox%sei%d.v", v_ld_index},
+        {match_vsoxei8_v, mask_vsoxei8_v, "vsox%sei%d.v", v_st_index},
 
-  DISASM_OPIV_S___INSN(vredsum,   1);
-  DISASM_OPIV_S___INSN(vredand,   1);
-  DISASM_OPIV_S___INSN(vredor,    1);
-  DISASM_OPIV_S___INSN(vredxor,   1);
-  DISASM_OPIV_S___INSN(vredminu,  0);
-  DISASM_OPIV_S___INSN(vredmin,   1);
-  DISASM_OPIV_S___INSN(vredmaxu,  0);
-  DISASM_OPIV_S___INSN(vredmax,   1);
-  DISASM_OPIV__X__INSN(vslide1up,  1);
-  DISASM_OPIV__X__INSN(vslide1down,1);
+        {match_vle8ff_v, mask_vle8ff_v, "vl%se%dff.v", v_ld_unit}
+      };
 
-  //0b01_0000
-  //VWXUNARY0
-  DISASM_INSN("vmv.x.s", vmv_x_s, 0, {&xrd, &vs2});
-  DISASM_INSN("vcpop.m", vcpop_m, 0, {&xrd, &vs2, opt, &vm});
-  DISASM_INSN("vfirst.m", vfirst_m, 0, {&xrd, &vs2, opt, &vm});
+      reg_t elt_map[] = {0x00000000, 0x00005000, 0x00006000, 0x00007000,
+                         0x10000000, 0x10005000, 0x10006000, 0x10007000};
 
-  //VRXUNARY0
-  DISASM_INSN("vmv.s.x", vmv_s_x, 0, {&vd, &xrs1});
+      for (unsigned nf = 0; nf <= 7; ++nf) {
+        char seg_str[8] = "";
+        if (nf)
+          sprintf(seg_str, "seg%u", nf + 1);
 
-  //VXUNARY0
-  DEFINE_VECTOR_V(vzext_vf2);
-  DEFINE_VECTOR_V(vsext_vf2);
-  DEFINE_VECTOR_V(vzext_vf4);
-  DEFINE_VECTOR_V(vsext_vf4);
-  DEFINE_VECTOR_V(vzext_vf8);
-  DEFINE_VECTOR_V(vsext_vf8);
+        for (auto item : template_insn) {
+          const reg_t match_nf = nf << 29;
+          char buf[128];
+          sprintf(buf, item.fmt, seg_str, 8 << elt);
+          add_insn(new disasm_insn_t(
+            buf,
+            ((item.match | match_nf) & ~mask_vldst) | elt_map[elt],
+            item.mask | mask_nf,
+            item.arg
+            ));
+        }
+      }
 
-  //VMUNARY0
-  DEFINE_VECTOR_V(vmsbf_m);
-  DEFINE_VECTOR_V(vmsof_m);
-  DEFINE_VECTOR_V(vmsif_m);
-  DEFINE_VECTOR_V(viota_m);
-  DISASM_INSN("vid.v", vid_v, 0, {&vd, opt, &vm});
+      const custom_fmt_t template_insn2[] = {
+        {match_vl1re8_v,   mask_vl1re8_v,   "vl%dre%d.v",   v_ld_unit},
+      };
 
-  DISASM_INSN("vid.v", vid_v, 0, {&vd, opt, &vm});
+      for (reg_t i = 0, nf = 7; i < 4; i++, nf >>= 1) {
+        for (auto item : template_insn2) {
+          const reg_t match_nf = nf << 29;
+          char buf[128];
+          sprintf(buf, item.fmt, nf + 1, 8 << elt);
+          add_insn(new disasm_insn_t(
+            buf,
+            item.match | match_nf | elt_map[elt],
+            item.mask | mask_nf,
+            item.arg
+          ));
+        }
+      }
+    }
 
-  DISASM_INSN("vcompress.vm", vcompress_vm, 0, {&vd, &vs2, &vs1});
+    #define DISASM_ST_WHOLE_INSN(name, nf) \
+      add_insn(new disasm_insn_t(#name, match_vs1r_v | (nf << 29), \
+                                        mask_vs1r_v | mask_nf, \
+                                        {&vs3, &v_address}));
+    DISASM_ST_WHOLE_INSN(vs1r.v, 0);
+    DISASM_ST_WHOLE_INSN(vs2r.v, 1);
+    DISASM_ST_WHOLE_INSN(vs4r.v, 3);
+    DISASM_ST_WHOLE_INSN(vs8r.v, 7);
 
-  DISASM_OPIV_M___INSN(vmandn,    1);
-  DISASM_OPIV_M___INSN(vmand,     1);
-  DISASM_OPIV_M___INSN(vmor,      1);
-  DISASM_OPIV_M___INSN(vmxor,     1);
-  DISASM_OPIV_M___INSN(vmorn,     1);
-  DISASM_OPIV_M___INSN(vmnand,    1);
-  DISASM_OPIV_M___INSN(vmnor,     1);
-  DISASM_OPIV_M___INSN(vmxnor,    1);
+    #undef DISASM_ST_WHOLE_INSN
 
-  //0b10_0000
-  DISASM_OPIV_VX__INSN(vdivu,     0);
-  DISASM_OPIV_VX__INSN(vdiv,      1);
-  DISASM_OPIV_VX__INSN(vremu,     0);
-  DISASM_OPIV_VX__INSN(vrem,      1);
-  DISASM_OPIV_VX__INSN(vmulhu,    0);
-  DISASM_OPIV_VX__INSN(vmul,      1);
-  DISASM_OPIV_VX__INSN(vmulhsu,   0);
-  DISASM_OPIV_VX__INSN(vmulh,     1);
-  DISASM_OPIV_VX__INSN(vmadd,     1);
-  DISASM_OPIV_VX__INSN(vnmsub,    1);
-  DISASM_OPIV_VX__INSN(vmacc,     1);
-  DISASM_OPIV_VX__INSN(vnmsac,    1);
+    #define DEFINE_VECTOR_V(code) add_vector_v_insn(this, #code, match_##code, mask_##code)
+    #define DEFINE_VECTOR_VV(code) add_vector_vv_insn(this, #code, match_##code, mask_##code)
+    #define DEFINE_VECTOR_VX(code) add_vector_vx_insn(this, #code, match_##code, mask_##code)
+    #define DEFINE_VECTOR_VF(code) add_vector_vf_insn(this, #code, match_##code, mask_##code)
+    #define DEFINE_VECTOR_VI(code) add_vector_vi_insn(this, #code, match_##code, mask_##code)
+    #define DEFINE_VECTOR_VIU(code) add_vector_viu_insn(this, #code, match_##code, mask_##code)
 
-  //0b11_0000
-  DISASM_OPIV_VX__INSN(vwaddu,    0);
-  DISASM_OPIV_VX__INSN(vwadd,     1);
-  DISASM_OPIV_VX__INSN(vwsubu,    0);
-  DISASM_OPIV_VX__INSN(vwsub,     1);
-  DISASM_OPIV_W___INSN(vwaddu,    0);
-  DISASM_OPIV_W___INSN(vwadd,     1);
-  DISASM_OPIV_W___INSN(vwsubu,    0);
-  DISASM_OPIV_W___INSN(vwsub,     1);
-  DISASM_OPIV_VX__INSN(vwmulu,    0);
-  DISASM_OPIV_VX__INSN(vwmulsu,   0);
-  DISASM_OPIV_VX__INSN(vwmul,     1);
-  DISASM_OPIV_VX__INSN(vwmaccu,   0);
-  DISASM_OPIV_VX__INSN(vwmacc,    1);
-  DISASM_OPIV__X__INSN(vwmaccus,  1);
-  DISASM_OPIV_VX__INSN(vwmaccsu,  0);
+    #define DISASM_OPIV_VXI_INSN(name, sign, suf) \
+      DEFINE_VECTOR_VV(name##_##suf##v); \
+      DEFINE_VECTOR_VX(name##_##suf##x); \
+      if (sign) \
+        DEFINE_VECTOR_VI(name##_##suf##i); \
+      else \
+        DEFINE_VECTOR_VIU(name##_##suf##i)
 
-  #undef DISASM_OPIV_VXI_INSN
-  #undef DISASM_OPIV_VX__INSN
-  #undef DISASM_OPIV__XI_INSN
-  #undef DISASM_OPIV_V___INSN
-  #undef DISASM_OPIV_S___INSN
-  #undef DISASM_OPIV_W___INSN
-  #undef DISASM_OPIV_M___INSN
-  #undef DISASM_OPIV__X__INSN
-  #undef DISASM_OPIV_VXIM_INSN
-  #undef DISASM_OPIV_VX_M_INSN
+    #define DISASM_OPIV_VX__INSN(name, sign) \
+      DEFINE_VECTOR_VV(name##_vv); \
+      DEFINE_VECTOR_VX(name##_vx)
 
-  #define DISASM_OPIV_VF_INSN(name) \
-    DEFINE_VECTOR_VV(name##_vv); \
-    DEFINE_VECTOR_VF(name##_vf)
+    #define DISASM_OPIV__XI_INSN(name, sign) \
+      DEFINE_VECTOR_VX(name##_vx); \
+      if (sign) \
+        DEFINE_VECTOR_VI(name##_vi); \
+      else \
+        DEFINE_VECTOR_VIU(name##_vi)
 
-  #define DISASM_OPIV_WF_INSN(name) \
-    DEFINE_VECTOR_VV(name##_wv); \
-    DEFINE_VECTOR_VF(name##_wf)
+    #define DISASM_OPIV_V___INSN(name, sign) DEFINE_VECTOR_VV(name##_vv)
 
-  #define DISASM_OPIV_S__INSN(name) \
-    DEFINE_VECTOR_VV(name##_vs)
+    #define DISASM_OPIV_S___INSN(name, sign) DEFINE_VECTOR_VV(name##_vs)
 
-  #define DISASM_OPIV__F_INSN(name) \
-    DEFINE_VECTOR_VF(name##_vf)
+    #define DISASM_OPIV_W___INSN(name, sign) \
+      DEFINE_VECTOR_VV(name##_wv); \
+      DEFINE_VECTOR_VX(name##_wx)
 
-  #define DISASM_VFUNARY0_INSN(name, suf) \
-    DEFINE_VECTOR_V(name##cvt_rtz_xu_f_##suf); \
-    DEFINE_VECTOR_V(name##cvt_rtz_x_f_##suf); \
-    DEFINE_VECTOR_V(name##cvt_xu_f_##suf); \
-    DEFINE_VECTOR_V(name##cvt_x_f_##suf); \
-    DEFINE_VECTOR_V(name##cvt_f_xu_##suf); \
-    DEFINE_VECTOR_V(name##cvt_f_x_##suf)
+    #define DISASM_OPIV_M___INSN(name, sign) DEFINE_VECTOR_VV(name##_mm)
 
-  //OPFVV/OPFVF
-  //0b00_0000
-  DISASM_OPIV_VF_INSN(vfadd);
-  DISASM_OPIV_S__INSN(vfredusum);
-  DISASM_OPIV_VF_INSN(vfsub);
-  DISASM_OPIV_S__INSN(vfredosum);
-  DISASM_OPIV_VF_INSN(vfmin);
-  DISASM_OPIV_S__INSN(vfredmin);
-  DISASM_OPIV_VF_INSN(vfmax);
-  DISASM_OPIV_S__INSN(vfredmax);
-  DISASM_OPIV_VF_INSN(vfsgnj);
-  DISASM_OPIV_VF_INSN(vfsgnjn);
-  DISASM_OPIV_VF_INSN(vfsgnjx);
-  DISASM_INSN("vfmv.f.s", vfmv_f_s, 0, {&frd, &vs2});
-  DISASM_INSN("vfmv.s.f", vfmv_s_f, mask_vfmv_s_f, {&vd, &frs1});
-  DISASM_OPIV__F_INSN(vfslide1up);
-  DISASM_OPIV__F_INSN(vfslide1down);
+    #define DISASM_OPIV__X__INSN(name, sign) DEFINE_VECTOR_VX(name##_vx)
 
-  //0b01_0000
-  DISASM_INSN("vfmerge.vfm", vfmerge_vfm, 0, {&vd, &vs2, &frs1, &v0});
-  DISASM_INSN("vfmv.v.f", vfmv_v_f, 0, {&vd, &frs1});
-  DISASM_OPIV_VF_INSN(vmfeq);
-  DISASM_OPIV_VF_INSN(vmfle);
-  DISASM_OPIV_VF_INSN(vmflt);
-  DISASM_OPIV_VF_INSN(vmfne);
-  DISASM_OPIV__F_INSN(vmfgt);
-  DISASM_OPIV__F_INSN(vmfge);
+    #define DEFINE_VECTOR_VVM(name, has_vm) \
+      add_vector_vvm_insn(this, #name, match_##name, mask_##name | mask_vm); \
+      if (has_vm) \
+        add_vector_vv_insn(this, #name, match_##name, mask_##name | mask_vm)
 
-  //0b10_0000
-  DISASM_OPIV_VF_INSN(vfdiv);
-  DISASM_OPIV__F_INSN(vfrdiv);
+    #define DEFINE_VECTOR_VXM(name, has_vm) \
+      add_vector_vxm_insn(this, #name, match_##name, mask_##name | mask_vm); \
+      if (has_vm) \
+        add_vector_vx_insn(this, #name, match_##name, mask_##name | mask_vm)
 
-  //vfunary0
-  DISASM_VFUNARY0_INSN(vf,  v);
+    #define DEFINE_VECTOR_VIM(name, has_vm) \
+      add_vector_vim_insn(this, #name, match_##name, mask_##name | mask_vm); \
+      if (has_vm) \
+        add_vector_vi_insn(this, #name, match_##name, mask_##name | mask_vm)
 
-  DISASM_VFUNARY0_INSN(vfw, v);
-  DEFINE_VECTOR_V(vfwcvt_f_f_v);
+    #define DISASM_OPIV_VXIM_INSN(name, sign, has_vm) \
+      DEFINE_VECTOR_VVM(name##_vvm, has_vm); \
+      DEFINE_VECTOR_VXM(name##_vxm, has_vm); \
+      DEFINE_VECTOR_VIM(name##_vim, has_vm)
 
-  DISASM_VFUNARY0_INSN(vfn, w);
-  DEFINE_VECTOR_V(vfncvt_f_f_w);
-  DEFINE_VECTOR_V(vfncvt_rod_f_f_w);
+    #define DISASM_OPIV_VX_M_INSN(name, sign, has_vm) \
+      DEFINE_VECTOR_VVM(name##_vvm, has_vm); \
+      DEFINE_VECTOR_VXM(name##_vxm, has_vm)
 
-  //vfunary1
-  DEFINE_VECTOR_V(vfsqrt_v);
-  DEFINE_VECTOR_V(vfrsqrt7_v);
-  DEFINE_VECTOR_V(vfrec7_v);
-  DEFINE_VECTOR_V(vfclass_v);
+    //OPFVV/OPFVF
+    //0b00_0000
+    DISASM_OPIV_VXI_INSN(vadd,         1, v);
+    DISASM_OPIV_VX__INSN(vsub,         1);
+    DISASM_OPIV__XI_INSN(vrsub,        1);
+    DISASM_OPIV_VX__INSN(vminu,        0);
+    DISASM_OPIV_VX__INSN(vmin,         1);
+    DISASM_OPIV_VX__INSN(vmaxu,        1);
+    DISASM_OPIV_VX__INSN(vmax,         0);
+    DISASM_OPIV_VXI_INSN(vand,         1, v);
+    DISASM_OPIV_VXI_INSN(vor,          1, v);
+    DISASM_OPIV_VXI_INSN(vxor,         1, v);
+    DISASM_OPIV_VXI_INSN(vrgather,     0, v);
+    DISASM_OPIV_V___INSN(vrgatherei16, 0);
+    DISASM_OPIV__XI_INSN(vslideup,     0);
+    DISASM_OPIV__XI_INSN(vslidedown,   0);
 
-  DISASM_OPIV_VF_INSN(vfmul);
-  DISASM_OPIV__F_INSN(vfrsub);
-  DISASM_OPIV_VF_INSN(vfmadd);
-  DISASM_OPIV_VF_INSN(vfnmadd);
-  DISASM_OPIV_VF_INSN(vfmsub);
-  DISASM_OPIV_VF_INSN(vfnmsub);
-  DISASM_OPIV_VF_INSN(vfmacc);
-  DISASM_OPIV_VF_INSN(vfnmacc);
-  DISASM_OPIV_VF_INSN(vfmsac);
-  DISASM_OPIV_VF_INSN(vfnmsac);
+    //0b01_0000
+    DISASM_OPIV_VXIM_INSN(vadc,    1, 0);
+    DISASM_OPIV_VXIM_INSN(vmadc,   1, 1);
+    DISASM_OPIV_VX_M_INSN(vsbc,    1, 0);
+    DISASM_OPIV_VX_M_INSN(vmsbc,   1, 1);
+    DISASM_OPIV_VXIM_INSN(vmerge,  1, 0);
+    DISASM_INSN("vmv.v.i", vmv_v_i, 0, {&vd, &v_simm5});
+    DISASM_INSN("vmv.v.v", vmv_v_v, 0, {&vd, &vs1});
+    DISASM_INSN("vmv.v.x", vmv_v_x, 0, {&vd, &xrs1});
+    DISASM_OPIV_VXI_INSN(vmseq,     1, v);
+    DISASM_OPIV_VXI_INSN(vmsne,     1, v);
+    DISASM_OPIV_VX__INSN(vmsltu,    0);
+    DISASM_OPIV_VX__INSN(vmslt,     1);
+    DISASM_OPIV_VXI_INSN(vmsleu,    0, v);
+    DISASM_OPIV_VXI_INSN(vmsle,     1, v);
+    DISASM_OPIV__XI_INSN(vmsgtu,    0);
+    DISASM_OPIV__XI_INSN(vmsgt,     1);
 
-  //0b11_0000
-  DISASM_OPIV_VF_INSN(vfwadd);
-  DISASM_OPIV_S__INSN(vfwredusum);
-  DISASM_OPIV_VF_INSN(vfwsub);
-  DISASM_OPIV_S__INSN(vfwredosum);
-  DISASM_OPIV_WF_INSN(vfwadd);
-  DISASM_OPIV_WF_INSN(vfwsub);
-  DISASM_OPIV_VF_INSN(vfwmul);
-  DISASM_OPIV_VF_INSN(vfwmacc);
-  DISASM_OPIV_VF_INSN(vfwnmacc);
-  DISASM_OPIV_VF_INSN(vfwmsac);
-  DISASM_OPIV_VF_INSN(vfwnmsac);
+    //0b10_0000
+    DISASM_OPIV_VXI_INSN(vsaddu,    0, v);
+    DISASM_OPIV_VXI_INSN(vsadd,     1, v);
+    DISASM_OPIV_VX__INSN(vssubu,    0);
+    DISASM_OPIV_VX__INSN(vssub,     1);
+    DISASM_OPIV_VXI_INSN(vsll,      1, v);
+    DISASM_INSN("vmv1r.v", vmv1r_v, 0, {&vd, &vs2});
+    DISASM_INSN("vmv2r.v", vmv2r_v, 0, {&vd, &vs2});
+    DISASM_INSN("vmv4r.v", vmv4r_v, 0, {&vd, &vs2});
+    DISASM_INSN("vmv8r.v", vmv8r_v, 0, {&vd, &vs2});
+    DISASM_OPIV_VX__INSN(vsmul,     1);
+    DISASM_OPIV_VXI_INSN(vsrl,      0, v);
+    DISASM_OPIV_VXI_INSN(vsra,      0, v);
+    DISASM_OPIV_VXI_INSN(vssrl,     0, v);
+    DISASM_OPIV_VXI_INSN(vssra,     0, v);
+    DISASM_OPIV_VXI_INSN(vnsrl,     0, w);
+    DISASM_OPIV_VXI_INSN(vnsra,     0, w);
+    DISASM_OPIV_VXI_INSN(vnclipu,   0, w);
+    DISASM_OPIV_VXI_INSN(vnclip,    0, w);
 
-  #undef DISASM_OPIV_VF_INSN
-  #undef DISASM_OPIV__F_INSN
-  #undef DISASM_OPIV_S__INSN
-  #undef DISASM_OPIV_W__INSN
-  #undef DISASM_VFUNARY0_INSN
+    //0b11_0000
+    DISASM_OPIV_S___INSN(vwredsumu, 0);
+    DISASM_OPIV_S___INSN(vwredsum,  1);
 
-  // vector amo
-  std::vector<const arg_t *> v_fmt_amo_wd = {&vd, &v_address, &vs2, &vd, opt, &vm};
-  std::vector<const arg_t *> v_fmt_amo = {&x0, &v_address, &vs2, &vd, opt, &vm};
-  for (size_t elt = 0; elt <= 3; ++elt) {
-    const custom_fmt_t template_insn[] = {
-      {match_vamoaddei8_v | mask_wd,   mask_vamoaddei8_v | mask_wd,
-         "%sei%d.v", v_fmt_amo_wd},
-      {match_vamoaddei8_v,   mask_vamoaddei8_v | mask_wd,
-         "%sei%d.v", v_fmt_amo},
-    };
-    std::pair<const char*, reg_t> amo_map[] = {
-        {"vamoswap", 0x01ul << 27},
-        {"vamoadd",  0x00ul << 27},
-        {"vamoxor",  0x04ul << 27},
-        {"vamoand",  0x0cul << 27},
-        {"vamoor",   0x08ul << 27},
-        {"vamomin",  0x10ul << 27},
-        {"vamomax",  0x14ul << 27},
-        {"vamominu", 0x18ul << 27},
-        {"vamomaxu", 0x1cul << 27}};
-    const reg_t elt_map[] = {0x0ul << 12,  0x5ul << 12,
-                             0x6ul <<12, 0x7ul << 12};
+    //OPMVV/OPMVX
+    //0b00_0000
+    DISASM_OPIV_VX__INSN(vaaddu,    0);
+    DISASM_OPIV_VX__INSN(vaadd,     0);
+    DISASM_OPIV_VX__INSN(vasubu,    0);
+    DISASM_OPIV_VX__INSN(vasub,     0);
 
-    for (size_t idx = 0; idx < sizeof(amo_map) / sizeof(amo_map[0]); ++idx) {
-      for (auto item : template_insn) {
-        char buf[128];
-        sprintf(buf, item.fmt, amo_map[idx].first, 8 << elt);
-        add_insn(new disasm_insn_t(buf,
-                  item.match | amo_map[idx].second | elt_map[elt],
-                  item.mask,
-                  item.arg));
+    DISASM_OPIV_S___INSN(vredsum,   1);
+    DISASM_OPIV_S___INSN(vredand,   1);
+    DISASM_OPIV_S___INSN(vredor,    1);
+    DISASM_OPIV_S___INSN(vredxor,   1);
+    DISASM_OPIV_S___INSN(vredminu,  0);
+    DISASM_OPIV_S___INSN(vredmin,   1);
+    DISASM_OPIV_S___INSN(vredmaxu,  0);
+    DISASM_OPIV_S___INSN(vredmax,   1);
+    DISASM_OPIV__X__INSN(vslide1up,  1);
+    DISASM_OPIV__X__INSN(vslide1down,1);
+
+    //0b01_0000
+    //VWXUNARY0
+    DISASM_INSN("vmv.x.s", vmv_x_s, 0, {&xrd, &vs2});
+    DISASM_INSN("vcpop.m", vcpop_m, 0, {&xrd, &vs2, opt, &vm});
+    DISASM_INSN("vfirst.m", vfirst_m, 0, {&xrd, &vs2, opt, &vm});
+
+    //VRXUNARY0
+    DISASM_INSN("vmv.s.x", vmv_s_x, 0, {&vd, &xrs1});
+
+    //VXUNARY0
+    DEFINE_VECTOR_V(vzext_vf2);
+    DEFINE_VECTOR_V(vsext_vf2);
+    DEFINE_VECTOR_V(vzext_vf4);
+    DEFINE_VECTOR_V(vsext_vf4);
+    DEFINE_VECTOR_V(vzext_vf8);
+    DEFINE_VECTOR_V(vsext_vf8);
+
+    //VMUNARY0
+    DEFINE_VECTOR_V(vmsbf_m);
+    DEFINE_VECTOR_V(vmsof_m);
+    DEFINE_VECTOR_V(vmsif_m);
+    DEFINE_VECTOR_V(viota_m);
+    DISASM_INSN("vid.v", vid_v, 0, {&vd, opt, &vm});
+
+    DISASM_INSN("vid.v", vid_v, 0, {&vd, opt, &vm});
+
+    DISASM_INSN("vcompress.vm", vcompress_vm, 0, {&vd, &vs2, &vs1});
+
+    DISASM_OPIV_M___INSN(vmandn,    1);
+    DISASM_OPIV_M___INSN(vmand,     1);
+    DISASM_OPIV_M___INSN(vmor,      1);
+    DISASM_OPIV_M___INSN(vmxor,     1);
+    DISASM_OPIV_M___INSN(vmorn,     1);
+    DISASM_OPIV_M___INSN(vmnand,    1);
+    DISASM_OPIV_M___INSN(vmnor,     1);
+    DISASM_OPIV_M___INSN(vmxnor,    1);
+
+    //0b10_0000
+    DISASM_OPIV_VX__INSN(vdivu,     0);
+    DISASM_OPIV_VX__INSN(vdiv,      1);
+    DISASM_OPIV_VX__INSN(vremu,     0);
+    DISASM_OPIV_VX__INSN(vrem,      1);
+    DISASM_OPIV_VX__INSN(vmulhu,    0);
+    DISASM_OPIV_VX__INSN(vmul,      1);
+    DISASM_OPIV_VX__INSN(vmulhsu,   0);
+    DISASM_OPIV_VX__INSN(vmulh,     1);
+    DISASM_OPIV_VX__INSN(vmadd,     1);
+    DISASM_OPIV_VX__INSN(vnmsub,    1);
+    DISASM_OPIV_VX__INSN(vmacc,     1);
+    DISASM_OPIV_VX__INSN(vnmsac,    1);
+
+    //0b11_0000
+    DISASM_OPIV_VX__INSN(vwaddu,    0);
+    DISASM_OPIV_VX__INSN(vwadd,     1);
+    DISASM_OPIV_VX__INSN(vwsubu,    0);
+    DISASM_OPIV_VX__INSN(vwsub,     1);
+    DISASM_OPIV_W___INSN(vwaddu,    0);
+    DISASM_OPIV_W___INSN(vwadd,     1);
+    DISASM_OPIV_W___INSN(vwsubu,    0);
+    DISASM_OPIV_W___INSN(vwsub,     1);
+    DISASM_OPIV_VX__INSN(vwmulu,    0);
+    DISASM_OPIV_VX__INSN(vwmulsu,   0);
+    DISASM_OPIV_VX__INSN(vwmul,     1);
+    DISASM_OPIV_VX__INSN(vwmaccu,   0);
+    DISASM_OPIV_VX__INSN(vwmacc,    1);
+    DISASM_OPIV__X__INSN(vwmaccus,  1);
+    DISASM_OPIV_VX__INSN(vwmaccsu,  0);
+
+    #undef DISASM_OPIV_VXI_INSN
+    #undef DISASM_OPIV_VX__INSN
+    #undef DISASM_OPIV__XI_INSN
+    #undef DISASM_OPIV_V___INSN
+    #undef DISASM_OPIV_S___INSN
+    #undef DISASM_OPIV_W___INSN
+    #undef DISASM_OPIV_M___INSN
+    #undef DISASM_OPIV__X__INSN
+    #undef DISASM_OPIV_VXIM_INSN
+    #undef DISASM_OPIV_VX_M_INSN
+
+    #define DISASM_OPIV_VF_INSN(name) \
+      DEFINE_VECTOR_VV(name##_vv); \
+      DEFINE_VECTOR_VF(name##_vf)
+
+    #define DISASM_OPIV_WF_INSN(name) \
+      DEFINE_VECTOR_VV(name##_wv); \
+      DEFINE_VECTOR_VF(name##_wf)
+
+    #define DISASM_OPIV_S__INSN(name) \
+      DEFINE_VECTOR_VV(name##_vs)
+
+    #define DISASM_OPIV__F_INSN(name) \
+      DEFINE_VECTOR_VF(name##_vf)
+
+    #define DISASM_VFUNARY0_INSN(name, suf) \
+      DEFINE_VECTOR_V(name##cvt_rtz_xu_f_##suf); \
+      DEFINE_VECTOR_V(name##cvt_rtz_x_f_##suf); \
+      DEFINE_VECTOR_V(name##cvt_xu_f_##suf); \
+      DEFINE_VECTOR_V(name##cvt_x_f_##suf); \
+      DEFINE_VECTOR_V(name##cvt_f_xu_##suf); \
+      DEFINE_VECTOR_V(name##cvt_f_x_##suf)
+
+    //OPFVV/OPFVF
+    //0b00_0000
+    DISASM_OPIV_VF_INSN(vfadd);
+    DISASM_OPIV_S__INSN(vfredusum);
+    DISASM_OPIV_VF_INSN(vfsub);
+    DISASM_OPIV_S__INSN(vfredosum);
+    DISASM_OPIV_VF_INSN(vfmin);
+    DISASM_OPIV_S__INSN(vfredmin);
+    DISASM_OPIV_VF_INSN(vfmax);
+    DISASM_OPIV_S__INSN(vfredmax);
+    DISASM_OPIV_VF_INSN(vfsgnj);
+    DISASM_OPIV_VF_INSN(vfsgnjn);
+    DISASM_OPIV_VF_INSN(vfsgnjx);
+    DISASM_INSN("vfmv.f.s", vfmv_f_s, 0, {&frd, &vs2});
+    DISASM_INSN("vfmv.s.f", vfmv_s_f, mask_vfmv_s_f, {&vd, &frs1});
+    DISASM_OPIV__F_INSN(vfslide1up);
+    DISASM_OPIV__F_INSN(vfslide1down);
+
+    //0b01_0000
+    DISASM_INSN("vfmerge.vfm", vfmerge_vfm, 0, {&vd, &vs2, &frs1, &v0});
+    DISASM_INSN("vfmv.v.f", vfmv_v_f, 0, {&vd, &frs1});
+    DISASM_OPIV_VF_INSN(vmfeq);
+    DISASM_OPIV_VF_INSN(vmfle);
+    DISASM_OPIV_VF_INSN(vmflt);
+    DISASM_OPIV_VF_INSN(vmfne);
+    DISASM_OPIV__F_INSN(vmfgt);
+    DISASM_OPIV__F_INSN(vmfge);
+
+    //0b10_0000
+    DISASM_OPIV_VF_INSN(vfdiv);
+    DISASM_OPIV__F_INSN(vfrdiv);
+
+    //vfunary0
+    DISASM_VFUNARY0_INSN(vf,  v);
+    DISASM_VFUNARY0_INSN(vfw, v);
+    DEFINE_VECTOR_V(vfwcvt_f_f_v);
+
+    DISASM_VFUNARY0_INSN(vfn, w);
+    DEFINE_VECTOR_V(vfncvt_f_f_w);
+    DEFINE_VECTOR_V(vfncvt_rod_f_f_w);
+
+    //vfunary1
+    DEFINE_VECTOR_V(vfsqrt_v);
+    DEFINE_VECTOR_V(vfrsqrt7_v);
+    DEFINE_VECTOR_V(vfrec7_v);
+    DEFINE_VECTOR_V(vfclass_v);
+
+    DISASM_OPIV_VF_INSN(vfmul);
+    DISASM_OPIV__F_INSN(vfrsub);
+    DISASM_OPIV_VF_INSN(vfmadd);
+    DISASM_OPIV_VF_INSN(vfnmadd);
+    DISASM_OPIV_VF_INSN(vfmsub);
+    DISASM_OPIV_VF_INSN(vfnmsub);
+    DISASM_OPIV_VF_INSN(vfmacc);
+    DISASM_OPIV_VF_INSN(vfnmacc);
+    DISASM_OPIV_VF_INSN(vfmsac);
+    DISASM_OPIV_VF_INSN(vfnmsac);
+
+    //0b11_0000
+    DISASM_OPIV_VF_INSN(vfwadd);
+    DISASM_OPIV_S__INSN(vfwredusum);
+    DISASM_OPIV_VF_INSN(vfwsub);
+    DISASM_OPIV_S__INSN(vfwredosum);
+    DISASM_OPIV_WF_INSN(vfwadd);
+    DISASM_OPIV_WF_INSN(vfwsub);
+    DISASM_OPIV_VF_INSN(vfwmul);
+    DISASM_OPIV_VF_INSN(vfwmacc);
+    DISASM_OPIV_VF_INSN(vfwnmacc);
+    DISASM_OPIV_VF_INSN(vfwmsac);
+    DISASM_OPIV_VF_INSN(vfwnmsac);
+
+    #undef DISASM_OPIV_VF_INSN
+    #undef DISASM_OPIV__F_INSN
+    #undef DISASM_OPIV_S__INSN
+    #undef DISASM_OPIV_W__INSN
+    #undef DISASM_VFUNARY0_INSN
+
+    // vector amo
+    std::vector<const arg_t *> v_fmt_amo_wd = {&vd, &v_address, &vs2, &vd, opt, &vm};
+    std::vector<const arg_t *> v_fmt_amo = {&x0, &v_address, &vs2, &vd, opt, &vm};
+    for (size_t elt = 0; elt <= 3; ++elt) {
+      const custom_fmt_t template_insn[] = {
+        {match_vamoaddei8_v | mask_wd,   mask_vamoaddei8_v | mask_wd,
+          "%sei%d.v", v_fmt_amo_wd},
+        {match_vamoaddei8_v,   mask_vamoaddei8_v | mask_wd,
+          "%sei%d.v", v_fmt_amo},
+      };
+      std::pair<const char*, reg_t> amo_map[] = {
+          {"vamoswap", 0x01ul << 27},
+          {"vamoadd",  0x00ul << 27},
+          {"vamoxor",  0x04ul << 27},
+          {"vamoand",  0x0cul << 27},
+          {"vamoor",   0x08ul << 27},
+          {"vamomin",  0x10ul << 27},
+          {"vamomax",  0x14ul << 27},
+          {"vamominu", 0x18ul << 27},
+          {"vamomaxu", 0x1cul << 27}};
+      const reg_t elt_map[] = {0x0ul << 12,  0x5ul << 12,
+                               0x6ul <<12, 0x7ul << 12};
+
+      for (size_t idx = 0; idx < sizeof(amo_map) / sizeof(amo_map[0]); ++idx) {
+        for (auto item : template_insn) {
+          char buf[128];
+          sprintf(buf, item.fmt, amo_map[idx].first, 8 << elt);
+          add_insn(new disasm_insn_t(buf,
+                    item.match | amo_map[idx].second | elt_map[elt],
+                    item.mask,
+                    item.arg));
+        }
       }
     }
   }
@@ -1541,294 +1577,332 @@ disassembler_t::disassembler_t(int xlen)
 #define DISASM_RINSN_AND_ROUND(code) \
   DEFINE_RTYPE(code); \
   DEFINE_RTYPE(code##_u); \
+  
+  if (isa->extension_enabled(EXT_ZMMUL)) {
+    DEFINE_RTYPE(mul);
+    DEFINE_RTYPE(mulh);
+    DEFINE_RTYPE(mulhu);
+    DEFINE_RTYPE(mulhsu);
+    DEFINE_RTYPE(mulw);
+  }
 
-  DISASM_8_AND_16_RINSN(add);
-  DISASM_8_AND_16_RINSN(radd);
-  DISASM_8_AND_16_RINSN(uradd);
-  DISASM_8_AND_16_RINSN(kadd);
-  DISASM_8_AND_16_RINSN(ukadd);
-  DISASM_8_AND_16_RINSN(sub);
-  DISASM_8_AND_16_RINSN(rsub);
-  DISASM_8_AND_16_RINSN(ursub);
-  DISASM_8_AND_16_RINSN(ksub);
-  DISASM_8_AND_16_RINSN(uksub);
-  DEFINE_RTYPE(cras16);
-  DEFINE_RTYPE(rcras16);
-  DEFINE_RTYPE(urcras16);
-  DEFINE_RTYPE(kcras16);
-  DEFINE_RTYPE(ukcras16);
-  DEFINE_RTYPE(crsa16);
-  DEFINE_RTYPE(rcrsa16);
-  DEFINE_RTYPE(urcrsa16);
-  DEFINE_RTYPE(kcrsa16);
-  DEFINE_RTYPE(ukcrsa16);
-  DEFINE_RTYPE(stas16);
-  DEFINE_RTYPE(rstas16);
-  DEFINE_RTYPE(urstas16);
-  DEFINE_RTYPE(kstas16);
-  DEFINE_RTYPE(ukstas16);
-  DEFINE_RTYPE(stsa16);
-  DEFINE_RTYPE(rstsa16);
-  DEFINE_RTYPE(urstsa16);
-  DEFINE_RTYPE(kstsa16);
-  DEFINE_RTYPE(ukstsa16);
+  if (isa->extension_enabled(EXT_ZBPBO)) {
+    DEFINE_RTYPE(min);
+    DEFINE_RTYPE(max);
+    DEFINE_R3TYPE(cmix);
+    DEFINE_RTYPE(pack);
+    DEFINE_RTYPE(packu);
+    add_insn(new disasm_insn_t("rev", match_grevi | ((isa->get_max_xlen() - 1) << imm_shift), mask_grevi | mask_imm, {&xrd, &xrs1}));
+    add_insn(new disasm_insn_t("rev8.h", match_grevi | (0x8 << imm_shift), mask_grevi | mask_imm, {&xrd, &xrs1})); // swap16
+    if (isa->get_max_xlen() == 32) {
+      DEFINE_R1TYPE(clz);
+      DEFINE_R3TYPE(fsr);
+      DEFINE_R3TYPE(fsri);
+    } else {
+      DEFINE_R3TYPE(fsrw);
+    }
+  }
 
-  DISASM_8_AND_16_RINSN(sra);
-  DISASM_8_AND_16_RINSN(srl);
-  DISASM_8_AND_16_RINSN(sll);
-  DISASM_8_AND_16_RINSN(ksll);
-  DISASM_8_AND_16_RINSN(kslra);
-  DISASM_8_AND_16_PIINSN(srai);
-  DISASM_8_AND_16_PIINSN(srli);
-  DISASM_8_AND_16_PIINSN(slli);
-  DISASM_8_AND_16_PIINSN(kslli);
-  DISASM_8_AND_16_RINSN_ROUND(sra);
-  DISASM_8_AND_16_RINSN_ROUND(srl);
-  DISASM_8_AND_16_RINSN_ROUND(kslra);
-  DISASM_8_AND_16_PIINSN_ROUND(srai);
-  DISASM_8_AND_16_PIINSN_ROUND(srli);
+  if (isa->extension_enabled(EXT_ZPSFOPERAND)) {
+    DEFINE_RTYPE(smal)
+    DEFINE_RTYPE(radd64);
+    DEFINE_RTYPE(uradd64);
+    DEFINE_RTYPE(kadd64);
+    DEFINE_RTYPE(ukadd64);
+    DEFINE_RTYPE(rsub64);
+    DEFINE_RTYPE(ursub64);
+    DEFINE_RTYPE(ksub64);
+    DEFINE_RTYPE(uksub64);
+    DEFINE_RTYPE(smar64);
+    DEFINE_RTYPE(smsr64);
+    DEFINE_RTYPE(umar64);
+    DEFINE_RTYPE(umsr64);
+    DEFINE_RTYPE(kmar64);
+    DEFINE_RTYPE(kmsr64);
+    DEFINE_RTYPE(ukmar64);
+    DEFINE_RTYPE(ukmsr64);
+    DEFINE_RTYPE(smalbb);
+    DEFINE_RTYPE(smalbt);
+    DEFINE_RTYPE(smaltt);
+    DEFINE_RTYPE(smalda);
+    DEFINE_RTYPE(smalxda);
+    DEFINE_RTYPE(smalds);
+    DEFINE_RTYPE(smaldrs);
+    DEFINE_RTYPE(smalxds);
+    DEFINE_RTYPE(smslda);
+    DEFINE_RTYPE(smslxda);
+    DEFINE_RTYPE(mulr64);
+    DEFINE_RTYPE(mulsr64);
+    if (isa->get_max_xlen() == 32) {
+      DEFINE_RTYPE(add64);
+      DEFINE_RTYPE(sub64);
+    }
+  }
 
-  DISASM_8_AND_16_RINSN(cmpeq);
-  DISASM_8_AND_16_RINSN(scmplt);
-  DISASM_8_AND_16_RINSN(scmple);
-  DISASM_8_AND_16_RINSN(ucmplt);
-  DISASM_8_AND_16_RINSN(ucmple);
+  if (isa->extension_enabled(EXT_ZPN)) {
+    DISASM_8_AND_16_RINSN(add);
+    DISASM_8_AND_16_RINSN(radd);
+    DISASM_8_AND_16_RINSN(uradd);
+    DISASM_8_AND_16_RINSN(kadd);
+    DISASM_8_AND_16_RINSN(ukadd);
+    DISASM_8_AND_16_RINSN(sub);
+    DISASM_8_AND_16_RINSN(rsub);
+    DISASM_8_AND_16_RINSN(ursub);
+    DISASM_8_AND_16_RINSN(ksub);
+    DISASM_8_AND_16_RINSN(uksub);
+    DEFINE_RTYPE(cras16);
+    DEFINE_RTYPE(rcras16);
+    DEFINE_RTYPE(urcras16);
+    DEFINE_RTYPE(kcras16);
+    DEFINE_RTYPE(ukcras16);
+    DEFINE_RTYPE(crsa16);
+    DEFINE_RTYPE(rcrsa16);
+    DEFINE_RTYPE(urcrsa16);
+    DEFINE_RTYPE(kcrsa16);
+    DEFINE_RTYPE(ukcrsa16);
+    DEFINE_RTYPE(stas16);
+    DEFINE_RTYPE(rstas16);
+    DEFINE_RTYPE(urstas16);
+    DEFINE_RTYPE(kstas16);
+    DEFINE_RTYPE(ukstas16);
+    DEFINE_RTYPE(stsa16);
+    DEFINE_RTYPE(rstsa16);
+    DEFINE_RTYPE(urstsa16);
+    DEFINE_RTYPE(kstsa16);
+    DEFINE_RTYPE(ukstsa16);
+    DISASM_8_AND_16_RINSN(sra);
+    DISASM_8_AND_16_RINSN(srl);
+    DISASM_8_AND_16_RINSN(sll);
+    DISASM_8_AND_16_RINSN(ksll);
+    DISASM_8_AND_16_RINSN(kslra);
+    DISASM_8_AND_16_PIINSN(srai);
+    DISASM_8_AND_16_PIINSN(srli);
+    DISASM_8_AND_16_PIINSN(slli);
+    DISASM_8_AND_16_PIINSN(kslli);
+    DISASM_8_AND_16_RINSN_ROUND(sra);
+    DISASM_8_AND_16_RINSN_ROUND(srl);
+    DISASM_8_AND_16_RINSN_ROUND(kslra);
+    DISASM_8_AND_16_PIINSN_ROUND(srai);
+    DISASM_8_AND_16_PIINSN_ROUND(srli);
 
-  DISASM_8_AND_16_RINSN(smul);
-  DISASM_8_AND_16_RINSN(smulx);
-  DISASM_8_AND_16_RINSN(umul);
-  DISASM_8_AND_16_RINSN(umulx);
-  DISASM_8_AND_16_RINSN(khm);
-  DISASM_8_AND_16_RINSN(khmx);
+    DISASM_8_AND_16_RINSN(cmpeq);
+    DISASM_8_AND_16_RINSN(scmplt);
+    DISASM_8_AND_16_RINSN(scmple);
+    DISASM_8_AND_16_RINSN(ucmplt);
+    DISASM_8_AND_16_RINSN(ucmple);
 
-  DISASM_8_AND_16_RINSN(smin);
-  DISASM_8_AND_16_RINSN(umin);
-  DISASM_8_AND_16_RINSN(smax);
-  DISASM_8_AND_16_RINSN(umax);
-  DISASM_8_AND_16_PIINSN(sclip);
-  DISASM_8_AND_16_PIINSN(uclip);
-  DEFINE_R1TYPE(kabs16);
-  DEFINE_R1TYPE(clrs16);
-  DEFINE_R1TYPE(clz16);
-  DEFINE_R1TYPE(kabs8);
-  DEFINE_R1TYPE(clrs8);
-  DEFINE_R1TYPE(clz8);
+    DISASM_8_AND_16_RINSN(smul);
+    DISASM_8_AND_16_RINSN(smulx);
+    DISASM_8_AND_16_RINSN(umul);
+    DISASM_8_AND_16_RINSN(umulx);
+    DISASM_8_AND_16_RINSN(khm);
+    DISASM_8_AND_16_RINSN(khmx);
 
-  DEFINE_R1TYPE(sunpkd810);
-  DEFINE_R1TYPE(sunpkd820);
-  DEFINE_R1TYPE(sunpkd830);
-  DEFINE_R1TYPE(sunpkd831);
-  DEFINE_R1TYPE(sunpkd832);
-  DEFINE_R1TYPE(zunpkd810);
-  DEFINE_R1TYPE(zunpkd820);
-  DEFINE_R1TYPE(zunpkd830);
-  DEFINE_R1TYPE(zunpkd831);
-  DEFINE_R1TYPE(zunpkd832);
+    DISASM_8_AND_16_RINSN(smin);
+    DISASM_8_AND_16_RINSN(umin);
+    DISASM_8_AND_16_RINSN(smax);
+    DISASM_8_AND_16_RINSN(umax);
+    DISASM_8_AND_16_PIINSN(sclip);
+    DISASM_8_AND_16_PIINSN(uclip);
+    DEFINE_R1TYPE(kabs16);
+    DEFINE_R1TYPE(clrs16);
+    DEFINE_R1TYPE(clz16);
+    DEFINE_R1TYPE(kabs8);
+    DEFINE_R1TYPE(clrs8);
+    DEFINE_R1TYPE(clz8);
 
-  DEFINE_RTYPE(pkbb16);
-  DEFINE_RTYPE(pkbt16);
-  DEFINE_RTYPE(pktb16);
-  DEFINE_RTYPE(pktt16);
-  DISASM_RINSN_AND_ROUND(smmul);
-  DISASM_RINSN_AND_ROUND(kmmac);
-  DISASM_RINSN_AND_ROUND(kmmsb);
-  DISASM_RINSN_AND_ROUND(kwmmul);
-  DISASM_RINSN_AND_ROUND(smmwb);
-  DISASM_RINSN_AND_ROUND(smmwt);
-  DISASM_RINSN_AND_ROUND(kmmawb);
-  DISASM_RINSN_AND_ROUND(kmmawt);
-  DISASM_RINSN_AND_ROUND(kmmwb2);
-  DISASM_RINSN_AND_ROUND(kmmwt2);
-  DISASM_RINSN_AND_ROUND(kmmawb2);
-  DISASM_RINSN_AND_ROUND(kmmawt2);
-  DEFINE_RTYPE(smbb16)
-  DEFINE_RTYPE(smbt16)
-  DEFINE_RTYPE(smtt16)
-  DEFINE_RTYPE(kmda)
-  DEFINE_RTYPE(kmxda)
-  DEFINE_RTYPE(smds)
-  DEFINE_RTYPE(smdrs)
-  DEFINE_RTYPE(smxds)
-  DEFINE_RTYPE(kmabb)
-  DEFINE_RTYPE(kmabt)
-  DEFINE_RTYPE(kmatt)
-  DEFINE_RTYPE(kmada)
-  DEFINE_RTYPE(kmaxda)
-  DEFINE_RTYPE(kmads)
-  DEFINE_RTYPE(kmadrs)
-  DEFINE_RTYPE(kmaxds)
-  DEFINE_RTYPE(kmsda)
-  DEFINE_RTYPE(kmsxda)
-  DEFINE_RTYPE(smal)
-  DEFINE_RTYPE(sclip32)
-  DEFINE_RTYPE(uclip32)
-  DEFINE_R1TYPE(clrs32);
-  DEFINE_R1TYPE(clz32);
-  DEFINE_RTYPE(pbsad);
-  DEFINE_RTYPE(pbsada);
-  DEFINE_RTYPE(smaqa);
-  DEFINE_RTYPE(umaqa);
-  DEFINE_RTYPE(smaqa_su);
+    DEFINE_R1TYPE(sunpkd810);
+    DEFINE_R1TYPE(sunpkd820);
+    DEFINE_R1TYPE(sunpkd830);
+    DEFINE_R1TYPE(sunpkd831);
+    DEFINE_R1TYPE(sunpkd832);
+    DEFINE_R1TYPE(zunpkd810);
+    DEFINE_R1TYPE(zunpkd820);
+    DEFINE_R1TYPE(zunpkd830);
+    DEFINE_R1TYPE(zunpkd831);
+    DEFINE_R1TYPE(zunpkd832);
 
-  DEFINE_RTYPE(radd64);
-  DEFINE_RTYPE(uradd64);
-  DEFINE_RTYPE(kadd64);
-  DEFINE_RTYPE(ukadd64);
-  DEFINE_RTYPE(rsub64);
-  DEFINE_RTYPE(ursub64);
-  DEFINE_RTYPE(ksub64);
-  DEFINE_RTYPE(uksub64);
-  DEFINE_RTYPE(smar64);
-  DEFINE_RTYPE(smsr64);
-  DEFINE_RTYPE(umar64);
-  DEFINE_RTYPE(umsr64);
-  DEFINE_RTYPE(kmar64);
-  DEFINE_RTYPE(kmsr64);
-  DEFINE_RTYPE(ukmar64);
-  DEFINE_RTYPE(ukmsr64);
-  DEFINE_RTYPE(smalbb);
-  DEFINE_RTYPE(smalbt);
-  DEFINE_RTYPE(smaltt);
-  DEFINE_RTYPE(smalda);
-  DEFINE_RTYPE(smalxda);
-  DEFINE_RTYPE(smalds);
-  DEFINE_RTYPE(smaldrs);
-  DEFINE_RTYPE(smalxds);
-  DEFINE_RTYPE(smslda);
-  DEFINE_RTYPE(smslxda);
+    DEFINE_RTYPE(pkbb16);
+    DEFINE_RTYPE(pkbt16);
+    DEFINE_RTYPE(pktb16);
+    DEFINE_RTYPE(pktt16);
+    DISASM_RINSN_AND_ROUND(smmul);
+    DISASM_RINSN_AND_ROUND(kmmac);
+    DISASM_RINSN_AND_ROUND(kmmsb);
+    DISASM_RINSN_AND_ROUND(kwmmul);
+    DISASM_RINSN_AND_ROUND(smmwb);
+    DISASM_RINSN_AND_ROUND(smmwt);
+    DISASM_RINSN_AND_ROUND(kmmawb);
+    DISASM_RINSN_AND_ROUND(kmmawt);
+    DISASM_RINSN_AND_ROUND(kmmwb2);
+    DISASM_RINSN_AND_ROUND(kmmwt2);
+    DISASM_RINSN_AND_ROUND(kmmawb2);
+    DISASM_RINSN_AND_ROUND(kmmawt2);
+    DEFINE_RTYPE(smbb16)
+    DEFINE_RTYPE(smbt16)
+    DEFINE_RTYPE(smtt16)
+    DEFINE_RTYPE(kmda)
+    DEFINE_RTYPE(kmxda)
+    DEFINE_RTYPE(smds)
+    DEFINE_RTYPE(smdrs)
+    DEFINE_RTYPE(smxds)
+    DEFINE_RTYPE(kmabb)
+    DEFINE_RTYPE(kmabt)
+    DEFINE_RTYPE(kmatt)
+    DEFINE_RTYPE(kmada)
+    DEFINE_RTYPE(kmaxda)
+    DEFINE_RTYPE(kmads)
+    DEFINE_RTYPE(kmadrs)
+    DEFINE_RTYPE(kmaxds)
+    DEFINE_RTYPE(kmsda)
+    DEFINE_RTYPE(kmsxda)
+    DEFINE_RTYPE(sclip32)
+    DEFINE_RTYPE(uclip32)
+    DEFINE_R1TYPE(clrs32);
+    DEFINE_R1TYPE(clz32);
+    DEFINE_RTYPE(pbsad);
+    DEFINE_RTYPE(pbsada);
+    DEFINE_RTYPE(smaqa);
+    DEFINE_RTYPE(umaqa);
+    DEFINE_RTYPE(smaqa_su);
 
-  DEFINE_RTYPE(kaddh);
-  DEFINE_RTYPE(ksubh);
-  DEFINE_RTYPE(khmbb);
-  DEFINE_RTYPE(khmbt);
-  DEFINE_RTYPE(khmtt);
-  DEFINE_RTYPE(ukaddh);
-  DEFINE_RTYPE(uksubh);
-  DEFINE_RTYPE(kaddw);
-  DEFINE_RTYPE(ukaddw);
-  DEFINE_RTYPE(ksubw);
-  DEFINE_RTYPE(uksubw);
-  DEFINE_RTYPE(kdmbb);
-  DEFINE_RTYPE(kdmbt);
-  DEFINE_RTYPE(kdmtt);
-  DEFINE_RTYPE(kslraw);
-  DEFINE_RTYPE(kslraw_u);
-  DEFINE_RTYPE(ksllw);
-  DEFINE_PI5TYPE(kslliw);
-  DEFINE_RTYPE(kdmabb);
-  DEFINE_RTYPE(kdmabt);
-  DEFINE_RTYPE(kdmatt);
-  DEFINE_RTYPE(kabsw);
-  DEFINE_RTYPE(raddw);
-  DEFINE_RTYPE(uraddw);
-  DEFINE_RTYPE(rsubw);
-  DEFINE_RTYPE(ursubw);
-  DEFINE_RTYPE(max);
-  DEFINE_RTYPE(min);
-  DEFINE_RTYPE(mulr64);
-  DEFINE_RTYPE(mulsr64);
-  DEFINE_RTYPE(msubr32);
-  DEFINE_RTYPE(ave);
-  DEFINE_RTYPE(sra_u);
-  DEFINE_PI5TYPE(srai_u);
-  DEFINE_PI3TYPE(insb);
-  DEFINE_RTYPE(maddr32)
+    DEFINE_RTYPE(kaddh);
+    DEFINE_RTYPE(ksubh);
+    DEFINE_RTYPE(khmbb);
+    DEFINE_RTYPE(khmbt);
+    DEFINE_RTYPE(khmtt);
+    DEFINE_RTYPE(ukaddh);
+    DEFINE_RTYPE(uksubh);
+    DEFINE_RTYPE(kaddw);
+    DEFINE_RTYPE(ukaddw);
+    DEFINE_RTYPE(ksubw);
+    DEFINE_RTYPE(uksubw);
+    DEFINE_RTYPE(kdmbb);
+    DEFINE_RTYPE(kdmbt);
+    DEFINE_RTYPE(kdmtt);
+    DEFINE_RTYPE(kslraw);
+    DEFINE_RTYPE(kslraw_u);
+    DEFINE_RTYPE(ksllw);
+    DEFINE_PI5TYPE(kslliw);
+    DEFINE_RTYPE(kdmabb);
+    DEFINE_RTYPE(kdmabt);
+    DEFINE_RTYPE(kdmatt);
+    DEFINE_RTYPE(kabsw);
+    DEFINE_RTYPE(raddw);
+    DEFINE_RTYPE(uraddw);
+    DEFINE_RTYPE(rsubw);
+    DEFINE_RTYPE(ursubw);
+    DEFINE_RTYPE(msubr32);
+    DEFINE_RTYPE(ave);
+    DEFINE_RTYPE(sra_u);
+    DEFINE_PI5TYPE(srai_u);
+    DEFINE_PI3TYPE(insb);
+    DEFINE_RTYPE(maddr32)
 
-  if (xlen == 32) {
-    DISASM_INSN("c.flw", c_flw, 0, {&rvc_fp_rs2s, &rvc_lw_address});
-    DISASM_INSN("c.flwsp", c_flwsp, 0, {&frd, &rvc_lwsp_address});
-    DISASM_INSN("c.fsw", c_fsw, 0, {&rvc_fp_rs2s, &rvc_lw_address});
-    DISASM_INSN("c.fswsp", c_fswsp, 0, {&rvc_fp_rs2, &rvc_swsp_address});
-    DISASM_INSN("c.jal", c_jal, 0, {&rvc_jump_target});
+    if (isa->get_max_xlen() == 64) {
+      DEFINE_RTYPE(add32);
+      DEFINE_RTYPE(radd32);
+      DEFINE_RTYPE(uradd32);
+      DEFINE_RTYPE(kadd32);
+      DEFINE_RTYPE(ukadd32);
+      DEFINE_RTYPE(sub32);
+      DEFINE_RTYPE(rsub32);
+      DEFINE_RTYPE(ursub32);
+      DEFINE_RTYPE(ksub32);
+      DEFINE_RTYPE(uksub32);
+      DEFINE_RTYPE(cras32);
+      DEFINE_RTYPE(rcras32);
+      DEFINE_RTYPE(urcras32);
+      DEFINE_RTYPE(kcras32);
+      DEFINE_RTYPE(ukcras32);
+      DEFINE_RTYPE(crsa32);
+      DEFINE_RTYPE(rcrsa32);
+      DEFINE_RTYPE(urcrsa32);
+      DEFINE_RTYPE(kcrsa32);
+      DEFINE_RTYPE(ukcrsa32);
+      DEFINE_RTYPE(stas32);
+      DEFINE_RTYPE(rstas32);
+      DEFINE_RTYPE(urstas32);
+      DEFINE_RTYPE(kstas32);
+      DEFINE_RTYPE(ukstas32);
+      DEFINE_RTYPE(stsa32);
+      DEFINE_RTYPE(rstsa32);
+      DEFINE_RTYPE(urstsa32);
+      DEFINE_RTYPE(kstsa32);
+      DEFINE_RTYPE(ukstsa32);
+      DEFINE_RTYPE(sra32);
+      DEFINE_PI5TYPE(srai32);
+      DEFINE_RTYPE(sra32_u);
+      DEFINE_PI5TYPE(srai32_u);
+      DEFINE_RTYPE(srl32);
+      DEFINE_PI5TYPE(srli32);
+      DEFINE_RTYPE(srl32_u);
+      DEFINE_PI5TYPE(srli32_u);
+      DEFINE_RTYPE(sll32);
+      DEFINE_PI5TYPE(slli32);
+      DEFINE_RTYPE(ksll32);
+      DEFINE_PI5TYPE(kslli32);
+      DEFINE_RTYPE(kslra32);
+      DEFINE_RTYPE(kslra32_u);
+      DEFINE_RTYPE(smin32);
+      DEFINE_RTYPE(umin32);
+      DEFINE_RTYPE(smax32);
+      DEFINE_RTYPE(umax32);
+      DEFINE_R1TYPE(kabs32);
+      DEFINE_RTYPE(khmbb16);
+      DEFINE_RTYPE(khmbt16);
+      DEFINE_RTYPE(khmtt16);
+      DEFINE_RTYPE(kdmbb16);
+      DEFINE_RTYPE(kdmbt16);
+      DEFINE_RTYPE(kdmtt16);
+      DEFINE_RTYPE(kdmabb16);
+      DEFINE_RTYPE(kdmabt16);
+      DEFINE_RTYPE(kdmatt16);
+      DEFINE_RTYPE(smbt32);
+      DEFINE_RTYPE(smtt32);
+      DEFINE_RTYPE(kmabb32);
+      DEFINE_RTYPE(kmabt32);
+      DEFINE_RTYPE(kmatt32);
+      DEFINE_RTYPE(kmda32);
+      DEFINE_RTYPE(kmxda32);
+      DEFINE_RTYPE(kmaxda32);
+      DEFINE_RTYPE(kmads32);
+      DEFINE_RTYPE(kmadrs32);
+      DEFINE_RTYPE(kmaxds32);
+      DEFINE_RTYPE(kmsda32);
+      DEFINE_RTYPE(kmsxda32);
+      DEFINE_RTYPE(smds32);
+      DEFINE_RTYPE(smdrs32);
+      DEFINE_RTYPE(smxds32);
+      DEFINE_PI5TYPE(sraiw_u);
+      DEFINE_RTYPE(pkbb32);
+      DEFINE_RTYPE(pkbt32);
+      DEFINE_RTYPE(pktb32);
+      DEFINE_RTYPE(pktt32);
+    }
+  }
 
-    DEFINE_RTYPE(add64);
-    DEFINE_RTYPE(sub64);
-  } else {
-    DISASM_INSN("c.ld", c_ld, 0, {&rvc_rs2s, &rvc_ld_address});
-    DISASM_INSN("c.ldsp", c_ldsp, 0, {&xrd, &rvc_ldsp_address});
-    DISASM_INSN("c.sd", c_sd, 0, {&rvc_rs2s, &rvc_ld_address});
-    DISASM_INSN("c.sdsp", c_sdsp, 0, {&rvc_rs2, &rvc_sdsp_address});
-    DISASM_INSN("c.addiw", c_addiw, 0, {&xrd, &rvc_imm});
+  if (isa->extension_enabled(EXT_XBITMANIP)) {
+    DEFINE_ITYPE_SHIFT(grevi);
+    DEFINE_ITYPE_SHIFT(gorci);
+    DEFINE_RTYPE(pack);
+    DEFINE_RTYPE(packh);
+    DEFINE_RTYPE(packu);
+    DEFINE_RTYPE(grev);
+    DEFINE_RTYPE(gorc);
+    DEFINE_RTYPE(xperm4);
+    DEFINE_RTYPE(xperm8);
+    DEFINE_RTYPE(xperm16);
+    DEFINE_RTYPE(xperm32);
 
-    DEFINE_RTYPE(add32);
-    DEFINE_RTYPE(radd32);
-    DEFINE_RTYPE(uradd32);
-    DEFINE_RTYPE(kadd32);
-    DEFINE_RTYPE(ukadd32);
-    DEFINE_RTYPE(sub32);
-    DEFINE_RTYPE(rsub32);
-    DEFINE_RTYPE(ursub32);
-    DEFINE_RTYPE(ksub32);
-    DEFINE_RTYPE(uksub32);
-    DEFINE_RTYPE(cras32);
-    DEFINE_RTYPE(rcras32);
-    DEFINE_RTYPE(urcras32);
-    DEFINE_RTYPE(kcras32);
-    DEFINE_RTYPE(ukcras32);
-    DEFINE_RTYPE(crsa32);
-    DEFINE_RTYPE(rcrsa32);
-    DEFINE_RTYPE(urcrsa32);
-    DEFINE_RTYPE(kcrsa32);
-    DEFINE_RTYPE(ukcrsa32);
-    DEFINE_RTYPE(stas32);
-    DEFINE_RTYPE(rstas32);
-    DEFINE_RTYPE(urstas32);
-    DEFINE_RTYPE(kstas32);
-    DEFINE_RTYPE(ukstas32);
-    DEFINE_RTYPE(stsa32);
-    DEFINE_RTYPE(rstsa32);
-    DEFINE_RTYPE(urstsa32);
-    DEFINE_RTYPE(kstsa32);
-    DEFINE_RTYPE(ukstsa32);
-    DEFINE_RTYPE(sra32);
-    DEFINE_PI5TYPE(srai32);
-    DEFINE_RTYPE(sra32_u);
-    DEFINE_PI5TYPE(srai32_u);
-    DEFINE_RTYPE(srl32);
-    DEFINE_PI5TYPE(srli32);
-    DEFINE_RTYPE(srl32_u);
-    DEFINE_PI5TYPE(srli32_u);
-    DEFINE_RTYPE(sll32);
-    DEFINE_PI5TYPE(slli32);
-    DEFINE_RTYPE(ksll32);
-    DEFINE_PI5TYPE(kslli32);
-    DEFINE_RTYPE(kslra32);
-    DEFINE_RTYPE(kslra32_u);
-    DEFINE_RTYPE(smin32);
-    DEFINE_RTYPE(umin32);
-    DEFINE_RTYPE(smax32);
-    DEFINE_RTYPE(umax32);
-    DEFINE_R1TYPE(kabs32);
-    DEFINE_RTYPE(khmbb16);
-    DEFINE_RTYPE(khmbt16);
-    DEFINE_RTYPE(khmtt16);
-    DEFINE_RTYPE(kdmbb16);
-    DEFINE_RTYPE(kdmbt16);
-    DEFINE_RTYPE(kdmtt16);
-    DEFINE_RTYPE(kdmabb16);
-    DEFINE_RTYPE(kdmabt16);
-    DEFINE_RTYPE(kdmatt16);
-    DEFINE_RTYPE(smbt32);
-    DEFINE_RTYPE(smtt32);
-    DEFINE_RTYPE(kmabb32);
-    DEFINE_RTYPE(kmabt32);
-    DEFINE_RTYPE(kmatt32);
-    DEFINE_RTYPE(kmda32);
-    DEFINE_RTYPE(kmxda32);
-    DEFINE_RTYPE(kmaxda32);
-    DEFINE_RTYPE(kmads32);
-    DEFINE_RTYPE(kmadrs32);
-    DEFINE_RTYPE(kmaxds32);
-    DEFINE_RTYPE(kmsda32);
-    DEFINE_RTYPE(kmsxda32);
-    DEFINE_RTYPE(smds32);
-    DEFINE_RTYPE(smdrs32);
-    DEFINE_RTYPE(smxds32);
-    DEFINE_PI5TYPE(sraiw_u);
-    DEFINE_RTYPE(pkbb32);
-    DEFINE_RTYPE(pkbt32);
-    DEFINE_RTYPE(pktb32);
-    DEFINE_RTYPE(pktt32);
+    DEFINE_R3TYPE(cmix);
+    DEFINE_R3TYPE(fsr);
+    DEFINE_R3TYPE(fsri);
+    if(isa->get_max_xlen() == 64) {
+      DEFINE_RTYPE(packw);
+      DEFINE_R3TYPE(fsriw);
+      DEFINE_R3TYPE(fsrw);
+    }
   }
 
   add_unknown_insns(this);

--- a/riscv/disasm.h
+++ b/riscv/disasm.h
@@ -4,6 +4,7 @@
 #define _RISCV_DISASM_H
 
 #include "decode.h"
+#include "processor.h"
 #include <string>
 #include <sstream>
 #include <algorithm>
@@ -80,7 +81,7 @@ class disasm_insn_t
 class disassembler_t
 {
  public:
-  disassembler_t(int xlen);
+  disassembler_t(isa_parser_t* isa);
   ~disassembler_t();
 
   std::string disassemble(insn_t insn) const;

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -39,7 +39,7 @@ processor_t::processor_t(const char* isa, const char* priv, const char* varch,
   register_base_instructions();
   mmu = new mmu_t(sim, this);
 
-  disassembler = new disassembler_t(max_xlen);
+  disassembler = new disassembler_t(this);
   for (auto e : custom_extensions)
     register_extension(e.second);
 

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -26,14 +26,13 @@
 processor_t::processor_t(const char* isa, const char* priv, const char* varch,
                          simif_t* sim, uint32_t id, bool halt_on_reset,
                          FILE* log_file, std::ostream& sout_)
-  : debug(false), halt_request(HR_NONE), sim(sim), id(id), xlen(0),
+  : isa_parser_t(isa), debug(false), halt_request(HR_NONE), sim(sim), id(id), xlen(0),
   histogram_enabled(false), log_commits_enabled(false),
   log_file(log_file), sout_(sout_.rdbuf()), halt_on_reset(halt_on_reset),
-  extension_table(256, false), impl_table(256, false), last_pc(1), executions(1)
+  impl_table(256, false), last_pc(1), executions(1)
 {
   VU.p = this;
 
-  parse_isa_string(isa);
   parse_priv_string(priv);
   parse_varch_string(varch);
 
@@ -42,8 +41,7 @@ processor_t::processor_t(const char* isa, const char* priv, const char* varch,
 
   disassembler = new disassembler_t(max_xlen);
   for (auto e : custom_extensions)
-    for (auto disasm_insn : e.second->get_disasms())
-      disassembler->add_insn(disasm_insn);
+    register_extension(e.second);
 
   set_pmp_granularity(1 << PMP_SHIFT);
   set_pmp_num(state.max_pmp);
@@ -195,7 +193,8 @@ void processor_t::parse_priv_string(const char* str)
   }
 }
 
-void processor_t::parse_isa_string(const char* str)
+isa_parser_t::isa_parser_t(const char* str)
+  : extension_table(256, false)
 {
   isa_string = strtolower(str);
   const char* all_subsets = "mafdqchp"
@@ -344,7 +343,12 @@ void processor_t::parse_isa_string(const char* str)
       } else if (ext_str.size() == 1) {
         bad_isa_string(str, "single 'X' is not a proper name");
       } else if (ext_str != "xdummy") {
-        register_extension(find_extension(ext_str.substr(1).c_str())());
+         extension_t* x = find_extension(ext_str.substr(1).c_str())();
+         if (!custom_extensions.insert(std::make_pair(x->name(), x)).second) {
+           fprintf(stderr, "extensions must have unique names (got two named \"%s\"!)\n", x->name());
+           abort();
+         }
+
       }
     } else {
       bad_isa_string(str, ("unsupported extension: " + ext_str).c_str());
@@ -1095,14 +1099,8 @@ void processor_t::register_extension(extension_t* x)
     register_insn(insn);
   build_opcode_map();
 
-  if (disassembler)
-    for (auto disasm_insn : x->get_disasms())
-      disassembler->add_insn(disasm_insn);
-
-  if (!custom_extensions.insert(std::make_pair(x->name(), x)).second) {
-    fprintf(stderr, "extensions must have unique names (got two named \"%s\"!)\n", x->name());
-    abort();
-  }
+  for (auto disasm_insn : x->get_disasms())
+    disassembler->add_insn(disasm_insn);
 
   x->set_processor(this);
 }

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -268,6 +268,10 @@ typedef enum {
   EXT_SVNAPOT,
   EXT_SVPBMT,
   EXT_SVINVAL,
+  EXT_ZDINX,
+  EXT_ZFINX,
+  EXT_ZHINX,
+  EXT_ZHINXMIN,
   EXT_XBITMANIP,
 } isa_extension_t;
 

--- a/spike_dasm/spike-dasm.cc
+++ b/spike_dasm/spike-dasm.cc
@@ -28,7 +28,7 @@ int main(int argc, char** argv)
   parser.parse(argv);
 
   isa_parser_t isa_parser(isa);
-  disassembler_t* disassembler = new disassembler_t(isa_parser.get_max_xlen());
+  disassembler_t* disassembler = new disassembler_t(&isa_parser);
   if (extension) {
     for (auto disasm_insn : extension()->get_disasms()) {
       disassembler->add_insn(disasm_insn);

--- a/spike_dasm/spike-dasm.cc
+++ b/spike_dasm/spike-dasm.cc
@@ -27,21 +27,8 @@ int main(int argc, char** argv)
   parser.option(0, "isa", 1, [&](const char* s){isa = s;});
   parser.parse(argv);
 
-  std::string lowercase;
-  for (const char *p = isa; *p; p++)
-    lowercase += std::tolower(*p);
-
-  int xlen;
-  if (lowercase.compare(0, 4, "rv32") == 0) {
-    xlen = 32;
-  } else if (lowercase.compare(0, 4, "rv64") == 0) {
-    xlen = 64;
-  } else {
-    fprintf(stderr, "bad ISA string: %s\n", isa);
-    return 1;
-  }
-
-  disassembler_t* disassembler = new disassembler_t(xlen);
+  isa_parser_t isa_parser(isa);
+  disassembler_t* disassembler = new disassembler_t(isa_parser.get_max_xlen());
   if (extension) {
     for (auto disasm_insn : extension()->get_disasms()) {
       disassembler->add_insn(disasm_insn);

--- a/spike_dasm/spike_dasm.mk.in
+++ b/spike_dasm/spike_dasm.mk.in
@@ -1,5 +1,6 @@
 spike_dasm_subproject_deps = \
 	disasm \
+  softfloat \
   $(if $(HAVE_DLOPEN),riscv,) \
 
 spike_dasm_srcs = \


### PR DESCRIPTION
There are many encoding overlaps for different extensions currently, such as Zfinx/Zdinx/Zhinx{min} with 'F'/'D'/'Zfh{min}', Zce(Zcmb, Zcmp, Zcmt) with 'D', cmo(Zicboz, Zicbom) with RV128(lq instruction). 
However, In current disas support, only xlen is passed to disassembler  which make it difficult to distinguish the overlaped instructions.
In this PR, we try to bind the disas support for instructions with  extension to solve this problem:
- Firstly, we use an unified ISA-string processing in spike-dasm and spike (partitioned from https://github.com/riscv-software-src/riscv-isa-sim/pull/831). 
- Then, we try to only add the disas support for instructions within the enabled extension in the ISA string.
- Finally, we add the disas support for Zfinx as a example.
