### PR TITLE
Remove dead code in VI_VV_EXT macro

### DIFF
--- a/riscv/v_ext_macros.h
+++ b/riscv/v_ext_macros.h
@@ -1468,9 +1468,6 @@ reg_t index[P.VU.vlmax]; \
       case 0x84: \
         P.VU.elt<type##64_t>(rd_num, i, true) = P.VU.elt<type##32_t>(rs2_num, i); \
         break; \
-      case 0x88: \
-        P.VU.elt<type##64_t>(rd_num, i, true) = P.VU.elt<type##32_t>(rs2_num, i); \
-        break; \
       default: \
         break; \
     } \


### PR DESCRIPTION
Fix #1064 

Tested with the following files, but the test coverage may not be enough though.

[vzext.vf2_LMUL2SEW16.S](https://github.com/ksco/riscv-tests/blob/spike/isa/rv64uv/vzext.vf2_LMUL2SEW16.S)
[vzext.vf2_LMUL2SEW32.S](https://github.com/ksco/riscv-tests/blob/spike/isa/rv64uv/vzext.vf2_LMUL2SEW32.S)
[vzext.vf2_LMUL2SEW64.S](https://github.com/ksco/riscv-tests/blob/spike/isa/rv64uv/vzext.vf2_LMUL2SEW64.S)
[vzext.vf2_LMUL4SEW16.S](https://github.com/ksco/riscv-tests/blob/spike/isa/rv64uv/vzext.vf2_LMUL4SEW16.S)
[vzext.vf2_LMUL4SEW32.S](https://github.com/ksco/riscv-tests/blob/spike/isa/rv64uv/vzext.vf2_LMUL4SEW32.S)
[vzext.vf2_LMUL4SEW64.S](https://github.com/ksco/riscv-tests/blob/spike/isa/rv64uv/vzext.vf2_LMUL4SEW64.S)
[vzext.vf2_LMUL8SEW16.S](https://github.com/ksco/riscv-tests/blob/spike/isa/rv64uv/vzext.vf2_LMUL8SEW16.S)
[vzext.vf2_LMUL8SEW32.S](https://github.com/ksco/riscv-tests/blob/spike/isa/rv64uv/vzext.vf2_LMUL8SEW32.S)
[vzext.vf2_LMUL8SEW64.S](https://github.com/ksco/riscv-tests/blob/spike/isa/rv64uv/vzext.vf2_LMUL8SEW64.S)
[vzext.vf4_LMUL4SEW32.S](https://github.com/ksco/riscv-tests/blob/spike/isa/rv64uv/vzext.vf4_LMUL4SEW32.S)
[vzext.vf4_LMUL4SEW64.S](https://github.com/ksco/riscv-tests/blob/spike/isa/rv64uv/vzext.vf4_LMUL4SEW64.S)
[vzext.vf4_LMUL8SEW32.S](https://github.com/ksco/riscv-tests/blob/spike/isa/rv64uv/vzext.vf4_LMUL8SEW32.S)
[vzext.vf4_LMUL8SEW64.S](https://github.com/ksco/riscv-tests/blob/spike/isa/rv64uv/vzext.vf4_LMUL8SEW64.S)
[vzext.vf8_LMUL8SEW64.S](https://github.com/ksco/riscv-tests/blob/spike/isa/rv64uv/vzext.vf8_LMUL8SEW64.S)
[vsext.vf2_LMUL2SEW16.S](https://github.com/ksco/riscv-tests/blob/spike/isa/rv64uv/vsext.vf2_LMUL2SEW16.S)
[vsext.vf2_LMUL2SEW32.S](https://github.com/ksco/riscv-tests/blob/spike/isa/rv64uv/vsext.vf2_LMUL2SEW32.S)
[vsext.vf2_LMUL2SEW64.S](https://github.com/ksco/riscv-tests/blob/spike/isa/rv64uv/vsext.vf2_LMUL2SEW64.S)
[vsext.vf2_LMUL4SEW16.S](https://github.com/ksco/riscv-tests/blob/spike/isa/rv64uv/vsext.vf2_LMUL4SEW16.S)
[vsext.vf2_LMUL4SEW32.S](https://github.com/ksco/riscv-tests/blob/spike/isa/rv64uv/vsext.vf2_LMUL4SEW32.S)
[vsext.vf2_LMUL4SEW64.S](https://github.com/ksco/riscv-tests/blob/spike/isa/rv64uv/vsext.vf2_LMUL4SEW64.S)
[vsext.vf2_LMUL8SEW16.S](https://github.com/ksco/riscv-tests/blob/spike/isa/rv64uv/vsext.vf2_LMUL8SEW16.S)
[vsext.vf2_LMUL8SEW32.S](https://github.com/ksco/riscv-tests/blob/spike/isa/rv64uv/vsext.vf2_LMUL8SEW32.S)
[vsext.vf2_LMUL8SEW64.S](https://github.com/ksco/riscv-tests/blob/spike/isa/rv64uv/vsext.vf2_LMUL8SEW64.S)
[vsext.vf4_LMUL4SEW32.S](https://github.com/ksco/riscv-tests/blob/spike/isa/rv64uv/vsext.vf4_LMUL4SEW32.S)
[vsext.vf4_LMUL4SEW64.S](https://github.com/ksco/riscv-tests/blob/spike/isa/rv64uv/vsext.vf4_LMUL4SEW64.S)
[vsext.vf4_LMUL8SEW32.S](https://github.com/ksco/riscv-tests/blob/spike/isa/rv64uv/vsext.vf4_LMUL8SEW32.S)
[vsext.vf4_LMUL8SEW64.S](https://github.com/ksco/riscv-tests/blob/spike/isa/rv64uv/vsext.vf4_LMUL8SEW64.S)
[vsext.vf8_LMUL8SEW64.S](https://github.com/ksco/riscv-tests/blob/spike/isa/rv64uv/vsext.vf8_LMUL8SEW64.S)