### PR TITLE
add missed extensions specified by '--extension' to custom_extensions

### DIFF
--- a/customext/cflush.cc
+++ b/customext/cflush.cc
@@ -24,9 +24,9 @@ class cflush_t : public extension_t
 
   std::vector<insn_desc_t> get_instructions() {
     std::vector<insn_desc_t> insns;
-    insns.push_back((insn_desc_t){0xFC000073, 0xFFF07FFF, custom_cflush, custom_cflush});
-    insns.push_back((insn_desc_t){0xFC200073, 0xFFF07FFF, custom_cflush, custom_cflush});
-    insns.push_back((insn_desc_t){0xFC100073, 0xFFF07FFF, custom_cflush, custom_cflush});
+    insns.push_back((insn_desc_t){0xFC000073, 0xFFF07FFF, custom_cflush, custom_cflush, custom_cflush, custom_cflush});
+    insns.push_back((insn_desc_t){0xFC200073, 0xFFF07FFF, custom_cflush, custom_cflush, custom_cflush, custom_cflush});
+    insns.push_back((insn_desc_t){0xFC100073, 0xFFF07FFF, custom_cflush, custom_cflush, custom_cflush, custom_cflush});
     return insns;
   }
 

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -326,7 +326,7 @@ protected:
   reg_t max_isa;
   std::vector<bool> extension_table;
   std::string isa_string;
-  std::unordered_map<std::string, extension_t*> custom_extensions;
+  std::unordered_map<std::string, extension_t*> isa_extensions;
 };
 
 // this class represents one processor in a RISC-V machine.

--- a/riscv/rocc.cc
+++ b/riscv/rocc.cc
@@ -32,10 +32,10 @@ customX(3)
 std::vector<insn_desc_t> rocc_t::get_instructions()
 {
   std::vector<insn_desc_t> insns;
-  insns.push_back((insn_desc_t){0x0b, 0x7f, &::illegal_instruction, c0});
-  insns.push_back((insn_desc_t){0x2b, 0x7f, &::illegal_instruction, c1});
-  insns.push_back((insn_desc_t){0x5b, 0x7f, &::illegal_instruction, c2});
-  insns.push_back((insn_desc_t){0x7b, 0x7f, &::illegal_instruction, c3});
+  insns.push_back((insn_desc_t){0x0b, 0x7f, &::illegal_instruction, c0, &::illegal_instruction, c0});
+  insns.push_back((insn_desc_t){0x2b, 0x7f, &::illegal_instruction, c1, &::illegal_instruction, c1});
+  insns.push_back((insn_desc_t){0x5b, 0x7f, &::illegal_instruction, c2, &::illegal_instruction, c2});
+  insns.push_back((insn_desc_t){0x7b, 0x7f, &::illegal_instruction, c3, &::illegal_instruction, c3});
   return insns;
 }
 


### PR DESCRIPTION
This PR is to fix the problem of https://github.com/riscv-software-src/riscv-isa-sim/issues/931 which is caused by  https://github.com/riscv-software-src/riscv-isa-sim/pull/912 :
Because the move of register_extension progress for custom extension, extensions specified by '--extension' is missed to add into custom_extensions which makes get_extension() in function return NULL.
