### PR TITLE
Fix vmv.x.s for RV32

### DIFF
--- a/riscv/insns/vmv_x_s.h
+++ b/riscv/insns/vmv_x_s.h
@@ -1,27 +1,28 @@
 // vmv_x_s: rd = vs2[0]
 require_vector(true);
 require(insn.v_vm() == 1);
-uint64_t xmask = UINT64_MAX >> (64 - P.get_isa().get_max_xlen());
 reg_t rs1 = RS1;
 reg_t sew = P.VU.vsew;
 reg_t rs2_num = insn.rs2();
+reg_t res;
 
 switch (sew) {
 case e8:
-  WRITE_RD(P.VU.elt<int8_t>(rs2_num, 0));
+  res = P.VU.elt<int8_t>(rs2_num, 0);
   break;
 case e16:
-  WRITE_RD(P.VU.elt<int16_t>(rs2_num, 0));
+  res = P.VU.elt<int16_t>(rs2_num, 0);
   break;
 case e32:
-  WRITE_RD(P.VU.elt<int32_t>(rs2_num, 0));
+  res = P.VU.elt<int32_t>(rs2_num, 0);
   break;
 case e64:
-  if (P.get_isa().get_max_xlen() <= sew)
-    WRITE_RD(P.VU.elt<uint64_t>(rs2_num, 0) & xmask);
-  else
-    WRITE_RD(P.VU.elt<uint64_t>(rs2_num, 0));
+  res = P.VU.elt<uint64_t>(rs2_num, 0);
   break;
+default:
+  abort();
 }
+
+WRITE_RD(sext_xlen(res));
 
 P.VU.vstart->write(0);


### PR DESCRIPTION
The Spike internals require that, when XLEN is narrower than reg_t, values be sign-extended to the width of reg_t.