### PR TITLE
Bug Fix for bug introduced in PR #976

### DIFF
--- a/riscv/mmu.h
+++ b/riscv/mmu.h
@@ -147,7 +147,7 @@ public:
 
   // template for functions that store an aligned value to memory
   #define store_func(type, prefix, xlate_flags) \
-    void prefix##_##type(reg_t addr, type##_t val, bool actually_store=true) {   \
+    void prefix##_##type(reg_t addr, type##_t val, bool actually_store=true, bool require_alignment=false) { \
       if (unlikely(addr & (sizeof(type##_t)-1))) \
         return misaligned_store(addr, val, sizeof(type##_t), xlate_flags); \
       reg_t vpn = addr >> PGSHIFT; \

--- a/riscv/mmu.h
+++ b/riscv/mmu.h
@@ -196,7 +196,7 @@ public:
     template<typename op> \
     type##_t amo_##type(reg_t addr, op f) { \
       convert_load_traps_to_store_traps({ \
-        store_##type(addr, 0, false); \
+        store_##type(addr, 0, false, true); \
         auto lhs = load_##type(addr, true); \
         store_##type(addr, f(lhs)); \
         return lhs; \

--- a/riscv/mmu.h
+++ b/riscv/mmu.h
@@ -150,7 +150,7 @@ public:
     void prefix##_##type(reg_t addr, type##_t val, bool actually_store=true, bool require_alignment=false) { \
       if (unlikely(addr & (sizeof(type##_t)-1))) { \
         if (require_alignment) store_conditional_address_misaligned(addr); \
-        else return misaligned_store(addr, val, sizeof(type##_t), xlate_flags); \
+        else return misaligned_store(addr, val, sizeof(type##_t), xlate_flags, actually_store); \
       } \
       reg_t vpn = addr >> PGSHIFT; \
       size_t size = sizeof(type##_t); \

--- a/riscv/mmu.h
+++ b/riscv/mmu.h
@@ -148,8 +148,10 @@ public:
   // template for functions that store an aligned value to memory
   #define store_func(type, prefix, xlate_flags) \
     void prefix##_##type(reg_t addr, type##_t val, bool actually_store=true, bool require_alignment=false) { \
-      if (unlikely(addr & (sizeof(type##_t)-1))) \
-        return misaligned_store(addr, val, sizeof(type##_t), xlate_flags); \
+      if (unlikely(addr & (sizeof(type##_t)-1))) { \
+        if (require_alignment) store_conditional_address_misaligned(addr); \
+        else return misaligned_store(addr, val, sizeof(type##_t), xlate_flags); \
+      } \
       reg_t vpn = addr >> PGSHIFT; \
       size_t size = sizeof(type##_t); \
       if ((xlate_flags) == 0 && likely(tlb_store_tag[vpn % TLB_ENTRIES] == vpn)) { \

--- a/riscv/mmu.h
+++ b/riscv/mmu.h
@@ -65,11 +65,11 @@ public:
 #endif
   }
 
-  inline void misaligned_store(reg_t addr, reg_t data, size_t size, uint32_t xlate_flags)
+  inline void misaligned_store(reg_t addr, reg_t data, size_t size, uint32_t xlate_flags, bool actually_store=true)
   {
 #ifdef RISCV_ENABLE_MISALIGNED
     for (size_t i = 0; i < size; i++)
-      store_uint8(addr + (target_big_endian? size-1-i : i), data >> (i * 8));
+      store_uint8(addr + (target_big_endian? size-1-i : i), data >> (i * 8), actually_store);
 #else
     bool gva = ((proc) ? proc->state.v : false) || (RISCV_XLATE_VIRT & xlate_flags);
     throw trap_store_address_misaligned(gva, addr, 0, 0);


### PR DESCRIPTION
In PR #976 we introduced a bug that would cause a store to occur on a misaligned AMO. To refresh, the strategy for the fix to bug #873 was to add a "Fake" store that would Table-walk but not actually store before the initial load in an AMO sequence. However, the case of a misaligned AMO was ignored, with the result being that the "fake" store during a misaligned AMO would actually modify the memory. This patch fixes that bug by adding a tag `require_alignment` to store_func similar to load_func. This will be set to true of the fake store, and will lead to a misaligned-fault/access-fault being thrown if the address is misaligned. This will take priority over any page-faults, the same behavior Spike exhibited prior to these changes.