### PR TITLE
Fix debug_rom.S build

### DIFF
--- a/debug_rom/Makefile
+++ b/debug_rom/Makefile
@@ -18,7 +18,7 @@ all: $(patsubst %,%.h,$(ELFS))
 	$(OBJCOPY) -O binary --only-section .text $^ $@
 
 debug_rom:	$(DEPS)
-	$(COMPILE) -o $@ $^
+	$(COMPILE) -o $@ $<
 
 clean:
 	rm -f $(ELFS) debug_rom*.raw debug_rom.h

--- a/debug_rom/debug_rom.S
+++ b/debug_rom/debug_rom.S
@@ -23,7 +23,7 @@ _entry:
         // This fence is required because the execution may have written something
         // into the Abstract Data or Program Buffer registers.
         fence
-        csrw CSR_DSCRATCH, s0  // Save s0 to allow signaling MHARTID
+        csrw CSR_DSCRATCH0, s0  // Save s0 to allow signaling MHARTID
 
         // We continue to let the hart know that we are halted in order that
         // a DM which was reset is still made aware that a hart is halted.
@@ -46,14 +46,14 @@ _exception:
         // Restore S0, which we always save to dscratch.
         // We need this in case the user tried an abstract write to a
         // non-existent CSR.
-        csrr    s0, CSR_DSCRATCH
+        csrr    s0, CSR_DSCRATCH0
         sw      zero, DEBUG_ROM_EXCEPTION(zero) // Let debug module know you got an exception.
         ebreak
 
 going:
         csrr s0, CSR_MHARTID
         sw s0, DEBUG_ROM_GOING(zero)     // When debug module sees this write, the GO flag is reset.
-        csrr s0, CSR_DSCRATCH            // Restore s0 here
+        csrr s0, CSR_DSCRATCH0            // Restore s0 here
         fence
         fence.i
         jalr zero, zero, %lo(whereto)    // Debug module will put different instructions and data in the RAM, 
@@ -63,7 +63,7 @@ going:
 _resume:
         csrr s0, CSR_MHARTID
         sw   s0, DEBUG_ROM_RESUMING(zero) // When Debug Module sees this write, the RESUME flag is reset.
-        csrr s0, CSR_DSCRATCH   // Restore s0
+        csrr s0, CSR_DSCRATCH0   // Restore s0
         dret
 
         // END OF ACTUAL "ROM" CONTENTS. BELOW IS JUST FOR LINKER SCRIPT.


### PR DESCRIPTION
CSR_DSCRATCH is now CSR_DSCRATCH0, and the Makefile needed a tweak for (presumably) newer gcc.)