### PR TITLE
automatic calendar-versioning based releases

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -27,7 +27,7 @@ jobs:
 
       - run: ci-tests/test-spike
 
-      - name: Calver Release
+      - name: Calendar versioning Release
         uses: StephaneBour/actions-calver@master
         id: calver
         with:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -26,3 +26,26 @@ jobs:
         run: sudo xargs apt-get install -y < .github/workflows/apt-packages.txt
 
       - run: ci-tests/test-spike
+
+      - name: Calver Release
+        uses: StephaneBour/actions-calver@master
+        id: calver
+        with:
+          date_format: "%Y-%m-%d"
+          release: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create Release
+        id: create_release
+        if: github.ref == 'refs/heads/master'
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
+        with:
+          release_branch: refs/heads/master
+          release_name: ${{ steps.calver.outputs.release }}
+          tag_name: ${{ steps.calver.outputs.release }}
+          draft: false
+          prerelease: false
+

--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,0 @@
-#define SPIKE_VERSION "1.1.1-dev"

--- a/config.h.in
+++ b/config.h.in
@@ -123,14 +123,14 @@
 /* Define if subproject MCPPBS_SPROJ_NORM is enabled */
 #undef SPIKE_MAIN_ENABLED
 
+/* Define version of spike installed */
+#undef SPIKE_VERSION
+
 /* Define to 1 if you have the ANSI C header files. */
 #undef STDC_HEADERS
 
 /* Default value for --with-target switch */
 #undef TARGET_ARCH
-
-/* Define git release version */
-#undef VERSION
 
 /* Define WORDS_BIGENDIAN to 1 if your processor stores words with the most
    significant byte first (like Motorola and SPARC, unlike Intel). */

--- a/config.h.in
+++ b/config.h.in
@@ -129,6 +129,9 @@
 /* Default value for --with-target switch */
 #undef TARGET_ARCH
 
+/* Define git release version */
+#undef VERSION
+
 /* Define WORDS_BIGENDIAN to 1 if your processor stores words with the most
    significant byte first (like Motorola and SPARC, unlike Intel). */
 #if defined AC_APPLE_UNIVERSAL_BUILD

--- a/configure
+++ b/configure
@@ -6423,10 +6423,10 @@ ac_config_files="$ac_config_files riscv-fesvr.pc"
 
 ac_config_files="$ac_config_files riscv-disasm.pc"
 
-VERSION=`git describe --tags $(git rev-list --tags --max-count=1)`
+SPIKE_VERSION=`git describe --tags --dirty`
 
 cat >>confdefs.h <<_ACEOF
-#define VERSION "$VERSION"
+#define SPIKE_VERSION "$SPIKE_VERSION"
 _ACEOF
 
 cat >confcache <<\_ACEOF

--- a/configure
+++ b/configure
@@ -6423,6 +6423,12 @@ ac_config_files="$ac_config_files riscv-fesvr.pc"
 
 ac_config_files="$ac_config_files riscv-disasm.pc"
 
+VERSION=`git describe --tags $(git rev-list --tags --max-count=1)`
+
+cat >>confdefs.h <<_ACEOF
+#define VERSION "$VERSION"
+_ACEOF
+
 cat >confcache <<\_ACEOF
 # This file is a shell script that caches the results of configure
 # tests run on this system so they can be shared between configure

--- a/configure.ac
+++ b/configure.ac
@@ -123,4 +123,8 @@ AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_FILES([Makefile])
 AC_CONFIG_FILES([riscv-fesvr.pc])
 AC_CONFIG_FILES([riscv-disasm.pc])
+VERSION=`git describe --tags $(git rev-list --tags --max-count=1)`
+AC_DEFINE_UNQUOTED([VERSION],
+                   ["$VERSION"],
+                   [Define git release version])
 AC_OUTPUT

--- a/configure.ac
+++ b/configure.ac
@@ -123,8 +123,8 @@ AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_FILES([Makefile])
 AC_CONFIG_FILES([riscv-fesvr.pc])
 AC_CONFIG_FILES([riscv-disasm.pc])
-VERSION=`git describe --tags $(git rev-list --tags --max-count=1)`
-AC_DEFINE_UNQUOTED([VERSION],
-                   ["$VERSION"],
-                   [Define git release version])
+SPIKE_VERSION=`git describe --tags --dirty`
+AC_DEFINE_UNQUOTED([SPIKE_VERSION],
+                   ["$SPIKE_VERSION"],
+                   [Define version of spike installed])
 AC_OUTPUT

--- a/spike_main/spike.cc
+++ b/spike_main/spike.cc
@@ -17,7 +17,7 @@
 
 static void help(int exit_code = 1)
 {
-  fprintf(stderr, "Spike RISC-V ISA Simulator " SPIKE_VERSION "\n\n");
+  fprintf(stderr, "Spike RISC-V ISA Simulator " VERSION "\n\n");
   fprintf(stderr, "usage: spike [host options] <target program> [target options]\n");
   fprintf(stderr, "Host Options:\n");
   fprintf(stderr, "  -p<n>                 Simulate <n> processors [default 1]\n");

--- a/spike_main/spike.cc
+++ b/spike_main/spike.cc
@@ -13,11 +13,10 @@
 #include <string>
 #include <memory>
 #include <fstream>
-#include "../VERSION"
 
 static void help(int exit_code = 1)
 {
-  fprintf(stderr, "Spike RISC-V ISA Simulator " VERSION "\n\n");
+  fprintf(stderr, "Spike RISC-V ISA Simulator " SPIKE_VERSION "\n\n");
   fprintf(stderr, "usage: spike [host options] <target program> [target options]\n");
   fprintf(stderr, "Host Options:\n");
   fprintf(stderr, "  -p<n>                 Simulate <n> processors [default 1]\n");


### PR DESCRIPTION
This PR upgrades the github actions script to create a new release each time the master is updated. The release name is based on calendar-versioning : `YYYY-MM-DD.MINOR`. Eg. `2022-02-28.1`.

I have always found the lack of linear versioning on spike a major pain-point to figure out where my local build is with respect to the master. Hence this PR. 

~~A probable next step is to include the recent-tag  into the cli parser (via the build process) which can be queried later via a `--version` cli arg~~

I managed to fix the configure scripts to capture the recent most tag and use it as a VERSION string in the help command.