### PR TITLE
Fix for issue #990, implements the PBMTE bit in the henvcfg /menvcfg reisters

### DIFF
--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -840,6 +840,13 @@ bool masked_csr_t::unlogged_write(const reg_t val) noexcept {
 }
 
 
+// implement class henvcfg_csr_t
+henvcfg_csr_t::henvcfg_csr_t(processor_t* const proc, const reg_t addr, const reg_t mask, const reg_t init, csr_t_p menvcfg):
+  masked_csr_t(proc, addr, mask, init),
+  menvcfg(menvcfg) {
+}
+
+
 // implement class base_atp_csr_t and family
 base_atp_csr_t::base_atp_csr_t(processor_t* const proc, const reg_t addr):
   basic_csr_t(proc, addr, 0) {

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -448,6 +448,20 @@ class masked_csr_t: public basic_csr_t {
 };
 
 
+// henvcfg.pbmte is read_only 0 when menvcfg.pbmte = 0
+class henvcfg_csr_t final: public masked_csr_t {
+ public:
+  henvcfg_csr_t(processor_t* const proc, const reg_t addr, const reg_t mask, const reg_t init, csr_t_p menvcfg);
+
+  reg_t read() const noexcept override {
+    return (menvcfg->read() | ~MENVCFG_PBMTE) & masked_csr_t::read();
+  }
+
+ private:
+  csr_t_p menvcfg;
+};
+
+
 // For satp and vsatp
 // These are three classes in order to handle the [V]TVM bits permission checks
 class base_atp_csr_t: public basic_csr_t {

--- a/riscv/mmu.cc
+++ b/riscv/mmu.cc
@@ -302,6 +302,8 @@ reg_t mmu_t::s2xlate(reg_t gva, reg_t gpa, access_type type, access_type trap_ty
         break;
       } else if (!pbmte && (pte & PTE_PBMT)) {
         break;
+      } else if ((pte & PTE_PBMT) == PTE_PBMT) {
+        break;
       } else if (PTE_TABLE(pte)) { // next level of page table
         if (pte & (PTE_D | PTE_A | PTE_U | PTE_N | PTE_PBMT))
           break;
@@ -392,6 +394,8 @@ reg_t mmu_t::walk(reg_t addr, access_type type, reg_t mode, bool virt, bool hlvx
     } else if (!proc->extension_enabled(EXT_SVNAPOT) && (pte & PTE_N)) {
       break;
     } else if (!pbmte && (pte & PTE_PBMT)) {
+      break;
+    } else if ((pte & PTE_PBMT) == PTE_PBMT) {
       break;
     } else if (PTE_TABLE(pte)) { // next level of page table
       if (pte & (PTE_D | PTE_A | PTE_U | PTE_N | PTE_PBMT))

--- a/riscv/mmu.cc
+++ b/riscv/mmu.cc
@@ -294,12 +294,13 @@ reg_t mmu_t::s2xlate(reg_t gva, reg_t gpa, access_type type, access_type trap_ty
 
       reg_t pte = vm.ptesize == 4 ? from_target(*(target_endian<uint32_t>*)ppte) : from_target(*(target_endian<uint64_t>*)ppte);
       reg_t ppn = (pte & ~reg_t(PTE_ATTR)) >> PTE_PPN_SHIFT;
+      bool pbmte = proc->get_state()->menvcfg->read() & MENVCFG_PBMTE;
 
       if (pte & PTE_RSVD) {
         break;
       } else if (!proc->extension_enabled(EXT_SVNAPOT) && (pte & PTE_N)) {
         break;
-      } else if (!proc->extension_enabled(EXT_SVPBMT) && (pte & PTE_PBMT)) {
+      } else if (!pbmte && (pte & PTE_PBMT)) {
         break;
       } else if (PTE_TABLE(pte)) { // next level of page table
         if (pte & (PTE_D | PTE_A | PTE_U | PTE_N | PTE_PBMT))
@@ -384,12 +385,13 @@ reg_t mmu_t::walk(reg_t addr, access_type type, reg_t mode, bool virt, bool hlvx
 
     reg_t pte = vm.ptesize == 4 ? from_target(*(target_endian<uint32_t>*)ppte) : from_target(*(target_endian<uint64_t>*)ppte);
     reg_t ppn = (pte & ~reg_t(PTE_ATTR)) >> PTE_PPN_SHIFT;
+    bool pbmte = virt ? (proc->get_state()->henvcfg->read() & HENVCFG_PBMTE) : (proc->get_state()->menvcfg->read() & MENVCFG_PBMTE);
 
     if (pte & PTE_RSVD) {
       break;
     } else if (!proc->extension_enabled(EXT_SVNAPOT) && (pte & PTE_N)) {
       break;
-    } else if (!proc->extension_enabled(EXT_SVPBMT) && (pte & PTE_PBMT)) {
+    } else if (!pbmte && (pte & PTE_PBMT)) {
       break;
     } else if (PTE_TABLE(pte)) { // next level of page table
       if (pte & (PTE_D | PTE_A | PTE_U | PTE_N | PTE_PBMT))

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -380,14 +380,18 @@ void state_t::reset(processor_t* const proc, reg_t max_isa)
   csrmap[CSR_MVENDORID] = std::make_shared<const_csr_t>(proc, CSR_MVENDORID, 0);
   csrmap[CSR_MHARTID] = std::make_shared<const_csr_t>(proc, CSR_MHARTID, proc->get_id());
   const reg_t menvcfg_mask = (proc->extension_enabled(EXT_ZICBOM) ? MENVCFG_CBCFE | MENVCFG_CBIE : 0) |
-                             (proc->extension_enabled(EXT_ZICBOZ) ? MENVCFG_CBZE : 0);
-  csrmap[CSR_MENVCFG] = menvcfg = std::make_shared<masked_csr_t>(proc, CSR_MENVCFG, menvcfg_mask, 0);
+                             (proc->extension_enabled(EXT_ZICBOZ) ? MENVCFG_CBZE : 0) |
+                             (proc->extension_enabled(EXT_SVPBMT) ? MENVCFG_PBMTE : 0);
+  const reg_t menvcfg_init = (proc->extension_enabled(EXT_SVPBMT) ? MENVCFG_PBMTE : 0);
+  csrmap[CSR_MENVCFG] = menvcfg = std::make_shared<masked_csr_t>(proc, CSR_MENVCFG, menvcfg_mask, menvcfg_init);
   const reg_t senvcfg_mask = (proc->extension_enabled(EXT_ZICBOM) ? SENVCFG_CBCFE | SENVCFG_CBIE : 0) |
                              (proc->extension_enabled(EXT_ZICBOZ) ? SENVCFG_CBZE : 0);
   csrmap[CSR_SENVCFG] = senvcfg = std::make_shared<masked_csr_t>(proc, CSR_SENVCFG, senvcfg_mask, 0);
   const reg_t henvcfg_mask = (proc->extension_enabled(EXT_ZICBOM) ? HENVCFG_CBCFE | HENVCFG_CBIE : 0) |
-                             (proc->extension_enabled(EXT_ZICBOZ) ? HENVCFG_CBZE : 0);
-  csrmap[CSR_HENVCFG] = henvcfg = std::make_shared<henvcfg_csr_t>(proc, CSR_HENVCFG, henvcfg_mask, 0, menvcfg);
+                             (proc->extension_enabled(EXT_ZICBOZ) ? HENVCFG_CBZE : 0) |
+                             (proc->extension_enabled(EXT_SVPBMT) ? HENVCFG_PBMTE : 0);
+  const reg_t henvcfg_init = (proc->extension_enabled(EXT_SVPBMT) ? HENVCFG_PBMTE : 0);
+  csrmap[CSR_HENVCFG] = henvcfg = std::make_shared<henvcfg_csr_t>(proc, CSR_HENVCFG, henvcfg_mask, henvcfg_init, menvcfg);
 
   serialized = false;
 

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -387,7 +387,7 @@ void state_t::reset(processor_t* const proc, reg_t max_isa)
   csrmap[CSR_SENVCFG] = senvcfg = std::make_shared<masked_csr_t>(proc, CSR_SENVCFG, senvcfg_mask, 0);
   const reg_t henvcfg_mask = (proc->extension_enabled(EXT_ZICBOM) ? HENVCFG_CBCFE | HENVCFG_CBIE : 0) |
                              (proc->extension_enabled(EXT_ZICBOZ) ? HENVCFG_CBZE : 0);
-  csrmap[CSR_HENVCFG] = henvcfg = std::make_shared<masked_csr_t>(proc, CSR_HENVCFG, henvcfg_mask, 0);
+  csrmap[CSR_HENVCFG] = henvcfg = std::make_shared<henvcfg_csr_t>(proc, CSR_HENVCFG, henvcfg_mask, 0, menvcfg);
 
   serialized = false;
 


### PR DESCRIPTION
- Implements the `PBMTE` bit in the `henvcfg` /`menvcfg` registers and checks them during TableWalks
- Makes the value `PBMT==3`, which is reserved in the spec, cause a fault during a TableWalk
- Makes the reset value of `*envcfg.PBMTE = 1` for backward compatibility