### PR TITLE
rvv: fix the checking eew and elen for index load

### DIFF
--- a/riscv/v_ext_macros.h
+++ b/riscv/v_ext_macros.h
@@ -84,6 +84,7 @@ static inline bool is_aligned(const unsigned val, const unsigned pos)
 
 #define VI_CHECK_ST_INDEX(elt_width) \
   require_vector(false); \
+  require(elt_width <= P.VU.ELEN); \
   float vemul = ((float)elt_width / P.VU.vsew * P.VU.vflmul); \
   require(vemul >= 0.125 && vemul <= 8); \
   reg_t emul = vemul < 1 ? 1 : vemul; \


### PR DESCRIPTION
eew of index register can't be larger than elen

ex:
   elen = 32,  vloxei64.v is illegal

Signed-off-by: Chih-Min Chao <chihmin.chao@sifive.com>