### PR TITLE
Simplify decode_insn and insn_desc_t

### DIFF
--- a/customext/cflush.cc
+++ b/customext/cflush.cc
@@ -24,9 +24,9 @@ class cflush_t : public extension_t
 
   std::vector<insn_desc_t> get_instructions() {
     std::vector<insn_desc_t> insns;
-    insns.push_back((insn_desc_t){true, 0xFC000073, 0xFFF07FFF, custom_cflush, custom_cflush, custom_cflush, custom_cflush});
-    insns.push_back((insn_desc_t){true, 0xFC200073, 0xFFF07FFF, custom_cflush, custom_cflush, custom_cflush, custom_cflush});
-    insns.push_back((insn_desc_t){true, 0xFC100073, 0xFFF07FFF, custom_cflush, custom_cflush, custom_cflush, custom_cflush});
+    insns.push_back((insn_desc_t){0xFC000073, 0xFFF07FFF, custom_cflush, custom_cflush, custom_cflush, custom_cflush});
+    insns.push_back((insn_desc_t){0xFC200073, 0xFFF07FFF, custom_cflush, custom_cflush, custom_cflush, custom_cflush});
+    insns.push_back((insn_desc_t){0xFC100073, 0xFFF07FFF, custom_cflush, custom_cflush, custom_cflush, custom_cflush});
     return insns;
   }
 

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -907,6 +907,8 @@ insn_func_t processor_t::decode_insn(insn_t insn)
 
 void processor_t::register_insn(insn_desc_t desc)
 {
+  assert(desc.rv32i && desc.rv64i && desc.rv32e && desc.rv64e);
+
   instructions.push_back(desc);
 }
 

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -881,11 +881,11 @@ insn_func_t processor_t::decode_insn(insn_t insn)
 
   bool rve = extension_enabled('E');
 
-  if (unlikely(insn.bits() != desc.match || !desc.func(xlen, rve))) {
+  if (unlikely(insn.bits() != desc.match)) {
     // fall back to linear search
     int cnt = 0;
     insn_desc_t* p = &instructions[0];
-    while ((insn.bits() & p->mask) != p->match || !desc.func(xlen, rve))
+    while ((insn.bits() & p->mask) != p->match)
       p++, cnt++;
     desc = *p;
 

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -959,14 +959,16 @@ void processor_t::register_base_instructions()
     extern reg_t rv64i_##name(processor_t*, insn_t, reg_t); \
     extern reg_t rv32e_##name(processor_t*, insn_t, reg_t); \
     extern reg_t rv64e_##name(processor_t*, insn_t, reg_t); \
-    register_insn((insn_desc_t) { \
-      name##_supported, \
-      name##_match, \
-      name##_mask, \
-      rv32i_##name, \
-      rv64i_##name, \
-      rv32e_##name, \
-      rv64e_##name});
+    if (name##_supported) { \
+      register_insn((insn_desc_t) { \
+        name##_supported, \
+        name##_match, \
+        name##_mask, \
+        rv32i_##name, \
+        rv64i_##name, \
+        rv32e_##name, \
+        rv64e_##name}); \
+    }
   #include "insn_list.h"
   #undef DEFINE_INSN
 

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -961,7 +961,6 @@ void processor_t::register_base_instructions()
     extern reg_t rv64e_##name(processor_t*, insn_t, reg_t); \
     if (name##_supported) { \
       register_insn((insn_desc_t) { \
-        name##_supported, \
         name##_match, \
         name##_mask, \
         rv32i_##name, \

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -29,7 +29,6 @@ reg_t illegal_instruction(processor_t* p, insn_t insn, reg_t pc);
 
 struct insn_desc_t
 {
-  bool supported;
   insn_bits_t match;
   insn_bits_t mask;
   insn_func_t rv32i;
@@ -39,9 +38,6 @@ struct insn_desc_t
 
   insn_func_t func(int xlen, bool rve)
   {
-    if (!supported)
-      return NULL;
-
     if (rve)
       return xlen == 64 ? rv64e : rv32e;
     else
@@ -50,7 +46,7 @@ struct insn_desc_t
 
   static insn_desc_t illegal()
   {
-    return {true, 0, 0, &illegal_instruction, &illegal_instruction, &illegal_instruction, &illegal_instruction};
+    return {0, 0, &illegal_instruction, &illegal_instruction, &illegal_instruction, &illegal_instruction};
   }
 };
 

--- a/riscv/rocc.cc
+++ b/riscv/rocc.cc
@@ -32,10 +32,10 @@ customX(3)
 std::vector<insn_desc_t> rocc_t::get_instructions()
 {
   std::vector<insn_desc_t> insns;
-  insns.push_back((insn_desc_t){true, 0x0b, 0x7f, &::illegal_instruction, c0, &::illegal_instruction, c0});
-  insns.push_back((insn_desc_t){true, 0x2b, 0x7f, &::illegal_instruction, c1, &::illegal_instruction, c1});
-  insns.push_back((insn_desc_t){true, 0x5b, 0x7f, &::illegal_instruction, c2, &::illegal_instruction, c2});
-  insns.push_back((insn_desc_t){true, 0x7b, 0x7f, &::illegal_instruction, c3, &::illegal_instruction, c3});
+  insns.push_back((insn_desc_t){0x0b, 0x7f, &::illegal_instruction, c0, &::illegal_instruction, c0});
+  insns.push_back((insn_desc_t){0x2b, 0x7f, &::illegal_instruction, c1, &::illegal_instruction, c1});
+  insns.push_back((insn_desc_t){0x5b, 0x7f, &::illegal_instruction, c2, &::illegal_instruction, c2});
+  insns.push_back((insn_desc_t){0x7b, 0x7f, &::illegal_instruction, c3, &::illegal_instruction, c3});
   return insns;
 }
 


### PR DESCRIPTION
... by removing the possibility of unsupported instructions in the instruction list, and hence the possibility of `nullptr`s within insn_desc_t.

Supersedes #996 