### PR TITLE
Fix libdir and includedir in pkg-config files

### DIFF
--- a/riscv-disasm.pc.in
+++ b/riscv-disasm.pc.in
@@ -1,7 +1,7 @@
 prefix=@prefix@
 exec_prefix=@prefix@
-libdir=${prefix}/@libdir@
-includedir=${prefix}/@includedir@
+libdir=@libdir@
+includedir=@includedir@
 
 Name: riscv-disasm
 Description: RISC-V disassembler

--- a/riscv-fesvr.pc.in
+++ b/riscv-fesvr.pc.in
@@ -1,7 +1,7 @@
 prefix=@prefix@
 exec_prefix=@prefix@
-libdir=${prefix}/@libdir@
-includedir=${prefix}/@includedir@
+libdir=@libdir@
+includedir=@includedir@
 
 Name: riscv-fesvr
 Description: RISC-V front-end server


### PR DESCRIPTION
The autoconf `@libdir@` and `@includedir@` variables include the
prefix part so we were generating things like "`/usr//usr/lib`".