### PR TITLE
Incorporate supported privilege levels into isa_parser_t

### DIFF
--- a/disasm/disasm.cc
+++ b/disasm/disasm.cc
@@ -2032,7 +2032,7 @@ disassembler_t::disassembler_t(const isa_parser_t *isa)
   // next-highest priority: other instructions in same base ISA
   std::string fallback_isa_string = std::string("rv") + std::to_string(isa->get_max_xlen()) +
     "gcv_zfh_zba_zbb_zbc_zbs_zkn_zkr_zks_xbitmanip";
-  isa_parser_t fallback_isa(fallback_isa_string.c_str());
+  isa_parser_t fallback_isa(fallback_isa_string.c_str(), DEFAULT_PRIV);
   add_instructions(&fallback_isa);
 
   // finally: instructions with known opcodes but unknown arguments

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -311,9 +311,10 @@ static int cto(reg_t val)
 
 class isa_parser_t {
 public:
-  isa_parser_t(const char* str);
+  isa_parser_t(const char* str, const char *priv);
   ~isa_parser_t(){};
   unsigned get_max_xlen() const { return max_xlen; }
+  reg_t get_max_isa() const { return max_isa; }
   std::string get_isa_string() const { return isa_string; }
   bool extension_enabled(unsigned char ext) const {
     if (ext >= 'A' && ext <= 'Z')

--- a/spike_dasm/spike-dasm.cc
+++ b/spike_dasm/spike-dasm.cc
@@ -27,7 +27,7 @@ int main(int argc, char** argv)
   parser.option(0, "isa", 1, [&](const char* s){isa = s;});
   parser.parse(argv);
 
-  isa_parser_t isa_parser(isa);
+  isa_parser_t isa_parser(isa, DEFAULT_PRIV);
   disassembler_t* disassembler = new disassembler_t(&isa_parser);
   if (extension) {
     for (auto disasm_insn : extension()->get_disasms()) {


### PR DESCRIPTION
*This is another commit plucked from #938. It probably makes sense no matter what we think about the general direction of that PR*

These affect the "max_isa" value (now exposed as get_max_isa()) and
feel like they're similar to the other computations done in
isa_parser_t.