### PR TITLE
Slightly simplify LR/SC implementation

### DIFF
--- a/riscv/mmu.h
+++ b/riscv/mmu.h
@@ -218,8 +218,8 @@ public:
   inline void acquire_load_reservation(reg_t vaddr)
   {
     reg_t paddr = translate(vaddr, 1, LOAD, 0);
-    if (auto host_addr = sim->addr_to_mem(paddr))
-      load_reservation_address = refill_tlb(vaddr, paddr, host_addr, LOAD).target_offset + vaddr;
+    if (sim->addr_to_mem(paddr))
+      load_reservation_address = paddr;
     else
       throw trap_load_access_fault((proc) ? proc->state.v : false, vaddr, 0, 0); // disallow LR to I/O space
   }
@@ -232,8 +232,8 @@ public:
     }
 
     reg_t paddr = translate(vaddr, 1, STORE, 0);
-    if (auto host_addr = sim->addr_to_mem(paddr))
-      return load_reservation_address == refill_tlb(vaddr, paddr, host_addr, STORE).target_offset + vaddr;
+    if (sim->addr_to_mem(paddr))
+      return load_reservation_address == paddr;
     else
       throw trap_store_access_fault((proc) ? proc->state.v : false, vaddr, 0, 0); // disallow SC to I/O space
   }


### PR DESCRIPTION
The call to refill_tlb is a bit baroque and isn't necessary. (Also, the LR instruction will have populated the TLB anyway by invoking load_uintXX, so it doesn't even help performance.)