### PR TITLE
Detect loading isa-incompatible code

### DIFF
--- a/fesvr/elfloader.cc
+++ b/fesvr/elfloader.cc
@@ -16,7 +16,7 @@
 #include <vector>
 #include <map>
 
-std::map<std::string, uint64_t> load_elf(const char* fn, memif_t* memif, reg_t* entry)
+std::map<std::string, uint64_t> load_elf(const char* fn, memif_t* memif, reg_t* entry, unsigned required_xlen = 0)
 {
   int fd = open(fn, O_RDONLY);
   struct stat s;
@@ -32,6 +32,10 @@ std::map<std::string, uint64_t> load_elf(const char* fn, memif_t* memif, reg_t* 
   assert(size >= sizeof(Elf64_Ehdr));
   const Elf64_Ehdr* eh64 = (const Elf64_Ehdr*)buf;
   assert(IS_ELF32(*eh64) || IS_ELF64(*eh64));
+  unsigned xlen = IS_ELF32(*eh64) ? 32 : 64;
+  if (required_xlen != 0 && required_xlen != xlen) {
+    throw incompat_xlen(required_xlen, xlen);
+  }
   assert(IS_ELFLE(*eh64) || IS_ELFBE(*eh64));
   assert(IS_ELF_EXEC(*eh64));
   assert(IS_ELF_RISCV(*eh64) || IS_ELF_EM_NONE(*eh64));

--- a/fesvr/elfloader.h
+++ b/fesvr/elfloader.h
@@ -8,6 +8,6 @@
 #include <string>
 
 class memif_t;
-std::map<std::string, uint64_t> load_elf(const char* fn, memif_t* memif, reg_t* entry);
+std::map<std::string, uint64_t> load_elf(const char* fn, memif_t* memif, reg_t* entry, unsigned required_xlen = 0);
 
 #endif

--- a/fesvr/htif.h
+++ b/fesvr/htif.h
@@ -26,7 +26,7 @@ class htif_t : public chunked_memif_t
   int run();
   bool done();
   int exit_code();
-
+  void set_expected_xlen(unsigned int m) { expected_xlen = m; }
   virtual memif_t& memif() { return mem; }
 
   template<typename T> inline T from_target(target_endian<T> n) const
@@ -74,7 +74,7 @@ class htif_t : public chunked_memif_t
   void parse_arguments(int argc, char ** argv);
   void register_devices();
   void usage(const char * program_name);
-
+  unsigned int expected_xlen = 0;
   memif_t mem;
   reg_t entry;
   bool writezeros;

--- a/fesvr/memif.h
+++ b/fesvr/memif.h
@@ -5,6 +5,7 @@
 
 #include <stdint.h>
 #include <stddef.h>
+#include <stdexcept>
 #include "byteorder.h"
 
 typedef uint64_t reg_t;
@@ -77,6 +78,13 @@ public:
 
 protected:
   chunked_memif_t* cmemif;
+};
+
+class incompat_xlen : public std::exception {
+public:
+  const unsigned expected_xlen;
+  const unsigned actual_xlen;
+  incompat_xlen(unsigned _expected_xlen, unsigned _actual_xlen) : expected_xlen(_expected_xlen), actual_xlen(_actual_xlen) {}
 };
 
 #endif // __MEMIF_H

--- a/riscv/sim.cc
+++ b/riscv/sim.cc
@@ -202,6 +202,7 @@ int sim_t::run()
 {
   host = context_t::current();
   target.init(sim_thread_main, this);
+  htif_t::set_expected_xlen(isa.get_max_xlen());
   return htif_t::run();
 }
 


### PR DESCRIPTION
This would detect incompatibility between loaded code and the specified '--isa' option. (only checks xlen)
Issues stemming from unsupported extension are easy to detect from error messages, but xlen is not. See: https://github.com/riscv-software-src/riscv-pk/issues/283 (it really doesn't make sense to have spike load incompatible code, you'd expect spike to just throw an error in this case)