### PR TITLE
adding ports to run  F, D and E extension architectural tests on spike

### DIFF
--- a/arch_test_target/spike/device/rv32e_unratified/C/Makefile.include
+++ b/arch_test_target/spike/device/rv32e_unratified/C/Makefile.include
@@ -1,0 +1,40 @@
+TARGET_SIM   ?= spike
+TARGET_FLAGS ?= $(RISCV_TARGET_FLAGS)
+ifeq ($(shell command -v $(TARGET_SIM) 2> /dev/null),)
+    $(error Target simulator executable '$(TARGET_SIM)` not found)
+endif
+
+RISCV_PREFIX   ?= riscv32-unknown-elf-
+RISCV_GCC      ?= $(RISCV_PREFIX)gcc
+RISCV_OBJDUMP  ?= $(RISCV_PREFIX)objdump
+RISCV_GCC_OPTS ?= -g -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles $(RVTEST_DEFINES)
+
+COMPILE_CMD = $$(RISCV_GCC) $(1) $$(RISCV_GCC_OPTS) \
+							-I$(ROOTDIR)/riscv-test-suite/env/ \
+							-I$(TARGETDIR)/$(RISCV_TARGET)/ \
+							-T$(TARGETDIR)/$(RISCV_TARGET)/link.ld \
+							$$(<) -o $$@ 
+OBJ_CMD = $$(RISCV_OBJDUMP) $$@ -D > $$@.objdump; \
+					$$(RISCV_OBJDUMP) $$@ --source > $$@.debug
+
+
+COMPILE_TARGET=\
+				$(COMPILE_CMD); \
+        if [ $$$$? -ne 0 ] ; \
+                then \
+                echo "\e[31m$$(RISCV_GCC) failed for target $$(@) \e[39m" ; \
+                exit 1 ; \
+                fi ; \
+				$(OBJ_CMD); \
+        if [ $$$$? -ne 0 ] ; \
+                then \
+                echo "\e[31m $$(RISCV_OBJDUMP) failed for target $$(@) \e[39m" ; \
+                exit 1 ; \
+                fi ;
+
+RUN_CMD = $(TARGET_SIM) $(TARGET_FLAGS) --isa=rv32ec \
+        +signature=$(*).signature.output +signature-granularity=4\
+        $< 
+
+RUN_TARGET=\
+	$(RUN_CMD)

--- a/arch_test_target/spike/device/rv32e_unratified/E/Makefile.include
+++ b/arch_test_target/spike/device/rv32e_unratified/E/Makefile.include
@@ -1,0 +1,40 @@
+TARGET_SIM   ?= spike
+TARGET_FLAGS ?= $(RISCV_TARGET_FLAGS)
+ifeq ($(shell command -v $(TARGET_SIM) 2> /dev/null),)
+    $(error Target simulator executable '$(TARGET_SIM)` not found)
+endif
+
+RISCV_PREFIX   ?= riscv32-unknown-elf-
+RISCV_GCC      ?= $(RISCV_PREFIX)gcc
+RISCV_OBJDUMP  ?= $(RISCV_PREFIX)objdump
+RISCV_GCC_OPTS ?= -g -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles $(RVTEST_DEFINES)
+
+COMPILE_CMD = $$(RISCV_GCC) $(1) $$(RISCV_GCC_OPTS) \
+							-I$(ROOTDIR)/riscv-test-suite/env/ \
+							-I$(TARGETDIR)/$(RISCV_TARGET)/ \
+							-T$(TARGETDIR)/$(RISCV_TARGET)/link.ld \
+							$$(<) -o $$@ 
+OBJ_CMD = $$(RISCV_OBJDUMP) $$@ -D > $$@.objdump; \
+					$$(RISCV_OBJDUMP) $$@ --source > $$@.debug
+
+
+COMPILE_TARGET=\
+				$(COMPILE_CMD); \
+        if [ $$$$? -ne 0 ] ; \
+                then \
+                echo "\e[31m$$(RISCV_GCC) failed for target $$(@) \e[39m" ; \
+                exit 1 ; \
+                fi ; \
+				$(OBJ_CMD); \
+        if [ $$$$? -ne 0 ] ; \
+                then \
+                echo "\e[31m $$(RISCV_OBJDUMP) failed for target $$(@) \e[39m" ; \
+                exit 1 ; \
+                fi ;
+
+RUN_CMD = $(TARGET_SIM) $(TARGET_FLAGS) --isa=rv32e \
+        +signature=$(*).signature.output +signature-granularity=4\
+        $< 
+
+RUN_TARGET=\
+	$(RUN_CMD) 

--- a/arch_test_target/spike/device/rv32e_unratified/M/Makefile.include
+++ b/arch_test_target/spike/device/rv32e_unratified/M/Makefile.include
@@ -1,0 +1,40 @@
+TARGET_SIM   ?= spike
+TARGET_FLAGS ?= $(RISCV_TARGET_FLAGS)
+ifeq ($(shell command -v $(TARGET_SIM) 2> /dev/null),)
+    $(error Target simulator executable '$(TARGET_SIM)` not found)
+endif
+
+RISCV_PREFIX   ?= riscv32-unknown-elf-
+RISCV_GCC      ?= $(RISCV_PREFIX)gcc
+RISCV_OBJDUMP  ?= $(RISCV_PREFIX)objdump
+RISCV_GCC_OPTS ?= -g -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles $(RVTEST_DEFINES)
+
+COMPILE_CMD = $$(RISCV_GCC) $(1) $$(RISCV_GCC_OPTS) \
+							-I$(ROOTDIR)/riscv-test-suite/env/ \
+							-I$(TARGETDIR)/$(RISCV_TARGET)/ \
+							-T$(TARGETDIR)/$(RISCV_TARGET)/link.ld \
+							$$(<) -o $$@ 
+OBJ_CMD = $$(RISCV_OBJDUMP) $$@ -D > $$@.objdump; \
+					$$(RISCV_OBJDUMP) $$@ --source > $$@.debug
+
+
+COMPILE_TARGET=\
+				$(COMPILE_CMD); \
+        if [ $$$$? -ne 0 ] ; \
+                then \
+                echo "\e[31m$$(RISCV_GCC) failed for target $$(@) \e[39m" ; \
+                exit 1 ; \
+                fi ; \
+				$(OBJ_CMD); \
+        if [ $$$$? -ne 0 ] ; \
+                then \
+                echo "\e[31m $$(RISCV_OBJDUMP) failed for target $$(@) \e[39m" ; \
+                exit 1 ; \
+                fi ;
+
+RUN_CMD = $(TARGET_SIM) $(TARGET_FLAGS) --isa=rv32em \
+        +signature=$(*).signature.output +signature-granularity=4\
+        $< 
+
+RUN_TARGET=\
+	$(RUN_CMD)

--- a/arch_test_target/spike/device/rv32i_m/F/Makefile.include
+++ b/arch_test_target/spike/device/rv32i_m/F/Makefile.include
@@ -1,0 +1,40 @@
+TARGET_SIM   ?= spike
+TARGET_FLAGS ?= $(RISCV_TARGET_FLAGS)
+ifeq ($(shell command -v $(TARGET_SIM) 2> /dev/null),)
+    $(error Target simulator executable '$(TARGET_SIM)` not found)
+endif
+
+RISCV_PREFIX   ?= riscv32-unknown-elf-
+RISCV_GCC      ?= $(RISCV_PREFIX)gcc
+RISCV_OBJDUMP  ?= $(RISCV_PREFIX)objdump
+RISCV_GCC_OPTS ?= -g -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles $(RVTEST_DEFINES)
+
+COMPILE_CMD = $$(RISCV_GCC) $(1) $$(RISCV_GCC_OPTS) \
+							-I$(ROOTDIR)/riscv-test-suite/env/ \
+							-I$(TARGETDIR)/$(RISCV_TARGET)/ \
+							-T$(TARGETDIR)/$(RISCV_TARGET)/link.ld \
+							$$(<) -o $$@ 
+OBJ_CMD = $$(RISCV_OBJDUMP) $$@ -D > $$@.objdump; \
+					$$(RISCV_OBJDUMP) $$@ --source > $$@.debug
+
+
+COMPILE_TARGET=\
+				$(COMPILE_CMD); \
+        if [ $$$$? -ne 0 ] ; \
+                then \
+                echo "\e[31m$$(RISCV_GCC) failed for target $$(@) \e[39m" ; \
+                exit 1 ; \
+                fi ; \
+				$(OBJ_CMD); \
+        if [ $$$$? -ne 0 ] ; \
+                then \
+                echo "\e[31m $$(RISCV_OBJDUMP) failed for target $$(@) \e[39m" ; \
+                exit 1 ; \
+                fi ;
+
+RUN_CMD = $(TARGET_SIM) $(TARGET_FLAGS) --isa=rv32if \
+        +signature=$(*).signature.output +signature-granularity=4\
+        $< 
+
+RUN_TARGET=\
+	$(RUN_CMD) 

--- a/arch_test_target/spike/device/rv64i_m/D/Makefile.include
+++ b/arch_test_target/spike/device/rv64i_m/D/Makefile.include
@@ -1,0 +1,41 @@
+TARGET_SIM   ?= spike
+TARGET_FLAGS ?= $(RISCV_TARGET_FLAGS)
+ifeq ($(shell command -v $(TARGET_SIM) 2> /dev/null),)
+    $(error Target simulator executable '$(TARGET_SIM)` not found)
+endif
+
+RISCV_PREFIX   ?= riscv64-unknown-elf-
+RISCV_GCC      ?= $(RISCV_PREFIX)gcc
+RISCV_OBJDUMP  ?= $(RISCV_PREFIX)objdump
+RISCV_GCC_OPTS ?= -g -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles $(RVTEST_DEFINES)
+
+COMPILE_CMD = $$(RISCV_GCC) $(1) $$(RISCV_GCC_OPTS) \
+							-I$(ROOTDIR)/riscv-test-suite/env/ \
+							-I$(TARGETDIR)/$(RISCV_TARGET)/ \
+							-T$(TARGETDIR)/$(RISCV_TARGET)/link.ld \
+							$$(<) -o $$@ 
+OBJ_CMD = $$(RISCV_OBJDUMP) $$@ -D > $$@.objdump; \
+					$$(RISCV_OBJDUMP) $$@ --source > $$@.debug
+
+
+COMPILE_TARGET=\
+				$(COMPILE_CMD); \
+        if [ $$$$? -ne 0 ] ; \
+                then \
+                echo "\e[31m$$(RISCV_GCC) failed for target $$(@) \e[39m" ; \
+                exit 1 ; \
+                fi ; \
+				$(OBJ_CMD); \
+        if [ $$$$? -ne 0 ] ; \
+                then \
+                echo "\e[31m $$(RISCV_OBJDUMP) failed for target $$(@) \e[39m" ; \
+                exit 1 ; \
+                fi ;
+
+RUN_CMD = $(TARGET_SIM) $(TARGET_FLAGS) --isa=rv64ifd \
+        +signature=$(*).signature.output +signature-granularity=4\
+        $< 
+
+RUN_TARGET=\
+	$(RUN_CMD) 
+

--- a/arch_test_target/spike/model_test.h
+++ b/arch_test_target/spike/model_test.h
@@ -22,7 +22,7 @@
   addi x1, x1, 4; \
   li x1, 1;                                                                   \
   write_tohost:                                                               \
-    sw x1, tohost, t5;                                                        \
+    sw x1, tohost, t1;                                                        \
   self_loop:  j self_loop;
 
 #define RVMODEL_BOOT


### PR DESCRIPTION
- updated the arch_test_target/device directory to include F, D and rv32e_unratified extensions
- using register t1 instead of t5 in RVMODEL_HALT since its supported in E as well 
- Related issue https://github.com/riscv-non-isa/riscv-arch-test/issues/227