### PR TITLE
WFI condition fix

### DIFF
--- a/riscv/insns/wfi.h
+++ b/riscv/insns/wfi.h
@@ -5,7 +5,9 @@ if (STATE.v && STATE.prv == PRV_U) {
 } else if (STATE.v) { // VS-mode
   if (get_field(STATE.hstatus->read(), HSTATUS_VTW))
     require_novirt();
-} else {
+} else if (p->extension_enabled('S')) {
+  // When S-mode is implemented, then executing WFI in
+  // U-mode causes an illegal instruction exception.
   require_privilege(PRV_S);
 }
 wfi();


### PR DESCRIPTION
Before this commit Spike was requiring S mode privilege even without
S mode implemented. In Machine Mode ISA v1.12 it specifies:

```
When S-mode is implemented, then executing WFI in U-mode causes an illegal instruction exception, unless it completes within an implementation-specific, bounded time limit. 
```

So in the case of S-mode being not implemented, executing WFI in u-mode should not cause any problems (as long as `MSTATUS.TW` is low). This commit controls S-mode implementation before enforcing the illegal instruction exception in U-mode.

Signed-off-by: Canberk Topal <ctopal@lowrisc.org>