### PR TITLE
make sv57 default maximum paging mode

### DIFF
--- a/riscv/dts.cc
+++ b/riscv/dts.cc
@@ -56,7 +56,7 @@ std::string make_dts(size_t insns_per_rtc_tick, size_t cpu_hz,
          "      status = \"okay\";\n"
          "      compatible = \"riscv\";\n"
          "      riscv,isa = \"" << procs[i]->get_isa().get_isa_string() << "\";\n"
-         "      mmu-type = \"riscv," << (procs[i]->get_isa().get_max_xlen() <= 32 ? "sv32" : "sv48") << "\";\n"
+         "      mmu-type = \"riscv," << (procs[i]->get_isa().get_max_xlen() <= 32 ? "sv32" : "sv57") << "\";\n"
          "      riscv,pmpregions = <16>;\n"
          "      riscv,pmpgranularity = <4>;\n"
          "      clock-frequency = <" << cpu_hz << ">;\n"


### PR DESCRIPTION
Updates to the ``dts.cc`` file to make the default maximum paging mode ``sv57``.

Since support for sv57 is in the master after #958 was merged. I thought it made sense to change the default maximum paging mode to sv57.

Verified if the change actually works with ``--dump-dts`` option of SPIKE. Additionally, I was also able to run a sv57 test without having to pass a custom ``dtb`` file.

log:
``` bash
$ spike --dump-dts dut.elf
/dts-v1/;

/ {
  #address-cells = <2>;
  #size-cells = <2>;
  compatible = "ucbbar,spike-bare-dev";
  model = "ucbbar,spike-bare";
  chosen {
    bootargs = "console=hvc0 earlycon=sbi";
  };
  cpus {
    #address-cells = <1>;
    #size-cells = <0>;
    timebase-frequency = <10000000>;
    CPU0: cpu@0 {
      device_type = "cpu";
      reg = <0>;
      status = "okay";
      compatible = "riscv";
      riscv,isa = "rv64imafdc";
      mmu-type = "riscv,sv57";
      riscv,pmpregions = <16>;
      riscv,pmpgranularity = <4>;
      clock-frequency = <1000000000>;
      CPU0_intc: interrupt-controller {
        #address-cells = <2>;
        #interrupt-cells = <1>;
        interrupt-controller;
        compatible = "riscv,cpu-intc";
      };
    };
  };
  memory@80000000 {
    device_type = "memory";
    reg = <0x0 0x80000000 0x0 0x80000000>;
  };
  soc {
    #address-cells = <2>;
    #size-cells = <2>;
    compatible = "ucbbar,spike-bare-soc", "simple-bus";
    ranges;
    clint@2000000 {
      compatible = "riscv,clint0";
      interrupts-extended = <&CPU0_intc 3 &CPU0_intc 7 >;
      reg = <0x0 0x2000000 0x0 0xc0000>;
    };
  };
  htif {
    compatible = "ucb,htif0";
  };
};
```
the ``mmu-type`` has changed from the current default of sv48 to sv57.

Need for this change:
- Even though SPIKE supports sv57 out of the box, it is necessary (as mentioned here -> <https://github.com/riscv-software-src/riscv-isa-sim/issues/956#issuecomment-1082695402>) to pass a modified ``dtb`` file with ``mmu-type`` overridden to ``sv57``. This change fixes this.

Let me know if there are any more changes to be made.

Thanks,
Alenkruth