### PR TITLE
Fix RV32 hgatp write mask computation

### DIFF
--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -1075,7 +1075,7 @@ bool hgatp_csr_t::unlogged_write(const reg_t val) noexcept {
   if (proc->get_const_xlen() == 32) {
     mask = HGATP32_PPN |
         HGATP32_MODE |
-        proc->supports_impl(IMPL_MMU_VMID) ? HGATP32_VMID : 0;
+        (proc->supports_impl(IMPL_MMU_VMID) ? HGATP32_VMID : 0);
   } else {
     mask = (HGATP64_PPN & ((reg_t(1) << (MAX_PADDR_BITS - PGSHIFT)) - 1)) |
         (proc->supports_impl(IMPL_MMU_VMID) ? HGATP64_VMID : 0);


### PR DESCRIPTION
clang with `-Wall` happened to catch this.