### PR TITLE
Run CI with -Werror

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -98,7 +98,7 @@ default-CXXFLAGS := $(default-CFLAGS) -std=c++17
 
 mcppbs-CPPFLAGS := @CPPFLAGS@
 mcppbs-CFLAGS   := $(default-CFLAGS) @CFLAGS@
-mcppbs-CXXFLAGS := $(default-CXXFLAGS) @CXXFLAGS@
+mcppbs-CXXFLAGS := $(mcppbs-CFLAGS) $(default-CXXFLAGS) @CXXFLAGS@
 
 CC            := @CC@
 CXX           := @CXX@

--- a/ci-tests/test-spike
+++ b/ci-tests/test-spike
@@ -6,6 +6,6 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 mkdir build
 cd build
 mkdir install
-$DIR/../configure --prefix=`pwd`/install
+CFLAGS="-Werror" $DIR/../configure --prefix=`pwd`/install
 make -j4
 make install


### PR DESCRIPTION
I don't want to enable `-Werror` by default, because we don't know what compilers our users are using and we don't want to make their builds fail for no good reason.  But I still think we should run CI with `-Werror` to avoid new warnings creeping in.

Over time, we can add extra flags to be more pedantic, but this will require experimentation and code improvements.