### PR TITLE
Change some methods to take a const isa_parser_t

### DIFF
--- a/disasm/disasm.cc
+++ b/disasm/disasm.cc
@@ -622,7 +622,7 @@ static void NOINLINE add_unknown_insns(disassembler_t* d)
   #undef DECLARE_INSN
 }
 
-void disassembler_t::add_instructions(isa_parser_t* isa)
+void disassembler_t::add_instructions(const isa_parser_t* isa)
 {
   const uint32_t mask_rd = 0x1fUL << 7;
   const uint32_t match_rd_ra = 1UL << 7;
@@ -2024,7 +2024,7 @@ void disassembler_t::add_instructions(isa_parser_t* isa)
   }
 }
 
-disassembler_t::disassembler_t(isa_parser_t* isa)
+disassembler_t::disassembler_t(const isa_parser_t *isa)
 {
   // highest priority: instructions explicitly enabled
   add_instructions(isa);

--- a/riscv/disasm.h
+++ b/riscv/disasm.h
@@ -81,7 +81,7 @@ class disasm_insn_t
 class disassembler_t
 {
  public:
-  disassembler_t(isa_parser_t* isa);
+  disassembler_t(const isa_parser_t *isa);
   ~disassembler_t();
 
   std::string disassemble(insn_t insn) const;
@@ -93,7 +93,7 @@ class disassembler_t
   static const int HASH_SIZE = 255;
   std::vector<const disasm_insn_t*> chain[HASH_SIZE+1];
 
-  void add_instructions(isa_parser_t* isa);
+  void add_instructions(const isa_parser_t* isa);
 
   const disasm_insn_t* probe_once(insn_t insn, size_t idx) const;
 

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -313,8 +313,8 @@ class isa_parser_t {
 public:
   isa_parser_t(const char* str);
   ~isa_parser_t(){};
-  unsigned get_max_xlen() { return max_xlen; }
-  std::string get_isa_string() { return isa_string; }
+  unsigned get_max_xlen() const { return max_xlen; }
+  std::string get_isa_string() const { return isa_string; }
   bool extension_enabled(unsigned char ext) const {
     if (ext >= 'A' && ext <= 'Z')
       return (max_isa >> (ext - 'A')) & 1;


### PR DESCRIPTION
*This is part of the chain of commits in #938 but seemed easy to review separately. I'll rebase the larger PR if this one is merged*

No functional change, but this is needed for a following refactor
where we're passing it around `const`.