### PR TITLE
Simplify handling of load/store/fetch slow-path cases; fix two minor trigger bugs

### DIFF
--- a/riscv/execute.cc
+++ b/riscv/execute.cc
@@ -309,15 +309,6 @@ void processor_t::step(size_t n)
     catch (triggers::matched_t& t)
     {
       if (mmu->matched_trigger) {
-        // This exception came from the MMU. That means the instruction hasn't
-        // fully executed yet. We start it again, but this time it won't throw
-        // an exception because matched_trigger is already set. (All memory
-        // instructions are idempotent so restarting is safe.)
-
-        insn_fetch_t fetch = mmu->load_insn(pc);
-        pc = execute_insn(this, pc, fetch);
-        advance_pc();
-
         delete mmu->matched_trigger;
         mmu->matched_trigger = NULL;
       }

--- a/riscv/mmu.cc
+++ b/riscv/mmu.cc
@@ -93,8 +93,7 @@ tlb_entry_t mmu_t::fetch_slow_path(reg_t vaddr)
     result = tlb_data[vpn % TLB_ENTRIES];
   }
 
-  target_endian<uint16_t>* ptr = (target_endian<uint16_t>*)(result.host_offset + vaddr);
-  check_triggers(triggers::OPERATION_EXECUTE, vaddr, true, from_target(*ptr));
+  check_triggers(triggers::OPERATION_EXECUTE, vaddr, true, from_le(*(const uint16_t*)(result.host_offset + vaddr)));
 
   return result;
 }

--- a/riscv/mmu.cc
+++ b/riscv/mmu.cc
@@ -165,8 +165,11 @@ void mmu_t::check_triggers(triggers::operation_t operation, reg_t address, bool 
       throw triggers::matched_t(operation, address, data, action);
 
     case triggers::MATCH_FIRE_AFTER:
+      // We want to take this exception on the next instruction.  We check
+      // whether to do so in the I$ refill path, so flush the I$.
+      flush_icache();
       matched_trigger = new triggers::matched_t(operation, address, data, action);
-      throw *matched_trigger;
+      return;
   }
 }
 

--- a/riscv/mmu.h
+++ b/riscv/mmu.h
@@ -247,6 +247,9 @@ public:
 
   inline icache_entry_t* refill_icache(reg_t addr, icache_entry_t* entry)
   {
+    if (matched_trigger)
+      throw *matched_trigger;
+
     auto tlb_entry = translate_insn_addr(addr);
     insn_bits_t insn = from_le(*(uint16_t*)(tlb_entry.host_offset + addr));
     int length = insn_length(insn);

--- a/riscv/mmu.h
+++ b/riscv/mmu.h
@@ -391,23 +391,7 @@ private:
     reg_t vpn = addr >> PGSHIFT;
     if (likely(tlb_insn_tag[vpn % TLB_ENTRIES] == vpn))
       return tlb_data[vpn % TLB_ENTRIES];
-    triggers::action_t action;
-    auto match = proc->TM.memory_access_match(&action, triggers::OPERATION_EXECUTE, addr, false);
-    if (match != triggers::MATCH_NONE) {
-      throw triggers::matched_t(triggers::OPERATION_EXECUTE, addr, 0, action);
-    }
-    tlb_entry_t result;
-    if (unlikely(tlb_insn_tag[vpn % TLB_ENTRIES] != (vpn | TLB_CHECK_TRIGGERS))) {
-      result = fetch_slow_path(addr);
-    } else {
-      result = tlb_data[vpn % TLB_ENTRIES];
-    }
-    target_endian<uint16_t>* ptr = (target_endian<uint16_t>*)(result.host_offset + addr);
-    match = proc->TM.memory_access_match(&action, triggers::OPERATION_EXECUTE, addr, true, from_target(*ptr));
-    if (match != triggers::MATCH_NONE) {
-      throw triggers::matched_t(triggers::OPERATION_EXECUTE, addr, from_target(*ptr), action);
-    }
-    return result;
+    return fetch_slow_path(addr);
   }
 
   inline const uint16_t* translate_insn_addr_to_host(reg_t addr) {

--- a/riscv/mmu.h
+++ b/riscv/mmu.h
@@ -384,6 +384,7 @@ private:
   bool mmio_load(reg_t addr, size_t len, uint8_t* bytes);
   bool mmio_store(reg_t addr, size_t len, const uint8_t* bytes);
   bool mmio_ok(reg_t addr, access_type type);
+  void check_triggers(triggers::operation_t operation, reg_t address, bool has_data, reg_t data = 0);
   reg_t translate(reg_t addr, reg_t len, access_type type, uint32_t xlate_flags);
 
   // ITLB lookup
@@ -396,22 +397,6 @@ private:
 
   inline const uint16_t* translate_insn_addr_to_host(reg_t addr) {
     return (uint16_t*)(translate_insn_addr(addr).host_offset + addr);
-  }
-
-  inline triggers::matched_t *trigger_exception(triggers::operation_t operation,
-      reg_t address, bool has_data, reg_t data=0)
-  {
-    if (!proc) {
-      return NULL;
-    }
-    triggers::action_t action;
-    auto match = proc->TM.memory_access_match(&action, operation, address, has_data, data);
-    if (match == triggers::MATCH_NONE)
-      return NULL;
-    if (match == triggers::MATCH_FIRE_BEFORE) {
-      throw triggers::matched_t(operation, address, data, action);
-    }
-    return new triggers::matched_t(operation, address, data, action);
   }
 
   reg_t pmp_homogeneous(reg_t addr, reg_t len);


### PR DESCRIPTION
The load/store code in particular has been becoming difficult to maintain because of the competing interests of keeping the common case fast and correctly handling the less-common cases (triggers and misaligned accesses).  Refactor so that only the fast path is in the harder-to-maintain inlined code.

As a side effect, misaligned accesses now behave the same as aligned accesses with respect to triggers: only the first byte is checked.

This refactoring suggested several opportunities for DRY in the handling of triggers.  Address that, too.

Finally, being forced to understand the code revealed two bugs:
- Fetch triggers on big-endian machines were using the wrong endianness (instruction fetch is always little-endian)
- Trigger-after was relying on memory accesses being idempotent, which is not entirely true: MMIO loads can have side effects, and re-executing them because of a data value trigger isn't correct.  Avoiding re-execution is also a bit cleaner.