### PR TITLE
Fix #1022 by removing need to mask insn_t bits

### DIFF
--- a/riscv/decode.h
+++ b/riscv/decode.h
@@ -79,7 +79,7 @@ class insn_t
 public:
   insn_t() = default;
   insn_t(insn_bits_t bits) : b(bits) {}
-  insn_bits_t bits() { return b & ~((UINT64_MAX) << (length() * 8)); }
+  insn_bits_t bits() { return b; }
   int length() { return insn_length(b); }
   int64_t i_imm() { return xs(20, 12); }
   int64_t shamt() { return x(20, 6); }

--- a/riscv/decode.h
+++ b/riscv/decode.h
@@ -81,11 +81,11 @@ public:
   insn_t(insn_bits_t bits) : b(bits) {}
   insn_bits_t bits() { return b & ~((UINT64_MAX) << (length() * 8)); }
   int length() { return insn_length(b); }
-  int64_t i_imm() { return int64_t(b) >> 20; }
+  int64_t i_imm() { return xs(20, 12); }
   int64_t shamt() { return x(20, 6); }
   int64_t s_imm() { return x(7, 5) + (xs(25, 7) << 5); }
   int64_t sb_imm() { return (x(8, 4) << 1) + (x(25, 6) << 5) + (x(7, 1) << 11) + (imm_sign() << 12); }
-  int64_t u_imm() { return int64_t(b) >> 12 << 12; }
+  int64_t u_imm() { return xs(12, 20) << 12; }
   int64_t uj_imm() { return (x(21, 10) << 1) + (x(20, 1) << 11) + (x(12, 8) << 12) + (imm_sign() << 20); }
   uint64_t rd() { return x(7, 5); }
   uint64_t rs1() { return x(15, 5); }
@@ -144,7 +144,7 @@ private:
   insn_bits_t b;
   uint64_t x(int lo, int len) { return (b >> lo) & ((insn_bits_t(1) << len) - 1); }
   uint64_t xs(int lo, int len) { return int64_t(b) << (64 - lo - len) >> (64 - len); }
-  uint64_t imm_sign() { return xs(63, 1); }
+  uint64_t imm_sign() { return xs(31, 1); }
 };
 
 template <class T, size_t N, bool zero_reg>

--- a/riscv/mmu.h
+++ b/riscv/mmu.h
@@ -319,15 +319,15 @@ public:
     int length = insn_length(insn);
 
     if (likely(length == 4)) {
-      insn |= (insn_bits_t)from_le(*(const int16_t*)translate_insn_addr_to_host(addr + 2)) << 16;
+      insn |= (insn_bits_t)from_le(*(const uint16_t*)translate_insn_addr_to_host(addr + 2)) << 16;
     } else if (length == 2) {
-      insn = (int16_t)insn;
+      // entire instruction already fetched
     } else if (length == 6) {
-      insn |= (insn_bits_t)from_le(*(const int16_t*)translate_insn_addr_to_host(addr + 4)) << 32;
+      insn |= (insn_bits_t)from_le(*(const uint16_t*)translate_insn_addr_to_host(addr + 4)) << 32;
       insn |= (insn_bits_t)from_le(*(const uint16_t*)translate_insn_addr_to_host(addr + 2)) << 16;
     } else {
       static_assert(sizeof(insn_bits_t) == 8, "insn_bits_t must be uint64_t");
-      insn |= (insn_bits_t)from_le(*(const int16_t*)translate_insn_addr_to_host(addr + 6)) << 48;
+      insn |= (insn_bits_t)from_le(*(const uint16_t*)translate_insn_addr_to_host(addr + 6)) << 48;
       insn |= (insn_bits_t)from_le(*(const uint16_t*)translate_insn_addr_to_host(addr + 4)) << 32;
       insn |= (insn_bits_t)from_le(*(const uint16_t*)translate_insn_addr_to_host(addr + 2)) << 16;
     }

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -796,7 +796,7 @@ void processor_t::take_trap(trap_t& t, reg_t epc)
 
 void processor_t::disasm(insn_t insn)
 {
-  uint64_t bits = insn.bits() & ((1ULL << (8 * insn_length(insn.bits()))) - 1);
+  uint64_t bits = insn.bits();
   if (last_pc != state.pc || last_bits != bits) {
     std::stringstream s;  // first put everything in a string, later send it to output
 

--- a/spike_dasm/spike-dasm.cc
+++ b/spike_dasm/spike-dasm.cc
@@ -50,13 +50,9 @@ int main(int argc, char** argv)
         continue;
 
       char* endp;
-      int64_t bits = strtoull(&s[pos], &endp, 16);
+      insn_bits_t bits = strtoull(&s[pos], &endp, 16);
       if (*endp != ')')
         continue;
-
-      size_t nbits = 4 * (endp - &s[pos]);
-      if (nbits < 64)
-        bits = bits << (64 - nbits) >> (64 - nbits);
 
       string dis = disassembler->disassemble(bits);
       s = s.substr(0, start) + dis + s.substr(endp - &s[0] + 1);


### PR DESCRIPTION
#1022 is ultimately caused by undefined behavior in left-shifting by >= the datatype's width.  This only manifests for 8-byte instructions, which is why it wasn't noticed until now.

Directly fixing the bug would be easy, but it seemed better to me to attack the need to shift & mask, by arranging for the MSBs of `insn_t::b` to be zero.

As a side effect, this also gets rid of a few dependences on the right-shifting of negative values.