### PR TITLE
Non-functional changes for RVV

### DIFF
--- a/riscv/decode.h
+++ b/riscv/decode.h
@@ -306,12 +306,10 @@ do { \
     WRITE_VSTATUS; \
     dirty_vs_state; \
   } while (0);
-#define require_vector_novtype(is_log, alu) \
+#define require_vector_novtype(is_log) \
   do { \
     require_vector_vs; \
     require_extension('V'); \
-    if (alu && !P.VU.vstart_alu) \
-      require(P.VU.vstart->read() == 0); \
     if (is_log) \
       WRITE_VSTATUS; \
     dirty_vs_state; \

--- a/riscv/insns/vsetivli.h
+++ b/riscv/insns/vsetivli.h
@@ -1,2 +1,2 @@
-require_vector_novtype(false, false);
+require_vector_novtype(false);
 WRITE_RD(P.VU.set_vl(insn.rd(), -1, insn.rs1(), insn.v_zimm10()));

--- a/riscv/insns/vsetvl.h
+++ b/riscv/insns/vsetvl.h
@@ -1,2 +1,2 @@
-require_vector_novtype(false, false);
+require_vector_novtype(false);
 WRITE_RD(P.VU.set_vl(insn.rd(), insn.rs1(), RS1, RS2));

--- a/riscv/insns/vsetvli.h
+++ b/riscv/insns/vsetvli.h
@@ -1,2 +1,2 @@
-require_vector_novtype(false, false);
+require_vector_novtype(false);
 WRITE_RD(P.VU.set_vl(insn.rd(), insn.rs1(), RS1, insn.v_zimm11()));

--- a/riscv/v_ext_macros.h
+++ b/riscv/v_ext_macros.h
@@ -1317,7 +1317,7 @@ reg_t index[P.VU.vlmax]; \
   p->VU.vstart->write(0);
 
 #define VI_LD_WHOLE(elt_width) \
-  require_vector_novtype(true, false); \
+  require_vector_novtype(true); \
   require(sizeof(elt_width ## _t) * 8 <= P.VU.ELEN); \
   const reg_t baseAddr = RS1; \
   const reg_t vd = insn.rd(); \
@@ -1349,7 +1349,7 @@ reg_t index[P.VU.vlmax]; \
   P.VU.vstart->write(0);
 
 #define VI_ST_WHOLE \
-  require_vector_novtype(true, false); \
+  require_vector_novtype(true); \
   const reg_t baseAddr = RS1; \
   const reg_t vs3 = insn.rd(); \
   const reg_t len = insn.v_nf() + 1; \

--- a/riscv/v_ext_macros.h
+++ b/riscv/v_ext_macros.h
@@ -517,7 +517,6 @@ static inline bool is_aligned(const unsigned val, const unsigned pos)
   bool use_first = (P.VU.elt<uint64_t>(0, midx) >> mpos) & 0x1;
 
 #define VI_MERGE_LOOP_BASE \
-  require_vector(true); \
   VI_GENERAL_LOOP_BASE \
   VI_MERGE_VARS
 

--- a/riscv/v_ext_macros.h
+++ b/riscv/v_ext_macros.h
@@ -1079,7 +1079,6 @@ static inline bool is_aligned(const unsigned val, const unsigned pos)
   VI_LOOP_CARRY_END
 
 #define VI_VV_LOOP_WITH_CARRY(BODY) \
-  require_vm; \
   VI_CHECK_SSS(true); \
   VI_LOOP_WITH_CARRY_BASE \
     if (sew == e8) { \
@@ -1098,7 +1097,6 @@ static inline bool is_aligned(const unsigned val, const unsigned pos)
   VI_LOOP_END
 
 #define VI_XI_LOOP_WITH_CARRY(BODY) \
-  require_vm; \
   VI_CHECK_SSS(false); \
   VI_LOOP_WITH_CARRY_BASE \
     if (sew == e8) { \


### PR DESCRIPTION
Remove redundant require_vm/require_vector in current RVV macros. and remove unnecessary argument alu from require_vector_notype.