### PR TITLE
Revert "remove unnecessary ifdef for RISCV_ENABLE_DUAL_ENDIAN"

### DIFF
--- a/fesvr/htif.h
+++ b/fesvr/htif.h
@@ -31,18 +31,26 @@ class htif_t : public chunked_memif_t
 
   template<typename T> inline T from_target(target_endian<T> n) const
   {
+#ifdef RISCV_ENABLE_DUAL_ENDIAN
     memif_endianness_t endianness = get_target_endianness();
     assert(endianness == memif_endianness_little || endianness == memif_endianness_big);
 
     return endianness == memif_endianness_big? n.from_be() : n.from_le();
+#else
+    return n.from_le();
+#endif
   }
 
   template<typename T> inline target_endian<T> to_target(T n) const
   {
+#ifdef RISCV_ENABLE_DUAL_ENDIAN
     memif_endianness_t endianness = get_target_endianness();
     assert(endianness == memif_endianness_little || endianness == memif_endianness_big);
 
     return endianness == memif_endianness_big? target_endian<T>::to_be(n) : target_endian<T>::to_le(n);
+#else
+    return target_endian<T>::to_le(n);
+#endif
   }
 
  protected:


### PR DESCRIPTION
This reverts commit https://github.com/riscv-software-src/riscv-isa-sim/commit/f82e54124345f348abaa80ec82d67528a9a8f774. 

[playground](https://github.com/chipsalliance/playground)'s CI [failed](https://github.com/chipsalliance/playground/runs/7710418003?check_suite_focus=true) due to https://github.com/riscv-software-src/riscv-isa-sim/commit/f82e54124345f348abaa80ec82d67528a9a8f774. Reverting this commit solves the problem.