### PR TITLE
Fix for #873 AMO exception priorities

### DIFF
--- a/riscv/mmu.cc
+++ b/riscv/mmu.cc
@@ -161,7 +161,7 @@ void mmu_t::load_slow_path(reg_t addr, reg_t len, uint8_t* bytes, uint32_t xlate
   }
 }
 
-void mmu_t::store_slow_path(reg_t addr, reg_t len, const uint8_t* bytes, uint32_t xlate_flags)
+void mmu_t::store_slow_path(reg_t addr, reg_t len, const uint8_t* bytes, uint32_t xlate_flags, bool actually_store)
 {
   reg_t paddr = translate(addr, len, STORE, xlate_flags);
 

--- a/riscv/mmu.cc
+++ b/riscv/mmu.cc
@@ -172,6 +172,7 @@ void mmu_t::store_slow_path(reg_t addr, reg_t len, const uint8_t* bytes, uint32_
       throw *matched_trigger;
   }
 
+  if (actually_store) {
   if (auto host_addr = sim->addr_to_mem(paddr)) {
     memcpy(host_addr, bytes, len);
     if (tracer.interested_in_range(paddr, paddr + PGSIZE, STORE))
@@ -180,6 +181,7 @@ void mmu_t::store_slow_path(reg_t addr, reg_t len, const uint8_t* bytes, uint32_
       refill_tlb(addr, paddr, host_addr, STORE);
   } else if (!mmio_store(paddr, len, bytes)) {
     throw trap_store_access_fault((proc) ? proc->state.v : false, addr, 0, 0);
+  }
   }
 }
 

--- a/riscv/mmu.cc
+++ b/riscv/mmu.cc
@@ -173,15 +173,15 @@ void mmu_t::store_slow_path(reg_t addr, reg_t len, const uint8_t* bytes, uint32_
   }
 
   if (actually_store) {
-  if (auto host_addr = sim->addr_to_mem(paddr)) {
-    memcpy(host_addr, bytes, len);
-    if (tracer.interested_in_range(paddr, paddr + PGSIZE, STORE))
-      tracer.trace(paddr, len, STORE);
-    else if (xlate_flags == 0)
-      refill_tlb(addr, paddr, host_addr, STORE);
-  } else if (!mmio_store(paddr, len, bytes)) {
-    throw trap_store_access_fault((proc) ? proc->state.v : false, addr, 0, 0);
-  }
+    if (auto host_addr = sim->addr_to_mem(paddr)) {
+      memcpy(host_addr, bytes, len);
+      if (tracer.interested_in_range(paddr, paddr + PGSIZE, STORE))
+        tracer.trace(paddr, len, STORE);
+      else if (xlate_flags == 0)
+        refill_tlb(addr, paddr, host_addr, STORE);
+    } else if (!mmio_store(paddr, len, bytes)) {
+      throw trap_store_access_fault((proc) ? proc->state.v : false, addr, 0, 0);
+    }
   }
 }
 

--- a/riscv/mmu.h
+++ b/riscv/mmu.h
@@ -154,19 +154,19 @@ public:
       size_t size = sizeof(type##_t); \
       if ((xlate_flags) == 0 && likely(tlb_store_tag[vpn % TLB_ENTRIES] == vpn)) { \
         if (actually_store) { \
-        if (proc) WRITE_MEM(addr, val, size); \
-        *(target_endian<type##_t>*)(tlb_data[vpn % TLB_ENTRIES].host_offset + addr) = to_target(val); \
+          if (proc) WRITE_MEM(addr, val, size); \
+          *(target_endian<type##_t>*)(tlb_data[vpn % TLB_ENTRIES].host_offset + addr) = to_target(val); \
         } \
       } \
       else if ((xlate_flags) == 0 && unlikely(tlb_store_tag[vpn % TLB_ENTRIES] == (vpn | TLB_CHECK_TRIGGERS))) { \
         if (actually_store) { \
-        if (!matched_trigger) { \
-          matched_trigger = trigger_exception(triggers::OPERATION_STORE, addr, val); \
-          if (matched_trigger) \
-            throw *matched_trigger; \
-        } \
-        if (proc) WRITE_MEM(addr, val, size); \
-        *(target_endian<type##_t>*)(tlb_data[vpn % TLB_ENTRIES].host_offset + addr) = to_target(val); \
+          if (!matched_trigger) { \
+            matched_trigger = trigger_exception(triggers::OPERATION_STORE, addr, val); \
+            if (matched_trigger) \
+              throw *matched_trigger; \
+          } \
+          if (proc) WRITE_MEM(addr, val, size); \
+          *(target_endian<type##_t>*)(tlb_data[vpn % TLB_ENTRIES].host_offset + addr) = to_target(val); \
         } \
       } \
       else { \

--- a/riscv/mmu.h
+++ b/riscv/mmu.h
@@ -147,7 +147,7 @@ public:
 
   // template for functions that store an aligned value to memory
   #define store_func(type, prefix, xlate_flags) \
-    void prefix##_##type(reg_t addr, type##_t val) { \
+    void prefix##_##type(reg_t addr, type##_t val, bool actually_store=true) {   \
       if (unlikely(addr & (sizeof(type##_t)-1))) \
         return misaligned_store(addr, val, sizeof(type##_t), xlate_flags); \
       reg_t vpn = addr >> PGSHIFT; \
@@ -167,7 +167,7 @@ public:
       } \
       else { \
         target_endian<type##_t> target_val = to_target(val); \
-        store_slow_path(addr, sizeof(type##_t), (const uint8_t*)&target_val, (xlate_flags)); \
+        store_slow_path(addr, sizeof(type##_t), (const uint8_t*)&target_val, (xlate_flags), actually_store); \
         if (proc) WRITE_MEM(addr, val, size); \
       } \
   }
@@ -438,7 +438,7 @@ private:
   // handle uncommon cases: TLB misses, page faults, MMIO
   tlb_entry_t fetch_slow_path(reg_t addr);
   void load_slow_path(reg_t addr, reg_t len, uint8_t* bytes, uint32_t xlate_flags);
-  void store_slow_path(reg_t addr, reg_t len, const uint8_t* bytes, uint32_t xlate_flags);
+  void store_slow_path(reg_t addr, reg_t len, const uint8_t* bytes, uint32_t xlate_flags, bool actually_store);
   bool mmio_load(reg_t addr, size_t len, uint8_t* bytes);
   bool mmio_store(reg_t addr, size_t len, const uint8_t* bytes);
   bool mmio_ok(reg_t addr, access_type type);


### PR DESCRIPTION
These changes are designed to fix the AMO fault priority bug described in #873. 

The solution implemented is to run through the store first before the AMO load-store sequence, but without storing any data. By doing this, we will check all the store attributes first (and throw the proper fault for them as well). This is a valid solution since the priority of the store fault will be greater than or equal to the load fault priority (since write permission can only be granted if read permissions are also granted). 

The MMIO store issues discussed in the original issue thread are not an issue because if the store permission check reaches the MMIO store, we can skip the MMIO store because we've already passed any possible store exceptions that could possibly be higher priority than any load exceptions. 