### PR TITLE
Remove disasm.cc/disasm.h from riscv subproject

### DIFF
--- a/riscv/riscv.mk.in
+++ b/riscv/riscv.mk.in
@@ -12,7 +12,6 @@ riscv_hdrs = \
 	common.h \
 	decode.h \
 	devices.h \
-	disasm.h \
 	dts.h \
 	mmu.h \
 	processor.h \
@@ -47,7 +46,6 @@ riscv_srcs = \
 	trap.cc \
 	cachesim.cc \
 	mmu.cc \
-	disasm.cc \
 	extension.cc \
 	extensions.cc \
 	rocc.cc \


### PR DESCRIPTION
These also appear in the `disasm` subproject (where they make more
sense), which generates Make warnings about duplicate rules.

Before this commit, we were including the code in both `libriscv.a` and
`libdisasm.a`:

    $ git rev-parse HEAD
    c2f30c33304c96917bdb0ab7e2d4d6a2d71d1d25
    $ nm libriscv.a | c++filt | grep ' T ' | grep disassemble
    nm: libsoftfloat.a: file format not recognized
    nm: libfdt.a: file format not recognized
    0000000000010b00 T disassembler_t::add_instructions(isa_parser_t*)
    00000000000070c0 T disassembler_t::add_insn(disasm_insn_t*)
    000000000001be00 T disassembler_t::disassembler_t(isa_parser_t*)
    000000000001be00 T disassembler_t::disassembler_t(isa_parser_t*)
    0000000000003d30 T disassembler_t::~disassembler_t()
    0000000000003d30 T disassembler_t::~disassembler_t()
    0000000000003ae0 T disassembler_t::probe_once(insn_t, unsigned long) const
    0000000000003cb0 T disassembler_t::disassemble[abi:cxx11](insn_t) const
    0000000000003bb0 T disassembler_t::lookup(insn_t) const
    $ nm libdisasm.a | c++filt | grep ' T '
    0000000000010b00 T disassembler_t::add_instructions(isa_parser_t*)
    00000000000070c0 T disassembler_t::add_insn(disasm_insn_t*)
    000000000001be00 T disassembler_t::disassembler_t(isa_parser_t*)
    000000000001be00 T disassembler_t::disassembler_t(isa_parser_t*)
    0000000000003d30 T disassembler_t::~disassembler_t()
    0000000000003d30 T disassembler_t::~disassembler_t()
    0000000000003ae0 T disassembler_t::probe_once(insn_t, unsigned long) const
    0000000000003cb0 T disassembler_t::disassemble[abi:cxx11](insn_t) const
    0000000000003bb0 T disassembler_t::lookup(insn_t) const
    0000000000000000 T csr_name(int)

Note that this change will have no effect on the contents of
`libspike_main.a` or `libspike_dasm.a`: both of these include `libriscv.a`
and `libdisasm.a`.