### PR TITLE
update disasm priority for custom extensions loaded from extlib

### DIFF
--- a/disasm/disasm.cc
+++ b/disasm/disasm.cc
@@ -2098,9 +2098,12 @@ disassembler_t::disassembler_t(const isa_parser_t *isa)
 {
   // highest priority: instructions explicitly enabled
   add_instructions(isa);
+}
 
+void disassembler_t::add_other_insns(unsigned xlen)
+{
   // next-highest priority: other instructions in same base ISA
-  std::string fallback_isa_string = std::string("rv") + std::to_string(isa->get_max_xlen()) +
+  std::string fallback_isa_string = std::string("rv") + std::to_string(xlen) +
     "gcv_zfh_zba_zbb_zbc_zbs_zkn_zkr_zks_xbitmanip";
   isa_parser_t fallback_isa(fallback_isa_string.c_str(), DEFAULT_PRIV);
   add_instructions(&fallback_isa);

--- a/riscv/disasm.h
+++ b/riscv/disasm.h
@@ -88,6 +88,7 @@ class disassembler_t
   const disasm_insn_t* lookup(insn_t insn) const;
 
   void add_insn(disasm_insn_t* insn);
+  void add_other_insns(unsigned xlen);
 
  private:
   static const int HASH_SIZE = 255;

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -49,6 +49,7 @@ processor_t::processor_t(const isa_parser_t *isa, const char* varch,
   disassembler = new disassembler_t(isa);
   for (auto e : isa->get_extensions())
     register_extension(e.second);
+  disassembler->add_other_insns(isa->get_max_xlen());
 
   set_pmp_granularity(1 << PMP_SHIFT);
   set_pmp_num(state.max_pmp);

--- a/spike_dasm/spike-dasm.cc
+++ b/spike_dasm/spike-dasm.cc
@@ -34,6 +34,7 @@ int main(int argc, char** argv)
       disassembler->add_insn(disasm_insn);
     }
   }
+  disassembler->add_other_insns(isa_parser.get_max_xlen());
 
   while (getline(cin, s))
   {


### PR DESCRIPTION
The disasms for custom extensions loaded from extlib are registered as the lowest priority currently which means they will be recognized as the unspecified instructions if they reuse the encode. 
For example, if they reuse the encode for custom* instructions(which is designed for custom instructions),  they will be recgonized as "custom*" instructions.
This patch update the priority for custom extensions to the highest priority to avoid this problem which is also in line with the comment: "highest priority: instructions explicitly enabled".