### PR TITLE
Change misa CSR in associate with priv spec.

### DIFF
--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -488,7 +488,7 @@ bool sstatus_csr_t::enabled(const reg_t which) {
 misa_csr_t::misa_csr_t(processor_t* const proc, const reg_t addr, const reg_t max_isa):
   basic_csr_t(proc, addr, max_isa),
   max_isa(max_isa),
-  write_mask(max_isa & (0  // allow MAFDQCH bits in MISA to be modified
+  write_mask(max_isa & (0  // allow MAFDQCHV bits in MISA to be modified
                         | (1L << ('M' - 'A'))
                         | (1L << ('A' - 'A'))
                         | (1L << ('F' - 'A'))
@@ -496,6 +496,7 @@ misa_csr_t::misa_csr_t(processor_t* const proc, const reg_t addr, const reg_t ma
                         | (1L << ('Q' - 'A'))
                         | (1L << ('C' - 'A'))
                         | (1L << ('H' - 'A'))
+                        | (1L << ('V' - 'A'))
                         )
              ) {
 }
@@ -512,6 +513,7 @@ bool misa_csr_t::unlogged_write(const reg_t val) noexcept {
   reg_t adjusted_val = val;
   adjusted_val = dependency(adjusted_val, 'D', 'F');
   adjusted_val = dependency(adjusted_val, 'Q', 'D');
+  adjusted_val = dependency(adjusted_val, 'V', 'D');
 
   const reg_t old_misa = read();
   const bool prev_h = old_misa & (1L << ('H' - 'A'));

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -320,8 +320,8 @@ reg_t base_status_csr_t::compute_sstatus_write_mask() const noexcept {
   // If a configuration has FS bits, they will always be accessible no
   // matter the state of misa.
   const bool has_fs = proc->extension_enabled('S') || proc->extension_enabled('F')
-              || proc->extension_enabled_const('V');
-  const bool has_vs = proc->extension_enabled_const('V');
+              || proc->extension_enabled('V');
+  const bool has_vs = proc->extension_enabled('V');
   return 0
     | (proc->extension_enabled('S') ? (SSTATUS_SIE | SSTATUS_SPIE | SSTATUS_SPP) : 0)
     | (has_page ? (SSTATUS_SUM | SSTATUS_MXR) : 0)

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -488,11 +488,12 @@ bool sstatus_csr_t::enabled(const reg_t which) {
 misa_csr_t::misa_csr_t(processor_t* const proc, const reg_t addr, const reg_t max_isa):
   basic_csr_t(proc, addr, max_isa),
   max_isa(max_isa),
-  write_mask(max_isa & (0  // allow MAFDCH bits in MISA to be modified
+  write_mask(max_isa & (0  // allow MAFDQCH bits in MISA to be modified
                         | (1L << ('M' - 'A'))
                         | (1L << ('A' - 'A'))
                         | (1L << ('F' - 'A'))
                         | (1L << ('D' - 'A'))
+                        | (1L << ('Q' - 'A'))
                         | (1L << ('C' - 'A'))
                         | (1L << ('H' - 'A'))
                         )
@@ -510,6 +511,7 @@ bool misa_csr_t::unlogged_write(const reg_t val) noexcept {
 
   reg_t adjusted_val = val;
   adjusted_val = dependency(adjusted_val, 'D', 'F');
+  adjusted_val = dependency(adjusted_val, 'Q', 'D');
 
   const reg_t old_misa = read();
   const bool prev_h = old_misa & (1L << ('H' - 'A'));

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -299,6 +299,7 @@ class misa_csr_t final: public basic_csr_t {
  private:
   const reg_t max_isa;
   const reg_t write_mask;
+  const reg_t dependency(const reg_t val, const char feature, const char depends_on) const noexcept;
 };
 
 typedef std::shared_ptr<misa_csr_t> misa_csr_t_p;

--- a/riscv/isa_parser.cc
+++ b/riscv/isa_parser.cc
@@ -81,6 +81,7 @@ isa_parser_t::isa_parser_t(const char* str, const char *priv)
                 extension_table[EXT_ZPN] = true;
                 extension_table[EXT_ZPSFOPERAND] = true;
                 extension_table[EXT_ZMMUL] = true; break;
+      case 'v': // even rv32iv implies double float
       case 'q': max_isa |= 1L << ('d' - 'a');
                 // Fall through
       case 'd': max_isa |= 1L << ('f' - 'a');


### PR DESCRIPTION
These patches implement appropriate misa manipulations for `Q` and `V` extensions.
