### PR TITLE
vmv<nf>r.v depends on vtype, and therefore should check vill

### DIFF
--- a/riscv/insns/vmvnfr_v.h
+++ b/riscv/insns/vmvnfr_v.h
@@ -1,4 +1,4 @@
-// vmv1r.v vd, vs2
+// vmv<nf>r.v vd, vs2
 require_vector(true);
 const reg_t baseAddr = RS1;
 const reg_t vd = insn.rd();

--- a/riscv/insns/vmvnfr_v.h
+++ b/riscv/insns/vmvnfr_v.h
@@ -1,5 +1,5 @@
 // vmv1r.v vd, vs2
-require_vector_novtype(true, true);
+require_vector(true);
 const reg_t baseAddr = RS1;
 const reg_t vd = insn.rd();
 const reg_t vs2 = insn.rs2();


### PR DESCRIPTION
Resolves #1078 