### PR TITLE
workaround to support access to large 64-bit physical addresses

### DIFF
--- a/riscv/sim.h
+++ b/riscv/sim.h
@@ -68,6 +68,8 @@ public:
   // Callback for processors to let the simulation know they were reset.
   void proc_reset(unsigned id);
 
+  bool paddr_ok(reg_t addr) const;
+
 private:
   isa_parser_t isa;
   const cfg_t * const cfg;

--- a/spike_main/spike.cc
+++ b/spike_main/spike.cc
@@ -236,17 +236,6 @@ static std::vector<mem_cfg_t> parse_mem_layout(const char* arg)
       exit(EXIT_FAILURE);
     }
 
-    const uint64_t max_allowed_pa = (1ull << MAX_PADDR_BITS) - 1ull;
-    if (mem_region.get_inclusive_end() > max_allowed_pa) {
-      fprintf(stderr, "unsupported memory region [0x%llX, 0x%llX] specified ("
-                      "currently, spike does not support physical adresses "
-                      "larger than 0x%llX)\n",
-                      (unsigned long long)mem_region.get_base(),
-                      (unsigned long long)mem_region.get_inclusive_end(),
-                      (unsigned long long)max_allowed_pa);
-      exit(EXIT_FAILURE);
-    }
-
     res.push_back(mem_region);
     if (!*p)
       break;

--- a/spike_main/spike.cc
+++ b/spike_main/spike.cc
@@ -236,6 +236,17 @@ static std::vector<mem_cfg_t> parse_mem_layout(const char* arg)
       exit(EXIT_FAILURE);
     }
 
+    const uint64_t max_allowed_pa = (1ull << MAX_PADDR_BITS) - 1ull;
+    if (mem_region.get_inclusive_end() > max_allowed_pa) {
+      fprintf(stderr, "unsupported memory region [0x%llX, 0x%llX] specified ("
+                      "currently, spike does not support physical adresses "
+                      "larger than 0x%llX)\n",
+                      (unsigned long long)mem_region.get_base(),
+                      (unsigned long long)mem_region.get_inclusive_end(),
+                      (unsigned long long)max_allowed_pa);
+      exit(EXIT_FAILURE);
+    }
+
     res.push_back(mem_region);
     if (!*p)
       break;


### PR DESCRIPTION
Current spike implementation erroneously assumes that a maximum physical address is limited to (1 << MAX_PADDR_BITS).

There are few issues with this assumption:
1. if satp.MODE == Bare, then virtual addresses are equal to physical and there are no limitations and no additional requirements on the number of address bits and address values one may use.
2. the actual limit can only be derived from the current privilege mode and CSR configuration and thus can be determined only in runtime.

This patch implements a simple workaround by making queries to the platform configuration as a last-ditch effort before memory access abort.

To figure out if the current configuration supports large 64-bit addresses only ordinary memory regions are taken into account - bus devices (abstract devices) are excluded. Proper support for such cases may require significant refactoring.