### PR TITLE
Compile using C++17 standard

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -94,7 +94,7 @@ VPATH := $(addprefix $(src_dir)/, $(sprojs_enabled))
 # highest.
 
 default-CFLAGS   := -DPREFIX=\"$(prefix)\" -Wall -Wno-unused -Wno-nonportable-include-path -g -O2 -fPIC
-default-CXXFLAGS := $(default-CFLAGS) -std=c++11
+default-CXXFLAGS := $(default-CFLAGS) -std=c++17
 
 mcppbs-CPPFLAGS := @CPPFLAGS@
 mcppbs-CFLAGS   := $(default-CFLAGS) @CFLAGS@


### PR DESCRIPTION
It would [be nice](https://github.com/riscv-software-src/riscv-isa-sim/pull/946#discussion_r826335981) to be able to use modern C++ features like `std::optional`.

Are all users of Spike using modern C++ compilers by now?