### PR TITLE
Remove nonstandard length encoding

### DIFF
--- a/riscv/decode.h
+++ b/riscv/decode.h
@@ -69,7 +69,6 @@ const int NCSR = 4096;
   (((x) & 0x03) < 0x03 ? 2 : \
    ((x) & 0x1f) < 0x1f ? 4 : \
    ((x) & 0x3f) < 0x3f ? 6 : \
-   ((x) & 0x7f) == 0x7f ? 4 : \
    8)
 #define MAX_INSN_LENGTH 8
 #define PC_ALIGN 2


### PR DESCRIPTION
This was an artifact of an old P-extension draft that erroneously allocated a reserved major opcode.  The newer draft uses a different opcode in the 32-bit encoding space, so this hack is no longer needed.