### PR TITLE
Split Xbitmanip into its proposed component extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,14 @@ is provided under the Spike-custom extension name _Xbitmanip_.
 These instructions (and, of course, the extension name) are not RISC-V
 standards.
 
+These proposed bit-manipulation extensions can be split into further
+groups: Zbp, Zbs, Zbe, Zbf, Zbc, Zbm, Zbr, Zbt. Note that Zbc is
+ratified, but the original proposal contained some extra instructions
+(64-bit carryless multiplies) which are captured here.
+
+To enable these extensions individually, use the Spike-custom
+extension names _XZbp_, _XZbs_, _XZbc_, and so on.
+
 Versioning and APIs
 -------------------
 

--- a/disasm/disasm.cc
+++ b/disasm/disasm.cc
@@ -1981,7 +1981,7 @@ void disassembler_t::add_instructions(isa_parser_t* isa)
     }
   }
 
-  if (isa->extension_enabled(EXT_XBITMANIP)) {
+  if (isa->extension_enabled(EXT_XZBP)) {
     DEFINE_ITYPE_SHIFT(grevi);
     DEFINE_ITYPE_SHIFT(gorci);
     DEFINE_RTYPE(pack);
@@ -1993,12 +1993,21 @@ void disassembler_t::add_instructions(isa_parser_t* isa)
     DEFINE_RTYPE(xperm8);
     DEFINE_RTYPE(xperm16);
     DEFINE_RTYPE(xperm32);
+  }
 
+  if (isa->extension_enabled(EXT_XZBP) ||
+      isa->extension_enabled(EXT_XZBE) ||
+      isa->extension_enabled(EXT_XZBF)) {
+    if(isa->get_max_xlen() == 64) {
+      DEFINE_RTYPE(packw);
+    }
+  }
+
+  if (isa->extension_enabled(EXT_XZBT)) {
     DEFINE_R3TYPE(cmix);
     DEFINE_R3TYPE(fsr);
     DEFINE_R3TYPE(fsri);
     if(isa->get_max_xlen() == 64) {
-      DEFINE_RTYPE(packw);
       DEFINE_R3TYPE(fsriw);
       DEFINE_R3TYPE(fsrw);
     }

--- a/riscv/insns/bcompress.h
+++ b/riscv/insns/bcompress.h
@@ -1,4 +1,4 @@
-require_extension(EXT_XBITMANIP);
+require_extension(EXT_XZBE);
 uint64_t c = 0, i = 0, data = zext_xlen(RS1), mask = zext_xlen(RS2);
 while (mask) {
 	uint64_t b = mask & ~((mask | (mask-1)) + 1);

--- a/riscv/insns/bcompressw.h
+++ b/riscv/insns/bcompressw.h
@@ -1,5 +1,5 @@
 require_rv64;
-require_extension(EXT_XBITMANIP);
+require_extension(EXT_XZBE);
 uint64_t c = 0, i = 0, data = zext32(RS1), mask = zext32(RS2);
 while (mask) {
 	uint64_t b = mask & ~((mask | (mask-1)) + 1);

--- a/riscv/insns/bdecompress.h
+++ b/riscv/insns/bdecompress.h
@@ -1,4 +1,4 @@
-require_extension(EXT_XBITMANIP);
+require_extension(EXT_XZBE);
 uint64_t c = 0, i = 0, data = zext_xlen(RS1), mask = zext_xlen(RS2);
 while (mask) {
 	uint64_t b = mask & ~((mask | (mask-1)) + 1);

--- a/riscv/insns/bdecompressw.h
+++ b/riscv/insns/bdecompressw.h
@@ -1,5 +1,5 @@
 require_rv64;
-require_extension(EXT_XBITMANIP);
+require_extension(EXT_XZBE);
 uint64_t c = 0, i = 0, data = zext32(RS1), mask = zext32(RS2);
 while (mask) {
 	uint64_t b = mask & ~((mask | (mask-1)) + 1);

--- a/riscv/insns/bfp.h
+++ b/riscv/insns/bfp.h
@@ -1,4 +1,4 @@
-require_extension(EXT_XBITMANIP);
+require_extension(EXT_XZBF);
 reg_t cfg = RS2 >> (xlen/2);
 if ((cfg >> 30) == 2)
 	cfg = cfg >> 16;

--- a/riscv/insns/bfpw.h
+++ b/riscv/insns/bfpw.h
@@ -1,5 +1,5 @@
 require_rv64;
-require_extension(EXT_XBITMANIP);
+require_extension(EXT_XZBF);
 reg_t cfg = RS2 >> 16;
 int len = (cfg >> 8) & 15;
 int off = cfg & 31;

--- a/riscv/insns/bmatflip.h
+++ b/riscv/insns/bmatflip.h
@@ -1,5 +1,5 @@
 require_rv64;
-require_extension(EXT_XBITMANIP);
+require_extension(EXT_XZBM);
 reg_t x = RS1;
 for (int i = 0; i < 3; i++) {
 	x = (x & 0xFFFF00000000FFFFLL) | ((x & 0x0000FFFF00000000LL) >> 16) | ((x & 0x00000000FFFF0000LL) << 16);

--- a/riscv/insns/bmator.h
+++ b/riscv/insns/bmator.h
@@ -1,5 +1,5 @@
 require_rv64;
-require_extension(EXT_XBITMANIP);
+require_extension(EXT_XZBM);
 
 // transpose of rs2
 int64_t rs2t = RS2;

--- a/riscv/insns/bmatxor.h
+++ b/riscv/insns/bmatxor.h
@@ -1,5 +1,5 @@
 require_rv64;
-require_extension(EXT_XBITMANIP);
+require_extension(EXT_XZBM);
 
 // transpose of rs2
 int64_t rs2t = RS2;

--- a/riscv/insns/clmulhw.h
+++ b/riscv/insns/clmulhw.h
@@ -1,4 +1,4 @@
-require_extension(EXT_XBITMANIP);
+require_extension(EXT_XZBC);
 reg_t a = zext32(RS1), b = zext32(RS2), x = 0;
 for (int i = 1; i < 32; i++)
   if ((b >> i) & 1)

--- a/riscv/insns/clmulrw.h
+++ b/riscv/insns/clmulrw.h
@@ -1,4 +1,4 @@
-require_extension(EXT_XBITMANIP);
+require_extension(EXT_XZBC);
 reg_t a = zext32(RS1), b = zext32(RS2), x = 0;
 for (int i = 0; i < 32; i++)
   if ((b >> i) & 1)

--- a/riscv/insns/clmulw.h
+++ b/riscv/insns/clmulw.h
@@ -1,4 +1,4 @@
-require_extension(EXT_XBITMANIP);
+require_extension(EXT_XZBC);
 reg_t a = zext32(RS1), b = zext32(RS2), x = 0;
 for (int i = 0; i < 32; i++)
   if ((b >> i) & 1)

--- a/riscv/insns/cmix.h
+++ b/riscv/insns/cmix.h
@@ -1,2 +1,2 @@
-require_either_extension(EXT_ZBPBO, EXT_XBITMANIP);
+require_either_extension(EXT_ZBPBO, EXT_XZBT);
 WRITE_RD((RS1 & RS2) | (RS3 & ~RS2));

--- a/riscv/insns/cmov.h
+++ b/riscv/insns/cmov.h
@@ -1,2 +1,2 @@
-require_extension(EXT_XBITMANIP);
+require_extension(EXT_XZBT);
 WRITE_RD(RS2 ? RS1 : RS3);

--- a/riscv/insns/crc32_b.h
+++ b/riscv/insns/crc32_b.h
@@ -1,4 +1,4 @@
-require_extension(EXT_XBITMANIP);
+require_extension(EXT_XZBR);
 reg_t x = zext_xlen(RS1);
 for (int i = 0; i < 8; i++)
   x = (x >> 1) ^ (0xEDB88320 & ~((x&1)-1));

--- a/riscv/insns/crc32_d.h
+++ b/riscv/insns/crc32_d.h
@@ -1,5 +1,5 @@
 require_rv64;
-require_extension(EXT_XBITMANIP);
+require_extension(EXT_XZBR);
 reg_t x = zext_xlen(RS1);
 for (int i = 0; i < 64; i++)
   x = (x >> 1) ^ (0xEDB88320 & ~((x&1)-1));

--- a/riscv/insns/crc32_h.h
+++ b/riscv/insns/crc32_h.h
@@ -1,4 +1,4 @@
-require_extension(EXT_XBITMANIP);
+require_extension(EXT_XZBR);
 reg_t x = zext_xlen(RS1);
 for (int i = 0; i < 16; i++)
   x = (x >> 1) ^ (0xEDB88320 & ~((x&1)-1));

--- a/riscv/insns/crc32_w.h
+++ b/riscv/insns/crc32_w.h
@@ -1,4 +1,4 @@
-require_extension(EXT_XBITMANIP);
+require_extension(EXT_XZBR);
 reg_t x = zext_xlen(RS1);
 for (int i = 0; i < 32; i++)
   x = (x >> 1) ^ (0xEDB88320 & ~((x&1)-1));

--- a/riscv/insns/crc32c_b.h
+++ b/riscv/insns/crc32c_b.h
@@ -1,4 +1,4 @@
-require_extension(EXT_XBITMANIP);
+require_extension(EXT_XZBR);
 reg_t x = zext_xlen(RS1);
 for (int i = 0; i < 8; i++)
   x = (x >> 1) ^ (0x82F63B78 & ~((x&1)-1));

--- a/riscv/insns/crc32c_d.h
+++ b/riscv/insns/crc32c_d.h
@@ -1,5 +1,5 @@
 require_rv64;
-require_extension(EXT_XBITMANIP);
+require_extension(EXT_XZBR);
 reg_t x = zext_xlen(RS1);
 for (int i = 0; i < 64; i++)
   x = (x >> 1) ^ (0x82F63B78 & ~((x&1)-1));

--- a/riscv/insns/crc32c_h.h
+++ b/riscv/insns/crc32c_h.h
@@ -1,4 +1,4 @@
-require_extension(EXT_XBITMANIP);
+require_extension(EXT_XZBR);
 reg_t x = zext_xlen(RS1);
 for (int i = 0; i < 16; i++)
   x = (x >> 1) ^ (0x82F63B78 & ~((x&1)-1));

--- a/riscv/insns/crc32c_w.h
+++ b/riscv/insns/crc32c_w.h
@@ -1,4 +1,4 @@
-require_extension(EXT_XBITMANIP);
+require_extension(EXT_XZBR);
 reg_t x = zext_xlen(RS1);
 for (int i = 0; i < 32; i++)
   x = (x >> 1) ^ (0x82F63B78 & ~((x&1)-1));

--- a/riscv/insns/fsl.h
+++ b/riscv/insns/fsl.h
@@ -1,4 +1,4 @@
-require_extension(EXT_XBITMANIP);
+require_extension(EXT_XZBT);
 int shamt = RS2 & (2*xlen-1);
 reg_t a = RS1, b = RS3;
 if (shamt >= xlen) {

--- a/riscv/insns/fslw.h
+++ b/riscv/insns/fslw.h
@@ -1,5 +1,5 @@
 require_rv64;
-require_extension(EXT_XBITMANIP);
+require_extension(EXT_XZBT);
 int shamt = RS2 & 63;
 reg_t a = RS1, b = RS3;
 if (shamt >= 32) {

--- a/riscv/insns/fsr.h
+++ b/riscv/insns/fsr.h
@@ -1,4 +1,4 @@
-require_either_extension(xlen == 32 ? EXT_ZBPBO : EXT_XBITMANIP, EXT_XBITMANIP);
+require_either_extension(xlen == 32 ? EXT_ZBPBO : EXT_XZBT, EXT_XZBT);
 int shamt = RS2 & (2*xlen-1);
 reg_t a = RS1, b = RS3;
 if (shamt >= xlen) {

--- a/riscv/insns/fsri.h
+++ b/riscv/insns/fsri.h
@@ -1,4 +1,4 @@
-require_either_extension(xlen == 32 ? EXT_ZBPBO : EXT_XBITMANIP, EXT_XBITMANIP);
+require_either_extension(xlen == 32 ? EXT_ZBPBO : EXT_XZBT, EXT_XZBT);
 int shamt = SHAMT & (2*xlen-1);
 reg_t a = RS1, b = RS3;
 if (shamt >= xlen) {

--- a/riscv/insns/fsriw.h
+++ b/riscv/insns/fsriw.h
@@ -1,5 +1,5 @@
 require_rv64;
-require_extension(EXT_XBITMANIP);
+require_extension(EXT_XZBT);
 int shamt = SHAMT & 63;
 reg_t a = RS1, b = RS3;
 if (shamt >= 32) {

--- a/riscv/insns/fsrw.h
+++ b/riscv/insns/fsrw.h
@@ -1,5 +1,5 @@
 require_rv64;
-require_either_extension(EXT_ZBPBO, EXT_XBITMANIP);
+require_either_extension(EXT_ZBPBO, EXT_XZBT);
 int shamt = RS2 & 63;
 reg_t a = RS1, b = RS3;
 if (shamt >= 32) {

--- a/riscv/insns/gorc.h
+++ b/riscv/insns/gorc.h
@@ -1,4 +1,4 @@
-require_extension(EXT_XBITMANIP);
+require_extension(EXT_XZBP);
 reg_t x = RS1;
 int shamt = RS2 & (xlen-1);
 if (shamt &  1) x |= ((x & 0x5555555555555555LL) <<  1) | ((x & 0xAAAAAAAAAAAAAAAALL) >>  1);

--- a/riscv/insns/gorci.h
+++ b/riscv/insns/gorci.h
@@ -1,6 +1,6 @@
 // Zbb contains orc.b but not general gorci
 require(((SHAMT == 7) && p->extension_enabled(EXT_ZBB))
-  || p->extension_enabled(EXT_XBITMANIP));
+  || p->extension_enabled(EXT_XZBP));
 require(SHAMT < xlen);
 reg_t x = RS1;
 int shamt = SHAMT;

--- a/riscv/insns/gorciw.h
+++ b/riscv/insns/gorciw.h
@@ -1,5 +1,5 @@
 require_rv64;
-require_extension(EXT_XBITMANIP);
+require_extension(EXT_XZBP);
 require(SHAMT < 32);
 reg_t x = RS1;
 int shamt = SHAMT;

--- a/riscv/insns/gorcw.h
+++ b/riscv/insns/gorcw.h
@@ -1,5 +1,5 @@
 require_rv64;
-require_extension(EXT_XBITMANIP);
+require_extension(EXT_XZBP);
 reg_t x = RS1;
 int shamt = RS2 & 31;
 if (shamt &  1) x |= ((x & 0x5555555555555555LL) <<  1) | ((x & 0xAAAAAAAAAAAAAAAALL) >>  1);

--- a/riscv/insns/grev.h
+++ b/riscv/insns/grev.h
@@ -1,4 +1,4 @@
-require_extension(EXT_XBITMANIP);
+require_extension(EXT_XZBP);
 reg_t x = RS1;
 int shamt = RS2 & (xlen-1);
 if (shamt &  1) x = ((x & 0x5555555555555555LL) <<  1) | ((x & 0xAAAAAAAAAAAAAAAALL) >>  1);

--- a/riscv/insns/grevi.h
+++ b/riscv/insns/grevi.h
@@ -5,7 +5,7 @@ require(((shamt == xlen - 8) && (p->extension_enabled(EXT_ZBB) || p->extension_e
   || ((shamt == 7) && p->extension_enabled(EXT_ZBKB)) // rev8.b
   || ((shamt == 8) && p->extension_enabled(EXT_ZPN)) // rev8.h
   || ((shamt == xlen - 1) && p->extension_enabled(EXT_ZPN)) // rev
-  || p->extension_enabled(EXT_XBITMANIP));
+  || p->extension_enabled(EXT_XZBP));
 require(shamt < xlen);
 reg_t x = RS1;
 if (shamt &  1) x = ((x & 0x5555555555555555LL) <<  1) | ((x & 0xAAAAAAAAAAAAAAAALL) >>  1);

--- a/riscv/insns/greviw.h
+++ b/riscv/insns/greviw.h
@@ -1,5 +1,5 @@
 require_rv64;
-require_extension(EXT_XBITMANIP);
+require_extension(EXT_XZBP);
 require(SHAMT < 32);
 reg_t x = RS1;
 int shamt = SHAMT;

--- a/riscv/insns/grevw.h
+++ b/riscv/insns/grevw.h
@@ -1,5 +1,5 @@
 require_rv64;
-require_extension(EXT_XBITMANIP);
+require_extension(EXT_XZBP);
 reg_t x = RS1;
 int shamt = RS2 & 31;
 if (shamt &  1) x = ((x & 0x5555555555555555LL) <<  1) | ((x & 0xAAAAAAAAAAAAAAAALL) >>  1);

--- a/riscv/insns/pack.h
+++ b/riscv/insns/pack.h
@@ -2,7 +2,10 @@
 require(((xlen == 32) && (insn.rs2() == 0) && p->extension_enabled(EXT_ZBB))
   || p->extension_enabled(EXT_ZPN)
   || p->extension_enabled(EXT_ZBKB)
-  || p->extension_enabled(EXT_XBITMANIP));
+  || p->extension_enabled(EXT_XZBP)
+  || p->extension_enabled(EXT_XZBE)
+  || p->extension_enabled(EXT_XZBF)
+  || ((xlen == 64) && p->extension_enabled(EXT_XZBM)));
 reg_t lo = zext_xlen(RS1 << (xlen/2)) >> (xlen/2);
 reg_t hi = zext_xlen(RS2 << (xlen/2));
 WRITE_RD(sext_xlen(lo | hi));

--- a/riscv/insns/packh.h
+++ b/riscv/insns/packh.h
@@ -1,4 +1,7 @@
-require_either_extension(EXT_ZBKB, EXT_XBITMANIP);
+require(p->extension_enabled(EXT_ZBKB) ||
+        p->extension_enabled(EXT_XZBP) ||
+        p->extension_enabled(EXT_XZBE) ||
+        p->extension_enabled(EXT_XZBF));
 reg_t lo = zext_xlen(RS1 << (xlen-8)) >> (xlen-8);
 reg_t hi = zext_xlen(RS2 << (xlen-8)) >> (xlen-16);
 WRITE_RD(sext_xlen(lo | hi));

--- a/riscv/insns/packu.h
+++ b/riscv/insns/packu.h
@@ -1,4 +1,6 @@
-require_either_extension(EXT_ZPN, EXT_XBITMANIP);
+require(p->extension_enabled(EXT_ZPN) ||
+        p->extension_enabled(EXT_XZBP) ||
+        ((xlen == 64) && p->extension_enabled(EXT_XZBM)));
 reg_t lo = zext_xlen(RS1) >> (xlen/2);
 reg_t hi = zext_xlen(RS2) >> (xlen/2) << (xlen/2);
 WRITE_RD(sext_xlen(lo | hi));

--- a/riscv/insns/packuw.h
+++ b/riscv/insns/packuw.h
@@ -1,5 +1,5 @@
 require_rv64;
-require_extension(EXT_XBITMANIP);
+require_extension(EXT_XZBP);
 reg_t lo = zext32(RS1) >> 16;
 reg_t hi = zext32(RS2) >> 16 << 16;
 WRITE_RD(sext32(lo | hi));

--- a/riscv/insns/packw.h
+++ b/riscv/insns/packw.h
@@ -1,7 +1,9 @@
 // RV64Zbb contains zext.h but not general packw
 require(((insn.rs2() == 0) && p->extension_enabled(EXT_ZBB))
   || p->extension_enabled(EXT_ZBKB)
-  || p->extension_enabled(EXT_XBITMANIP));
+  || p->extension_enabled(EXT_XZBP)
+  || p->extension_enabled(EXT_XZBE)
+  || p->extension_enabled(EXT_XZBF));
 require_rv64;
 reg_t lo = zext32(RS1 << 16) >> 16;
 reg_t hi = zext32(RS2 << 16);

--- a/riscv/insns/shfl.h
+++ b/riscv/insns/shfl.h
@@ -1,4 +1,4 @@
-require_extension(EXT_XBITMANIP);
+require_extension(EXT_XZBP);
 reg_t x = RS1;
 int shamt = RS2 & ((xlen-1) >> 1);
 if (shamt & 16) x = (x & 0xFFFF00000000FFFFLL) | ((x & 0x0000FFFF00000000LL) >> 16) | ((x & 0x00000000FFFF0000LL) << 16);

--- a/riscv/insns/shfli.h
+++ b/riscv/insns/shfli.h
@@ -1,6 +1,6 @@
 // Zbkb contains zip but not general shfli
 require(((insn.rs2() == (xlen / 2 - 1)) && p->extension_enabled(EXT_ZBKB))
-  || p->extension_enabled(EXT_XBITMANIP));
+  || p->extension_enabled(EXT_XZBP));
 require(SHAMT < (xlen/2));
 reg_t x = RS1;
 int shamt = SHAMT & ((xlen-1) >> 1);

--- a/riscv/insns/shflw.h
+++ b/riscv/insns/shflw.h
@@ -1,5 +1,5 @@
 require_rv64;
-require_extension(EXT_XBITMANIP);
+require_extension(EXT_XZBP);
 reg_t x = RS1;
 int shamt = RS2 & 15;
 if (shamt &  8) x = (x & 0xFF0000FFFF0000FFLL) | ((x & 0x00FF000000FF0000LL) >>  8) | ((x & 0x0000FF000000FF00LL) <<  8);

--- a/riscv/insns/slo.h
+++ b/riscv/insns/slo.h
@@ -1,2 +1,2 @@
-require_extension(EXT_XBITMANIP);
+require_extension(EXT_XZBP);
 WRITE_RD(sext_xlen(~((~RS1) << (RS2 & (xlen-1)))));

--- a/riscv/insns/sloi.h
+++ b/riscv/insns/sloi.h
@@ -1,3 +1,3 @@
 require(SHAMT < xlen);
-require_extension(EXT_XBITMANIP);
+require_extension(EXT_XZBP);
 WRITE_RD(sext_xlen(~((~RS1) << SHAMT)));

--- a/riscv/insns/sloiw.h
+++ b/riscv/insns/sloiw.h
@@ -1,3 +1,3 @@
 require_rv64;
-require_extension(EXT_XBITMANIP);
+require_extension(EXT_XZBP);
 WRITE_RD(sext32(~((~RS1) << SHAMT)));

--- a/riscv/insns/slow.h
+++ b/riscv/insns/slow.h
@@ -1,3 +1,3 @@
 require_rv64;
-require_extension(EXT_XBITMANIP);
+require_extension(EXT_XZBP);
 WRITE_RD(sext32(~((~RS1) << (RS2 & 0x1F))));

--- a/riscv/insns/sro.h
+++ b/riscv/insns/sro.h
@@ -1,2 +1,2 @@
-require_extension(EXT_XBITMANIP);
+require_extension(EXT_XZBP);
 WRITE_RD(sext_xlen(~((zext_xlen(~RS1)) >> (RS2 & (xlen-1)))));

--- a/riscv/insns/sroi.h
+++ b/riscv/insns/sroi.h
@@ -1,3 +1,3 @@
 require(SHAMT < xlen);
-require_extension(EXT_XBITMANIP);
+require_extension(EXT_XZBP);
 WRITE_RD(sext_xlen(~((zext_xlen(~RS1)) >> SHAMT)));

--- a/riscv/insns/sroiw.h
+++ b/riscv/insns/sroiw.h
@@ -1,3 +1,3 @@
 require_rv64;
-require_extension(EXT_XBITMANIP);
+require_extension(EXT_XZBP);
 WRITE_RD(sext32(~((~(uint32_t)RS1) >> SHAMT)));

--- a/riscv/insns/srow.h
+++ b/riscv/insns/srow.h
@@ -1,3 +1,3 @@
 require_rv64;
-require_extension(EXT_XBITMANIP);
+require_extension(EXT_XZBP);
 WRITE_RD(sext32(~((~(uint32_t)RS1) >> (RS2 & 0x1F))));

--- a/riscv/insns/unshfl.h
+++ b/riscv/insns/unshfl.h
@@ -1,4 +1,4 @@
-require_extension(EXT_XBITMANIP);
+require_extension(EXT_XZBP);
 reg_t x = RS1;
 int shamt = RS2 & ((xlen-1) >> 1);
 if (shamt &  1) x = (x & 0x9999999999999999LL) | ((x & 0x4444444444444444LL) >>  1) | ((x & 0x2222222222222222LL) <<  1);

--- a/riscv/insns/unshfli.h
+++ b/riscv/insns/unshfli.h
@@ -1,6 +1,6 @@
 // Zbkb contains unzip but not general unshfli
 require(((insn.rs2() == (xlen / 2 - 1)) && p->extension_enabled(EXT_ZBKB))
-  || p->extension_enabled(EXT_XBITMANIP));
+  || p->extension_enabled(EXT_XZBP));
 require(SHAMT < (xlen/2));
 reg_t x = RS1;
 int shamt = SHAMT & ((xlen-1) >> 1);

--- a/riscv/insns/unshflw.h
+++ b/riscv/insns/unshflw.h
@@ -1,5 +1,5 @@
 require_rv64;
-require_extension(EXT_XBITMANIP);
+require_extension(EXT_XZBP);
 reg_t x = RS1;
 int shamt = RS2 & 15;
 if (shamt &  1) x = (x & 0x9999999999999999LL) | ((x & 0x4444444444444444LL) >>  1) | ((x & 0x2222222222222222LL) <<  1);

--- a/riscv/insns/xperm16.h
+++ b/riscv/insns/xperm16.h
@@ -1,2 +1,2 @@
-require_extension(EXT_XBITMANIP);
+require_extension(EXT_XZBP);
 WRITE_RD(sext_xlen(xperm(RS1, RS2, 4, xlen)));

--- a/riscv/insns/xperm32.h
+++ b/riscv/insns/xperm32.h
@@ -1,3 +1,3 @@
 require_rv64;
-require_extension(EXT_XBITMANIP);
+require_extension(EXT_XZBP);
 WRITE_RD(xperm(RS1, RS2, 5, xlen));

--- a/riscv/insns/xperm4.h
+++ b/riscv/insns/xperm4.h
@@ -1,2 +1,2 @@
-require_either_extension(EXT_ZBKX, EXT_XBITMANIP);
+require_either_extension(EXT_ZBKX, EXT_XZBP);
 WRITE_RD(sext_xlen(xperm(RS1, RS2, 2, xlen)));

--- a/riscv/insns/xperm8.h
+++ b/riscv/insns/xperm8.h
@@ -1,2 +1,2 @@
-require_either_extension(EXT_ZBKX, EXT_XBITMANIP);
+require_either_extension(EXT_ZBKX, EXT_XZBP);
 WRITE_RD(sext_xlen(xperm(RS1, RS2, 3, xlen)));

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -347,7 +347,30 @@ isa_parser_t::isa_parser_t(const char* str)
       max_isa |= 1L << ('x' - 'a');
       extension_table[toupper('x')] = true;
       if (ext_str == "xbitmanip") {
-        extension_table[EXT_XBITMANIP] = true;
+        extension_table[EXT_XZBP] = true;
+        extension_table[EXT_XZBS] = true;
+        extension_table[EXT_XZBE] = true;
+        extension_table[EXT_XZBF] = true;
+        extension_table[EXT_XZBC] = true;
+        extension_table[EXT_XZBM] = true;
+        extension_table[EXT_XZBR] = true;
+        extension_table[EXT_XZBT] = true;
+      } else if (ext_str == "xzbp") {
+        extension_table[EXT_XZBP] = true;
+      } else if (ext_str == "xzbs") {
+        extension_table[EXT_XZBS] = true;
+      } else if (ext_str == "xzbe") {
+        extension_table[EXT_XZBE] = true;
+      } else if (ext_str == "xzbf") {
+        extension_table[EXT_XZBF] = true;
+      } else if (ext_str == "xzbc") {
+        extension_table[EXT_XZBC] = true;
+      } else if (ext_str == "xzbm") {
+        extension_table[EXT_XZBM] = true;
+      } else if (ext_str == "xzbr") {
+        extension_table[EXT_XZBR] = true;
+      } else if (ext_str == "xzbt") {
+        extension_table[EXT_XZBT] = true;
       } else if (ext_str.size() == 1) {
         bad_isa_string(str, "single 'X' is not a proper name");
       } else if (ext_str != "xdummy") {

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -277,9 +277,16 @@ typedef enum {
   EXT_ZFINX,
   EXT_ZHINX,
   EXT_ZHINXMIN,
-  EXT_XBITMANIP,
   EXT_ZICBOM,
   EXT_ZICBOZ,
+  EXT_XZBP,
+  EXT_XZBS,
+  EXT_XZBE,
+  EXT_XZBF,
+  EXT_XZBC,
+  EXT_XZBM,
+  EXT_XZBR,
+  EXT_XZBT,
 } isa_extension_t;
 
 typedef enum {


### PR DESCRIPTION
Before this patch, spike just had an `Xbitmanip` extension which
covered everything in the proposed bitmanip extension that hadn't been
ratified. The problem is that if you want to model (or verify) a
processor that targetted just some of the proposed bitmanip extension,
you couldn't configure Spike to do that.

For example, the lowRISC Ibex processor has several different
configurations. The "balanced" configuration targetted Zba, Zbb, Zbs,
Zbf and Zbt of the 0.92 spec. With the Zba, Zbb and Zbs ratified,
we'll now be able to use an ISA string like

    rv32imc_Zba_Zbb_Zbs_XZbf_XZbt

and Spike will correctly fail to decode instructions like `bcompress`,
which would have been decoded with `Xbitmanip`.

This patch adds a new custom extension name for each part of the
extension that wasn't fully ratified. These have an 'X' prefix so, for
example, the bit permutation instructions that were proposed as Zbp
can be found under `XZbp`.

Specifying `Xbitmanip` gets all of these extensions, so its behaviour
should be unchanged.

Note that the `slo(i)` / `sro(i)` instructions have been moved from the
proposed Zbb to `XZbp`. This matches a comment in the Change History
section of v0.93 of the bitmanip spec: it seems that the authors
forgot to also move them in Table 2.1 (which gives the lists of
instructions for each extension). This change won't break anything
that currently exists, but it took quite a while to figure out what
was going on so I thought I'd leave a breadcrumb trail for the next
engineer!

The bulk of the patch is just defining some more entries in the
`isa_extension_t` enum and rewriting each of the instructions to depend
on the relevant entry. This is mostly a straight textual replacement
but it's slightly more complicated for things like the "pack"
instruction that are defined by several different proposed extensions.