### PR TITLE
make device_list.tick()  run when tohost is zero

### DIFF
--- a/fesvr/htif.cc
+++ b/fesvr/htif.cc
@@ -245,7 +245,6 @@ int htif_t::run()
       try {
         command_t cmd(mem, tohost, fromhost_callback);
         device_list.handle_command(cmd);
-        device_list.tick();
       } catch (mem_trap_t& t) {
         std::stringstream tohost_hex;
         tohost_hex << std::hex << tohost;
@@ -254,6 +253,8 @@ int htif_t::run()
     } else {
       idle();
     }
+
+    device_list.tick();
 
     try {
       if (!fromhost_queue.empty() && !mem.read_uint64(fromhost_addr)) {


### PR DESCRIPTION
My colleague stuck at step 15 when running xvisor on spike following the [riscv64-spike](https://github.com/xvisor/xvisor/blob/master/docs/riscv/riscv64-spike.txt) document. I help him debug the reason. Since it can run successfully on my local spike(equal to recently commit https://github.com/riscv-software-src/riscv-isa-sim/commit/38f085d2fc96fb7fb4c4a60834617446e424f23d), I tracked the commit history, and found this is introduced by commit https://github.com/riscv-software-src/riscv-isa-sim/commit/1fea2afbf46d2641d77f2db3d6108e0897431a84.
This fix is to restore the only changes  I found that may be caused by this commit to original logic . And it can make xvisor running successfully. However I don't quite understand why.