### PR TITLE
Fix tval on illegal instruction faults with long illegal instruction

### DIFF
--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -949,7 +949,10 @@ reg_t processor_t::get_csr(int which, insn_t insn, bool write, bool peek)
 
 reg_t illegal_instruction(processor_t* p, insn_t insn, reg_t pc)
 {
-  throw trap_illegal_instruction(insn.bits());
+  // The illegal instruction can be longer than ILEN bits, where the tval will
+  // contain the first ILEN bits of the faulting instruction. We hard-code the
+  // ILEN to 32 bits since all official instructions have at most 32 bits.
+  throw trap_illegal_instruction(insn.bits() & 0xffffffffULL);
 }
 
 insn_func_t processor_t::decode_insn(insn_t insn)


### PR DESCRIPTION
The current spike implementation does not include the ILEN (maximum
instruction length supported by the implementation), which is required
to constrain the value of tval on an illegal instruction exception.

Consider an implementation supporting only an RV64I base instruction
set. The ILEN is 32 bits (spec sec. 1.5), and the MXLEN is 64 bits (spec
sec. 5.1). Under an illegal instruction exception with the instruction
longer than the ILEN, the mtval should contain the first ILEN (32 bits)
of the faulting instruction. However, the current spike implementation
lets the mtval be the instruction's first MXLEN (64 bits).

To fix this bug, this PR adds a new variable ilen into the class
processor_t. The processor_t::reset() obtains the ilen from the class
isa_parser_t (along with the xlen) because the ilen depends on the
supported extensions. The class isa_parser_t decides the max_ilen during
the construction (along with the max_xlen).

To my knowledge, all extensions have at most 32-bit instructions. Thus,
the max_xlen is always 32 bits.