### PR TITLE
Reorder 'H'-extension

### DIFF
--- a/riscv/isa_parser.cc
+++ b/riscv/isa_parser.cc
@@ -31,7 +31,7 @@ isa_parser_t::isa_parser_t(const char* str, const char *priv)
   : extension_table(256, false)
 {
   isa_string = strtolower(str);
-  const char* all_subsets = "mafdqchpv";
+  const char* all_subsets = "mafdqcpvh";
 
   max_isa = reg_t(2) << 62;
   // enable zicntr and zihpm unconditionally for backward compatibility


### PR DESCRIPTION
Based on current consensus made in:
<https://github.com/riscv/riscv-isa-manual/issues/837>, this commit changes the canonical order of 'H'.

Of course, making `--isa` string more permissive can be a solution to possible incompatibility caused by this.

But it'll be a TODO.