### PR TITLE
Move towards configuring Spike through a device tree

### DIFF
--- a/riscv/cfg.cc
+++ b/riscv/cfg.cc
@@ -1,0 +1,25 @@
+// See LICENSE for license details.
+
+#include "cfg.h"
+#include "isa_parser.h"
+
+cfg_t::~cfg_t() {}
+
+const cfg_t &cfg_t::freeze()
+{
+  assert(!frozen);
+
+  assert(!isa_parser);
+  isa_parser.reset(new isa_parser_t(isa(), priv()));
+
+  frozen = true;
+  return *this;
+}
+
+cfg_arg_t<const isa_parser_t *> cfg_t::get_isa_parser() const
+{
+  assert(frozen && isa_parser);
+  cfg_arg_t<const isa_parser_t *> ret(isa_parser.get());
+  if (isa.overridden() || priv.overridden()) ret.set_overridden();
+  return ret;
+}

--- a/riscv/dts.cc
+++ b/riscv/dts.cc
@@ -60,6 +60,7 @@ static std::string make_dts(size_t insns_per_rtc_tick,
          "      status = \"okay\";\n"
          "      compatible = \"riscv\";\n"
          "      riscv,isa = \"" << isa->get_isa_string() << "\";\n"
+         "      riscv,priv = \"" << isa->get_priv_string() << "\";\n"
          "      mmu-type = \"riscv," << (isa->get_max_xlen() <= 32 ? "sv32" : "sv48") << "\";\n"
          "      riscv,pmpregions = <16>;\n"
          "      riscv,pmpgranularity = <4>;\n"

--- a/riscv/dts.h
+++ b/riscv/dts.h
@@ -2,16 +2,11 @@
 #ifndef _RISCV_DTS_H
 #define _RISCV_DTS_H
 
-#include "devices.h"
-#include "processor.h"
-#include "mmu.h"
+#include "cfg.h"
+#include "isa_parser.h"
 #include <string>
 
-std::string make_dts(size_t insns_per_rtc_tick, size_t cpu_hz,
-                     reg_t initrd_start, reg_t initrd_end,
-                     const char* bootargs,
-                     std::vector<processor_t*> procs,
-                     std::vector<std::pair<reg_t, mem_t*>> mems);
+std::string make_dts(size_t insns_per_rtc_tick, size_t cpu_hz, const cfg_t &cfg);
 
 std::string dts_compile(const std::string& dts);
 

--- a/riscv/dts.h
+++ b/riscv/dts.h
@@ -6,17 +6,61 @@
 #include "isa_parser.h"
 #include <string>
 
-std::string make_dts(size_t insns_per_rtc_tick, size_t cpu_hz, const cfg_t &cfg);
+class devicetree_t
+{
+public:
+  devicetree_t(std::string dtb, std::string dts, const char *src_path);
 
-std::string dts_compile(const std::string& dts);
+  // Factory method that either loads a DTB file from dtb_path (if non-null) or
+  // otherwise generates a standardised layout by generating a standardised DTS
+  // file and then compiling it to DTB.
+  static devicetree_t make(const char *dtb_path,
+                           size_t insns_per_rtc_tick, size_t cpu_hz,
+                           const cfg_t &cfg);
 
-int fdt_get_offset(void *fdt, const char *field);
-int fdt_get_first_subnode(void *fdt, int node);
-int fdt_get_next_subnode(void *fdt, int node);
+  // A wrapper for fdt_path_offset: returns non-negative block offset of node
+  // with the given path or a negative libfdt error code on failure.
+  int get_offset(const char *path) const;
 
-int fdt_parse_clint(void *fdt, reg_t *clint_addr,
-                    const char *compatible);
-int fdt_parse_pmp_num(void *fdt, int cpu_offset, reg_t *pmp_num);
-int fdt_parse_pmp_alignment(void *fdt, int cpu_offset, reg_t *pmp_align);
-int fdt_parse_mmu_type(void *fdt, int cpu_offset, const char **mmu_type);
+  // Search DTB for a CLINT. On success, writes its address to the non-null
+  // clint_addr and returns 0. On failure, returns a negative libfdt error
+  // code.
+  int find_clint(reg_t *clint_addr, const char *compatible) const;
+
+  // Get the number of PMP regions for CPU node at cpu_offset. On success,
+  // writes the number to the non-null pmp_num and returns 0. On failure,
+  // returns a negative libfdt error code.
+  int get_pmp_num(int cpu_offset, reg_t *pmp_num) const;
+
+  // Get PMP granularity for CPU node at cpu_offset. On success, writes the
+  // number to the non-null pmp_align and returns 0. On failure, returns a
+  // negative libfdt error code.
+  int get_pmp_alignment(int cpu_offset, reg_t *pmp_align) const;
+
+  // Get MMU type for CPU node at cpu_offset. On success, writes the pointer to
+  // the property string to the non-null mmu_type and returns 0. On failure,
+  // returns a negative libfdt error code.
+  int get_mmu_type(int cpu_offset, const char **mmu_type) const;
+
+  // Get access to the DTS form of the device tree. This is empty if the device
+  // tree was constructed directly from a DTB.
+  const char *get_dts() const { return dts.c_str(); }
+
+  // Get access to the DTB form of the device tree. This will always be
+  // nonempty and has already passed the fdt_check_header() well-formedness
+  // check.
+  const void *get_dtb() const { return dtb.c_str(); }
+
+  // Get access to the DTB in string form. This is useful if you want to know
+  // its size in advance
+  const std::string &get_dtb_str() const { return dtb; }
+
+private:
+  std::string dtb;
+  std::string dts;
+};
+
+int fdt_get_first_subnode(const void *fdt, int node);
+int fdt_get_next_subnode(const void *fdt, int node);
+
 #endif

--- a/riscv/isa_parser.cc
+++ b/riscv/isa_parser.cc
@@ -245,3 +245,11 @@ isa_parser_t::isa_parser_t(const char* str, const char *priv)
     extension_table['S'] = true;
   }
 }
+
+std::string isa_parser_t::get_priv_string() const
+{
+  std::string priv = "m";
+  if (extension_enabled('S')) priv += "s";
+  if (extension_enabled('U')) priv += "u";
+  return priv;
+}

--- a/riscv/isa_parser.h
+++ b/riscv/isa_parser.h
@@ -67,9 +67,12 @@ class isa_parser_t {
 public:
   isa_parser_t(const char* str, const char *priv);
   ~isa_parser_t(){};
+
   unsigned get_max_xlen() const { return max_xlen; }
   reg_t get_max_isa() const { return max_isa; }
   std::string get_isa_string() const { return isa_string; }
+  std::string get_priv_string() const;
+
   bool extension_enabled(unsigned char ext) const {
     if (ext >= 'A' && ext <= 'Z')
       return (max_isa >> (ext - 'A')) & 1;

--- a/riscv/riscv.mk.in
+++ b/riscv/riscv.mk.in
@@ -48,6 +48,7 @@ riscv_srcs = \
 	interactive.cc \
 	cachesim.cc \
 	mmu.cc \
+	cfg.cc \
 	extension.cc \
 	extensions.cc \
 	rocc.cc \

--- a/riscv/sim.cc
+++ b/riscv/sim.cc
@@ -41,7 +41,6 @@ sim_t::sim_t(const cfg_t *cfg, const char* varch, bool halted, bool real_time_cl
 #endif
              FILE *cmd_file) // needed for command line option --cmd
   : htif_t(args),
-    isa(cfg->isa(), cfg->priv()),
     cfg(cfg),
     mems(mems),
     plugin_devices(plugin_devices),
@@ -88,7 +87,7 @@ sim_t::sim_t(const cfg_t *cfg, const char* varch, bool halted, bool real_time_cl
 
   for (size_t i = 0; i < nprocs(); i++) {
     int hart_id = hartids.empty() ? i : hartids[i];
-    procs[i] = new processor_t(&isa, varch, this, hart_id, halted,
+    procs[i] = new processor_t(cfg->get_isa_parser()(), varch, this, hart_id, halted,
                                log_file.get(), sout_);
   }
 

--- a/riscv/sim.cc
+++ b/riscv/sim.cc
@@ -309,10 +309,7 @@ void sim_t::make_dtb()
 
     dtb = strstream.str();
   } else {
-    std::pair<reg_t, reg_t> initrd_bounds = cfg->initrd_bounds();
-    dts = make_dts(INSNS_PER_RTC_TICK, CPU_HZ,
-                   initrd_bounds.first, initrd_bounds.second,
-                   cfg->bootargs(), procs, mems);
+    dts = make_dts(INSNS_PER_RTC_TICK, CPU_HZ, *cfg);
     dtb = dts_compile(dts);
   }
 

--- a/riscv/sim.h
+++ b/riscv/sim.h
@@ -17,6 +17,7 @@
 #include "log_file.h"
 #include "processor.h"
 #include "simif.h"
+#include "dts.h"
 
 #include <fesvr/htif.h>
 #include <fesvr/context.h>
@@ -61,7 +62,7 @@ public:
   void set_remote_bitbang(remote_bitbang_t* remote_bitbang) {
     this->remote_bitbang = remote_bitbang;
   }
-  const char* get_dts() { if (dts.empty()) reset(); return dts.c_str(); }
+  const char* get_dts() { return devicetree.get_dts(); }
   processor_t* get_core(size_t i) { return procs.at(i); }
   unsigned nprocs() const { return procs.size(); }
 
@@ -76,9 +77,7 @@ private:
   std::vector<processor_t*> procs;
   std::pair<reg_t, reg_t> initrd_range;
   reg_t start_pc;
-  std::string dts;
-  std::string dtb;
-  std::string dtb_file;
+  devicetree_t devicetree;
   bool dtb_enabled;
   std::unique_ptr<rom_device_t> boot_rom;
   std::unique_ptr<clint_t> clint;
@@ -113,7 +112,6 @@ private:
   char* addr_to_mem(reg_t addr);
   bool mmio_load(reg_t addr, size_t len, uint8_t* bytes);
   bool mmio_store(reg_t addr, size_t len, const uint8_t* bytes);
-  void make_dtb();
   void set_rom();
 
   const char* get_symbol(uint64_t addr);

--- a/riscv/sim.h
+++ b/riscv/sim.h
@@ -11,7 +11,6 @@
 #include <boost/asio.hpp>
 #endif
 
-#include "cfg.h"
 #include "debug_module.h"
 #include "devices.h"
 #include "log_file.h"
@@ -33,7 +32,7 @@ class remote_bitbang_t;
 class sim_t : public htif_t, public simif_t
 {
 public:
-  sim_t(const cfg_t *cfg, const char* varch, bool halted, bool real_time_clint,
+  sim_t(const devicetree_t *devicetree, const char* varch, bool halted, bool real_time_clint,
         reg_t start_pc, std::vector<std::pair<reg_t, mem_t*>> mems,
         std::vector<std::pair<reg_t, abstract_device_t*>> plugin_devices,
         const std::vector<std::string>& args, const std::vector<int> hartids,
@@ -63,7 +62,6 @@ public:
   void set_remote_bitbang(remote_bitbang_t* remote_bitbang) {
     this->remote_bitbang = remote_bitbang;
   }
-  const char* get_dts() { return devicetree.get_dts(); }
   processor_t* get_core(size_t i) { return procs.at(i); }
   unsigned nprocs() const { return procs.size(); }
 
@@ -71,14 +69,13 @@ public:
   void proc_reset(unsigned id);
 
 private:
-  const cfg_t * const cfg;
   std::vector<std::pair<reg_t, mem_t*>> mems;
   std::vector<std::pair<reg_t, abstract_device_t*>> plugin_devices;
   mmu_t* debug_mmu;  // debug port into main memory
   std::vector<processor_t*> procs;
   std::pair<reg_t, reg_t> initrd_range;
   reg_t start_pc;
-  devicetree_t devicetree;
+  const devicetree_t * const devicetree;
   bool dtb_enabled;
   std::unique_ptr<rom_device_t> boot_rom;
   std::unique_ptr<clint_t> clint;

--- a/riscv/sim.h
+++ b/riscv/sim.h
@@ -42,7 +42,8 @@ public:
 #ifdef HAVE_BOOST_ASIO
         boost::asio::io_service *io_service_ptr_ctor, boost::asio::ip::tcp::acceptor *acceptor_ptr_ctor,  // option -s
 #endif
-        FILE *cmd_file); // needed for command line option --cmd
+        FILE *cmd_file, // needed for command line option --cmd
+        size_t interleave, size_t insns_per_rtc_tick, size_t cpu_hz);
   ~sim_t();
 
   // run the simulation to completion
@@ -98,9 +99,9 @@ private:
 
   processor_t* get_core(const std::string& i);
   void step(size_t n); // step through simulation
-  static const size_t INTERLEAVE = 5000;
-  static const size_t INSNS_PER_RTC_TICK = 100; // 10 MHz clock for 1 BIPS core
-  static const size_t CPU_HZ = 1000000000; // 1GHz CPU
+  size_t interleave;
+  size_t insns_per_rtc_tick;
+  size_t cpu_hz;
   size_t current_step;
   size_t current_proc;
   bool debug;

--- a/riscv/sim.h
+++ b/riscv/sim.h
@@ -69,7 +69,6 @@ public:
   void proc_reset(unsigned id);
 
 private:
-  isa_parser_t isa;
   const cfg_t * const cfg;
   std::vector<std::pair<reg_t, mem_t*>> mems;
   std::vector<std::pair<reg_t, abstract_device_t*>> plugin_devices;

--- a/spike_main/spike.cc
+++ b/spike_main/spike.cc
@@ -462,7 +462,15 @@ int main(int argc, char** argv)
   }
 #endif
 
-  sim_t s(&frozen_cfg, varch, halted, real_time_clint,
+  devicetree_t devicetree =
+    devicetree_t::make(dtb_file, INSNS_PER_RTC_TICK, CPU_HZ, frozen_cfg);
+
+  if (dump_dts) {
+    printf("%s", devicetree.get_dts());
+    return 0;
+  }
+
+  sim_t s(&devicetree, varch, halted, real_time_clint,
       start_pc, mems, plugin_devices, htif_args,
       std::move(hartids), dm_config, log_path, dtb_enabled, dtb_file,
 #ifdef HAVE_BOOST_ASIO
@@ -475,11 +483,6 @@ int main(int argc, char** argv)
   if (use_rbb) {
     remote_bitbang.reset(new remote_bitbang_t(rbb_port, &(*jtag_dtm)));
     s.set_remote_bitbang(&(*remote_bitbang));
-  }
-
-  if (dump_dts) {
-    printf("%s", s.get_dts());
-    return 0;
   }
 
   if (ic && l2) ic->set_miss_handler(&*l2);

--- a/spike_main/spike.cc
+++ b/spike_main/spike.cc
@@ -433,6 +433,8 @@ int main(int argc, char** argv)
     }
   }
 
+  const cfg_t &frozen_cfg = cfg.freeze();
+
 #ifdef HAVE_BOOST_ASIO
   boost::asio::io_service *io_service_ptr = NULL; // needed for socket command interface option -s
   boost::asio::ip::tcp::acceptor *acceptor_ptr = NULL;
@@ -456,7 +458,7 @@ int main(int argc, char** argv)
   }
 #endif
 
-  sim_t s(&cfg, varch, halted, real_time_clint,
+  sim_t s(&frozen_cfg, varch, halted, real_time_clint,
       start_pc, mems, plugin_devices, htif_args,
       std::move(hartids), dm_config, log_path, dtb_enabled, dtb_file,
 #ifdef HAVE_BOOST_ASIO
@@ -480,7 +482,7 @@ int main(int argc, char** argv)
   if (dc && l2) dc->set_miss_handler(&*l2);
   if (ic) ic->set_log(log_cache);
   if (dc) dc->set_log(log_cache);
-  for (size_t i = 0; i < cfg.nprocs(); i++)
+  for (size_t i = 0; i < frozen_cfg.nprocs(); i++)
   {
     if (ic) s.get_core(i)->get_mmu()->register_memtracer(&*ic);
     if (dc) s.get_core(i)->get_mmu()->register_memtracer(&*dc);

--- a/spike_main/spike.cc
+++ b/spike_main/spike.cc
@@ -16,6 +16,10 @@
 #include <fstream>
 #include "../VERSION"
 
+static const size_t INTERLEAVE = 5000;
+static const size_t INSNS_PER_RTC_TICK = 100; // 10 MHz clock for 1 BIPS core
+static const size_t CPU_HZ = 1000000000; // 1GHz CPU
+
 static void help(int exit_code = 1)
 {
   fprintf(stderr, "Spike RISC-V ISA Simulator " SPIKE_VERSION "\n\n");
@@ -464,7 +468,7 @@ int main(int argc, char** argv)
 #ifdef HAVE_BOOST_ASIO
       io_service_ptr, acceptor_ptr,
 #endif
-      cmd_file);
+      cmd_file, INTERLEAVE, INSNS_PER_RTC_TICK, CPU_HZ);
   std::unique_ptr<remote_bitbang_t> remote_bitbang((remote_bitbang_t *) NULL);
   std::unique_ptr<jtag_dtm_t> jtag_dtm(
       new jtag_dtm_t(&s.debug_module, dmi_rti));


### PR DESCRIPTION
*This is a long series of commits (sorry!) and is reasonably invasive. I'm very happy to split the PR into several pieces to be merged separately if that's more helpful, but I thought it might make sense to show an "end goal" for the staging commits that appear near the start. I'm also happy to rewrite/refactor things as desired, but it probably only makes sense to do that if we agree that this is going in a sensible direction overall.*

The basic idea is to represent more and more of Spike configuration by a "DTB" file (a binary representation of a devicetree).

Before these changes, we could dump a devicetree in textual form (with the `--dump-dts` argument) or consume a binary device tree representation (with the `--dtb` argument). If a user passed `--dtb` and also some other configuration arguments (`--isa` or `-p`, say) we'd do *something* based on the two. In particular, we ignored the ISA implied by the DTB file, always taking the value of `--isa` from the command line. But we spat out an error if `-p` from the command line didn't match the devicetree. 

With these changes, the configuration goes like this if you have no DTB:
```
    cmd line -> DTS -> DTB -- (dtb parser) --> config
```
and this if you have a DTB:
```
    DTB -- (dtb parser) -->
                     /----> config -\
                     |              v
    cmd line --------+----> consistency check
```
(pardon the rubbish ASCII art!)

The consistency check is intended to be a bit more principled than what we had before. At the moment, it fails with an error if a command line argument has been explicitly given and doesn't match the DTB. We could equally well change that behaviour to e.g. override the DTB: I went with the semantics that more closely matched what I think is there at the moment, but I'm happy to go the other way.

At the moment, the configuration information that we get from the DTB is used for exactly the arguments that were needed by the `make_dts` function. This is the bare minimum needed to be able to pull this configuration machinery out of `sim_t`. Clearly, there are lots more configuration arguments that can follow suit if we decide to take this further, but this PR was intended as the "MVP" version to avoid wasting lots of effort if people hated the general approach!