### PR TITLE
Add simple error checking to DTB parsing code

### DIFF
--- a/riscv/sim.cc
+++ b/riscv/sim.cc
@@ -6,6 +6,7 @@
 #include "remote_bitbang.h"
 #include "byteorder.h"
 #include "platform.h"
+#include "libfdt.h"
 #include <fstream>
 #include <map>
 #include <iostream>
@@ -295,6 +296,18 @@ void sim_t::make_dtb()
   } else {
     dts = make_dts(INSNS_PER_RTC_TICK, CPU_HZ, initrd_start, initrd_end, bootargs, procs, mems);
     dtb = dts_compile(dts);
+  }
+
+  int fdt_code = fdt_check_header(dtb.c_str());
+  if (fdt_code) {
+    std::cerr << "Failed to read DTB from ";
+    if (dtb_file.empty()) {
+      std::cerr << "auto-generated DTS string";
+    } else {
+      std::cerr << "`" << dtb_file << "'";
+    }
+    std::cerr << ": " << fdt_strerror(fdt_code) << ".\n";
+    exit(-1);
   }
 }
 

--- a/riscv/sim.cc
+++ b/riscv/sim.cc
@@ -335,23 +335,6 @@ void sim_t::set_rom()
 
   std::vector<char> rom((char*)reset_vec, (char*)reset_vec + sizeof(reset_vec));
 
-  std::string dtb;
-  if (!dtb_file.empty()) {
-    std::ifstream fin(dtb_file.c_str(), std::ios::binary);
-    if (!fin.good()) {
-      std::cerr << "can't find dtb file: " << dtb_file << std::endl;
-      exit(-1);
-    }
-
-    std::stringstream strstream;
-    strstream << fin.rdbuf();
-
-    dtb = strstream.str();
-  } else {
-    dts = make_dts(INSNS_PER_RTC_TICK, CPU_HZ, initrd_start, initrd_end, bootargs, procs, mems);
-    dtb = dts_compile(dts);
-  }
-
   rom.insert(rom.end(), dtb.begin(), dtb.end());
   const int align = 0x1000;
   rom.resize((rom.size() + align - 1) / align * align);


### PR DESCRIPTION
The first commit removes some duplicated code which doesn't do anything (I think the rom loading stuff predated the code that's now in the `sim_t` constructor?). The second commit is why I wanted to make the change, after spending 10 minutes very confused about why I couldn't pass a device tree...

Second commit message below:

This catches silly mistakes like accidentally passing a DTS file when
it should have been a DTB.

Now, you get something like this:

    $ /opt/spike/latest/bin/spike --dtb=bogus.dtb -l obj.o
    Failed to read DTB from `bogus.dtb': FDT_ERR_BADMAGIC.
