### PR TITLE
Check triggers before checking alignment

### DIFF
--- a/riscv/mmu.cc
+++ b/riscv/mmu.cc
@@ -143,11 +143,8 @@ void mmu_t::load_slow_path(reg_t addr, reg_t len, uint8_t* bytes, uint32_t xlate
 {
   reg_t paddr = translate(addr, len, LOAD, xlate_flags);
 
-  if (!matched_trigger) {
-    matched_trigger = check_trigger_address_before(triggers::OPERATION_LOAD, addr);
-    if (matched_trigger)
-      throw *matched_trigger;
-  }
+  if (!matched_trigger)
+    check_trigger_address_before(triggers::OPERATION_LOAD, addr);
 
   if (unlikely(addr & (len-1))) {
     if (require_alignment) {

--- a/riscv/mmu.cc
+++ b/riscv/mmu.cc
@@ -139,7 +139,7 @@ bool mmu_t::mmio_store(reg_t addr, size_t len, const uint8_t* bytes)
   return sim->mmio_store(addr, len, bytes);
 }
 
-void mmu_t::load_slow_path(reg_t addr, reg_t len, uint8_t* bytes, uint32_t xlate_flags)
+void mmu_t::load_slow_path(reg_t addr, reg_t len, uint8_t* bytes, uint32_t xlate_flags, bool require_alignment)
 {
   reg_t paddr = translate(addr, len, LOAD, xlate_flags);
 
@@ -149,8 +149,26 @@ void mmu_t::load_slow_path(reg_t addr, reg_t len, uint8_t* bytes, uint32_t xlate
       throw *matched_trigger;
   }
 
+  if (unlikely(addr & (len-1))) {
+    if (require_alignment) {
+      load_reserved_address_misaligned(addr);
+    } else {
+      reg_t value = misaligned_load(addr, len, xlate_flags);
+      for (size_t i = 0; i < len; i++) {
+        if (target_big_endian) {
+          bytes[len - i - 1] = value & 0xff;
+        } else {
+          bytes[i] = value & 0xff;
+        }
+        value >>= 8;
+      }
+      return;
+    }
+  }
+
   if (auto host_addr = sim->addr_to_mem(paddr)) {
     memcpy(bytes, host_addr, len);
+    if (proc) READ_MEM(addr, len);
     if (tracer.interested_in_range(paddr, paddr + PGSIZE, LOAD))
       tracer.trace(paddr, len, LOAD);
     else if (xlate_flags == 0)

--- a/riscv/mmu.cc
+++ b/riscv/mmu.cc
@@ -143,6 +143,12 @@ void mmu_t::load_slow_path(reg_t addr, reg_t len, uint8_t* bytes, uint32_t xlate
 {
   reg_t paddr = translate(addr, len, LOAD, xlate_flags);
 
+  if (!matched_trigger) {
+    matched_trigger = check_trigger_address_before(triggers::OPERATION_LOAD, addr);
+    if (matched_trigger)
+      throw *matched_trigger;
+  }
+
   if (auto host_addr = sim->addr_to_mem(paddr)) {
     memcpy(bytes, host_addr, len);
     if (tracer.interested_in_range(paddr, paddr + PGSIZE, LOAD))

--- a/riscv/mmu.cc
+++ b/riscv/mmu.cc
@@ -150,16 +150,7 @@ void mmu_t::load_slow_path(reg_t addr, reg_t len, uint8_t* bytes, uint32_t xlate
     if (require_alignment) {
       load_reserved_address_misaligned(addr);
     } else {
-      reg_t value = misaligned_load(addr, len, xlate_flags);
-      for (size_t i = 0; i < len; i++) {
-        if (target_big_endian) {
-          bytes[len - i - 1] = value & 0xff;
-        } else {
-          bytes[i] = value & 0xff;
-        }
-        value >>= 8;
-      }
-      return;
+      return misaligned_load(addr, len, bytes, xlate_flags);
     }
   }
 

--- a/riscv/mmu.h
+++ b/riscv/mmu.h
@@ -160,38 +160,48 @@ public:
   proc->state.log_mem_write.push_back(std::make_tuple(addr, val, size));
 #endif
 
+  template<class T, unsigned xlate_flags>
+  inline void store_fast(reg_t addr, T val, bool actually_store=true, bool require_alignment=false) {
+    const size_t size = sizeof(T);
+    if (unlikely(addr & (size-1))) {
+      if (require_alignment)
+        store_conditional_address_misaligned(addr);
+      else
+        return misaligned_store(addr, val, size, xlate_flags, actually_store);
+    }
+    reg_t vpn = addr >> PGSHIFT;
+    if (xlate_flags == 0 && likely(tlb_store_tag[vpn % TLB_ENTRIES] == vpn)) {
+      if (actually_store) {
+        if (proc)
+          WRITE_MEM(addr, val, size);
+        *(target_endian<T>*)(tlb_data[vpn % TLB_ENTRIES].host_offset + addr) = to_target(val);
+      }
+    }
+    else if (xlate_flags == 0 && unlikely(tlb_store_tag[vpn % TLB_ENTRIES] == (vpn | TLB_CHECK_TRIGGERS))) {
+      if (actually_store) {
+        if (!matched_trigger) {
+          matched_trigger = trigger_exception(triggers::OPERATION_STORE, addr, val);
+          if (matched_trigger)
+            throw *matched_trigger;
+        }
+        if (proc)
+          WRITE_MEM(addr, val, size);
+        *(target_endian<T>*)(tlb_data[vpn % TLB_ENTRIES].host_offset + addr) = to_target(val);
+      }
+    }
+    else {
+      target_endian<T> target_val = to_target(val);
+      store_slow_path(addr, size, (const uint8_t*)&target_val, xlate_flags, actually_store);
+      if (actually_store && proc)
+        WRITE_MEM(addr, val, size);
+    }
+  }
+
   // template for functions that store an aligned value to memory
   #define store_func(type, prefix, xlate_flags) \
     void prefix##_##type(reg_t addr, type##_t val, bool actually_store=true, bool require_alignment=false) { \
-      const size_t size = sizeof(type##_t); \
-      if (unlikely(addr & (size-1))) { \
-        if (require_alignment) store_conditional_address_misaligned(addr); \
-        else return misaligned_store(addr, val, size, xlate_flags, actually_store); \
-      } \
-      reg_t vpn = addr >> PGSHIFT; \
-      if ((xlate_flags) == 0 && likely(tlb_store_tag[vpn % TLB_ENTRIES] == vpn)) { \
-        if (actually_store) { \
-          if (proc) WRITE_MEM(addr, val, size); \
-          *(target_endian<type##_t>*)(tlb_data[vpn % TLB_ENTRIES].host_offset + addr) = to_target(val); \
-        } \
-      } \
-      else if ((xlate_flags) == 0 && unlikely(tlb_store_tag[vpn % TLB_ENTRIES] == (vpn | TLB_CHECK_TRIGGERS))) { \
-        if (actually_store) { \
-          if (!matched_trigger) { \
-            matched_trigger = trigger_exception(triggers::OPERATION_STORE, addr, val); \
-            if (matched_trigger) \
-              throw *matched_trigger; \
-          } \
-          if (proc) WRITE_MEM(addr, val, size); \
-          *(target_endian<type##_t>*)(tlb_data[vpn % TLB_ENTRIES].host_offset + addr) = to_target(val); \
-        } \
-      } \
-      else { \
-        target_endian<type##_t> target_val = to_target(val); \
-        store_slow_path(addr, size, (const uint8_t*)&target_val, (xlate_flags), actually_store); \
-        if (actually_store && proc) WRITE_MEM(addr, val, size); \
-      } \
-  }
+      store_fast<type##_t, (xlate_flags)>(addr, val, actually_store, require_alignment); \
+    }
 
   // AMO/Zicbom faults should be reported as store faults
   #define convert_load_traps_to_store_traps(BODY) \

--- a/riscv/mmu.h
+++ b/riscv/mmu.h
@@ -477,6 +477,22 @@ private:
     return (uint16_t*)(translate_insn_addr(addr).host_offset + addr);
   }
 
+  inline triggers::matched_t *check_trigger_address_before(triggers::operation_t operation,
+      reg_t address)
+  {
+    if (!proc) {
+      return NULL;
+    }
+    triggers::action_t action;
+    auto match = proc->TM.address_match(&action, operation, address);
+    if (match == triggers::MATCH_NONE)
+      return NULL;
+    if (match == triggers::MATCH_FIRE_BEFORE) {
+      throw triggers::matched_t(operation, address, 0, action);
+    }
+    return new triggers::matched_t(operation, address, 0, action);
+  }
+
   inline triggers::matched_t *trigger_exception(triggers::operation_t operation,
       reg_t address, reg_t data)
   {

--- a/riscv/mmu.h
+++ b/riscv/mmu.h
@@ -94,15 +94,19 @@ public:
           throw *matched_trigger;
       }
     }
-    if (unlikely(addr & (size-1))) {
-      if (require_alignment) load_reserved_address_misaligned(addr);
-      else return misaligned_load(addr, size, xlate_flags);
-    }
     if ((xlate_flags) == 0 && likely(tlb_load_tag[vpn % TLB_ENTRIES] == vpn)) {
+      if (unlikely(addr & (size-1))) {
+        if (require_alignment) load_reserved_address_misaligned(addr);
+        else return misaligned_load(addr, size, xlate_flags);
+      }
       if (proc) READ_MEM(addr, size);
       return from_target(*(target_endian<T>*)(tlb_data[vpn % TLB_ENTRIES].host_offset + addr));
     }
     if ((xlate_flags) == 0 && unlikely(tlb_load_tag[vpn % TLB_ENTRIES] == (vpn | TLB_CHECK_TRIGGERS))) {
+      if (unlikely(addr & (size-1))) {
+        if (require_alignment) load_reserved_address_misaligned(addr);
+        else return misaligned_load(addr, size, xlate_flags);
+      }
       T data = from_target(*(target_endian<T>*)(tlb_data[vpn % TLB_ENTRIES].host_offset + addr));
       if (!matched_trigger) {
         matched_trigger = trigger_exception(triggers::OPERATION_LOAD, addr, data);
@@ -113,8 +117,7 @@ public:
       return data;
     }
     target_endian<T> res;
-    load_slow_path(addr, size, (uint8_t*)&res, (xlate_flags));
-    if (proc) READ_MEM(addr, size);
+    load_slow_path(addr, size, (uint8_t*)&res, xlate_flags, require_alignment);
     return from_target(res);
   };
 
@@ -456,7 +459,7 @@ private:
 
   // handle uncommon cases: TLB misses, page faults, MMIO
   tlb_entry_t fetch_slow_path(reg_t addr);
-  void load_slow_path(reg_t addr, reg_t len, uint8_t* bytes, uint32_t xlate_flags);
+  void load_slow_path(reg_t addr, reg_t len, uint8_t* bytes, uint32_t xlate_flags, bool require_alignment);
   void store_slow_path(reg_t addr, reg_t len, const uint8_t* bytes, uint32_t xlate_flags, bool actually_store);
   bool mmio_load(reg_t addr, size_t len, uint8_t* bytes);
   bool mmio_store(reg_t addr, size_t len, const uint8_t* bytes);

--- a/riscv/mmu.h
+++ b/riscv/mmu.h
@@ -163,14 +163,23 @@ public:
   template<class T, unsigned xlate_flags>
   inline void store_fast(reg_t addr, T val, bool actually_store=true, bool require_alignment=false) {
     const size_t size = sizeof(T);
-    if (unlikely(addr & (size-1))) {
-      if (require_alignment)
-        store_conditional_address_misaligned(addr);
-      else
-        return misaligned_store(addr, val, size, xlate_flags, actually_store);
+    const reg_t vpn = addr >> PGSHIFT;
+    if (xlate_flags == 0 &&
+        unlikely(tlb_store_tag[vpn % TLB_ENTRIES] == (vpn | TLB_CHECK_TRIGGERS)) &&
+        actually_store) {
+      if (!matched_trigger) {
+        matched_trigger = trigger_exception(triggers::OPERATION_STORE, addr, val);
+        if (matched_trigger)
+          throw *matched_trigger;
+      }
     }
-    reg_t vpn = addr >> PGSHIFT;
     if (xlate_flags == 0 && likely(tlb_store_tag[vpn % TLB_ENTRIES] == vpn)) {
+      if (unlikely(addr & (size-1))) {
+        if (require_alignment)
+          store_conditional_address_misaligned(addr);
+        else
+          return misaligned_store(addr, val, size, xlate_flags, actually_store);
+      }
       if (actually_store) {
         if (proc)
           WRITE_MEM(addr, val, size);
@@ -178,12 +187,13 @@ public:
       }
     }
     else if (xlate_flags == 0 && unlikely(tlb_store_tag[vpn % TLB_ENTRIES] == (vpn | TLB_CHECK_TRIGGERS))) {
+      if (unlikely(addr & (size-1))) {
+        if (require_alignment)
+          store_conditional_address_misaligned(addr);
+        else
+          return misaligned_store(addr, val, size, xlate_flags, actually_store);
+      }
       if (actually_store) {
-        if (!matched_trigger) {
-          matched_trigger = trigger_exception(triggers::OPERATION_STORE, addr, val);
-          if (matched_trigger)
-            throw *matched_trigger;
-        }
         if (proc)
           WRITE_MEM(addr, val, size);
         *(target_endian<T>*)(tlb_data[vpn % TLB_ENTRIES].host_offset + addr) = to_target(val);
@@ -191,9 +201,8 @@ public:
     }
     else {
       target_endian<T> target_val = to_target(val);
-      store_slow_path(addr, size, (const uint8_t*)&target_val, xlate_flags, actually_store);
-      if (actually_store && proc)
-        WRITE_MEM(addr, val, size);
+      store_slow_path(addr, size, (const uint8_t*)&target_val, xlate_flags, actually_store,
+          require_alignment);
     }
   }
 
@@ -470,7 +479,8 @@ private:
   // handle uncommon cases: TLB misses, page faults, MMIO
   tlb_entry_t fetch_slow_path(reg_t addr);
   void load_slow_path(reg_t addr, reg_t len, uint8_t* bytes, uint32_t xlate_flags, bool require_alignment);
-  void store_slow_path(reg_t addr, reg_t len, const uint8_t* bytes, uint32_t xlate_flags, bool actually_store);
+  void store_slow_path(reg_t addr, reg_t len, const uint8_t* bytes, uint32_t xlate_flags, bool actually_store,
+      bool require_alignment);
   bool mmio_load(reg_t addr, size_t len, uint8_t* bytes);
   bool mmio_store(reg_t addr, size_t len, const uint8_t* bytes);
   bool mmio_ok(reg_t addr, access_type type);

--- a/riscv/mmu.h
+++ b/riscv/mmu.h
@@ -52,13 +52,11 @@ public:
 #define RISCV_XLATE_VIRT (1U << 0)
 #define RISCV_XLATE_VIRT_HLVX (1U << 1)
 
-  inline reg_t misaligned_load(reg_t addr, size_t size, uint32_t xlate_flags)
+  inline void misaligned_load(reg_t addr, reg_t len, uint8_t *bytes, uint32_t xlate_flags)
   {
 #ifdef RISCV_ENABLE_MISALIGNED
-    reg_t res = 0;
-    for (size_t i = 0; i < size; i++)
-      res += (reg_t)load_uint8(addr + (target_big_endian? size-1-i : i)) << (i * 8);
-    return res;
+    for (size_t i = 0; i < len; i++)
+      bytes[i] = load_uint8(addr + i);
 #else
     bool gva = ((proc) ? proc->state.v : false) || (RISCV_XLATE_VIRT & xlate_flags);
     throw trap_load_address_misaligned(gva, addr, 0, 0);

--- a/riscv/triggers.cc
+++ b/riscv/triggers.cc
@@ -165,9 +165,9 @@ match_result_t module_t::memory_access_match(action_t * const action, operation_
 
   bool chain_ok = true;
 
-  for (unsigned int i = 0; i < triggers.size(); i++) {
+  for (auto trigger : triggers) {
     if (!chain_ok) {
-      chain_ok |= !triggers[i]->chain();
+      chain_ok |= !trigger->chain();
       continue;
     }
 
@@ -177,9 +177,9 @@ match_result_t module_t::memory_access_match(action_t * const action, operation_
      * entire chain did not match. This is allowed by the spec, because the final
      * trigger in the chain will never get `hit` set unless the entire chain
      * matches. */
-    match_result_t result = triggers[i]->memory_access_match(proc, operation, address, data);
-    if (result != MATCH_NONE && !triggers[i]->chain()) {
-      *action = triggers[i]->action;
+    match_result_t result = trigger->memory_access_match(proc, operation, address, data);
+    if (result != MATCH_NONE && !trigger->chain()) {
+      *action = trigger->action;
       return result;
     }
 

--- a/riscv/triggers.cc
+++ b/riscv/triggers.cc
@@ -108,6 +108,13 @@ bool mcontrol_t::simple_match(unsigned xlen, reg_t value) const {
   assert(0);
 }
 
+match_result_t mcontrol_t::address_match(processor_t * const proc, operation_t operation, reg_t address) {
+  if (select) {
+    return MATCH_NONE;
+  }
+  return memory_access_match(proc, operation, address, 0);
+}
+
 match_result_t mcontrol_t::memory_access_match(processor_t * const proc, operation_t operation, reg_t address, reg_t data) {
   state_t * const state = proc->get_state();
   if ((operation == triggers::OPERATION_EXECUTE && !execute_bit) ||
@@ -155,6 +162,37 @@ module_t::~module_t() {
   for (auto trigger : triggers) {
     delete trigger;
   }
+}
+
+match_result_t module_t::address_match(action_t * const action, operation_t operation, reg_t address)
+{
+  state_t * const state = proc->get_state();
+  if (state->debug_mode)
+    return MATCH_NONE;
+
+  bool chain_ok = true;
+
+  for (auto trigger : triggers) {
+    if (!chain_ok) {
+      chain_ok |= !trigger->chain();
+      continue;
+    }
+
+    /* Note: We call memory_access_match for each trigger in a chain as long as
+     * the triggers are matching. This results in "temperature coding" so that
+     * `hit` is set on each of the consecutive triggeratched, even if the
+     * entire chain did not match. This is allowed by the spec, because the final
+     * trigger in the chain will never get `hit` set unless the entire chain
+     * matches. */
+    match_result_t result = trigger->address_match(proc, operation, address);
+    if (result != MATCH_NONE && !trigger->chain()) {
+      *action = trigger->action;
+      return result;
+    }
+
+    chain_ok = true;
+  }
+  return MATCH_NONE;
 }
 
 match_result_t module_t::memory_access_match(action_t * const action, operation_t operation, reg_t address, reg_t data)

--- a/riscv/triggers.h
+++ b/riscv/triggers.h
@@ -42,6 +42,8 @@ class matched_t
 
 class trigger_t {
 public:
+  virtual match_result_t address_match(processor_t * const proc,
+      operation_t operation, reg_t address) = 0;
   virtual match_result_t memory_access_match(processor_t * const proc,
       operation_t operation, reg_t address, reg_t data) = 0;
 
@@ -90,6 +92,8 @@ public:
   virtual bool store() const override { return store_bit; }
   virtual bool load() const override { return load_bit; }
 
+  virtual match_result_t address_match(processor_t * const proc,
+      operation_t operation, reg_t address) override;
   virtual match_result_t memory_access_match(processor_t * const proc,
       operation_t operation, reg_t address, reg_t data) override;
 
@@ -117,6 +121,8 @@ public:
 
   unsigned count() const { return triggers.size(); }
 
+  match_result_t address_match(action_t * const action,
+      operation_t operation, reg_t address);
   match_result_t memory_access_match(action_t * const action,
       operation_t operation, reg_t address, reg_t data);
 


### PR DESCRIPTION
Fixes #971.

Running the towers benchmark now takes 11% longer.

Tested this by running `make run` in riscv-tests/isa. I'm not sure this code is correct on both endiannesses.