### PR TITLE
add stateen related check to frm/fflags

### DIFF
--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -1324,10 +1324,9 @@ bool hstateen_csr_t::unlogged_write(const reg_t val) noexcept {
 }
 
 void hstateen_csr_t::verify_permissions(insn_t insn, bool write) const {
-  masked_csr_t::verify_permissions(insn, write);
-
   if ((state->prv < PRV_M) && !(state->mstateen[index]->read() & MSTATEEN_HSTATEEN))
     throw trap_illegal_instruction(insn.bits());
+  masked_csr_t::verify_permissions(insn, write);
 }
 
 // implement class sstateen_csr_t
@@ -1372,8 +1371,6 @@ senvcfg_csr_t::senvcfg_csr_t(processor_t* const proc, const reg_t addr, const re
 }
 
 void senvcfg_csr_t::verify_permissions(insn_t insn, bool write) const {
-  masked_csr_t::verify_permissions(insn, write);
-
   if (proc->extension_enabled(EXT_SMSTATEEN)) {
     if ((state->prv < PRV_M) && !(state->mstateen[0]->read() & MSTATEEN0_HENVCFG))
       throw trap_illegal_instruction(insn.bits());
@@ -1381,13 +1378,15 @@ void senvcfg_csr_t::verify_permissions(insn_t insn, bool write) const {
     if (state->v && !(state->hstateen[0]->read() & HSTATEEN0_SENVCFG))
       throw trap_virtual_instruction(insn.bits());
   }
+
+  masked_csr_t::verify_permissions(insn, write);
 }
 
 void henvcfg_csr_t::verify_permissions(insn_t insn, bool write) const {
-  masked_csr_t::verify_permissions(insn, write);
-
   if (proc->extension_enabled(EXT_SMSTATEEN)) {
     if ((state->prv < PRV_M) && !(state->mstateen[0]->read() & MSTATEEN0_HENVCFG))
       throw trap_illegal_instruction(insn.bits());
   }
+
+  masked_csr_t::verify_permissions(insn, write);
 }

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -717,12 +717,6 @@ class sstateen_csr_t: public hstateen_csr_t {
   virtual bool unlogged_write(const reg_t val) noexcept override;
 };
 
-class fcsr_csr_t: public composite_csr_t {
- public:
-  fcsr_csr_t(processor_t* const proc, const reg_t addr, csr_t_p upper_csr, csr_t_p lower_csr, const unsigned upper_lsb);
-  virtual void verify_permissions(insn_t insn, bool write) const override;
-};
-
 class senvcfg_csr_t final: public masked_csr_t {
  public:
   senvcfg_csr_t(processor_t* const proc, const reg_t addr, const reg_t mask, const reg_t init);

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -393,7 +393,7 @@ void state_t::reset(processor_t* const proc, reg_t max_isa)
   csrmap[CSR_FFLAGS] = fflags = std::make_shared<float_csr_t>(proc, CSR_FFLAGS, FSR_AEXC >> FSR_AEXC_SHIFT, 0);
   csrmap[CSR_FRM] = frm = std::make_shared<float_csr_t>(proc, CSR_FRM, FSR_RD >> FSR_RD_SHIFT, 0);
   assert(FSR_AEXC_SHIFT == 0);  // composite_csr_t assumes fflags begins at bit 0
-  csrmap[CSR_FCSR] = std::make_shared<fcsr_csr_t>(proc, CSR_FCSR, frm, fflags, FSR_RD_SHIFT);
+  csrmap[CSR_FCSR] = std::make_shared<composite_csr_t>(proc, CSR_FCSR, frm, fflags, FSR_RD_SHIFT);
 
   csrmap[CSR_SEED] = std::make_shared<seed_csr_t>(proc, CSR_SEED);
 


### PR DESCRIPTION
Add stateen related check to frm/fflags and then apply to fcsr implicitly
Fix exception type for accessing senvcfg/henvcfg/hstateen: Illegal instruciton trap should be raised when accessing senvcfg/henvcfg/hstateen if related bit of mstateen is zero in VU mode
