### PR TITLE
Fix perf regressions from CSR refactoring in FP-heavy code 

### DIFF
--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -421,11 +421,6 @@ mstatus_csr_t::mstatus_csr_t(processor_t* const proc, const reg_t addr):
 }
 
 
-reg_t mstatus_csr_t::read() const noexcept {
-  return val;
-}
-
-
 bool mstatus_csr_t::unlogged_write(const reg_t val) noexcept {
   const bool has_mpv = proc->extension_enabled('S') && proc->extension_enabled('H');
   const bool has_gva = has_mpv;

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -464,9 +464,9 @@ void sstatus_csr_t::dirty(const reg_t dirties) {
   // checking for mstatus.VS!=Off:
   if (!enabled(dirties)) abort();
 
-  orig_csr->write(orig_csr->read() | dirties);
+  orig_sstatus->write(orig_sstatus->read() | dirties);
   if (state->v) {
-    virt_csr->write(virt_csr->read() | dirties);
+    virt_sstatus->write(virt_sstatus->read() | dirties);
   }
 }
 

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -394,10 +394,6 @@ sstatus_proxy_csr_t::sstatus_proxy_csr_t(processor_t* const proc, const reg_t ad
   mstatus(mstatus) {
 }
 
-reg_t sstatus_proxy_csr_t::read() const noexcept {
-  return mstatus->read() & sstatus_read_mask;
-}
-
 bool sstatus_proxy_csr_t::unlogged_write(const reg_t val) noexcept {
   const reg_t new_mstatus = (mstatus->read() & ~sstatus_write_mask) | (val & sstatus_write_mask);
 

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -389,7 +389,7 @@ bool vsstatus_csr_t::unlogged_write(const reg_t val) noexcept {
 
 
 // implement class sstatus_proxy_csr_t
-sstatus_proxy_csr_t::sstatus_proxy_csr_t(processor_t* const proc, const reg_t addr, csr_t_p mstatus):
+sstatus_proxy_csr_t::sstatus_proxy_csr_t(processor_t* const proc, const reg_t addr, mstatus_csr_t_p mstatus):
   base_status_csr_t(proc, addr),
   mstatus(mstatus) {
 }

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -454,6 +454,12 @@ sstatus_csr_t::sstatus_csr_t(processor_t* const proc, sstatus_proxy_csr_t_p orig
 }
 
 void sstatus_csr_t::dirty(const reg_t dirties) {
+  // As an optimization, return early if already dirty.
+  if ((orig_sstatus->read() & dirties) == dirties) {
+    if (likely(!state->v || (virt_sstatus->read() & dirties) == dirties))
+      return;
+  }
+
   // Catch problems like #823 where P-extension instructions were not
   // checking for mstatus.VS!=Off:
   if (!enabled(dirties)) abort();

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -453,7 +453,7 @@ bool mstatush_csr_t::unlogged_write(const reg_t val) noexcept {
 }
 
 // implement class sstatus_csr_t
-sstatus_csr_t::sstatus_csr_t(processor_t* const proc, base_status_csr_t_p orig, base_status_csr_t_p virt):
+sstatus_csr_t::sstatus_csr_t(processor_t* const proc, sstatus_proxy_csr_t_p orig, vsstatus_csr_t_p virt):
   virtualized_csr_t(proc, orig, virt),
   orig_sstatus(orig),
   virt_sstatus(virt) {

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -380,10 +380,6 @@ vsstatus_csr_t::vsstatus_csr_t(processor_t* const proc, const reg_t addr):
   val(proc->get_state()->mstatus->read() & sstatus_read_mask) {
 }
 
-reg_t vsstatus_csr_t::read() const noexcept {
-  return val;
-}
-
 bool vsstatus_csr_t::unlogged_write(const reg_t val) noexcept {
   const reg_t newval = (this->val & ~sstatus_write_mask) | (val & sstatus_write_mask);
   if (state->v) maybe_flush_tlb(newval);

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -249,10 +249,14 @@ class mstatush_csr_t: public csr_t {
 };
 
 
-class sstatus_proxy_csr_t: public base_status_csr_t {
+class sstatus_proxy_csr_t final: public base_status_csr_t {
  public:
   sstatus_proxy_csr_t(processor_t* const proc, const reg_t addr, csr_t_p mstatus);
-  virtual reg_t read() const noexcept override;
+
+  reg_t read() const noexcept override {
+    return mstatus->read() & sstatus_read_mask;
+  }
+
  protected:
   virtual bool unlogged_write(const reg_t val) noexcept override;
  private:

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -263,18 +263,19 @@ class sstatus_proxy_csr_t final: public base_status_csr_t {
   csr_t_p mstatus;
 };
 
+typedef std::shared_ptr<sstatus_proxy_csr_t> sstatus_proxy_csr_t_p;
 
 class sstatus_csr_t: public virtualized_csr_t {
  public:
-  sstatus_csr_t(processor_t* const proc, base_status_csr_t_p orig, base_status_csr_t_p virt);
+  sstatus_csr_t(processor_t* const proc, sstatus_proxy_csr_t_p orig, vsstatus_csr_t_p virt);
 
   // Set FS, VS, or XS bits to dirty
   void dirty(const reg_t dirties);
   // Return true if the specified bits are not 00 (Off)
   bool enabled(const reg_t which);
  private:
-  base_status_csr_t_p orig_sstatus;
-  base_status_csr_t_p virt_sstatus;
+  sstatus_proxy_csr_t_p orig_sstatus;
+  vsstatus_csr_t_p virt_sstatus;
 };
 
 typedef std::shared_ptr<sstatus_csr_t> sstatus_csr_t_p;

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -219,10 +219,14 @@ class vsstatus_csr_t final: public base_status_csr_t {
 typedef std::shared_ptr<vsstatus_csr_t> vsstatus_csr_t_p;
 
 
-class mstatus_csr_t: public base_status_csr_t {
+class mstatus_csr_t final: public base_status_csr_t {
  public:
   mstatus_csr_t(processor_t* const proc, const reg_t addr);
-  virtual reg_t read() const noexcept override;
+
+  reg_t read() const noexcept override {
+    return val;
+  }
+
  protected:
   virtual bool unlogged_write(const reg_t val) noexcept override;
  private:

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -251,7 +251,7 @@ class mstatush_csr_t: public csr_t {
 
 class sstatus_proxy_csr_t final: public base_status_csr_t {
  public:
-  sstatus_proxy_csr_t(processor_t* const proc, const reg_t addr, csr_t_p mstatus);
+  sstatus_proxy_csr_t(processor_t* const proc, const reg_t addr, mstatus_csr_t_p mstatus);
 
   reg_t read() const noexcept override {
     return mstatus->read() & sstatus_read_mask;
@@ -260,7 +260,7 @@ class sstatus_proxy_csr_t final: public base_status_csr_t {
  protected:
   virtual bool unlogged_write(const reg_t val) noexcept override;
  private:
-  csr_t_p mstatus;
+  mstatus_csr_t_p mstatus;
 };
 
 typedef std::shared_ptr<sstatus_proxy_csr_t> sstatus_proxy_csr_t_p;

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -621,13 +621,15 @@ class dcsr_csr_t: public csr_t {
 typedef std::shared_ptr<dcsr_csr_t> dcsr_csr_t_p;
 
 
-class float_csr_t: public masked_csr_t {
+class float_csr_t final: public masked_csr_t {
  public:
   float_csr_t(processor_t* const proc, const reg_t addr, const reg_t mask, const reg_t init);
   virtual void verify_permissions(insn_t insn, bool write) const override;
  protected:
   virtual bool unlogged_write(const reg_t val) noexcept override;
 };
+
+typedef std::shared_ptr<float_csr_t> float_csr_t_p;
 
 
 // For a CSR like FCSR, that is actually a view into multiple

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -185,8 +185,11 @@ class cause_csr_t: public basic_csr_t {
 class base_status_csr_t: public csr_t {
  public:
   base_status_csr_t(processor_t* const proc, const reg_t addr);
-  // Return true if the specified bits are not 00 (Off)
-  bool enabled(const reg_t which);
+
+  bool field_exists(const reg_t which) {
+    return (sstatus_write_mask & which) != 0;
+  }
+
  protected:
   reg_t adjust_sd(const reg_t val) const noexcept;
   void maybe_flush_tlb(const reg_t newval) noexcept;

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -202,10 +202,14 @@ typedef std::shared_ptr<base_status_csr_t> base_status_csr_t_p;
 
 // For vsstatus, which is its own separate architectural register
 // (unlike sstatus)
-class vsstatus_csr_t: public base_status_csr_t {
+class vsstatus_csr_t final: public base_status_csr_t {
  public:
   vsstatus_csr_t(processor_t* const proc, const reg_t addr);
-  virtual reg_t read() const noexcept override;
+
+  reg_t read() const noexcept override {
+    return val;
+  }
+
  protected:
   virtual bool unlogged_write(const reg_t val) noexcept override;
  private:

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -215,17 +215,6 @@ class vsstatus_csr_t: public base_status_csr_t {
 typedef std::shared_ptr<vsstatus_csr_t> vsstatus_csr_t_p;
 
 
-class sstatus_proxy_csr_t: public base_status_csr_t {
- public:
-  sstatus_proxy_csr_t(processor_t* const proc, const reg_t addr, csr_t_p mstatus);
-  virtual reg_t read() const noexcept override;
- protected:
-  virtual bool unlogged_write(const reg_t val) noexcept override;
- private:
-  csr_t_p mstatus;
-};
-
-
 class mstatus_csr_t: public base_status_csr_t {
  public:
   mstatus_csr_t(processor_t* const proc, const reg_t addr);
@@ -249,6 +238,17 @@ class mstatush_csr_t: public csr_t {
  private:
   mstatus_csr_t_p mstatus;
   const reg_t mask;
+};
+
+
+class sstatus_proxy_csr_t: public base_status_csr_t {
+ public:
+  sstatus_proxy_csr_t(processor_t* const proc, const reg_t addr, csr_t_p mstatus);
+  virtual reg_t read() const noexcept override;
+ protected:
+  virtual bool unlogged_write(const reg_t val) noexcept override;
+ private:
+  csr_t_p mstatus;
 };
 
 

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -217,8 +217,8 @@ struct state_t
   static const int max_pmp = 16;
   pmpaddr_csr_t_p pmpaddr[max_pmp];
 
-  csr_t_p fflags;
-  csr_t_p frm;
+  float_csr_t_p fflags;
+  float_csr_t_p frm;
 
   csr_t_p menvcfg;
   csr_t_p senvcfg;


### PR DESCRIPTION
Since all FP instructions implicitly read `sstatus.FS` (and most implicitly write it), we are sensitive to the performance of those accesses.  Restructure accordingly.

For my simple test case (`for (volatile double f = 0; f < 200000000; f += 1.00000000001) {}`), these changes give a 3.4x speedup, which is roughly evenly divided between the changes to the read path (the first seven commits) and the changes to the write path (the final two).

This is a follow-on to #949.