### PR TITLE
Remove the now-unused PC_SERIALIZE_WFI

### DIFF
--- a/riscv/decode.h
+++ b/riscv/decode.h
@@ -315,8 +315,7 @@ private:
 class wait_for_interrupt_t {};
 
 #define wfi() \
-  do { set_pc_and_serialize(npc); \
-       npc = PC_SERIALIZE_WFI; \
+  do { STATE.pc = npc; \
        throw wait_for_interrupt_t(); \
      } while (0)
 
@@ -325,7 +324,6 @@ class wait_for_interrupt_t {};
 /* Sentinel PC values to serialize simulator pipeline */
 #define PC_SERIALIZE_BEFORE 3
 #define PC_SERIALIZE_AFTER 5
-#define PC_SERIALIZE_WFI 7
 #define invalid_pc(pc) ((pc) & 1)
 
 /* Convenience wrappers to simplify softfloat code sequences */

--- a/riscv/execute.cc
+++ b/riscv/execute.cc
@@ -242,7 +242,6 @@ void processor_t::step(size_t n)
        switch (pc) { \
          case PC_SERIALIZE_BEFORE: state.serialized = true; break; \
          case PC_SERIALIZE_AFTER: ++instret; break; \
-         case PC_SERIALIZE_WFI: n = ++instret; break; \
          default: abort(); \
        } \
        pc = state.pc; \


### PR DESCRIPTION
When WFI was changed to throw a C++ exception, the special-npc
signaling became obsolete.