### PR TITLE
perform hstatus probe/update for sret only when H extension enabled.

### DIFF
--- a/riscv/insns/sret.h
+++ b/riscv/insns/sret.h
@@ -16,11 +16,12 @@ s = set_field(s, MSTATUS_SPP, PRV_U);
 STATE.sstatus->write(s);
 p->set_privilege(prev_prv);
 if (!STATE.v) {
-  reg_t prev_virt = get_field(prev_hstatus, HSTATUS_SPV);
-  p->set_virt(prev_virt);
-
-  reg_t new_hstatus = set_field(prev_hstatus, HSTATUS_SPV, 0);
-  STATE.hstatus->write(new_hstatus);
+  if p->extension_enabled('H') {
+    reg_t prev_virt = get_field(prev_hstatus, HSTATUS_SPV);
+    p->set_virt(prev_virt);
+    reg_t new_hstatus = set_field(prev_hstatus, HSTATUS_SPV, 0);
+    STATE.hstatus->write(new_hstatus);
+  }
 
   STATE.mstatus->write(set_field(STATE.mstatus->read(), MSTATUS_MPRV, 0));
 }

--- a/riscv/insns/sret.h
+++ b/riscv/insns/sret.h
@@ -16,7 +16,7 @@ s = set_field(s, MSTATUS_SPP, PRV_U);
 STATE.sstatus->write(s);
 p->set_privilege(prev_prv);
 if (!STATE.v) {
-  if p->extension_enabled('H') {
+  if (p->extension_enabled('H')) {
     reg_t prev_virt = get_field(prev_hstatus, HSTATUS_SPV);
     p->set_virt(prev_virt);
     reg_t new_hstatus = set_field(prev_hstatus, HSTATUS_SPV, 0);


### PR DESCRIPTION
motivation for this is #932 . This fix is meant to disable logging of hstatus on srets when H extension is not enabled.