### PR TITLE
mmu: support asid/vmid

### DIFF
--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -782,8 +782,10 @@ reg_t base_atp_csr_t::compute_new_satp(reg_t val) const noexcept {
   reg_t rv64_ppn_mask = (reg_t(1) << (MAX_PADDR_BITS - PGSHIFT)) - 1;
 
   reg_t mode_mask = proc->get_xlen() == 32 ? SATP32_MODE : SATP64_MODE;
+  reg_t asid_mask_if_enabled = proc->get_xlen() == 32 ? SATP32_ASID : SATP64_ASID;
+  reg_t asid_mask = proc->supports_impl(IMPL_MMU_ASID) ? asid_mask_if_enabled : 0;
   reg_t ppn_mask = proc->get_xlen() == 32 ? SATP32_PPN : SATP64_PPN & rv64_ppn_mask;
-  reg_t new_mask = (satp_valid(val) ? mode_mask : 0) | ppn_mask;
+  reg_t new_mask = (satp_valid(val) ? mode_mask : 0) | asid_mask | ppn_mask;
   reg_t old_mask = satp_valid(val) ? 0 : mode_mask;
 
   return (new_mask & val) | (old_mask & read());
@@ -971,9 +973,12 @@ bool hgatp_csr_t::unlogged_write(const reg_t val) noexcept {
 
   reg_t mask;
   if (proc->get_const_xlen() == 32) {
-    mask = HGATP32_PPN | HGATP32_MODE;
+    mask = HGATP32_PPN |
+        HGATP32_MODE |
+        proc->supports_impl(IMPL_MMU_VMID) ? HGATP32_VMID : 0;
   } else {
-    mask = HGATP64_PPN & ((reg_t(1) << (MAX_PADDR_BITS - PGSHIFT)) - 1);
+    mask = (HGATP64_PPN & ((reg_t(1) << (MAX_PADDR_BITS - PGSHIFT)) - 1)) |
+        proc->supports_impl(IMPL_MMU_VMID) ? HGATP64_VMID : 0;
 
     if (get_field(val, HGATP64_MODE) == HGATP_MODE_OFF ||
         (proc->supports_impl(IMPL_MMU_SV39) && get_field(val, HGATP64_MODE) == HGATP_MODE_SV39X4) ||

--- a/riscv/isa_parser.h
+++ b/riscv/isa_parser.h
@@ -59,6 +59,8 @@ typedef enum {
   IMPL_MMU_SV57,
   IMPL_MMU_SBARE,
   IMPL_MMU,
+  IMPL_MMU_VMID,
+  IMPL_MMU_ASID,
 } impl_extension_t;
 
 class isa_parser_t {

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -57,6 +57,9 @@ processor_t::processor_t(isa_parser_t isa, const char* varch,
   else if (isa.get_max_xlen() == 64)
     set_mmu_capability(IMPL_MMU_SV48);
 
+  set_impl(IMPL_MMU_ASID, true);
+  set_impl(IMPL_MMU_VMID, true);
+
   reset();
 }
 


### PR DESCRIPTION
The change makes [v]satp.asid and hgatp.vmid writtable and supports
maximum length for rv32 and rv64. Software could write and read the
satp.asid to get the valid length or check if the core supports
asid/vmid or not.  However, there is no official way to describe this hardware
capability (device tree or something else).  Two implementation flags
are also added for future use and enabled by default.

Signed-off-by: Chih-Min Chao <chihmin.chao@sifive.com>