### PR TITLE
Report error if an unsupported memory configuration is detected

### DIFF
--- a/riscv/cfg.h
+++ b/riscv/cfg.h
@@ -32,18 +32,22 @@ private:
 class mem_cfg_t
 {
 public:
-  mem_cfg_t(reg_t base, reg_t size)
-    : base(base), size(size)
-  {
-    // The truth of these assertions should be ensured by whatever is creating
+  static bool check_if_supported(reg_t base, reg_t size) {
+    // The truth of these conditions should be ensured by whatever is creating
     // the regions in the first place, but we have them here to make sure that
     // we can't end up describing memory regions that don't make sense. They
     // ask that the page size is a multiple of the minimum page size, that the
     // page is aligned to the minimum page size, that the page is non-empty and
     // that the top address is still representable in a reg_t.
-    assert((size % PGSIZE == 0) &&
+    return (size % PGSIZE == 0) &&
            (base % PGSIZE == 0) &&
-           (base + size > base));
+           (base + size > base);
+  }
+
+  mem_cfg_t(reg_t base, reg_t size)
+    : base(base), size(size)
+  {
+    assert(mem_cfg_t::check_if_supported(base, size));
   }
 
   reg_t base;

--- a/spike_main/spike.cc
+++ b/spike_main/spike.cc
@@ -173,13 +173,18 @@ static std::vector<mem_cfg_t> parse_mem_layout(const char* arg)
     if (size % PGSIZE != 0)
       size += PGSIZE - size % PGSIZE;
 
-    if (base + size < base)
-      help();
-
     if (size != size0) {
       fprintf(stderr, "Warning: the memory at  [0x%llX, 0x%llX] has been realigned\n"
                       "to the %ld KiB page size: [0x%llX, 0x%llX]\n",
               base0, base0 + size0 - 1, long(PGSIZE / 1024), base, base + size - 1);
+    }
+
+    if (!mem_cfg_t::check_if_supported(base, size)) {
+      fprintf(stderr, "unsupported memory region "
+                      "{base = 0x%llX, size = 0x%llX} specified\n",
+                      (unsigned long long)base,
+                      (unsigned long long)size);
+      exit(EXIT_FAILURE);
     }
 
     res.push_back(mem_cfg_t(reg_t(base), reg_t(size)));


### PR DESCRIPTION
This commit adds error message for the case when an incorrect memory region is
detected. The check for invariant was moved to a separate function to simplify
the code of mem_cfg_t users.