### PR TITLE
Factor some of the command line configuration into base_cfg_t

### DIFF
--- a/riscv/cfg.h
+++ b/riscv/cfg.h
@@ -30,17 +30,19 @@ class cfg_t
 public:
   cfg_t(std::pair<reg_t, reg_t> default_initrd_bounds,
         const char *default_bootargs, size_t default_nprocs,
-        const char *default_isa)
+        const char *default_isa, const char *default_priv)
     : initrd_bounds(default_initrd_bounds),
       bootargs(default_bootargs),
       nprocs(default_nprocs),
-      isa(default_isa)
+      isa(default_isa),
+      priv(default_priv)
   {}
 
   cfg_arg_t<std::pair<reg_t, reg_t>> initrd_bounds;
   cfg_arg_t<const char *>            bootargs;
   cfg_arg_t<size_t>                  nprocs;
   cfg_arg_t<const char *>            isa;
+  cfg_arg_t<const char *>            priv;
 };
 
 #endif

--- a/riscv/cfg.h
+++ b/riscv/cfg.h
@@ -28,11 +28,14 @@ private:
 class cfg_t
 {
 public:
-  cfg_t(std::pair<reg_t, reg_t> default_initrd_bounds)
-    : initrd_bounds(default_initrd_bounds)
+  cfg_t(std::pair<reg_t, reg_t> default_initrd_bounds,
+        const char *default_bootargs)
+    : initrd_bounds(default_initrd_bounds),
+      bootargs(default_bootargs)
   {}
 
   cfg_arg_t<std::pair<reg_t, reg_t>> initrd_bounds;
+  cfg_arg_t<const char *>            bootargs;
 };
 
 #endif

--- a/riscv/cfg.h
+++ b/riscv/cfg.h
@@ -29,15 +29,18 @@ class cfg_t
 {
 public:
   cfg_t(std::pair<reg_t, reg_t> default_initrd_bounds,
-        const char *default_bootargs, size_t default_nprocs)
+        const char *default_bootargs, size_t default_nprocs,
+        const char *default_isa)
     : initrd_bounds(default_initrd_bounds),
       bootargs(default_bootargs),
-      nprocs(default_nprocs)
+      nprocs(default_nprocs),
+      isa(default_isa)
   {}
 
   cfg_arg_t<std::pair<reg_t, reg_t>> initrd_bounds;
   cfg_arg_t<const char *>            bootargs;
   cfg_arg_t<size_t>                  nprocs;
+  cfg_arg_t<const char *>            isa;
 };
 
 #endif

--- a/riscv/cfg.h
+++ b/riscv/cfg.h
@@ -1,0 +1,38 @@
+// See LICENSE for license details.
+#ifndef _RISCV_CFG_H
+#define _RISCV_CFG_H
+
+#include "decode.h"
+
+template <typename T>
+class cfg_arg_t {
+public:
+  cfg_arg_t(T default_val)
+    : value(default_val), was_set(false) {}
+
+  bool overridden() const { return was_set; }
+
+  T operator()() const { return value; }
+
+  T operator=(const T v) {
+    value = v;
+    was_set = true;
+    return value;
+  }
+
+private:
+  T value;
+  bool was_set;
+};
+
+class cfg_t
+{
+public:
+  cfg_t(std::pair<reg_t, reg_t> default_initrd_bounds)
+    : initrd_bounds(default_initrd_bounds)
+  {}
+
+  cfg_arg_t<std::pair<reg_t, reg_t>> initrd_bounds;
+};
+
+#endif

--- a/riscv/cfg.h
+++ b/riscv/cfg.h
@@ -29,13 +29,15 @@ class cfg_t
 {
 public:
   cfg_t(std::pair<reg_t, reg_t> default_initrd_bounds,
-        const char *default_bootargs)
+        const char *default_bootargs, size_t default_nprocs)
     : initrd_bounds(default_initrd_bounds),
-      bootargs(default_bootargs)
+      bootargs(default_bootargs),
+      nprocs(default_nprocs)
   {}
 
   cfg_arg_t<std::pair<reg_t, reg_t>> initrd_bounds;
   cfg_arg_t<const char *>            bootargs;
+  cfg_arg_t<size_t>                  nprocs;
 };
 
 #endif

--- a/riscv/riscv.mk.in
+++ b/riscv/riscv.mk.in
@@ -14,6 +14,7 @@ riscv_hdrs = \
 	devices.h \
 	dts.h \
 	mmu.h \
+	cfg.h \
 	processor.h \
 	sim.h \
 	simif.h \

--- a/riscv/sim.cc
+++ b/riscv/sim.cc
@@ -30,7 +30,7 @@ static void handle_signal(int sig)
 
 sim_t::sim_t(const cfg_t *cfg,
              const char* isa_string, const char* priv, const char* varch,
-             size_t nprocs, bool halted, bool real_time_clint,
+             bool halted, bool real_time_clint,
              reg_t start_pc, std::vector<std::pair<reg_t, mem_t*>> mems,
              std::vector<std::pair<reg_t, abstract_device_t*>> plugin_devices,
              const std::vector<std::string>& args,
@@ -47,7 +47,7 @@ sim_t::sim_t(const cfg_t *cfg,
     cfg(cfg),
     mems(mems),
     plugin_devices(plugin_devices),
-    procs(std::max(nprocs, size_t(1))),
+    procs(std::max(cfg->nprocs(), size_t(1))),
     start_pc(start_pc),
     dtb_file(dtb_file ? dtb_file : ""),
     dtb_enabled(dtb_enabled),
@@ -80,15 +80,15 @@ sim_t::sim_t(const cfg_t *cfg,
 
   debug_mmu = new mmu_t(this, NULL);
 
-  if (! (hartids.empty() || hartids.size() == nprocs)) {
+  if (! (hartids.empty() || hartids.size() == nprocs())) {
       std::cerr << "Number of specified hartids ("
                 << hartids.size()
                 << ") doesn't match number of processors ("
-                << nprocs << ").\n";
+                << nprocs() << ").\n";
       exit(1);
   }
 
-  for (size_t i = 0; i < nprocs; i++) {
+  for (size_t i = 0; i < nprocs(); i++) {
     int hart_id = hartids.empty() ? i : hartids[i];
     procs[i] = new processor_t(isa, varch, this, hart_id, halted,
                                log_file.get(), sout_);
@@ -121,7 +121,7 @@ sim_t::sim_t(const cfg_t *cfg,
   for (cpu_offset = fdt_get_first_subnode(fdt, cpu_offset); cpu_offset >= 0;
        cpu_offset = fdt_get_next_subnode(fdt, cpu_offset)) {
 
-    if (cpu_idx >= nprocs)
+    if (cpu_idx >= nprocs())
       break;
 
     //handle pmp
@@ -171,11 +171,11 @@ sim_t::sim_t(const cfg_t *cfg,
     cpu_idx++;
   }
 
-  if (cpu_idx != nprocs) {
+  if (cpu_idx != nprocs()) {
       std::cerr << "core number in dts ("
                 <<  cpu_idx
                 << ") doesn't match it in command line ("
-                << nprocs << ").\n";
+                << nprocs() << ").\n";
       exit(1);
   }
 }

--- a/riscv/sim.cc
+++ b/riscv/sim.cc
@@ -28,8 +28,7 @@ static void handle_signal(int sig)
   signal(sig, &handle_signal);
 }
 
-sim_t::sim_t(const cfg_t *cfg, const char* priv, const char* varch,
-             bool halted, bool real_time_clint,
+sim_t::sim_t(const cfg_t *cfg, const char* varch, bool halted, bool real_time_clint,
              reg_t start_pc, std::vector<std::pair<reg_t, mem_t*>> mems,
              std::vector<std::pair<reg_t, abstract_device_t*>> plugin_devices,
              const std::vector<std::string>& args,
@@ -42,7 +41,7 @@ sim_t::sim_t(const cfg_t *cfg, const char* priv, const char* varch,
 #endif
              FILE *cmd_file) // needed for command line option --cmd
   : htif_t(args),
-    isa(cfg->isa(), priv),
+    isa(cfg->isa(), cfg->priv()),
     cfg(cfg),
     mems(mems),
     plugin_devices(plugin_devices),

--- a/riscv/sim.cc
+++ b/riscv/sim.cc
@@ -28,9 +28,9 @@ static void handle_signal(int sig)
   signal(sig, &handle_signal);
 }
 
-sim_t::sim_t(const char* isa_string, const char* priv, const char* varch,
-             size_t nprocs, bool halted, bool real_time_clint,
-             reg_t initrd_start, reg_t initrd_end, const char* bootargs,
+sim_t::sim_t(const cfg_t *cfg,
+             const char* isa_string, const char* priv, const char* varch,
+             size_t nprocs, bool halted, bool real_time_clint, const char* bootargs,
              reg_t start_pc, std::vector<std::pair<reg_t, mem_t*>> mems,
              std::vector<std::pair<reg_t, abstract_device_t*>> plugin_devices,
              const std::vector<std::string>& args,
@@ -44,11 +44,10 @@ sim_t::sim_t(const char* isa_string, const char* priv, const char* varch,
              FILE *cmd_file) // needed for command line option --cmd
   : htif_t(args),
     isa(isa_string, priv),
+    cfg(cfg),
     mems(mems),
     plugin_devices(plugin_devices),
     procs(std::max(nprocs, size_t(1))),
-    initrd_start(initrd_start),
-    initrd_end(initrd_end),
     bootargs(bootargs),
     start_pc(start_pc),
     dtb_file(dtb_file ? dtb_file : ""),
@@ -312,7 +311,10 @@ void sim_t::make_dtb()
 
     dtb = strstream.str();
   } else {
-    dts = make_dts(INSNS_PER_RTC_TICK, CPU_HZ, initrd_start, initrd_end, bootargs, procs, mems);
+    std::pair<reg_t, reg_t> initrd_bounds = cfg->initrd_bounds();
+    dts = make_dts(INSNS_PER_RTC_TICK, CPU_HZ,
+                   initrd_bounds.first, initrd_bounds.second,
+                   bootargs, procs, mems);
     dtb = dts_compile(dts);
   }
 

--- a/riscv/sim.cc
+++ b/riscv/sim.cc
@@ -28,8 +28,7 @@ static void handle_signal(int sig)
   signal(sig, &handle_signal);
 }
 
-sim_t::sim_t(const cfg_t *cfg,
-             const char* isa_string, const char* priv, const char* varch,
+sim_t::sim_t(const cfg_t *cfg, const char* priv, const char* varch,
              bool halted, bool real_time_clint,
              reg_t start_pc, std::vector<std::pair<reg_t, mem_t*>> mems,
              std::vector<std::pair<reg_t, abstract_device_t*>> plugin_devices,
@@ -43,7 +42,7 @@ sim_t::sim_t(const cfg_t *cfg,
 #endif
              FILE *cmd_file) // needed for command line option --cmd
   : htif_t(args),
-    isa(isa_string, priv),
+    isa(cfg->isa(), priv),
     cfg(cfg),
     mems(mems),
     plugin_devices(plugin_devices),

--- a/riscv/sim.cc
+++ b/riscv/sim.cc
@@ -30,7 +30,7 @@ static void handle_signal(int sig)
 
 sim_t::sim_t(const cfg_t *cfg,
              const char* isa_string, const char* priv, const char* varch,
-             size_t nprocs, bool halted, bool real_time_clint, const char* bootargs,
+             size_t nprocs, bool halted, bool real_time_clint,
              reg_t start_pc, std::vector<std::pair<reg_t, mem_t*>> mems,
              std::vector<std::pair<reg_t, abstract_device_t*>> plugin_devices,
              const std::vector<std::string>& args,
@@ -48,7 +48,6 @@ sim_t::sim_t(const cfg_t *cfg,
     mems(mems),
     plugin_devices(plugin_devices),
     procs(std::max(nprocs, size_t(1))),
-    bootargs(bootargs),
     start_pc(start_pc),
     dtb_file(dtb_file ? dtb_file : ""),
     dtb_enabled(dtb_enabled),
@@ -314,7 +313,7 @@ void sim_t::make_dtb()
     std::pair<reg_t, reg_t> initrd_bounds = cfg->initrd_bounds();
     dts = make_dts(INSNS_PER_RTC_TICK, CPU_HZ,
                    initrd_bounds.first, initrd_bounds.second,
-                   bootargs, procs, mems);
+                   cfg->bootargs(), procs, mems);
     dtb = dts_compile(dts);
   }
 

--- a/riscv/sim.h
+++ b/riscv/sim.h
@@ -34,7 +34,7 @@ class sim_t : public htif_t, public simif_t
 public:
   sim_t(const cfg_t *cfg,
         const char* isa, const char* priv, const char* varch, size_t _nprocs,
-        bool halted, bool real_time_clint, const char* bootargs,
+        bool halted, bool real_time_clint,
         reg_t start_pc, std::vector<std::pair<reg_t, mem_t*>> mems,
         std::vector<std::pair<reg_t, abstract_device_t*>> plugin_devices,
         const std::vector<std::string>& args, const std::vector<int> hartids,
@@ -78,7 +78,6 @@ private:
   mmu_t* debug_mmu;  // debug port into main memory
   std::vector<processor_t*> procs;
   std::pair<reg_t, reg_t> initrd_range;
-  const char* bootargs;
   reg_t start_pc;
   std::string dts;
   std::string dtb;

--- a/riscv/sim.h
+++ b/riscv/sim.h
@@ -33,7 +33,7 @@ class sim_t : public htif_t, public simif_t
 {
 public:
   sim_t(const cfg_t *cfg,
-        const char* isa, const char* priv, const char* varch, size_t _nprocs,
+        const char* isa, const char* priv, const char* varch,
         bool halted, bool real_time_clint,
         reg_t start_pc, std::vector<std::pair<reg_t, mem_t*>> mems,
         std::vector<std::pair<reg_t, abstract_device_t*>> plugin_devices,

--- a/riscv/sim.h
+++ b/riscv/sim.h
@@ -11,6 +11,7 @@
 #include <boost/asio.hpp>
 #endif
 
+#include "cfg.h"
 #include "debug_module.h"
 #include "devices.h"
 #include "log_file.h"
@@ -31,9 +32,9 @@ class remote_bitbang_t;
 class sim_t : public htif_t, public simif_t
 {
 public:
-  sim_t(const char* isa, const char* priv, const char* varch, size_t _nprocs,
-        bool halted, bool real_time_clint,
-        reg_t initrd_start, reg_t initrd_end, const char* bootargs,
+  sim_t(const cfg_t *cfg,
+        const char* isa, const char* priv, const char* varch, size_t _nprocs,
+        bool halted, bool real_time_clint, const char* bootargs,
         reg_t start_pc, std::vector<std::pair<reg_t, mem_t*>> mems,
         std::vector<std::pair<reg_t, abstract_device_t*>> plugin_devices,
         const std::vector<std::string>& args, const std::vector<int> hartids,
@@ -71,12 +72,12 @@ public:
 
 private:
   isa_parser_t isa;
+  const cfg_t * const cfg;
   std::vector<std::pair<reg_t, mem_t*>> mems;
   std::vector<std::pair<reg_t, abstract_device_t*>> plugin_devices;
   mmu_t* debug_mmu;  // debug port into main memory
   std::vector<processor_t*> procs;
-  reg_t initrd_start;
-  reg_t initrd_end;
+  std::pair<reg_t, reg_t> initrd_range;
   const char* bootargs;
   reg_t start_pc;
   std::string dts;

--- a/riscv/sim.h
+++ b/riscv/sim.h
@@ -32,8 +32,7 @@ class remote_bitbang_t;
 class sim_t : public htif_t, public simif_t
 {
 public:
-  sim_t(const cfg_t *cfg, const char* priv, const char* varch,
-        bool halted, bool real_time_clint,
+  sim_t(const cfg_t *cfg, const char* varch, bool halted, bool real_time_clint,
         reg_t start_pc, std::vector<std::pair<reg_t, mem_t*>> mems,
         std::vector<std::pair<reg_t, abstract_device_t*>> plugin_devices,
         const std::vector<std::string>& args, const std::vector<int> hartids,

--- a/riscv/sim.h
+++ b/riscv/sim.h
@@ -32,8 +32,7 @@ class remote_bitbang_t;
 class sim_t : public htif_t, public simif_t
 {
 public:
-  sim_t(const cfg_t *cfg,
-        const char* isa, const char* priv, const char* varch,
+  sim_t(const cfg_t *cfg, const char* priv, const char* varch,
         bool halted, bool real_time_clint,
         reg_t start_pc, std::vector<std::pair<reg_t, mem_t*>> mems,
         std::vector<std::pair<reg_t, abstract_device_t*>> plugin_devices,

--- a/spike_main/spike.cc
+++ b/spike_main/spike.cc
@@ -232,7 +232,6 @@ int main(int argc, char** argv)
   const char *log_path = nullptr;
   std::vector<std::function<extension_t*()>> extensions;
   const char* initrd = NULL;
-  const char* priv = DEFAULT_PRIV;
   const char* varch = DEFAULT_VARCH;
   const char* dtb_file = NULL;
   uint16_t rbb_port = 0;
@@ -253,7 +252,8 @@ int main(int argc, char** argv)
   cfg_t cfg(/*default_initrd_bounds=*/std::make_pair((reg_t)0, (reg_t)0),
             /*default_bootargs=*/nullptr,
             /*default_nprocs=*/1,
-            /*default_isa=*/DEFAULT_ISA);
+            /*default_isa=*/DEFAULT_ISA,
+            /*default_priv=*/DEFAULT_PRIV);
 
   auto const hartids_parser = [&](const char *s) {
     std::string const str(s);
@@ -331,7 +331,7 @@ int main(int argc, char** argv)
   parser.option(0, "l2", 1, [&](const char* s){l2.reset(cache_sim_t::construct(s, "L2$"));});
   parser.option(0, "log-cache-miss", 0, [&](const char* s){log_cache = true;});
   parser.option(0, "isa", 1, [&](const char* s){cfg.isa = s;});
-  parser.option(0, "priv", 1, [&](const char* s){priv = s;});
+  parser.option(0, "priv", 1, [&](const char* s){cfg.priv = s;});
   parser.option(0, "varch", 1, [&](const char* s){varch = s;});
   parser.option(0, "device", 1, device_parser);
   parser.option(0, "extension", 1, [&](const char* s){extensions.push_back(find_extension(s));});
@@ -445,7 +445,7 @@ int main(int argc, char** argv)
   }
 #endif
 
-  sim_t s(&cfg, priv, varch, halted, real_time_clint,
+  sim_t s(&cfg, varch, halted, real_time_clint,
       start_pc, mems, plugin_devices, htif_args,
       std::move(hartids), dm_config, log_path, dtb_enabled, dtb_file,
 #ifdef HAVE_BOOST_ASIO

--- a/spike_main/spike.cc
+++ b/spike_main/spike.cc
@@ -222,7 +222,6 @@ int main(int argc, char** argv)
   size_t nprocs = 1;
   const char* kernel = NULL;
   reg_t kernel_offset, kernel_size;
-  const char* bootargs = NULL;
   reg_t start_pc = reg_t(-1);
   std::vector<std::pair<reg_t, mem_t*>> mems;
   std::vector<std::pair<reg_t, abstract_device_t*>> plugin_devices;
@@ -253,7 +252,8 @@ int main(int argc, char** argv)
     .support_impebreak = true
   };
   std::vector<int> hartids;
-  cfg_t cfg(/*default_initrd_bounds=*/std::make_pair((reg_t)0, (reg_t)0));
+  cfg_t cfg(/*default_initrd_bounds=*/std::make_pair((reg_t)0, (reg_t)0),
+            /*default_bootargs=*/nullptr);
 
   auto const hartids_parser = [&](const char *s) {
     std::string const str(s);
@@ -340,7 +340,7 @@ int main(int argc, char** argv)
   parser.option(0, "dtb", 1, [&](const char *s){dtb_file = s;});
   parser.option(0, "kernel", 1, [&](const char* s){kernel = s;});
   parser.option(0, "initrd", 1, [&](const char* s){initrd = s;});
-  parser.option(0, "bootargs", 1, [&](const char* s){bootargs = s;});
+  parser.option(0, "bootargs", 1, [&](const char* s){cfg.bootargs = s;});
   parser.option(0, "real-time-clint", 0, [&](const char *s){real_time_clint = true;});
   parser.option(0, "extlib", 1, [&](const char *s){
     void *lib = dlopen(s, RTLD_NOW | RTLD_GLOBAL);
@@ -445,7 +445,7 @@ int main(int argc, char** argv)
 #endif
 
   sim_t s(&cfg, isa, priv, varch, nprocs, halted, real_time_clint,
-      bootargs, start_pc, mems, plugin_devices, htif_args,
+      start_pc, mems, plugin_devices, htif_args,
       std::move(hartids), dm_config, log_path, dtb_enabled, dtb_file,
 #ifdef HAVE_BOOST_ASIO
       io_service_ptr, acceptor_ptr,

--- a/spike_main/spike.cc
+++ b/spike_main/spike.cc
@@ -232,7 +232,6 @@ int main(int argc, char** argv)
   const char *log_path = nullptr;
   std::vector<std::function<extension_t*()>> extensions;
   const char* initrd = NULL;
-  const char* isa = DEFAULT_ISA;
   const char* priv = DEFAULT_PRIV;
   const char* varch = DEFAULT_VARCH;
   const char* dtb_file = NULL;
@@ -253,7 +252,8 @@ int main(int argc, char** argv)
   std::vector<int> hartids;
   cfg_t cfg(/*default_initrd_bounds=*/std::make_pair((reg_t)0, (reg_t)0),
             /*default_bootargs=*/nullptr,
-            /*default_nprocs=*/1);
+            /*default_nprocs=*/1,
+            /*default_isa=*/DEFAULT_ISA);
 
   auto const hartids_parser = [&](const char *s) {
     std::string const str(s);
@@ -330,7 +330,7 @@ int main(int argc, char** argv)
   parser.option(0, "dc", 1, [&](const char* s){dc.reset(new dcache_sim_t(s));});
   parser.option(0, "l2", 1, [&](const char* s){l2.reset(cache_sim_t::construct(s, "L2$"));});
   parser.option(0, "log-cache-miss", 0, [&](const char* s){log_cache = true;});
-  parser.option(0, "isa", 1, [&](const char* s){isa = s;});
+  parser.option(0, "isa", 1, [&](const char* s){cfg.isa = s;});
   parser.option(0, "priv", 1, [&](const char* s){priv = s;});
   parser.option(0, "varch", 1, [&](const char* s){varch = s;});
   parser.option(0, "device", 1, device_parser);
@@ -395,6 +395,7 @@ int main(int argc, char** argv)
     help();
 
   if (kernel && check_file_exists(kernel)) {
+    const char *isa = cfg.isa();
     kernel_size = get_file_size(kernel);
     if (isa[2] == '6' && isa[3] == '4')
       kernel_offset = 0x200000;
@@ -444,7 +445,7 @@ int main(int argc, char** argv)
   }
 #endif
 
-  sim_t s(&cfg, isa, priv, varch, halted, real_time_clint,
+  sim_t s(&cfg, priv, varch, halted, real_time_clint,
       start_pc, mems, plugin_devices, htif_args,
       std::move(hartids), dm_config, log_path, dtb_enabled, dtb_file,
 #ifdef HAVE_BOOST_ASIO


### PR DESCRIPTION
*This commit comes from the series at #938*

This is overly complicated for what we're doing at the moment, but the
point is that this is what's going to feed into our DTB-parsing
routine. The fields basically map onto the current arguments of
`make_dts()`.

We also track whether a field was "explicit" or not. The idea is that
we want to spot when someone has passed a DTB but also passed
something like a conflicting `--isa` parameter. This isn't currently
used, but will be used in a follow-up commit.