### PR TITLE
Avoid an unnecessary strcpy

### DIFF
--- a/riscv/dts.cc
+++ b/riscv/dts.cc
@@ -3,6 +3,7 @@
 #include "dts.h"
 #include "libfdt.h"
 #include "platform.h"
+#include <cassert>
 #include <iostream>
 #include <sstream>
 #include <signal.h>
@@ -306,8 +307,10 @@ int fdt_parse_pmp_alignment(void *fdt, int cpu_offset, reg_t *pmp_align)
   return 0;
 }
 
-int fdt_parse_mmu_type(void *fdt, int cpu_offset, char *mmu_type)
+int fdt_parse_mmu_type(void *fdt, int cpu_offset, const char **mmu_type)
 {
+  assert(mmu_type);
+
   int len, rc;
   const void *prop;
 
@@ -318,7 +321,7 @@ int fdt_parse_mmu_type(void *fdt, int cpu_offset, char *mmu_type)
   if (!prop || !len)
     return -EINVAL;
 
-  strcpy(mmu_type, (char *)prop);
+  *mmu_type = (const char *)prop;
 
   return 0;
 }

--- a/riscv/dts.h
+++ b/riscv/dts.h
@@ -23,5 +23,5 @@ int fdt_parse_clint(void *fdt, reg_t *clint_addr,
                     const char *compatible);
 int fdt_parse_pmp_num(void *fdt, int cpu_offset, reg_t *pmp_num);
 int fdt_parse_pmp_alignment(void *fdt, int cpu_offset, reg_t *pmp_align);
-int fdt_parse_mmu_type(void *fdt, int cpu_offset, char *mmu_type);
+int fdt_parse_mmu_type(void *fdt, int cpu_offset, const char **mmu_type);
 #endif

--- a/riscv/sim.cc
+++ b/riscv/sim.cc
@@ -136,8 +136,8 @@ sim_t::sim_t(const char* isa, const char* priv, const char* varch,
     }
 
     //handle mmu-type
-    char mmu_type[256] = "";
-    rc = fdt_parse_mmu_type(fdt, cpu_offset, mmu_type);
+    const char *mmu_type;
+    rc = fdt_parse_mmu_type(fdt, cpu_offset, &mmu_type);
     if (rc == 0) {
       procs[cpu_idx]->set_mmu_capability(IMPL_MMU_SBARE);
       if (strncmp(mmu_type, "riscv,sv32", strlen("riscv,sv32")) == 0) {
@@ -151,7 +151,7 @@ sim_t::sim_t(const char* isa, const char* priv, const char* varch,
       } else {
         std::cerr << "core ("
                   << hartids.size()
-                  << ") doesn't have valid 'mmu-type'"
+                  << ") has an invalid 'mmu-type': "
                   << mmu_type << ").\n";
         exit(1);
       }


### PR DESCRIPTION
We don't actually know that the field in the DTB points at a string
that's less than 256 bytes long, I don't think, so this could probably
cause a buffer overflow on the stack. Anyway, it turns out that
there's no need to copy anything anyway, so let's just update a char**
instead.