### PR TITLE
Rename misleading variable

### DIFF
--- a/riscv/mmu.h
+++ b/riscv/mmu.h
@@ -263,8 +263,8 @@ public:
 
   void clean_inval(reg_t addr, bool clean, bool inval) {
     convert_load_traps_to_store_traps({
-      reg_t paddr = addr & ~(blocksz - 1);
-      paddr = translate(paddr, blocksz, LOAD, 0);
+      reg_t vaddr = addr & ~(blocksz - 1);
+      reg_t paddr = translate(vaddr, blocksz, LOAD, 0);
       if (auto host_addr = sim->addr_to_mem(paddr)) {
         if (tracer.interested_in_range(paddr, paddr + PGSIZE, LOAD))
           tracer.clean_invalidate(paddr, blocksz, clean, inval);

--- a/riscv/mmu.h
+++ b/riscv/mmu.h
@@ -263,8 +263,8 @@ public:
 
   void clean_inval(reg_t addr, bool clean, bool inval) {
     convert_load_traps_to_store_traps({
-      reg_t vaddr = addr & ~(blocksz - 1);
-      reg_t paddr = translate(vaddr, blocksz, LOAD, 0);
+      const reg_t vaddr = addr & ~(blocksz - 1);
+      const reg_t paddr = translate(vaddr, blocksz, LOAD, 0);
       if (auto host_addr = sim->addr_to_mem(paddr)) {
         if (tracer.interested_in_range(paddr, paddr + PGSIZE, LOAD))
           tracer.clean_invalidate(paddr, blocksz, clean, inval);


### PR DESCRIPTION
The variable named `paddr` actually contains a virtual address at first.