### PR TITLE
Linking spike_dasm misses libriscv.a dependance

### DIFF
--- a/spike_dasm/spike_dasm.mk.in
+++ b/spike_dasm/spike_dasm.mk.in
@@ -1,7 +1,7 @@
 spike_dasm_subproject_deps = \
 	disasm \
   softfloat \
-  $(if $(HAVE_DLOPEN),riscv,) \
+  riscv \
 
 spike_dasm_srcs = \
   spike_dasm_option_parser.cc \


### PR DESCRIPTION
Whereas spike-dasm.cc now instanciates an isa_parser_t,
the dependance on libriscv.a has become unconditional.