### PR TITLE
move fucntion cto() from processor.h to arith.h

### DIFF
--- a/riscv/arith.h
+++ b/riscv/arith.h
@@ -188,6 +188,15 @@ static inline int clz(uint64_t val)
   return res;
 }
 
+// Count number of contiguous 1 bits starting from the LSB.
+static inline int cto(uint64_t val)
+{
+  int res = 0;
+  while ((val & 1) == 1)
+    val >>= 1, res++;
+  return res;
+}
+
 static inline int log2(uint64_t val)
 {
   if (!val)

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -219,15 +219,6 @@ struct state_t
 #endif
 };
 
-// Count number of contiguous 1 bits starting from the LSB.
-static inline int cto(reg_t val)
-{
-  int res = 0;
-  while ((val & 1) == 1)
-    val >>= 1, res++;
-  return res;
-}
-
 // this class represents one processor in a RISC-V machine.
 class processor_t : public abstract_device_t
 {

--- a/riscv/triggers.cc
+++ b/riscv/triggers.cc
@@ -1,3 +1,4 @@
+#include "arith.h"
 #include "debug_defines.h"
 #include "processor.h"
 #include "triggers.h"


### PR DESCRIPTION
Only triggers.cc uses the arithmetic function cto(). Instead of putting the cto() in processor.h, putting it in arith.h with other arithmetic functions, e.g., ctz() and clz(), makes more sense.