### PR TITLE
Fix trigger priority

### DIFF
--- a/riscv/mmu.cc
+++ b/riscv/mmu.cc
@@ -170,11 +170,13 @@ void mmu_t::load_slow_path(reg_t addr, reg_t len, uint8_t* bytes, uint32_t xlate
 
 void mmu_t::store_slow_path(reg_t addr, reg_t len, const uint8_t* bytes, uint32_t xlate_flags, bool actually_store)
 {
-  if (!matched_trigger) {
-    reg_t data = reg_from_bytes(len, bytes);
-    matched_trigger = trigger_exception(triggers::OPERATION_STORE, addr, true, data);
-    if (matched_trigger)
-      throw *matched_trigger;
+  if (actually_store) {
+    if (!matched_trigger) {
+      reg_t data = reg_from_bytes(len, bytes);
+      matched_trigger = trigger_exception(triggers::OPERATION_STORE, addr, true, data);
+      if (matched_trigger)
+        throw *matched_trigger;
+    }
   }
 
   reg_t paddr = translate(addr, len, STORE, xlate_flags);

--- a/riscv/mmu.cc
+++ b/riscv/mmu.cc
@@ -141,6 +141,13 @@ bool mmu_t::mmio_store(reg_t addr, size_t len, const uint8_t* bytes)
 
 void mmu_t::load_slow_path(reg_t addr, reg_t len, uint8_t* bytes, uint32_t xlate_flags)
 {
+  if (!matched_trigger) {
+    reg_t data = reg_from_bytes(len, bytes);
+    matched_trigger = trigger_exception(triggers::OPERATION_LOAD, addr, false);
+    if (matched_trigger)
+      throw *matched_trigger;
+  }
+
   reg_t paddr = translate(addr, len, LOAD, xlate_flags);
 
   if (auto host_addr = sim->addr_to_mem(paddr)) {

--- a/riscv/mmu.cc
+++ b/riscv/mmu.cc
@@ -170,14 +170,14 @@ void mmu_t::load_slow_path(reg_t addr, reg_t len, uint8_t* bytes, uint32_t xlate
 
 void mmu_t::store_slow_path(reg_t addr, reg_t len, const uint8_t* bytes, uint32_t xlate_flags, bool actually_store)
 {
-  reg_t paddr = translate(addr, len, STORE, xlate_flags);
-
   if (!matched_trigger) {
     reg_t data = reg_from_bytes(len, bytes);
     matched_trigger = trigger_exception(triggers::OPERATION_STORE, addr, true, data);
     if (matched_trigger)
       throw *matched_trigger;
   }
+
+  reg_t paddr = translate(addr, len, STORE, xlate_flags);
 
   if (actually_store) {
     if (auto host_addr = sim->addr_to_mem(paddr)) {

--- a/riscv/mmu.cc
+++ b/riscv/mmu.cc
@@ -155,7 +155,7 @@ void mmu_t::load_slow_path(reg_t addr, reg_t len, uint8_t* bytes, uint32_t xlate
 
   if (!matched_trigger) {
     reg_t data = reg_from_bytes(len, bytes);
-    matched_trigger = trigger_exception(triggers::OPERATION_LOAD, addr, data);
+    matched_trigger = trigger_exception(triggers::OPERATION_LOAD, addr, true, data);
     if (matched_trigger)
       throw *matched_trigger;
   }
@@ -167,7 +167,7 @@ void mmu_t::store_slow_path(reg_t addr, reg_t len, const uint8_t* bytes, uint32_
 
   if (!matched_trigger) {
     reg_t data = reg_from_bytes(len, bytes);
-    matched_trigger = trigger_exception(triggers::OPERATION_STORE, addr, data);
+    matched_trigger = trigger_exception(triggers::OPERATION_STORE, addr, true, data);
     if (matched_trigger)
       throw *matched_trigger;
   }

--- a/riscv/mmu.h
+++ b/riscv/mmu.h
@@ -169,6 +169,13 @@ public:
   #define store_func(type, prefix, xlate_flags) \
     void ALWAYS_INLINE prefix##_##type(reg_t addr, type##_t val, bool actually_store=true, bool require_alignment=false) { \
       if (unlikely(addr & (sizeof(type##_t)-1))) { \
+        if (actually_store) { \
+          if (!matched_trigger) { \
+            matched_trigger = trigger_exception(triggers::OPERATION_STORE, addr, true, val); \
+            if (matched_trigger) \
+              throw *matched_trigger; \
+          } \
+        } \
         if (require_alignment) store_conditional_address_misaligned(addr); \
         else return misaligned_store(addr, val, sizeof(type##_t), xlate_flags, actually_store); \
       } \

--- a/riscv/mmu.h
+++ b/riscv/mmu.h
@@ -101,6 +101,11 @@ public:
   #define load_func(type, prefix, xlate_flags) \
     type##_t ALWAYS_INLINE prefix##_##type(reg_t addr, bool require_alignment = false) { \
       if (unlikely(addr & (sizeof(type##_t)-1))) { \
+        if (!matched_trigger) { \
+          matched_trigger = trigger_exception(triggers::OPERATION_LOAD, addr, false); \
+          if (matched_trigger) \
+            throw *matched_trigger; \
+        } \
         if (require_alignment) load_reserved_address_misaligned(addr); \
         else return misaligned_load(addr, sizeof(type##_t), xlate_flags); \
       } \

--- a/riscv/triggers.cc
+++ b/riscv/triggers.cc
@@ -101,7 +101,7 @@ bool mcontrol_t::simple_match(unsigned xlen, reg_t value) const {
   assert(0);
 }
 
-match_result_t mcontrol_t::memory_access_match(processor_t * const proc, operation_t operation, reg_t address, reg_t data) {
+match_result_t mcontrol_t::memory_access_match(processor_t * const proc, operation_t operation, reg_t address, bool has_data, reg_t data) {
   state_t * const state = proc->get_state();
   if ((operation == triggers::OPERATION_EXECUTE && !execute_bit) ||
       (operation == triggers::OPERATION_STORE && !store_bit) ||
@@ -115,6 +115,8 @@ match_result_t mcontrol_t::memory_access_match(processor_t * const proc, operati
   reg_t value;
   if (select) {
     value = data;
+    if (!has_data)
+      return MATCH_NONE;
   } else {
     value = address;
   }
@@ -150,7 +152,7 @@ module_t::~module_t() {
   }
 }
 
-match_result_t module_t::memory_access_match(action_t * const action, operation_t operation, reg_t address, reg_t data)
+match_result_t module_t::memory_access_match(action_t * const action, operation_t operation, reg_t address, bool has_data, reg_t data)
 {
   state_t * const state = proc->get_state();
   if (state->debug_mode)
@@ -170,7 +172,7 @@ match_result_t module_t::memory_access_match(action_t * const action, operation_
      * entire chain did not match. This is allowed by the spec, because the final
      * trigger in the chain will never get `hit` set unless the entire chain
      * matches. */
-    match_result_t result = triggers[i]->memory_access_match(proc, operation, address, data);
+    match_result_t result = triggers[i]->memory_access_match(proc, operation, address, has_data, data);
     if (result != MATCH_NONE && !triggers[i]->chain()) {
       *action = triggers[i]->action;
       return result;

--- a/riscv/triggers.h
+++ b/riscv/triggers.h
@@ -43,7 +43,7 @@ class matched_t
 class trigger_t {
 public:
   virtual match_result_t memory_access_match(processor_t * const proc,
-      operation_t operation, reg_t address, reg_t data) = 0;
+      operation_t operation, reg_t address, bool has_data, reg_t data=0) = 0;
 
   virtual reg_t tdata1_read(const processor_t * const proc) const noexcept = 0;
   virtual bool tdata1_write(processor_t * const proc, const reg_t val) noexcept = 0;
@@ -88,7 +88,7 @@ public:
   virtual bool load() const override { return load_bit; }
 
   virtual match_result_t memory_access_match(processor_t * const proc,
-      operation_t operation, reg_t address, reg_t data) override;
+      operation_t operation, reg_t address, bool has_data, reg_t data=0) override;
 
 private:
   bool simple_match(unsigned xlen, reg_t value) const;
@@ -115,7 +115,7 @@ public:
   unsigned count() const { return triggers.size(); }
 
   match_result_t memory_access_match(action_t * const action,
-      operation_t operation, reg_t address, reg_t data);
+      operation_t operation, reg_t address, bool has_data, reg_t data=0);
 
   reg_t tdata1_read(const processor_t * const proc, unsigned index) const noexcept;
   bool tdata1_write(processor_t * const proc, unsigned index, const reg_t val) noexcept;


### PR DESCRIPTION
This PR corrects the mcontrol trigger priority with other traps, e.g., page fault and address misaligned. (Debug spec, Table 5.2)
![image](https://user-images.githubusercontent.com/39526191/192961447-a239d285-3064-47fc-9f09-7da903283ec6.png)

The spec defines that the mcontrol execute address has a higher priority over the instruction page fault. Additionally, the mcontrol load address has a higher priority over the load page fault. Furthermore, the mcotnrol store address/data have higher priorities over the store page fault. The current implementation does not correctly satisfy the above priorities.

This PR fixes the priority issue with four commits. It adds address-only trigger checking functions first, then performs the address trigger checking with those functions for execution, load, and store in separate commits.