### PR TITLE
Fix trigger never fire on executing an instruction on devices

### DIFF
--- a/riscv/mmu.h
+++ b/riscv/mmu.h
@@ -477,13 +477,11 @@ private:
     } else {
       result = tlb_data[vpn % TLB_ENTRIES];
     }
-    if (unlikely(tlb_insn_tag[vpn % TLB_ENTRIES] == (vpn | TLB_CHECK_TRIGGERS))) {
-      target_endian<uint16_t>* ptr = (target_endian<uint16_t>*)(tlb_data[vpn % TLB_ENTRIES].host_offset + addr);
-      triggers::action_t action;
-      auto match = proc->TM.memory_access_match(&action, triggers::OPERATION_EXECUTE, addr, from_target(*ptr));
-      if (match != triggers::MATCH_NONE) {
-        throw triggers::matched_t(triggers::OPERATION_EXECUTE, addr, from_target(*ptr), action);
-      }
+    target_endian<uint16_t>* ptr = (target_endian<uint16_t>*)(result.host_offset + addr);
+    triggers::action_t action;
+    auto match = proc->TM.memory_access_match(&action, triggers::OPERATION_EXECUTE, addr, from_target(*ptr));
+    if (match != triggers::MATCH_NONE) {
+      throw triggers::matched_t(triggers::OPERATION_EXECUTE, addr, from_target(*ptr), action);
     }
     return result;
   }


### PR DESCRIPTION
The trigger matching logic searches TLB for instruction data. However, the TLB will not be filled with instructions on devices; thus, triggers cannot fire when executing instructions on devices.

The PR moves the trigger matching logic to another (upper) function, i.e., from translate_insn_addr() to refill_icache(). The movement makes the instruction data naturally available without searching the TLB and, thus, resolves the issue.