### PR TITLE
Adjust the access index of vs2 to zero in vmv_x_s.h

### DIFF
--- a/riscv/insns/vmv_x_s.h
+++ b/riscv/insns/vmv_x_s.h
@@ -1,4 +1,4 @@
-// vmv_x_s: rd = vs2[rs1]
+// vmv_x_s: rd = vs2[0]
 require_vector(true);
 require(insn.v_vm() == 1);
 uint64_t xmask = UINT64_MAX >> (64 - P.get_isa().get_max_xlen());
@@ -6,26 +6,22 @@ reg_t rs1 = RS1;
 reg_t sew = P.VU.vsew;
 reg_t rs2_num = insn.rs2();
 
-if (!(rs1 >= 0 && rs1 < (P.VU.get_vlen() / sew))) {
-  WRITE_RD(0);
-} else {
-  switch(sew) {
-  case e8:
-    WRITE_RD(P.VU.elt<int8_t>(rs2_num, rs1));
-    break;
-  case e16:
-    WRITE_RD(P.VU.elt<int16_t>(rs2_num, rs1));
-    break;
-  case e32:
-    WRITE_RD(P.VU.elt<int32_t>(rs2_num, rs1));
-    break;
-  case e64:
-    if (P.get_isa().get_max_xlen() <= sew)
-      WRITE_RD(P.VU.elt<uint64_t>(rs2_num, rs1) & xmask);
-    else
-      WRITE_RD(P.VU.elt<uint64_t>(rs2_num, rs1));
-    break;
-  }
+switch(sew) {
+case e8:
+  WRITE_RD(P.VU.elt<int8_t>(rs2_num, 0));
+  break;
+case e16:
+  WRITE_RD(P.VU.elt<int16_t>(rs2_num, 0));
+  break;
+case e32:
+  WRITE_RD(P.VU.elt<int32_t>(rs2_num, 0));
+  break;
+case e64:
+  if (P.get_isa().get_max_xlen() <= sew)
+    WRITE_RD(P.VU.elt<uint64_t>(rs2_num, 0) & xmask);
+  else
+    WRITE_RD(P.VU.elt<uint64_t>(rs2_num, 0));
+  break;
 }
 
 P.VU.vstart->write(0);


### PR DESCRIPTION
According to [scalar move](https://github.com/riscv/riscv-v-spec/blob/master/v-spec.adoc#161-integer-scalar-move-instructions), I guess the index of vs2 should always be 0 no matter what value is in rs1?