### PR TITLE
Raise illegal (not virtual) instruction exception on counter writes

### DIFF
--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -922,7 +922,7 @@ void counter_proxy_csr_t::verify_permissions(insn_t insn, bool write) const {
   const bool hctr_ok = state->v ? myenable(state->hcounteren) : true;
   const bool sctr_ok = (proc->extension_enabled('S') && state->prv < PRV_S) ? myenable(state->scounteren) : true;
 
-  if (!mctr_ok)
+  if (write || !mctr_ok)
     throw trap_illegal_instruction(insn.bits());
   if (!hctr_ok)
       throw trap_virtual_instruction(insn.bits());
@@ -932,9 +932,6 @@ void counter_proxy_csr_t::verify_permissions(insn_t insn, bool write) const {
     else
       throw trap_illegal_instruction(insn.bits());
   }
-
-  if (write)
-    throw trap_illegal_instruction(insn.bits());
 }
 
 


### PR DESCRIPTION
Looks like a regression introduced in 53a3002e8cdbf94016d36c6071945bd663e826d5

Writes to read-only CSRs are not HS-qualified so should not raise virtual instruction exceptions.

cc @ingallsj @chihminchao 