### PR TITLE
Fix the padding of register names in the log

### DIFF
--- a/riscv/execute.cc
+++ b/riscv/execute.cc
@@ -133,7 +133,7 @@ static void commit_log_print_insn(processor_t *p, reg_t pc, insn_t insn)
       if (prefix == 'c')
         fprintf(log_file, " c%d_%s ", rd, csr_name(rd));
       else
-        fprintf(log_file, " %c%2d ", prefix, rd);
+        fprintf(log_file, " %c%-2d ", prefix, rd);
       if (is_vreg)
         commit_log_print_value(log_file, size, &p->VU.elt<uint8_t>(rd, 0));
       else


### PR DESCRIPTION
Before this fix, register names with a single digit are printed with a space between the prefix and the digit (e.g. x5 is printed "x 5"). This fix moves the space after the digit (so x5 is now printed "x5 ").

