### PR TITLE
Move a few more configuration arguments into cfg_t

### DIFF
--- a/riscv/cfg.h
+++ b/riscv/cfg.h
@@ -56,12 +56,14 @@ public:
   cfg_t(std::pair<reg_t, reg_t> default_initrd_bounds,
         const char *default_bootargs,
         const char *default_isa, const char *default_priv,
+        const char *default_varch,
         const std::vector<mem_cfg_t> &default_mem_layout,
         const std::vector<int> default_hartids)
     : initrd_bounds(default_initrd_bounds),
       bootargs(default_bootargs),
       isa(default_isa),
       priv(default_priv),
+      varch(default_varch),
       mem_layout(default_mem_layout),
       hartids(default_hartids),
       explicit_hartids(false)
@@ -71,6 +73,7 @@ public:
   cfg_arg_t<const char *>            bootargs;
   cfg_arg_t<const char *>            isa;
   cfg_arg_t<const char *>            priv;
+  cfg_arg_t<const char *>            varch;
   cfg_arg_t<std::vector<mem_cfg_t>>  mem_layout;
   std::optional<reg_t>               start_pc;
   cfg_arg_t<std::vector<int>>        hartids;

--- a/riscv/cfg.h
+++ b/riscv/cfg.h
@@ -54,13 +54,12 @@ class cfg_t
 {
 public:
   cfg_t(std::pair<reg_t, reg_t> default_initrd_bounds,
-        const char *default_bootargs, size_t default_nprocs,
+        const char *default_bootargs,
         const char *default_isa, const char *default_priv,
         const std::vector<mem_cfg_t> &default_mem_layout,
         const std::vector<int> default_hartids)
     : initrd_bounds(default_initrd_bounds),
       bootargs(default_bootargs),
-      nprocs(default_nprocs),
       isa(default_isa),
       priv(default_priv),
       mem_layout(default_mem_layout),
@@ -70,13 +69,14 @@ public:
 
   cfg_arg_t<std::pair<reg_t, reg_t>> initrd_bounds;
   cfg_arg_t<const char *>            bootargs;
-  cfg_arg_t<size_t>                  nprocs;
   cfg_arg_t<const char *>            isa;
   cfg_arg_t<const char *>            priv;
   cfg_arg_t<std::vector<mem_cfg_t>>  mem_layout;
   std::optional<reg_t>               start_pc;
   cfg_arg_t<std::vector<int>>        hartids;
   bool                               explicit_hartids;
+
+  size_t nprocs() const { return hartids().size(); }
 };
 
 #endif

--- a/riscv/cfg.h
+++ b/riscv/cfg.h
@@ -2,6 +2,7 @@
 #ifndef _RISCV_CFG_H
 #define _RISCV_CFG_H
 
+#include <optional>
 #include "decode.h"
 #include "mmu.h"
 #include <cassert>
@@ -70,6 +71,7 @@ public:
   cfg_arg_t<const char *>            isa;
   cfg_arg_t<const char *>            priv;
   cfg_arg_t<std::vector<mem_cfg_t>>  mem_layout;
+  std::optional<reg_t>               start_pc;
 };
 
 #endif

--- a/riscv/cfg.h
+++ b/riscv/cfg.h
@@ -56,13 +56,16 @@ public:
   cfg_t(std::pair<reg_t, reg_t> default_initrd_bounds,
         const char *default_bootargs, size_t default_nprocs,
         const char *default_isa, const char *default_priv,
-        const std::vector<mem_cfg_t> &default_mem_layout)
+        const std::vector<mem_cfg_t> &default_mem_layout,
+        const std::vector<int> default_hartids)
     : initrd_bounds(default_initrd_bounds),
       bootargs(default_bootargs),
       nprocs(default_nprocs),
       isa(default_isa),
       priv(default_priv),
-      mem_layout(default_mem_layout)
+      mem_layout(default_mem_layout),
+      hartids(default_hartids),
+      explicit_hartids(false)
   {}
 
   cfg_arg_t<std::pair<reg_t, reg_t>> initrd_bounds;
@@ -72,6 +75,8 @@ public:
   cfg_arg_t<const char *>            priv;
   cfg_arg_t<std::vector<mem_cfg_t>>  mem_layout;
   std::optional<reg_t>               start_pc;
+  cfg_arg_t<std::vector<int>>        hartids;
+  bool                               explicit_hartids;
 };
 
 #endif

--- a/riscv/cfg.h
+++ b/riscv/cfg.h
@@ -58,7 +58,8 @@ public:
         const char *default_isa, const char *default_priv,
         const char *default_varch,
         const std::vector<mem_cfg_t> &default_mem_layout,
-        const std::vector<int> default_hartids)
+        const std::vector<int> default_hartids,
+        bool default_real_time_clint)
     : initrd_bounds(default_initrd_bounds),
       bootargs(default_bootargs),
       isa(default_isa),
@@ -66,7 +67,8 @@ public:
       varch(default_varch),
       mem_layout(default_mem_layout),
       hartids(default_hartids),
-      explicit_hartids(false)
+      explicit_hartids(false),
+      real_time_clint(default_real_time_clint)
   {}
 
   cfg_arg_t<std::pair<reg_t, reg_t>> initrd_bounds;
@@ -78,6 +80,7 @@ public:
   std::optional<reg_t>               start_pc;
   cfg_arg_t<std::vector<int>>        hartids;
   bool                               explicit_hartids;
+  cfg_arg_t<bool>                    real_time_clint;
 
   size_t nprocs() const { return hartids().size(); }
 };

--- a/riscv/sim.cc
+++ b/riscv/sim.cc
@@ -32,7 +32,6 @@ sim_t::sim_t(const cfg_t *cfg, const char* varch, bool halted, bool real_time_cl
              std::vector<std::pair<reg_t, mem_t*>> mems,
              std::vector<std::pair<reg_t, abstract_device_t*>> plugin_devices,
              const std::vector<std::string>& args,
-             std::vector<int> const hartids,
              const debug_module_config_t &dm_config,
              const char *log_path,
              bool dtb_enabled, const char *dtb_file,
@@ -63,7 +62,7 @@ sim_t::sim_t(const cfg_t *cfg, const char* varch, bool halted, bool real_time_cl
     remote_bitbang(NULL),
     debug_module(this, dm_config)
 {
-  assert(hartids.size() == cfg->nprocs());
+  assert(cfg->hartids().size() == cfg->nprocs());
 
   signal(SIGINT, &handle_signal);
 
@@ -79,8 +78,8 @@ sim_t::sim_t(const cfg_t *cfg, const char* varch, bool halted, bool real_time_cl
 
   debug_mmu = new mmu_t(this, NULL);
 
-  for (size_t i = 0; i < nprocs(); i++) {
-    procs[i] = new processor_t(&isa, varch, this, hartids[i], halted,
+  for (size_t i = 0; i < cfg->nprocs(); i++) {
+    procs[i] = new processor_t(&isa, varch, this, cfg->hartids()[i], halted,
                                log_file.get(), sout_);
   }
 

--- a/riscv/sim.cc
+++ b/riscv/sim.cc
@@ -29,7 +29,7 @@ static void handle_signal(int sig)
 }
 
 sim_t::sim_t(const cfg_t *cfg, const char* varch, bool halted, bool real_time_clint,
-             reg_t start_pc, std::vector<std::pair<reg_t, mem_t*>> mems,
+             std::vector<std::pair<reg_t, mem_t*>> mems,
              std::vector<std::pair<reg_t, abstract_device_t*>> plugin_devices,
              const std::vector<std::string>& args,
              std::vector<int> const hartids,
@@ -46,7 +46,6 @@ sim_t::sim_t(const cfg_t *cfg, const char* varch, bool halted, bool real_time_cl
     mems(mems),
     plugin_devices(plugin_devices),
     procs(std::max(cfg->nprocs(), size_t(1))),
-    start_pc(start_pc),
     dtb_file(dtb_file ? dtb_file : ""),
     dtb_enabled(dtb_enabled),
     log_file(log_path),
@@ -334,7 +333,7 @@ void sim_t::set_rom()
 {
   const int reset_vec_size = 8;
 
-  start_pc = start_pc == reg_t(-1) ? get_entry_point() : start_pc;
+  reg_t start_pc = cfg->start_pc.value_or(get_entry_point());
 
   uint32_t reset_vec[reset_vec_size] = {
     0x297,                                      // auipc  t0,0x0

--- a/riscv/sim.cc
+++ b/riscv/sim.cc
@@ -63,6 +63,8 @@ sim_t::sim_t(const cfg_t *cfg, const char* varch, bool halted, bool real_time_cl
     remote_bitbang(NULL),
     debug_module(this, dm_config)
 {
+  assert(hartids.size() == cfg->nprocs());
+
   signal(SIGINT, &handle_signal);
 
   sout_.rdbuf(std::cerr.rdbuf()); // debug output goes to stderr by default
@@ -77,17 +79,8 @@ sim_t::sim_t(const cfg_t *cfg, const char* varch, bool halted, bool real_time_cl
 
   debug_mmu = new mmu_t(this, NULL);
 
-  if (! (hartids.empty() || hartids.size() == nprocs())) {
-      std::cerr << "Number of specified hartids ("
-                << hartids.size()
-                << ") doesn't match number of processors ("
-                << nprocs() << ").\n";
-      exit(1);
-  }
-
   for (size_t i = 0; i < nprocs(); i++) {
-    int hart_id = hartids.empty() ? i : hartids[i];
-    procs[i] = new processor_t(&isa, varch, this, hart_id, halted,
+    procs[i] = new processor_t(&isa, varch, this, hartids[i], halted,
                                log_file.get(), sout_);
   }
 

--- a/riscv/sim.cc
+++ b/riscv/sim.cc
@@ -28,7 +28,7 @@ static void handle_signal(int sig)
   signal(sig, &handle_signal);
 }
 
-sim_t::sim_t(const cfg_t *cfg, const char* varch, bool halted, bool real_time_clint,
+sim_t::sim_t(const cfg_t *cfg, bool halted, bool real_time_clint,
              std::vector<std::pair<reg_t, mem_t*>> mems,
              std::vector<std::pair<reg_t, abstract_device_t*>> plugin_devices,
              const std::vector<std::string>& args,
@@ -77,7 +77,7 @@ sim_t::sim_t(const cfg_t *cfg, const char* varch, bool halted, bool real_time_cl
   debug_mmu = new mmu_t(this, NULL);
 
   for (size_t i = 0; i < cfg->nprocs(); i++) {
-    procs[i] = new processor_t(&isa, varch, this, cfg->hartids()[i], halted,
+    procs[i] = new processor_t(&isa, cfg->varch(), this, cfg->hartids()[i], halted,
                                log_file.get(), sout_);
   }
 

--- a/riscv/sim.cc
+++ b/riscv/sim.cc
@@ -28,7 +28,7 @@ static void handle_signal(int sig)
   signal(sig, &handle_signal);
 }
 
-sim_t::sim_t(const cfg_t *cfg, bool halted, bool real_time_clint,
+sim_t::sim_t(const cfg_t *cfg, bool halted,
              std::vector<std::pair<reg_t, mem_t*>> mems,
              std::vector<std::pair<reg_t, abstract_device_t*>> plugin_devices,
              const std::vector<std::string>& args,
@@ -94,7 +94,7 @@ sim_t::sim_t(const cfg_t *cfg, bool halted, bool real_time_clint,
   // setting the dtb_file argument has one.
   reg_t clint_base;
   if (fdt_parse_clint(fdt, &clint_base, "riscv,clint0") == 0) {
-    clint.reset(new clint_t(procs, CPU_HZ / INSNS_PER_RTC_TICK, real_time_clint));
+    clint.reset(new clint_t(procs, CPU_HZ / INSNS_PER_RTC_TICK, cfg->real_time_clint()));
     bus.add_device(clint_base, clint.get());
   }
 

--- a/riscv/sim.cc
+++ b/riscv/sim.cc
@@ -62,8 +62,6 @@ sim_t::sim_t(const cfg_t *cfg, const char* varch, bool halted, bool real_time_cl
     remote_bitbang(NULL),
     debug_module(this, dm_config)
 {
-  assert(cfg->hartids().size() == cfg->nprocs());
-
   signal(SIGINT, &handle_signal);
 
   sout_.rdbuf(std::cerr.rdbuf()); // debug output goes to stderr by default

--- a/riscv/sim.cc
+++ b/riscv/sim.cc
@@ -129,7 +129,7 @@ sim_t::sim_t(const cfg_t *cfg, const char* varch, bool halted, bool real_time_cl
         procs[cpu_idx]->set_pmp_num(pmp_num);
       } else {
         std::cerr << "core ("
-                  << hartids.size()
+                  << cpu_idx
                   << ") doesn't have valid 'riscv,pmpregions'"
                   << pmp_num << ").\n";
         exit(1);
@@ -159,7 +159,7 @@ sim_t::sim_t(const cfg_t *cfg, const char* varch, bool halted, bool real_time_cl
         //has been set in the beginning
       } else {
         std::cerr << "core ("
-                  << hartids.size()
+                  << cpu_idx
                   << ") has an invalid 'mmu-type': "
                   << mmu_type << ").\n";
         exit(1);

--- a/riscv/sim.h
+++ b/riscv/sim.h
@@ -33,7 +33,7 @@ class sim_t : public htif_t, public simif_t
 {
 public:
   sim_t(const cfg_t *cfg, const char* varch, bool halted, bool real_time_clint,
-        reg_t start_pc, std::vector<std::pair<reg_t, mem_t*>> mems,
+        std::vector<std::pair<reg_t, mem_t*>> mems,
         std::vector<std::pair<reg_t, abstract_device_t*>> plugin_devices,
         const std::vector<std::string>& args, const std::vector<int> hartids,
         const debug_module_config_t &dm_config, const char *log_path,
@@ -76,7 +76,6 @@ private:
   mmu_t* debug_mmu;  // debug port into main memory
   std::vector<processor_t*> procs;
   std::pair<reg_t, reg_t> initrd_range;
-  reg_t start_pc;
   std::string dts;
   std::string dtb;
   std::string dtb_file;

--- a/riscv/sim.h
+++ b/riscv/sim.h
@@ -35,7 +35,7 @@ public:
   sim_t(const cfg_t *cfg, const char* varch, bool halted, bool real_time_clint,
         std::vector<std::pair<reg_t, mem_t*>> mems,
         std::vector<std::pair<reg_t, abstract_device_t*>> plugin_devices,
-        const std::vector<std::string>& args, const std::vector<int> hartids,
+        const std::vector<std::string>& args,
         const debug_module_config_t &dm_config, const char *log_path,
         bool dtb_enabled, const char *dtb_file,
 #ifdef HAVE_BOOST_ASIO

--- a/riscv/sim.h
+++ b/riscv/sim.h
@@ -32,7 +32,7 @@ class remote_bitbang_t;
 class sim_t : public htif_t, public simif_t
 {
 public:
-  sim_t(const cfg_t *cfg, bool halted, bool real_time_clint,
+  sim_t(const cfg_t *cfg, bool halted,
         std::vector<std::pair<reg_t, mem_t*>> mems,
         std::vector<std::pair<reg_t, abstract_device_t*>> plugin_devices,
         const std::vector<std::string>& args,

--- a/riscv/sim.h
+++ b/riscv/sim.h
@@ -32,7 +32,7 @@ class remote_bitbang_t;
 class sim_t : public htif_t, public simif_t
 {
 public:
-  sim_t(const cfg_t *cfg, const char* varch, bool halted, bool real_time_clint,
+  sim_t(const cfg_t *cfg, bool halted, bool real_time_clint,
         std::vector<std::pair<reg_t, mem_t*>> mems,
         std::vector<std::pair<reg_t, abstract_device_t*>> plugin_devices,
         const std::vector<std::string>& args,

--- a/spike_main/spike.cc
+++ b/spike_main/spike.cc
@@ -272,9 +272,10 @@ int main(int argc, char** argv)
     .support_haltgroups = true,
     .support_impebreak = true
   };
+  cfg_arg_t<size_t> nprocs(1);
+
   cfg_t cfg(/*default_initrd_bounds=*/std::make_pair((reg_t)0, (reg_t)0),
             /*default_bootargs=*/nullptr,
-            /*default_nprocs=*/1,
             /*default_isa=*/DEFAULT_ISA,
             /*default_priv=*/DEFAULT_PRIV,
             /*default_mem_layout=*/parse_mem_layout("2048"),
@@ -332,7 +333,7 @@ int main(int argc, char** argv)
 #ifdef HAVE_BOOST_ASIO
   parser.option('s', 0, 0, [&](const char* s){socket = true;});
 #endif
-  parser.option('p', 0, 1, [&](const char* s){cfg.nprocs = atoul_nonzero_safe(s);});
+  parser.option('p', 0, 1, [&](const char* s){nprocs = atoul_nonzero_safe(s);});
   parser.option('m', 0, 1, [&](const char* s){cfg.mem_layout = parse_mem_layout(s);});
   // I wanted to use --halted, but for some reason that doesn't work.
   parser.option('H', 0, 0, [&](const char* s){halted = true;});
@@ -462,11 +463,11 @@ int main(int argc, char** argv)
 #endif
 
   if (cfg.explicit_hartids) {
-    if (cfg.nprocs.overridden() && (cfg.nprocs() != cfg.hartids().size())) {
+    if (nprocs.overridden() && (nprocs() != cfg.nprocs())) {
       std::cerr << "Number of specified hartids ("
-                << cfg.hartids().size()
+                << cfg.nprocs()
                 << ") doesn't match specified number of processors ("
-                << cfg.nprocs() << ").\n";
+                << nprocs() << ").\n";
       exit(1);
     }
   } else {
@@ -474,8 +475,8 @@ int main(int argc, char** argv)
     // explicit_hartids flag (which means that downstream code can know that
     // we've only set the number of harts, not explicitly chosen their IDs).
     std::vector<int> default_hartids;
-    default_hartids.reserve(cfg.nprocs());
-    for (size_t i = 0; i < cfg.nprocs(); ++i) {
+    default_hartids.reserve(nprocs());
+    for (size_t i = 0; i < nprocs(); ++i) {
       default_hartids.push_back(i);
     }
     cfg.hartids = default_hartids;

--- a/spike_main/spike.cc
+++ b/spike_main/spike.cc
@@ -232,7 +232,6 @@ int main(int argc, char** argv)
   bool real_time_clint = false;
   const char* kernel = NULL;
   reg_t kernel_offset, kernel_size;
-  reg_t start_pc = reg_t(-1);
   std::vector<std::pair<reg_t, abstract_device_t*>> plugin_devices;
   std::unique_ptr<icache_sim_t> ic;
   std::unique_ptr<dcache_sim_t> dc;
@@ -335,7 +334,7 @@ int main(int argc, char** argv)
   // I wanted to use --halted, but for some reason that doesn't work.
   parser.option('H', 0, 0, [&](const char* s){halted = true;});
   parser.option(0, "rbb-port", 1, [&](const char* s){use_rbb = true; rbb_port = atoul_safe(s);});
-  parser.option(0, "pc", 1, [&](const char* s){start_pc = strtoull(s, 0, 0);});
+  parser.option(0, "pc", 1, [&](const char* s){cfg.start_pc = strtoull(s, 0, 0);});
   parser.option(0, "hartids", 1, hartids_parser);
   parser.option(0, "ic", 1, [&](const char* s){ic.reset(new icache_sim_t(s));});
   parser.option(0, "dc", 1, [&](const char* s){dc.reset(new dcache_sim_t(s));});
@@ -457,7 +456,7 @@ int main(int argc, char** argv)
 #endif
 
   sim_t s(&cfg, varch, halted, real_time_clint,
-      start_pc, mems, plugin_devices, htif_args,
+      mems, plugin_devices, htif_args,
       std::move(hartids), dm_config, log_path, dtb_enabled, dtb_file,
 #ifdef HAVE_BOOST_ASIO
       io_service_ptr, acceptor_ptr,

--- a/spike_main/spike.cc
+++ b/spike_main/spike.cc
@@ -220,6 +220,21 @@ static unsigned long atoul_nonzero_safe(const char* s)
   return res;
 }
 
+static std::vector<int> parse_hartids(const char *s)
+{
+  std::string const str(s);
+  std::stringstream stream(str);
+  std::vector<int> hartids;
+
+  int n;
+  while (stream >> n) {
+    hartids.push_back(n);
+    if (stream.peek() == ',') stream.ignore();
+  }
+
+  return hartids;
+}
+
 int main(int argc, char** argv)
 {
   bool debug = false;
@@ -264,18 +279,6 @@ int main(int argc, char** argv)
             /*default_isa=*/DEFAULT_ISA,
             /*default_priv=*/DEFAULT_PRIV,
             /*default_mem_layout=*/parse_mem_layout("2048"));
-
-  auto const hartids_parser = [&](const char *s) {
-    std::string const str(s);
-    std::stringstream stream(str);
-
-    int n;
-    while (stream >> n)
-    {
-      hartids.push_back(n);
-      if (stream.peek() == ',') stream.ignore();
-    }
-  };
 
   auto const device_parser = [&plugin_devices](const char *s) {
     const std::string str(s);
@@ -335,7 +338,7 @@ int main(int argc, char** argv)
   parser.option('H', 0, 0, [&](const char* s){halted = true;});
   parser.option(0, "rbb-port", 1, [&](const char* s){use_rbb = true; rbb_port = atoul_safe(s);});
   parser.option(0, "pc", 1, [&](const char* s){cfg.start_pc = strtoull(s, 0, 0);});
-  parser.option(0, "hartids", 1, hartids_parser);
+  parser.option(0, "hartids", 1, [&](const char* s){hartids = parse_hartids(s);});
   parser.option(0, "ic", 1, [&](const char* s){ic.reset(new icache_sim_t(s));});
   parser.option(0, "dc", 1, [&](const char* s){dc.reset(new dcache_sim_t(s));});
   parser.option(0, "l2", 1, [&](const char* s){l2.reset(cache_sim_t::construct(s, "L2$"));});

--- a/spike_main/spike.cc
+++ b/spike_main/spike.cc
@@ -256,7 +256,6 @@ int main(int argc, char** argv)
   const char *log_path = nullptr;
   std::vector<std::function<extension_t*()>> extensions;
   const char* initrd = NULL;
-  const char* varch = DEFAULT_VARCH;
   const char* dtb_file = NULL;
   uint16_t rbb_port = 0;
   bool use_rbb = false;
@@ -278,6 +277,7 @@ int main(int argc, char** argv)
             /*default_bootargs=*/nullptr,
             /*default_isa=*/DEFAULT_ISA,
             /*default_priv=*/DEFAULT_PRIV,
+            /*default_varch=*/DEFAULT_VARCH,
             /*default_mem_layout=*/parse_mem_layout("2048"),
             /*default_hartids=*/std::vector<int>());
 
@@ -349,7 +349,7 @@ int main(int argc, char** argv)
   parser.option(0, "log-cache-miss", 0, [&](const char* s){log_cache = true;});
   parser.option(0, "isa", 1, [&](const char* s){cfg.isa = s;});
   parser.option(0, "priv", 1, [&](const char* s){cfg.priv = s;});
-  parser.option(0, "varch", 1, [&](const char* s){varch = s;});
+  parser.option(0, "varch", 1, [&](const char* s){cfg.varch = s;});
   parser.option(0, "device", 1, device_parser);
   parser.option(0, "extension", 1, [&](const char* s){extensions.push_back(find_extension(s));});
   parser.option(0, "dump-dts", 0, [&](const char *s){dump_dts = true;});
@@ -482,7 +482,7 @@ int main(int argc, char** argv)
     cfg.hartids = default_hartids;
   }
 
-  sim_t s(&cfg, varch, halted, real_time_clint,
+  sim_t s(&cfg, halted, real_time_clint,
       mems, plugin_devices, htif_args, dm_config, log_path, dtb_enabled, dtb_file,
 #ifdef HAVE_BOOST_ASIO
       io_service_ptr, acceptor_ptr,

--- a/spike_main/spike.cc
+++ b/spike_main/spike.cc
@@ -458,6 +458,22 @@ int main(int argc, char** argv)
   }
 #endif
 
+  if (!hartids.empty()) {
+    if (cfg.nprocs.overridden() && (cfg.nprocs() != hartids.size())) {
+      std::cerr << "Number of specified hartids ("
+                << hartids.size()
+                << ") doesn't match specified number of processors ("
+                << cfg.nprocs() << ").\n";
+      exit(1);
+    }
+  } else {
+    // Set default set of hartids based on nprocs
+    hartids.reserve(cfg.nprocs());
+    for (size_t i = 0; i < cfg.nprocs(); ++i) {
+      hartids.push_back(i);
+    }
+  }
+
   sim_t s(&cfg, varch, halted, real_time_clint,
       mems, plugin_devices, htif_args,
       std::move(hartids), dm_config, log_path, dtb_enabled, dtb_file,

--- a/spike_main/spike.cc
+++ b/spike_main/spike.cc
@@ -244,7 +244,6 @@ int main(int argc, char** argv)
   bool socket = false;  // command line option -s
   bool dump_dts = false;
   bool dtb_enabled = true;
-  bool real_time_clint = false;
   const char* kernel = NULL;
   reg_t kernel_offset, kernel_size;
   std::vector<std::pair<reg_t, abstract_device_t*>> plugin_devices;
@@ -279,7 +278,8 @@ int main(int argc, char** argv)
             /*default_priv=*/DEFAULT_PRIV,
             /*default_varch=*/DEFAULT_VARCH,
             /*default_mem_layout=*/parse_mem_layout("2048"),
-            /*default_hartids=*/std::vector<int>());
+            /*default_hartids=*/std::vector<int>(),
+            /*default_real_time_clint=*/false);
 
   auto const device_parser = [&plugin_devices](const char *s) {
     const std::string str(s);
@@ -358,7 +358,7 @@ int main(int argc, char** argv)
   parser.option(0, "kernel", 1, [&](const char* s){kernel = s;});
   parser.option(0, "initrd", 1, [&](const char* s){initrd = s;});
   parser.option(0, "bootargs", 1, [&](const char* s){cfg.bootargs = s;});
-  parser.option(0, "real-time-clint", 0, [&](const char *s){real_time_clint = true;});
+  parser.option(0, "real-time-clint", 0, [&](const char *s){cfg.real_time_clint = true;});
   parser.option(0, "extlib", 1, [&](const char *s){
     void *lib = dlopen(s, RTLD_NOW | RTLD_GLOBAL);
     if (lib == NULL) {
@@ -482,7 +482,7 @@ int main(int argc, char** argv)
     cfg.hartids = default_hartids;
   }
 
-  sim_t s(&cfg, halted, real_time_clint,
+  sim_t s(&cfg, halted,
       mems, plugin_devices, htif_args, dm_config, log_path, dtb_enabled, dtb_file,
 #ifdef HAVE_BOOST_ASIO
       io_service_ptr, acceptor_ptr,


### PR DESCRIPTION
This is a continuation of #946 and is sort of orthogonal to #938 (which sparked the work in the first place). The idea here is that we move more of the configuration that describes the simulated device into `cfg_t` (which will also eventually be used to represent the stuff that we parse from a device tree). I *think* this is the rest of the command line arguments that are easy to move from `spike.cc`.

Eventually, we might also want to move things like `mems`, parsing the command line arguments to some configuration object in `spike.cc` and then actually instantiating memory objects in the `sim_t` constructor. But that's a bit more difficult and invasive! So I've gone for the low hanging fruit here.