### PR TITLE
set tval on illegal instruction of aes64ks1i invalid opcode (rcon)

### DIFF
--- a/riscv/insns/aes64ks1i.h
+++ b/riscv/insns/aes64ks1i.h
@@ -12,7 +12,7 @@ uint8_t     enc_rcon          = insn.rcon() ;
 
 if (enc_rcon > 0xA) {
     // Invalid opcode.
-    throw trap_illegal_instruction(0);
+    throw trap_illegal_instruction(insn.bits());
 }
 
 uint32_t    temp              = (RS1 >> 32) & 0xFFFFFFFF  ;


### PR DESCRIPTION
Although the tval of illegal instruction can be either 0 or instruction bits, I think spike prefers the instruction bits more. This commit changes the tval of illegal instruction on an invalid opcode of aes64ks1i.