### PR TITLE
Fix trigger mcontrol.chain match issue #599 #627

### DIFF
--- a/riscv/triggers.cc
+++ b/riscv/triggers.cc
@@ -183,7 +183,7 @@ match_result_t module_t::memory_access_match(action_t * const action, operation_
       return result;
     }
 
-    chain_ok = true;
+    chain_ok = (result!=MATCH_NONE || !triggers[i]->chain());
   }
   return MATCH_NONE;
 }

--- a/riscv/triggers.cc
+++ b/riscv/triggers.cc
@@ -183,7 +183,7 @@ match_result_t module_t::memory_access_match(action_t * const action, operation_
       return result;
     }
 
-    chain_ok = (result!=MATCH_NONE || !triggers[i]->chain());
+    chain_ok = result != MATCH_NONE || !triggers[i]->chain();
   }
   return MATCH_NONE;
 }


### PR DESCRIPTION
A false condition of variable chain_ok is missing. The false condition should be mcontrol.chain=1 and not matching; otherwise, the chain_ok=true (including initialization).

Related issues:
https://github.com/riscv-software-src/riscv-isa-sim/issues/627
https://github.com/riscv-software-src/riscv-isa-sim/issues/599