### PR TITLE
Fix exception type for accessing (v)stimecmp

### DIFF
--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -1421,17 +1421,18 @@ virtualized_stimecmp_csr_t::virtualized_stimecmp_csr_t(processor_t* const proc, 
 }
 
 void virtualized_stimecmp_csr_t::verify_permissions(insn_t insn, bool write) const {
-  virtualized_csr_t::verify_permissions(insn, write);
-
-  // check for read permission to time as enabled by xcounteren
-  state->time_proxy->verify_permissions(insn, false);
-
   if (!(state->menvcfg->read() & MENVCFG_STCE)) {
     // access to (v)stimecmp with MENVCFG.STCE = 0
     if (state->prv < PRV_M)
       throw trap_illegal_instruction(insn.bits());
-  } else if (state->v && !(state->henvcfg->read() & HENVCFG_STCE)) {
+  }
+
+  state->time_proxy->verify_permissions(insn, false);
+
+  if (state->v && !(state->henvcfg->read() & HENVCFG_STCE)) {
     // access to vstimecmp with MENVCFG.STCE = 1 and HENVCFG.STCE = 0 when V = 1
     throw trap_virtual_instruction(insn.bits());
   }
+
+  virtualized_csr_t::verify_permissions(insn, write);
 }


### PR DESCRIPTION
Just as described in https://github.com/riscv-software-src/riscv-isa-sim/pull/1059, Illegal instruciton trap should be raised when accessing if related bit of mcounteren.TM or menvcfg.STCE is zero in VS/VU mode.
In current implementation:
-  If both of mcounteren.TM  and menvcfg.STCE are zero, virtualized_stimecmp_csr_t::verify_permissions will raise virtual instruction trap for access from VU mode, because of virtualized_csr_t::verify_permissions(insn, write).

- Ignore the check of virtualized_csr_t::verify_permissions(insn, write), If menvcfg.STCE are zero, mcounteren.TM is one, but hcounteren.TM is zero,  it also will raise virtual instruction trap for access from VS/VU mode because of state->time_proxy->verify_permissions

For the first case, Illegal instruciton trap should be raised  for both sstc and riscv-privileged spec.
For the second case, it's confused(not explicitly stated) in sstc spec. However according to common rules from section 8.6 of riscv-privileged spec,  Illegal instruciton trap should be raised.
