### PR TITLE
Fix start byte for vmv<nf>r.v

### DIFF
--- a/riscv/insns/vmvnfr_v.h
+++ b/riscv/insns/vmvnfr_v.h
@@ -7,11 +7,12 @@ const reg_t len = insn.rs1() + 1;
 require_align(vd, len);
 require_align(vs2, len);
 const reg_t size = len * P.VU.vlenb;
+const reg_t start = P.VU.vstart->read() * (P.VU.vsew >> 3);
 
 //register needs one-by-one copy to keep commitlog correct
-if (vd != vs2 && P.VU.vstart->read() < size) {
-  reg_t i = P.VU.vstart->read() / P.VU.vlenb;
-  reg_t off = P.VU.vstart->read() % P.VU.vlenb;
+if (vd != vs2 && start < size) {
+  reg_t i = start / P.VU.vlenb;
+  reg_t off = start % P.VU.vlenb;
   if (off) {
     memcpy(&P.VU.elt<uint8_t>(vd + i, off, true),
            &P.VU.elt<uint8_t>(vs2 + i, off), P.VU.vlenb - off);


### PR DESCRIPTION
As spec for vmv\<nf\>r,v said:

'The instructions operate as if EEW=SEW.EMUL = NREG, effective length evl= EMUL * VLEN/SEW.'

So the start byte should take sew into acount when vstart != 0.