### PR TITLE
Disallow write to xs and add xs field checking for rocc

### DIFF
--- a/customext/cflush.cc
+++ b/customext/cflush.cc
@@ -12,7 +12,7 @@ static reg_t custom_cflush(processor_t* p, insn_t insn, reg_t pc)
 {
   require_privilege(PRV_M);
 
-  return pc + 4; \
+  return pc + 4;
 }
 
 class cflush_t : public extension_t
@@ -20,7 +20,7 @@ class cflush_t : public extension_t
  public:
   const char* name() { return "cflush"; }
 
-  cflush_t() {}
+  cflush_t() : extension_t(true) {}
 
   std::vector<insn_desc_t> get_instructions() {
     std::vector<insn_desc_t> insns;

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -419,7 +419,7 @@ reg_t base_status_csr_t::compute_sstatus_write_mask() const noexcept {
     | (proc->extension_enabled('S') ? (SSTATUS_SIE | SSTATUS_SPIE | SSTATUS_SPP) : 0)
     | (has_page ? (SSTATUS_SUM | SSTATUS_MXR) : 0)
     | (has_fs ? SSTATUS_FS : 0)
-    | (proc->any_custom_extensions() ? SSTATUS_XS : 0)
+    | (proc->extension_enabled('X') ? SSTATUS_XS : 0)
     | (has_vs ? SSTATUS_VS : 0)
     ;
 }
@@ -689,7 +689,7 @@ mie_csr_t::mie_csr_t(processor_t* const proc, const reg_t addr):
 reg_t mie_csr_t::write_mask() const noexcept {
   const reg_t supervisor_ints = proc->extension_enabled('S') ? MIP_SSIP | MIP_STIP | MIP_SEIP : 0;
   const reg_t hypervisor_ints = proc->extension_enabled('H') ? MIP_HS_MASK : 0;
-  const reg_t coprocessor_ints = (reg_t)proc->any_custom_extensions() << IRQ_COP;
+  const reg_t coprocessor_ints = (reg_t)proc->extension_enabled('X') << IRQ_COP;
   const reg_t delegable_ints = supervisor_ints | coprocessor_ints;
   const reg_t all_ints = delegable_ints | hypervisor_ints | MIP_MSIP | MIP_MTIP | MIP_MEIP;
   return all_ints;
@@ -789,7 +789,7 @@ void mideleg_csr_t::verify_permissions(insn_t insn, bool write) const {
 
 bool mideleg_csr_t::unlogged_write(const reg_t val) noexcept {
   const reg_t supervisor_ints = proc->extension_enabled('S') ? MIP_SSIP | MIP_STIP | MIP_SEIP : 0;
-  const reg_t coprocessor_ints = (reg_t)proc->any_custom_extensions() << IRQ_COP;
+  const reg_t coprocessor_ints = (reg_t)proc->extension_enabled('X') << IRQ_COP;
   const reg_t delegable_ints = supervisor_ints | coprocessor_ints;
 
   return basic_csr_t::unlogged_write(val & delegable_ints);

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -202,9 +202,7 @@ class base_status_csr_t: public csr_t {
  public:
   base_status_csr_t(processor_t* const proc, const reg_t addr);
 
-  bool field_exists(const reg_t which) {
-    return (sstatus_write_mask & which) != 0;
-  }
+  bool field_exists(const reg_t which);
 
  protected:
   reg_t adjust_sd(const reg_t val) const noexcept;
@@ -225,9 +223,7 @@ class vsstatus_csr_t final: public base_status_csr_t {
  public:
   vsstatus_csr_t(processor_t* const proc, const reg_t addr);
 
-  reg_t read() const noexcept override {
-    return val;
-  }
+  reg_t read() const noexcept override;
 
  protected:
   virtual bool unlogged_write(const reg_t val) noexcept override;
@@ -242,9 +238,7 @@ class mstatus_csr_t final: public base_status_csr_t {
  public:
   mstatus_csr_t(processor_t* const proc, const reg_t addr);
 
-  reg_t read() const noexcept override {
-    return val;
-  }
+  reg_t read() const noexcept override;
 
  protected:
   virtual bool unlogged_write(const reg_t val) noexcept override;

--- a/riscv/extension.cc
+++ b/riscv/extension.cc
@@ -21,3 +21,25 @@ void extension_t::raise_interrupt()
 void extension_t::clear_interrupt()
 {
 }
+
+void xs_gatherer_t::reset() {
+  for (auto e : custom_extensions) {
+    e.second->reset();
+  }
+}
+
+void xs_gatherer_t::register_extension(extension_t* x)
+{
+  for (auto insn : x->get_instructions())
+    p->register_insn(insn);
+  p->build_opcode_map();
+
+  for (auto disasm_insn : x->get_disasms())
+    p->disassembler->add_insn(disasm_insn);
+
+  if (!custom_extensions.insert(std::make_pair(x->name(), x)).second) {
+    fprintf(stderr, "extensions must have unique names (got two named \"%s\"!)\n", x->name());
+    abort();
+  }
+  x->set_processor(p);
+}

--- a/riscv/extension.cc
+++ b/riscv/extension.cc
@@ -43,3 +43,23 @@ void xs_gatherer_t::register_extension(extension_t* x)
   }
   x->set_processor(p);
 }
+
+extension_t* xs_gatherer_t::get_extension()
+{
+  switch (custom_extensions.size()) {
+    case 0: return NULL;
+    case 1: return custom_extensions.begin()->second;
+    default:
+      fprintf(stderr, "xs_gatherer_t::get_extension() is ambiguous when multiple extensions\n");
+      fprintf(stderr, "are present!\n");
+      abort();
+  }
+}
+
+extension_t* xs_gatherer_t::get_extension(const char* name)
+{
+  auto it = custom_extensions.find(name);
+  if (it == custom_extensions.end())
+    abort();
+  return it->second;
+}

--- a/riscv/extension.cc
+++ b/riscv/extension.cc
@@ -28,6 +28,25 @@ void xs_gatherer_t::reset() {
   }
 }
 
+extension_state_t xs_gatherer_t::get_xs()
+{
+  bool clean = false, init = false;
+  for (auto e : custom_extensions) {
+      extension_state_t state = e.second->get_state();
+      if (state == EXT_STATE_DIRTY)
+        return EXT_STATE_DIRTY;
+      clean = (state == EXT_STATE_CLEAN) || clean;
+      init  = (state == EXT_STATE_INIT)  || init;
+  }
+
+  if (clean)
+    return EXT_STATE_CLEAN;
+  else if (init)
+    return EXT_STATE_INIT;
+  else
+    return EXT_STATE_OFF;
+}
+
 void xs_gatherer_t::register_extension(extension_t* x)
 {
   for (auto insn : x->get_instructions())

--- a/riscv/extension.h
+++ b/riscv/extension.h
@@ -61,6 +61,9 @@ public:
   void register_extension(extension_t*);
   extension_t* get_extension();
   extension_t* get_extension(const char* name);
+  bool any_custom_extensions() const {
+    return !custom_extensions.empty();
+  }
 protected:
   processor_t* p;
   std::unordered_map<std::string, extension_t*> custom_extensions;

--- a/riscv/extension.h
+++ b/riscv/extension.h
@@ -8,23 +8,39 @@
 #include <vector>
 #include <functional>
 
+typedef enum {
+  EXT_STATE_OFF,
+  EXT_STATE_INIT,
+  EXT_STATE_CLEAN,
+  EXT_STATE_DIRTY,
+
+  MAX_EXT_STATE
+} extension_state_t;
+
 class extension_t
 {
  public:
+  extension_t(bool always_dirty=false) : always_dirty(always_dirty) {}
   virtual std::vector<insn_desc_t> get_instructions() = 0;
   virtual std::vector<disasm_insn_t*> get_disasms() = 0;
   virtual const char* name() = 0;
-  virtual void reset() {};
+  virtual void reset() { state = always_dirty ? EXT_STATE_DIRTY : EXT_STATE_OFF; }
   virtual void set_debug(bool value) {};
   virtual ~extension_t();
 
   void set_processor(processor_t* _p) { p = _p; }
+  extension_state_t get_state() const { return state; }
+  void set_state(extension_state_t s) { state = s; }
  protected:
   processor_t* p;
 
   void illegal_instruction();
   void raise_interrupt();
   void clear_interrupt();
+
+ private:
+  const bool always_dirty;
+  extension_state_t state;
 };
 
 std::function<extension_t*()> find_extension(const char* name);

--- a/riscv/extension.h
+++ b/riscv/extension.h
@@ -51,4 +51,16 @@ void register_extension(const char* name, std::function<extension_t*()> f);
     public: register_##name() { register_extension(#name, constructor); } \
   }; static register_##name dummy_##name;
 
+class xs_gatherer_t
+{
+public:
+  xs_gatherer_t(processor_t* proc) : p(proc) {}
+  void reset() {}
+
+  extension_state_t get_xs();
+
+protected:
+  processor_t* p;
+};
+
 #endif

--- a/riscv/extension.h
+++ b/riscv/extension.h
@@ -59,6 +59,8 @@ public:
 
   extension_state_t get_xs();
   void register_extension(extension_t*);
+  extension_t* get_extension();
+  extension_t* get_extension(const char* name);
 protected:
   processor_t* p;
   std::unordered_map<std::string, extension_t*> custom_extensions;

--- a/riscv/extension.h
+++ b/riscv/extension.h
@@ -64,6 +64,10 @@ public:
   bool any_custom_extensions() const {
     return !custom_extensions.empty();
   }
+  void set_debug(bool value) {
+    for (auto e : custom_extensions)
+      e.second->set_debug(value);
+  };
 protected:
   processor_t* p;
   std::unordered_map<std::string, extension_t*> custom_extensions;

--- a/riscv/extension.h
+++ b/riscv/extension.h
@@ -5,6 +5,8 @@
 
 #include "processor.h"
 #include "disasm.h"
+#include "insn_macros.h"
+#include "decode.h"
 #include <vector>
 #include <functional>
 

--- a/riscv/extension.h
+++ b/riscv/extension.h
@@ -55,12 +55,13 @@ class xs_gatherer_t
 {
 public:
   xs_gatherer_t(processor_t* proc) : p(proc) {}
-  void reset() {}
+  void reset();
 
   extension_state_t get_xs();
-
+  void register_extension(extension_t*);
 protected:
   processor_t* p;
+  std::unordered_map<std::string, extension_t*> custom_extensions;
 };
 
 #endif

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -48,8 +48,10 @@ processor_t::processor_t(const isa_parser_t *isa, const char* varch,
 
   disassembler = new disassembler_t(isa);
   xs_gatherer = new xs_gatherer_t(this);
-  for (auto e : isa->get_extensions())
+  for (auto e : isa->get_extensions()) {
     register_extension(e.second);
+    xs_gatherer->register_extension(e.second);
+  }
 
   set_pmp_granularity(1 << PMP_SHIFT);
   set_pmp_num(state.max_pmp);

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -518,26 +518,6 @@ void processor_t::reset()
     sim->proc_reset(id);
 }
 
-extension_t* processor_t::get_extension()
-{
-  switch (custom_extensions.size()) {
-    case 0: return NULL;
-    case 1: return custom_extensions.begin()->second;
-    default:
-      fprintf(stderr, "processor_t::get_extension() is ambiguous when multiple extensions\n");
-      fprintf(stderr, "are present!\n");
-      abort();
-  }
-}
-
-extension_t* processor_t::get_extension(const char* name)
-{
-  auto it = custom_extensions.find(name);
-  if (it == custom_extensions.end())
-    abort();
-  return it->second;
-}
-
 void processor_t::set_pmp_num(reg_t n)
 {
   // check the number of pmp is in a reasonable range

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -47,6 +47,7 @@ processor_t::processor_t(const isa_parser_t *isa, const char* varch,
   mmu = new mmu_t(sim, this);
 
   disassembler = new disassembler_t(isa);
+  xs_gatherer = new xs_gatherer_t(this);
   for (auto e : isa->get_extensions())
     register_extension(e.second);
 
@@ -507,7 +508,8 @@ void processor_t::reset()
     put_csr(CSR_PMPCFG0, PMP_R | PMP_W | PMP_X | PMP_NAPOT);
   }
 
-   for (auto e : custom_extensions) // reset any extensions
+  xs_gatherer->reset();
+  for (auto e : custom_extensions) // reset any extensions
     e.second->reset();
 
   if (sim)

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -472,6 +472,7 @@ void processor_t::set_debug(bool value)
 {
   debug = value;
 
+  xs_gatherer->set_debug(value);
   for (auto e : custom_extensions)
     e.second->set_debug(value);
 }

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -260,8 +260,6 @@ public:
            extension_enabled('D') ? 64 :
            extension_enabled('F') ? 32 : 0;
   }
-  extension_t* get_extension();
-  extension_t* get_extension(const char* name);
   bool any_custom_extensions() const {
     return !custom_extensions.empty();
   }

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -24,6 +24,7 @@ class simif_t;
 class trap_t;
 class extension_t;
 class disassembler_t;
+class xs_gatherer_t;
 
 reg_t illegal_instruction(processor_t* p, insn_t insn, reg_t pc);
 
@@ -264,6 +265,7 @@ public:
   bool any_custom_extensions() const {
     return !custom_extensions.empty();
   }
+  xs_gatherer_t* get_xs_gatherer() { return xs_gatherer; }
   bool extension_enabled(unsigned char ext) const {
     if (ext >= 'A' && ext <= 'Z')
       return state.misa->extension_enabled(ext);
@@ -330,6 +332,7 @@ private:
   simif_t* sim;
   mmu_t* mmu; // main memory is always accessed via the mmu
   std::unordered_map<std::string, extension_t*> custom_extensions;
+  xs_gatherer_t* xs_gatherer;
   disassembler_t* disassembler;
   state_t state;
   uint32_t id;
@@ -360,6 +363,7 @@ private:
   friend class mmu_t;
   friend class clint_t;
   friend class extension_t;
+  friend class xs_gatherer_t;
 
   void parse_varch_string(const char*);
   void parse_priv_string(const char*);

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -260,9 +260,6 @@ public:
            extension_enabled('D') ? 64 :
            extension_enabled('F') ? 32 : 0;
   }
-  bool any_custom_extensions() const {
-    return !custom_extensions.empty();
-  }
   xs_gatherer_t* get_xs_gatherer() { return xs_gatherer; }
   bool extension_enabled(unsigned char ext) const {
     if (ext >= 'A' && ext <= 'Z')

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -296,7 +296,6 @@ public:
   FILE *get_log_file() { return log_file; }
 
   void register_insn(insn_desc_t);
-  void register_extension(extension_t*);
 
   // MMIO slave interface
   bool load(reg_t addr, size_t len, uint8_t* bytes);
@@ -326,7 +325,6 @@ private:
 
   simif_t* sim;
   mmu_t* mmu; // main memory is always accessed via the mmu
-  std::unordered_map<std::string, extension_t*> custom_extensions;
   xs_gatherer_t* xs_gatherer;
   disassembler_t* disassembler;
   state_t state;

--- a/riscv/rocc.cc
+++ b/riscv/rocc.cc
@@ -7,6 +7,7 @@
 #define customX(n) \
   static reg_t c##n(processor_t* p, insn_t insn, reg_t pc) \
   { \
+    require_accelerator; \
     rocc_t* rocc = static_cast<rocc_t*>(p->get_xs_gatherer()->get_extension()); \
     rocc_insn_union_t u; \
     u.i = insn; \

--- a/riscv/rocc.cc
+++ b/riscv/rocc.cc
@@ -7,7 +7,7 @@
 #define customX(n) \
   static reg_t c##n(processor_t* p, insn_t insn, reg_t pc) \
   { \
-    rocc_t* rocc = static_cast<rocc_t*>(p->get_extension()); \
+    rocc_t* rocc = static_cast<rocc_t*>(p->get_xs_gatherer()->get_extension()); \
     rocc_insn_union_t u; \
     u.i = insn; \
     reg_t xs1 = u.r.xs1 ? RS1 : -1; \

--- a/riscv/rocc.h
+++ b/riscv/rocc.h
@@ -24,6 +24,7 @@ union rocc_insn_union_t
 class rocc_t : public extension_t
 {
  public:
+  rocc_t(): extension_t(true) {}
   virtual reg_t custom0(rocc_insn_t insn, reg_t xs1, reg_t xs2);
   virtual reg_t custom1(rocc_insn_t insn, reg_t xs1, reg_t xs2);
   virtual reg_t custom2(rocc_insn_t insn, reg_t xs1, reg_t xs2);

--- a/spike_main/spike-log-parser.cc
+++ b/spike_main/spike-log-parser.cc
@@ -30,7 +30,7 @@ int main(int argc, char** argv)
   isa_parser_t isa(isa_string, DEFAULT_PRIV);
   processor_t p(&isa, DEFAULT_VARCH, 0, 0, false, nullptr, cerr);
   if (extension) {
-    p.register_extension(extension());
+    p.get_xs_gatherer()->register_extension(extension());
   }
 
   std::regex reg("^core\\s+\\d+:\\s+0x[0-9a-f]+\\s+\\(0x([0-9a-f]+)\\)", std::regex_constants::icase);

--- a/spike_main/spike.cc
+++ b/spike_main/spike.cc
@@ -511,7 +511,7 @@ int main(int argc, char** argv)
     if (ic) s.get_core(i)->get_mmu()->register_memtracer(&*ic);
     if (dc) s.get_core(i)->get_mmu()->register_memtracer(&*dc);
     for (auto e : extensions)
-      s.get_core(i)->register_extension(e());
+      s.get_core(i)->get_xs_gatherer()->register_extension(e());
     s.get_core(i)->get_mmu()->set_cache_blocksz(blocksz);
   }
 


### PR DESCRIPTION
In the specification, both of the xs fields should be read-only, I summarized the permissions of xs in spike:
|  | spike | rocket |
|:-:|:-:|:-:|
| [m/s]status | RW | R |
| vsstatus | RW | R |

The following test case shows that both of them are writable.
```
core   0: 0x0000000080000188 (0x30001073) csrw    mstatus, zero
core   0: 0x000000008000018c (0x10001073) csrw    sstatus, zero
core   0: 0x0000000080000190 (0x20001073) csrw    vsstatus, zero
core   0: 0x0000000080000194 (0x300023f3) csrr    t2, mstatus
core   0: 0x0000000080000198 (0x10002e73) csrr    t3, sstatus
core   0: 0x000000008000019c (0x20002ef3) csrr    t4, vsstatus
: reg 0
t2: 0x0000000a00000000 t3: 0x0000000200000000  t4: 0x0000000200000000

core   0: 0x00000000800001a0 (0x000182b7) lui     t0, 0x18
core   0: 0x00000000800001a4 (0x30029073) csrw    mstatus, t0
core   0: 0x00000000800001a8 (0x10029073) csrw    sstatus, t0
core   0: 0x00000000800001ac (0x20029073) csrw    vsstatus, t0
core   0: 0x00000000800001b0 (0x300023f3) csrr    t2, mstatus
core   0: 0x00000000800001b4 (0x10002e73) csrr    t3, sstatus
core   0: 0x00000000800001b8 (0x20002ef3) csrr    t4, vsstatus
: reg 0
t2: 0x8000000a00018000 t3: 0x8000000200018000  t4: 0x8000000200018000
```
[xs-writable.tar.gz](https://github.com/chipsalliance/rocket-chip/files/8747904/xs-writable.tar.gz)

