### PR TITLE
Move ebreak* logic from take_trap into instructions.

### DIFF
--- a/riscv/execute.cc
+++ b/riscv/execute.cc
@@ -337,6 +337,10 @@ void processor_t::step(size_t n)
           abort();
       }
     }
+    catch(trap_debug_mode&)
+    {
+      enter_debug_mode(DCSR_CAUSE_SWBP);
+    }
     catch (wait_for_interrupt_t &t)
     {
       // Return to the outer simulation loop, which gives other devices/harts a

--- a/riscv/insns/c_ebreak.h
+++ b/riscv/insns/c_ebreak.h
@@ -1,2 +1,9 @@
 require_extension('C');
-throw trap_breakpoint(STATE.v, pc);
+if (!STATE.debug_mode &&
+    ((STATE.prv == PRV_M && STATE.dcsr->ebreakm) ||
+     (STATE.prv == PRV_S && STATE.dcsr->ebreaks) ||
+     (STATE.prv == PRV_U && STATE.dcsr->ebreaku))) {
+	throw trap_debug_mode();
+} else {
+	throw trap_breakpoint(STATE.v, pc);
+}

--- a/riscv/insns/ebreak.h
+++ b/riscv/insns/ebreak.h
@@ -1,1 +1,8 @@
-throw trap_breakpoint(STATE.v, pc);
+if (!STATE.debug_mode &&
+    ((STATE.prv == PRV_M && STATE.dcsr->ebreakm) ||
+     (STATE.prv == PRV_S && STATE.dcsr->ebreaks) ||
+     (STATE.prv == PRV_U && STATE.dcsr->ebreaku))) {
+	throw trap_debug_mode();
+} else {
+	throw trap_breakpoint(STATE.v, pc);
+}

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -720,14 +720,6 @@ void processor_t::take_trap(trap_t& t, reg_t epc)
     return;
   }
 
-  if (t.cause() == CAUSE_BREAKPOINT && (
-              (state.prv == PRV_M && state.dcsr->ebreakm) ||
-              (state.prv == PRV_S && state.dcsr->ebreaks) ||
-              (state.prv == PRV_U && state.dcsr->ebreaku))) {
-    enter_debug_mode(DCSR_CAUSE_SWBP);
-    return;
-  }
-
   // By default, trap to M-mode, unless delegated to HS-mode or VS-mode
   reg_t vsdeleg, hsdeleg;
   reg_t bit = t.cause();

--- a/riscv/trap.h
+++ b/riscv/trap.h
@@ -8,6 +8,11 @@
 
 struct state_t;
 
+class trap_debug_mode
+{
+  /* Used to enter debug mode, which isn't quite a normal trap. */
+};
+
 class trap_t
 {
  public:


### PR DESCRIPTION
Now that logic only affects ebreak instructions, and does not affect triggers that also cause a trap to be taken.

Fixes #725. Although like Paul, I don't have a test for this case.