### PR TITLE
Fix build using Xcode 14

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -241,7 +241,7 @@ $(2)_lib_libnames   := $$(patsubst %, lib%.a, $$($(2)_lib_libs))
 $(2)_lib_libarg     := $$(patsubst %, -l%, $$($(2)_lib_libs))
 $(2)_lib_libnames_shared	:= $$(if $$($(2)_install_shared_lib),lib$(1).so,)
 
-lib$(1).a : $$($(2)_objs) $$($(2)_c_objs) $$($(2)_lib_libnames)
+lib$(1).a : $$($(2)_objs) $$($(2)_c_objs)
 	$(AR) rcs $$@ $$^
 lib$(1).so : $$($(2)_objs) $$($(2)_c_objs) $$($(2)_lib_libnames_shared) $$($(2)_lib_libnames)
 	$(LINK) -shared -o $$@ $(if $(filter Darwin,$(shell uname -s)),-install_name $(install_libs_dir)/$$@) $$^ $$($(2)_lib_libnames) $(LIBS)


### PR DESCRIPTION
Don't include .a files in other .a files.  Doing so trips a sanity check in the Xcode 14 toolchain, because the included .a files are not themselves mach-o format, even though their contents are.

Fixes #1101 