### PR TITLE
Teach cfg_t to "freeze" and add isa parsing to it

### DIFF
--- a/riscv/cfg.cc
+++ b/riscv/cfg.cc
@@ -1,0 +1,25 @@
+// See LICENSE for license details.
+
+#include "cfg.h"
+#include "isa_parser.h"
+
+cfg_t::~cfg_t() {}
+
+const cfg_t &cfg_t::freeze()
+{
+  assert(!frozen);
+
+  assert(!isa_parser);
+  isa_parser.reset(new isa_parser_t(isa(), priv()));
+
+  frozen = true;
+  return *this;
+}
+
+cfg_arg_t<const isa_parser_t *> cfg_t::get_isa_parser() const
+{
+  assert(frozen && isa_parser);
+  cfg_arg_t<const isa_parser_t *> ret(isa_parser.get());
+  if (isa.overridden() || priv.overridden()) ret.set_overridden();
+  return ret;
+}

--- a/riscv/riscv.mk.in
+++ b/riscv/riscv.mk.in
@@ -48,6 +48,7 @@ riscv_srcs = \
 	interactive.cc \
 	cachesim.cc \
 	mmu.cc \
+	cfg.cc \
 	extension.cc \
 	extensions.cc \
 	rocc.cc \

--- a/riscv/sim.cc
+++ b/riscv/sim.cc
@@ -41,7 +41,6 @@ sim_t::sim_t(const cfg_t *cfg, const char* varch, bool halted, bool real_time_cl
 #endif
              FILE *cmd_file) // needed for command line option --cmd
   : htif_t(args),
-    isa(cfg->isa(), cfg->priv()),
     cfg(cfg),
     mems(mems),
     plugin_devices(plugin_devices),
@@ -88,7 +87,7 @@ sim_t::sim_t(const cfg_t *cfg, const char* varch, bool halted, bool real_time_cl
 
   for (size_t i = 0; i < nprocs(); i++) {
     int hart_id = hartids.empty() ? i : hartids[i];
-    procs[i] = new processor_t(&isa, varch, this, hart_id, halted,
+    procs[i] = new processor_t(cfg->get_isa_parser()(), varch, this, hart_id, halted,
                                log_file.get(), sout_);
   }
 

--- a/riscv/sim.h
+++ b/riscv/sim.h
@@ -69,7 +69,6 @@ public:
   void proc_reset(unsigned id);
 
 private:
-  isa_parser_t isa;
   const cfg_t * const cfg;
   std::vector<std::pair<reg_t, mem_t*>> mems;
   std::vector<std::pair<reg_t, abstract_device_t*>> plugin_devices;

--- a/spike_main/spike.cc
+++ b/spike_main/spike.cc
@@ -433,6 +433,8 @@ int main(int argc, char** argv)
     }
   }
 
+  const cfg_t &frozen_cfg = cfg.freeze();
+
 #ifdef HAVE_BOOST_ASIO
   boost::asio::io_service *io_service_ptr = NULL; // needed for socket command interface option -s
   boost::asio::ip::tcp::acceptor *acceptor_ptr = NULL;
@@ -456,7 +458,7 @@ int main(int argc, char** argv)
   }
 #endif
 
-  sim_t s(&cfg, varch, halted, real_time_clint,
+  sim_t s(&frozen_cfg, varch, halted, real_time_clint,
       start_pc, mems, plugin_devices, htif_args,
       std::move(hartids), dm_config, log_path, dtb_enabled, dtb_file,
 #ifdef HAVE_BOOST_ASIO
@@ -480,7 +482,7 @@ int main(int argc, char** argv)
   if (dc && l2) dc->set_miss_handler(&*l2);
   if (ic) ic->set_log(log_cache);
   if (dc) dc->set_log(log_cache);
-  for (size_t i = 0; i < cfg.nprocs(); i++)
+  for (size_t i = 0; i < frozen_cfg.nprocs(); i++)
   {
     if (ic) s.get_core(i)->get_mmu()->register_memtracer(&*ic);
     if (dc) s.get_core(i)->get_mmu()->register_memtracer(&*dc);


### PR DESCRIPTION
*Split out from #938*

The idea here is that we want to compute some "derived" configuration
in `cfg_t`, which can depend on more than one of the config arguments.
Specifically, we've got an `isa_parser_t` that we want to construct
based on the "isa" and "priv" strings.

One way to do that would be to parse the strings on the fly in some
sort of getter function. A problem there is that we'd end up parsing
them multiple times (on each call to the getter).

To avoid that re-computation, we could add a local cache. But that's a
bit awkward too: we'd like to pass a "`const cfg_t *`" around, but then
we'd have to mess around with `const_cast`s to allow us to mutate the
cache. What's more, it would probably be better to do the parsing
at a known time so that we can generate any error messages at a time
we expect.

The "proper RAII way" to do this is probably to define some expanded
version of `cfg_t`, whose constructor does all the parsing. Then we'd
pass that expanded configuration around afterwards. Here, we do
something slightly more lightweight and just expect users not to alter
any of the (public) configuration arguments once they've called
`freeze()`.