### PR TITLE
Documentation: Cache block size for CMO operations default 64

### DIFF
--- a/spike_main/spike.cc
+++ b/spike_main/spike.cc
@@ -72,7 +72,7 @@ static void help(int exit_code = 1)
   fprintf(stderr, "  --dm-no-abstract-csr  Debug module won't support abstract to authenticate\n");
   fprintf(stderr, "  --dm-no-halt-groups   Debug module won't support halt groups\n");
   fprintf(stderr, "  --dm-no-impebreak     Debug module won't support implicit ebreak in program buffer\n");
-  fprintf(stderr, "  --blocksz=<size>     Cache block size (B) for CMO operations(powers of 2) [default 16]\n");
+  fprintf(stderr, "  --blocksz=<size>      Cache block size (B) for CMO operations(powers of 2) [default 64]\n");
 
   exit(exit_code);
 }


### PR DESCRIPTION
https://github.com/riscv-software-src/riscv-isa-sim/pull/891#discussion_r810250913

match https://github.com/riscv-software-src/riscv-isa-sim/blob/42cbf10dc1f6c6ce0a9591a53be2555f75da6c87/spike_main/spike.cc#L245