### PR TITLE
Add --dm-no-abstract-fpr option.

### DIFF
--- a/riscv/debug_module.cc
+++ b/riscv/debug_module.cc
@@ -672,7 +672,7 @@ bool debug_module_t::perform_abstract_command()
           write32(debug_abstract, i++, csrw(S0, CSR_DSCRATCH0));
         }
 
-      } else if (regno >= 0x1020 && regno < 0x1040) {
+      } else if (regno >= 0x1020 && regno < 0x1040 && config.support_abstract_fpr_access) {
         unsigned fprnum = regno - 0x1020;
 
         if (write) {

--- a/riscv/debug_module.h
+++ b/riscv/debug_module.h
@@ -19,6 +19,7 @@ typedef struct {
   unsigned abstract_rti;
   bool support_hasel;
   bool support_abstract_csr_access;
+  bool support_abstract_fpr_access;
   bool support_haltgroups;
   bool support_impebreak;
 } debug_module_config_t;

--- a/spike_main/spike.cc
+++ b/spike_main/spike.cc
@@ -72,7 +72,8 @@ static void help(int exit_code = 1)
   fprintf(stderr, "  --dm-abstract-rti=<n> Number of Run-Test/Idle cycles "
       "required for an abstract command to execute [default 0]\n");
   fprintf(stderr, "  --dm-no-hasel         Debug module supports hasel\n");
-  fprintf(stderr, "  --dm-no-abstract-csr  Debug module won't support abstract to authenticate\n");
+  fprintf(stderr, "  --dm-no-abstract-csr  Debug module won't support abstract CSR access\n");
+  fprintf(stderr, "  --dm-no-abstract-fpr  Debug module won't support abstract FPR access\n");
   fprintf(stderr, "  --dm-no-halt-groups   Debug module won't support halt groups\n");
   fprintf(stderr, "  --dm-no-impebreak     Debug module won't support implicit ebreak in program buffer\n");
   fprintf(stderr, "  --blocksz=<size>      Cache block size (B) for CMO operations(powers of 2) [default 64]\n");
@@ -269,6 +270,7 @@ int main(int argc, char** argv)
     .abstract_rti = 0,
     .support_hasel = true,
     .support_abstract_csr_access = true,
+    .support_abstract_fpr_access = true,
     .support_haltgroups = true,
     .support_impebreak = true
   };
@@ -384,6 +386,8 @@ int main(int argc, char** argv)
       [&](const char UNUSED *s){dm_config.support_hasel = false;});
   parser.option(0, "dm-no-abstract-csr", 0,
       [&](const char UNUSED *s){dm_config.support_abstract_csr_access = false;});
+  parser.option(0, "dm-no-abstract-fpr", 0,
+      [&](const char UNUSED *s){dm_config.support_abstract_fpr_access = false;});
   parser.option(0, "dm-no-halt-groups", 0,
       [&](const char UNUSED *s){dm_config.support_haltgroups = false;});
   parser.option(0, "log-commits", 0,


### PR DESCRIPTION
Previously FPRs could always be accessed using abstract commands. I need this to get coverage of some OpenOCD code that I broke. (See https://github.com/riscv/riscv-openocd/pull/745)