### PR TITLE
Add additional bits to medeleg

### DIFF
--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -822,7 +822,13 @@ void medeleg_csr_t::verify_permissions(insn_t insn, bool write) const {
 bool medeleg_csr_t::unlogged_write(const reg_t val) noexcept {
   const reg_t mask = 0
     | (1 << CAUSE_MISALIGNED_FETCH)
+    | (1 << CAUSE_FETCH_ACCESS)
+    | (1 << CAUSE_ILLEGAL_INSTRUCTION)
     | (1 << CAUSE_BREAKPOINT)
+    | (1 << CAUSE_MISALIGNED_LOAD)
+    | (1 << CAUSE_LOAD_ACCESS)
+    | (1 << CAUSE_MISALIGNED_STORE) 
+    | (1 << CAUSE_STORE_ACCESS)
     | (1 << CAUSE_USER_ECALL)
     | (1 << CAUSE_SUPERVISOR_ECALL)
     | (1 << CAUSE_FETCH_PAGE_FAULT)


### PR DESCRIPTION
Pursuant to https://github.com/riscv-software-src/riscv-isa-sim/issues/668 and https://github.com/riscv-software-src/riscv-isa-sim/issues/194, allowing for additional exceptions to be delegated from M-mode.
It is implementation-defined whether these bits are defined or are read-only-zero.
QEMU implements the added bits (Fetch/Load/StoreAMO access, Load/StoreAMO misalignment, and illegal instruction). (https://github.com/qemu/qemu/blob/f6cce6bcb2ef959cdd4da0e368f7c72045f21d6d/target/riscv/csr.c#L813)
ECALL_FROM_M is not implemented here because it would have no effect, although QEMU does implement it.
This allows Spike to emulate QEMU and other systems which allow for the delegation of such exceptions.
