### PR TITLE
Actually run a program in CI

### DIFF
--- a/ci-tests/create-ci-binary-tarball
+++ b/ci-tests/create-ci-binary-tarball
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -e
+
+rm -rf build
+
+mkdir -p build/pk && cd "$_"
+`git rev-parse --show-toplevel`/../riscv-pk/configure --host=riscv64-unknown-elf
+make -j4
+cd -
+
+mkdir -p build/hello && cd "$_"
+riscv64-unknown-elf-gcc -O2 -o hello `git rev-parse --show-toplevel`/ci-tests/hello.c
+cd -
+
+mv build/pk/pk .
+mv build/hello/hello .
+
+tar -cf spike-ci.tar pk hello
+
+rm pk hello

--- a/ci-tests/hello.c
+++ b/ci-tests/hello.c
@@ -1,0 +1,23 @@
+#include <stdio.h>
+
+int main()
+{
+  // As a simple benchmark, estimate pi
+  int n = 16384, misses = 0;
+
+  for (int i = 0; i < n; i++) {
+
+    for (int j = 0; j < n; j++) {
+      int x = i - (n / 2);
+      int y = j - (n / 2);
+
+      misses += (x * x + y * y >= (n / 2) * (n / 2));
+    }
+  }
+
+  double pi = 4.0 * (n * n - misses) / (n * n);
+
+  printf("Hello, world!  Pi is approximately %f.\n", pi);
+
+  return 0;
+}

--- a/ci-tests/test-spike
+++ b/ci-tests/test-spike
@@ -12,3 +12,11 @@ make install
 
 # check that help message prints without error
 install/bin/spike -h
+
+
+# run a program and check for correct output
+mkdir run
+cd run
+wget https://github.com/riscv-software-src/riscv-isa-sim/releases/download/dummy-tag-for-ci-storage/spike-ci.tar
+tar xf spike-ci.tar
+time ../install/bin/spike --isa=rv64gc pk hello | grep "Hello, world!  Pi is approximately 3.141588."


### PR DESCRIPTION
To avoid long CI times, keep the program in binary form.

To avoid storing binary files in this repository, store the binaries as an asset on a github release.