### PR TITLE
Implement Sv57 and Sv57x4 translation modes

### DIFF
--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -764,6 +764,7 @@ bool base_atp_csr_t::satp_valid(reg_t val) const noexcept {
     switch (get_field(val, SATP64_MODE)) {
       case SATP_MODE_SV39: return proc->supports_impl(IMPL_MMU_SV39);
       case SATP_MODE_SV48: return proc->supports_impl(IMPL_MMU_SV48);
+      case SATP_MODE_SV57: return proc->supports_impl(IMPL_MMU_SV57);
       case SATP_MODE_OFF: return true;
       default: return false;
     }
@@ -969,7 +970,8 @@ bool hgatp_csr_t::unlogged_write(const reg_t val) noexcept {
 
     if (get_field(val, HGATP64_MODE) == HGATP_MODE_OFF ||
         (proc->supports_impl(IMPL_MMU_SV39) && get_field(val, HGATP64_MODE) == HGATP_MODE_SV39X4) ||
-        (proc->supports_impl(IMPL_MMU_SV48) && get_field(val, HGATP64_MODE) == HGATP_MODE_SV48X4))
+        (proc->supports_impl(IMPL_MMU_SV48) && get_field(val, HGATP64_MODE) == HGATP_MODE_SV48X4) ||
+        (proc->supports_impl(IMPL_MMU_SV57) && get_field(val, HGATP64_MODE) == HGATP_MODE_SV57X4))
       mask |= HGATP64_MODE;
   }
   mask &= ~(reg_t)3;

--- a/riscv/encoding.h
+++ b/riscv/encoding.h
@@ -212,6 +212,7 @@
 #define HGATP_MODE_SV32X4 1
 #define HGATP_MODE_SV39X4 8
 #define HGATP_MODE_SV48X4 9
+#define HGATP_MODE_SV57X4 10
 
 #define PMP_R     0x01
 #define PMP_W     0x02

--- a/riscv/isa_parser.h
+++ b/riscv/isa_parser.h
@@ -56,6 +56,7 @@ typedef enum {
   IMPL_MMU_SV32,
   IMPL_MMU_SV39,
   IMPL_MMU_SV48,
+  IMPL_MMU_SV57,
   IMPL_MMU_SBARE,
   IMPL_MMU,
 } impl_extension_t;

--- a/riscv/mmu.h
+++ b/riscv/mmu.h
@@ -551,6 +551,7 @@ inline vm_info decode_vm_info(int xlen, bool stage2, reg_t prv, reg_t satp)
       case HGATP_MODE_OFF: return {0, 0, 0, 0, 0};
       case HGATP_MODE_SV39X4: return {3, 9, 2, 8, (satp & HGATP64_PPN) << PGSHIFT};
       case HGATP_MODE_SV48X4: return {4, 9, 2, 8, (satp & HGATP64_PPN) << PGSHIFT};
+      case HGATP_MODE_SV57X4: return {5, 9, 2, 8, (satp & HGATP64_PPN) << PGSHIFT};
       default: abort();
     }
   } else {

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -554,6 +554,9 @@ void processor_t::set_mmu_capability(int cap)
       set_impl(IMPL_MMU_SV32, true);
       set_impl(IMPL_MMU, true);
       break;
+    case IMPL_MMU_SV57:
+      set_impl(IMPL_MMU_SV57, true);
+      // Fall through
     case IMPL_MMU_SV48:
       set_impl(IMPL_MMU_SV48, true);
       // Fall through
@@ -565,6 +568,7 @@ void processor_t::set_mmu_capability(int cap)
       set_impl(IMPL_MMU_SV32, false);
       set_impl(IMPL_MMU_SV39, false);
       set_impl(IMPL_MMU_SV48, false);
+      set_impl(IMPL_MMU_SV57, false);
       set_impl(IMPL_MMU, false);
       break;
   }

--- a/riscv/sim.cc
+++ b/riscv/sim.cc
@@ -153,6 +153,8 @@ sim_t::sim_t(const cfg_t *cfg, const char* varch, bool halted, bool real_time_cl
         procs[cpu_idx]->set_mmu_capability(IMPL_MMU_SV39);
       } else if (strncmp(mmu_type, "riscv,sv48", strlen("riscv,sv48")) == 0) {
         procs[cpu_idx]->set_mmu_capability(IMPL_MMU_SV48);
+      } else if (strncmp(mmu_type, "riscv,sv57", strlen("riscv,sv57")) == 0) {
+        procs[cpu_idx]->set_mmu_capability(IMPL_MMU_SV57);
       } else if (strncmp(mmu_type, "riscv,sbare", strlen("riscv,sbare")) == 0) {
         //has been set in the beginning
       } else {


### PR DESCRIPTION
To do so cleanly, I also did some light refactoring (in the first two commits).

Unfortunately, I don't have a good way of testing this, beyond testing I didn't break Sv39/Sv48.