### PR TITLE
add check for H extension implicitly requires S mode

### DIFF
--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -474,7 +474,7 @@ mstatus_csr_t::mstatus_csr_t(processor_t* const proc, const reg_t addr):
 }
 
 bool mstatus_csr_t::unlogged_write(const reg_t val) noexcept {
-  const bool has_mpv = proc->extension_enabled('S') && proc->extension_enabled('H');
+  const bool has_mpv = proc->extension_enabled('H');
   const bool has_gva = has_mpv;
 
   const reg_t mask = sstatus_write_mask

--- a/riscv/isa_parser.cc
+++ b/riscv/isa_parser.cc
@@ -246,4 +246,7 @@ isa_parser_t::isa_parser_t(const char* str, const char *priv)
     max_isa |= reg_t(supervisor) << ('s' - 'a');
     extension_table['S'] = true;
   }
+
+  if (((max_isa >> ('h' - 'a')) & 1) && !supervisor)
+    bad_isa_string(str, "'H' extension requires S mode");
 }


### PR DESCRIPTION
Even though the spec doesn't explicitly say this,It seems that Hypervisor extension cannot work without S-mode.