### PR TITLE
Fix misaligned HLV/HLVX/HSV

### DIFF
--- a/riscv/mmu.h
+++ b/riscv/mmu.h
@@ -71,8 +71,11 @@ public:
   inline void misaligned_store(reg_t addr, reg_t data, size_t size, uint32_t xlate_flags, bool actually_store=true)
   {
 #ifdef RISCV_ENABLE_MISALIGNED
-    for (size_t i = 0; i < size; i++)
-      store_uint8(addr + (target_big_endian? size-1-i : i), data >> (i * 8), actually_store);
+    for (size_t i = 0; i < size; i++) {
+      const reg_t byteaddr = addr + (target_big_endian? size-1-i : i);
+      const reg_t bytedata = data >> (i * 8);
+      store_uint8(byteaddr, bytedata, actually_store);
+    }
 #else
     bool gva = ((proc) ? proc->state.v : false) || (RISCV_XLATE_VIRT & xlate_flags);
     throw trap_store_address_misaligned(gva, addr, 0, 0);

--- a/riscv/mmu.h
+++ b/riscv/mmu.h
@@ -78,7 +78,11 @@ public:
     for (size_t i = 0; i < size; i++) {
       const reg_t byteaddr = addr + (target_big_endian? size-1-i : i);
       const reg_t bytedata = data >> (i * 8);
-      store_uint8(byteaddr, bytedata, actually_store);
+      if (RISCV_XLATE_VIRT & xlate_flags) {
+        guest_store_uint8(byteaddr, bytedata, actually_store);
+      } else {
+        store_uint8(byteaddr, bytedata, actually_store);
+      }
     }
 #else
     bool gva = ((proc) ? proc->state.v : false) || (RISCV_XLATE_VIRT & xlate_flags);

--- a/riscv/mmu.h
+++ b/riscv/mmu.h
@@ -58,7 +58,7 @@ public:
     reg_t res = 0;
     for (size_t i = 0; i < size; i++) {
       const reg_t byteaddr = addr + (target_big_endian? size-1-i : i);
-      const reg_t bytedata = (reg_t)load_uint8(byteaddr);
+      const reg_t bytedata = load_uint8(byteaddr);
       res += bytedata << (i * 8);
     }
     return res;

--- a/riscv/mmu.h
+++ b/riscv/mmu.h
@@ -56,8 +56,11 @@ public:
   {
 #ifdef RISCV_ENABLE_MISALIGNED
     reg_t res = 0;
-    for (size_t i = 0; i < size; i++)
-      res += (reg_t)load_uint8(addr + (target_big_endian? size-1-i : i)) << (i * 8);
+    for (size_t i = 0; i < size; i++) {
+      const reg_t byteaddr = addr + (target_big_endian? size-1-i : i);
+      const reg_t bytedata = (reg_t)load_uint8(byteaddr);
+      res += bytedata << (i * 8);
+    }
     return res;
 #else
     bool gva = ((proc) ? proc->state.v : false) || (RISCV_XLATE_VIRT & xlate_flags);

--- a/riscv/mmu.h
+++ b/riscv/mmu.h
@@ -58,7 +58,11 @@ public:
     reg_t res = 0;
     for (size_t i = 0; i < size; i++) {
       const reg_t byteaddr = addr + (target_big_endian? size-1-i : i);
-      const reg_t bytedata = load_uint8(byteaddr);
+      const reg_t bytedata
+        = (RISCV_XLATE_VIRT_HLVX & xlate_flags) ? guest_load_x_uint8(byteaddr)
+        : (RISCV_XLATE_VIRT & xlate_flags)      ? guest_load_uint8(byteaddr)
+        :                                         load_uint8(byteaddr)
+        ;
       res += bytedata << (i * 8);
     }
     return res;
@@ -129,6 +133,7 @@ public:
   load_func(uint16, guest_load, RISCV_XLATE_VIRT)
   load_func(uint32, guest_load, RISCV_XLATE_VIRT)
   load_func(uint64, guest_load, RISCV_XLATE_VIRT)
+  load_func(uint8, guest_load_x, RISCV_XLATE_VIRT|RISCV_XLATE_VIRT_HLVX)  // only for use by misaligned HLVX
   load_func(uint16, guest_load_x, RISCV_XLATE_VIRT|RISCV_XLATE_VIRT_HLVX)
   load_func(uint32, guest_load_x, RISCV_XLATE_VIRT|RISCV_XLATE_VIRT_HLVX)
 


### PR DESCRIPTION
If the address was misaligned, these three instructions would access memory using the current privilege, instead of the guest privilege as intended.

This fix is a little messy but will probably be much simpler once we solve #872.
