### PR TITLE
Epmp updates 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Spike supports the following RISC-V ISA features:
   - Svinval extension, v1.0
   - CMO extension, v1.0
   - Debug v0.14
+  - Smepmp extension v1.0
 
 As a Spike extension, the remainder of the proposed
 [Bit-Manipulation Extensions](https://github.com/riscv/riscv-bitmanip)

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -89,6 +89,11 @@ class pmpaddr_csr_t: public csr_t {
   // Is the specified access allowed given the pmpcfg privileges?
   bool access_ok(access_type type, reg_t mode) const noexcept;
 
+  // To check lock bit status from outside like mseccfg
+  bool is_locked() const noexcept {
+    return cfg & PMP_L;
+  }
+
  protected:
   virtual bool unlogged_write(const reg_t val) noexcept override;
  private:
@@ -122,6 +127,17 @@ class pmpcfg_csr_t: public csr_t {
   virtual bool unlogged_write(const reg_t val) noexcept override;
 };
 
+class mseccfg_csr_t: public basic_csr_t {
+ public:
+  mseccfg_csr_t(processor_t* const proc, const reg_t addr);
+  bool get_mml() const noexcept;
+  bool get_mmwp() const noexcept;
+  bool get_rlb() const noexcept;
+ protected:
+  virtual bool unlogged_write(const reg_t val) noexcept override;
+};
+
+typedef std::shared_ptr<mseccfg_csr_t> mseccfg_csr_t_p;
 
 // For CSRs that have a virtualized copy under another name. Each
 // instance of virtualized_csr_t will read/write one of two CSRs,

--- a/riscv/mmu.cc
+++ b/riscv/mmu.cc
@@ -242,7 +242,11 @@ bool mmu_t::pmp_ok(reg_t addr, reg_t len, access_type type, reg_t mode)
     }
   }
 
-  return mode == PRV_M;
+  // in case matching region is not found
+  const bool mseccfg_mml = proc->state.mseccfg->get_mml();
+  const bool mseccfg_mmwp = proc->state.mseccfg->get_mmwp();
+  return ((mode == PRV_M) && !mseccfg_mmwp
+          && (!mseccfg_mml || ((type == LOAD) || (type == STORE))));
 }
 
 reg_t mmu_t::pmp_homogeneous(reg_t addr, reg_t len)

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -358,6 +358,8 @@ void state_t::reset(processor_t* const proc, reg_t max_isa)
   debug_mode = false;
   single_step = STEP_NONE;
 
+  csrmap[CSR_MSECCFG] = mseccfg = std::make_shared<mseccfg_csr_t>(proc, CSR_MSECCFG);
+
   for (int i = 0; i < max_pmp; ++i) {
     csrmap[CSR_PMPADDR0 + i] = pmpaddr[i] = std::make_shared<pmpaddr_csr_t>(proc, CSR_PMPADDR0 + i);
   }

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -179,6 +179,8 @@ struct state_t
   tdata2_csr_t_p tdata2;
   bool debug_mode;
 
+  mseccfg_csr_t_p mseccfg;
+
   static const int max_pmp = 16;
   pmpaddr_csr_t_p pmpaddr[max_pmp];
 


### PR DESCRIPTION
Add smepmp support to Spike.
This is a rebased version. Existed review comments can be found at https://github.com/riscv-software-src/riscv-isa-sim/pull/981. 