### PR TITLE
Remove obsolete enum trigger_operation_t

### DIFF
--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -218,12 +218,6 @@ struct state_t
 #endif
 };
 
-typedef enum {
-  OPERATION_EXECUTE,
-  OPERATION_STORE,
-  OPERATION_LOAD,
-} trigger_operation_t;
-
 // Count number of contiguous 1 bits starting from the LSB.
 static int cto(reg_t val)
 {


### PR DESCRIPTION
Moved to triggers.h and renamed in a2a2587426e57f6207d5389620e9109bc0f82e6b, but the old enum was mistakenly left behind.

cc @timsifive 