### PR TITLE
Initialize triggers using default member initializers

### DIFF
--- a/riscv/triggers.cc
+++ b/riscv/triggers.cc
@@ -4,13 +4,6 @@
 
 namespace triggers {
 
-mcontrol_t::mcontrol_t() :
-  select(false), timing(false), chain_bit(false),
-  match(MATCH_EQUAL), m(false), s(false), u(false),
-  execute_bit(false), store_bit(false), load_bit(false)
-{
-}
-
 reg_t mcontrol_t::tdata1_read(const processor_t * const proc) const noexcept {
   reg_t v = 0;
   auto xlen = proc->get_xlen();

--- a/riscv/triggers.h
+++ b/riscv/triggers.h
@@ -55,15 +55,14 @@ public:
   virtual bool store() const { return false; }
   virtual bool load() const { return false; }
 
-public:
-  bool dmode;
-  action_t action;
-  bool hit;
+  bool dmode = false;
+  action_t action = ACTION_DEBUG_EXCEPTION;
+  bool hit = false;
 
   virtual ~trigger_t() {};
 
 protected:
-  trigger_t() : dmode(false), action(ACTION_DEBUG_EXCEPTION), hit(false) {};
+  trigger_t() {}
 };
 
 class mcontrol_t : public trigger_t {
@@ -77,8 +76,6 @@ public:
     MATCH_MASK_LOW = MCONTROL_MATCH_MASK_LOW,
     MATCH_MASK_HIGH = MCONTROL_MATCH_MASK_HIGH
   } match_t;
-
-  mcontrol_t();
 
   virtual reg_t tdata1_read(const processor_t * const proc) const noexcept override;
   virtual bool tdata1_write(processor_t * const proc, const reg_t val) noexcept override;
@@ -97,16 +94,16 @@ private:
   bool simple_match(unsigned xlen, reg_t value) const;
 
 public:
-  bool select;
-  bool timing;
-  bool chain_bit;
-  match_t match;
-  bool m;
-  bool s;
-  bool u;
-  bool execute_bit;
-  bool store_bit;
-  bool load_bit;
+  bool select = false;
+  bool timing = false;
+  bool chain_bit = false;
+  match_t match = MATCH_EQUAL;
+  bool m = false;
+  bool s = false;
+  bool u = false;
+  bool execute_bit = false;
+  bool store_bit = false;
+  bool load_bit = false;
   reg_t tdata2;
 };
 


### PR DESCRIPTION
Instead of constructor member initializer lists, which require repeating the list of members, and cause ugly merge conflicts when the list of members changes.