### PR TITLE
Fix build warning and mmu bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,6 @@ Spike supports the following RISC-V ISA features:
   - Svnapot extension, v1.0
   - Svpbmt extension, v1.0
   - Svinval extension, v1.0
-  - CMO extension, v1.0
   - Debug v0.14
   - Smepmp extension v1.0
   - Smstateen extension, v1.0

--- a/riscv/dts.cc
+++ b/riscv/dts.cc
@@ -174,7 +174,7 @@ std::string dts_compile(const std::string& dts)
     close(dts_pipe[1]);
     close(dtb_pipe[0]);
     close(dtb_pipe[1]);
-    execlp(DTC, DTC, "-O", "dtb", 0);
+    execlp(DTC, DTC, "-O", "dtb", (char *)0);
     std::cerr << "Failed to run " DTC ": " << strerror(errno) << std::endl;
     exit(1);
   }

--- a/riscv/mmu.cc
+++ b/riscv/mmu.cc
@@ -223,8 +223,10 @@ void mmu_t::store_slow_path_intrapage(reg_t addr, reg_t len, const uint8_t* byte
 {
   reg_t vpn = addr >> PGSHIFT;
   if (xlate_flags == 0 && vpn == (tlb_store_tag[vpn % TLB_ENTRIES] & ~TLB_CHECK_TRIGGERS)) {
-    auto host_addr = tlb_data[vpn % TLB_ENTRIES].host_offset + addr;
-    memcpy(host_addr, bytes, len);
+    if (actually_store) {
+      auto host_addr = tlb_data[vpn % TLB_ENTRIES].host_offset + addr;
+      memcpy(host_addr, bytes, len);
+    }
     return;
   }
 


### PR DESCRIPTION
Fix missing sentinel warning in dts.cc when using gnu++17 standard
do memcpy only for actually_store in store_slow_path_intrapage
remove duplicate CMO item in README.md