### PR TITLE
Rename processor_t::set_csr to put_csr to fix build on RISC-V

### DIFF
--- a/fesvr/dtm.cc
+++ b/fesvr/dtm.cc
@@ -1,6 +1,5 @@
 #include "dtm.h"
 #include "debug_defines.h"
-#include "encoding.h"
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>

--- a/riscv/insns/csrrc.h
+++ b/riscv/insns/csrrc.h
@@ -2,7 +2,7 @@ bool write = insn.rs1() != 0;
 int csr = validate_csr(insn.csr(), write);
 reg_t old = p->get_csr(csr, insn, write);
 if (write) {
-  p->set_csr(csr, old & ~RS1);
+  p->put_csr(csr, old & ~RS1);
 }
 WRITE_RD(sext_xlen(old));
 serialize();

--- a/riscv/insns/csrrci.h
+++ b/riscv/insns/csrrci.h
@@ -2,7 +2,7 @@ bool write = insn.rs1() != 0;
 int csr = validate_csr(insn.csr(), write);
 reg_t old = p->get_csr(csr, insn, write);
 if (write) {
-  p->set_csr(csr, old & ~(reg_t)insn.rs1());
+  p->put_csr(csr, old & ~(reg_t)insn.rs1());
 }
 WRITE_RD(sext_xlen(old));
 serialize();

--- a/riscv/insns/csrrs.h
+++ b/riscv/insns/csrrs.h
@@ -2,7 +2,7 @@ bool write = insn.rs1() != 0;
 int csr = validate_csr(insn.csr(), write);
 reg_t old = p->get_csr(csr, insn, write);
 if (write) {
-  p->set_csr(csr, old | RS1);
+  p->put_csr(csr, old | RS1);
 }
 WRITE_RD(sext_xlen(old));
 serialize();

--- a/riscv/insns/csrrsi.h
+++ b/riscv/insns/csrrsi.h
@@ -2,7 +2,7 @@ bool write = insn.rs1() != 0;
 int csr = validate_csr(insn.csr(), write);
 reg_t old = p->get_csr(csr, insn, write);
 if (write) {
-  p->set_csr(csr, old | insn.rs1());
+  p->put_csr(csr, old | insn.rs1());
 }
 WRITE_RD(sext_xlen(old));
 serialize();

--- a/riscv/insns/csrrw.h
+++ b/riscv/insns/csrrw.h
@@ -1,5 +1,5 @@
 int csr = validate_csr(insn.csr(), true);
 reg_t old = p->get_csr(csr, insn, true);
-p->set_csr(csr, RS1);
+p->put_csr(csr, RS1);
 WRITE_RD(sext_xlen(old));
 serialize();

--- a/riscv/insns/csrrwi.h
+++ b/riscv/insns/csrrwi.h
@@ -1,5 +1,5 @@
 int csr = validate_csr(insn.csr(), true);
 reg_t old = p->get_csr(csr, insn, true);
-p->set_csr(csr, insn.rs1());
+p->put_csr(csr, insn.rs1());
 WRITE_RD(sext_xlen(old));
 serialize();

--- a/riscv/insns/mret.h
+++ b/riscv/insns/mret.h
@@ -9,6 +9,6 @@ s = set_field(s, MSTATUS_MIE, get_field(s, MSTATUS_MPIE));
 s = set_field(s, MSTATUS_MPIE, 1);
 s = set_field(s, MSTATUS_MPP, p->extension_enabled('U') ? PRV_U : PRV_M);
 s = set_field(s, MSTATUS_MPV, 0);
-p->set_csr(CSR_MSTATUS, s);
+p->put_csr(CSR_MSTATUS, s);
 p->set_privilege(prev_prv);
 p->set_virt(prev_virt);

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -496,8 +496,8 @@ void processor_t::reset()
   if (n_pmp > 0) {
     // For backwards compatibility with software that is unaware of PMP,
     // initialize PMP to permit unprivileged access to all of memory.
-    set_csr(CSR_PMPADDR0, ~reg_t(0));
-    set_csr(CSR_PMPCFG0, PMP_R | PMP_W | PMP_X | PMP_NAPOT);
+    put_csr(CSR_PMPADDR0, ~reg_t(0));
+    put_csr(CSR_PMPCFG0, PMP_R | PMP_W | PMP_X | PMP_NAPOT);
   }
 
    for (auto e : custom_extensions) // reset any extensions
@@ -838,7 +838,7 @@ int processor_t::paddr_bits()
   return max_xlen == 64 ? 50 : 34;
 }
 
-void processor_t::set_csr(int which, reg_t val)
+void processor_t::put_csr(int which, reg_t val)
 {
   val = zext_xlen(val);
   auto search = state.csrmap.find(which);

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -279,7 +279,7 @@ public:
 #endif
   void reset();
   void step(size_t n); // run for n cycles
-  void set_csr(int which, reg_t val);
+  void put_csr(int which, reg_t val);
   uint32_t get_id() const { return id; }
   reg_t get_csr(int which, insn_t insn, bool write, bool peek = 0);
   reg_t get_csr(int which) { return get_csr(which, insn_t(0), false, true); }


### PR DESCRIPTION
The alternative would be to `#undef set_csr` after including encoding.h, but the solution in this PR strikes me as cleaner.  Part of the reason is that `set_csr` was not a great name to begin with: it sounds like it implements the CSRRS (read & set) instruction, rather than implementing a simple write.

Fixes #965