### PR TITLE
Fix tval reporting for CBOs; constrain cache-block sizes to reasonable values

### DIFF
--- a/riscv/mmu.h
+++ b/riscv/mmu.h
@@ -341,7 +341,7 @@ public:
     return target_big_endian? target_endian<T>::to_be(n) : target_endian<T>::to_le(n);
   }
 
-  void set_cache_blocksz(uint64_t size)
+  void set_cache_blocksz(reg_t size)
   {
     blocksz = size;
   }
@@ -352,7 +352,7 @@ private:
   memtracer_list_t tracer;
   reg_t load_reservation_address;
   uint16_t fetch_temp;
-  uint64_t blocksz;
+  reg_t blocksz;
 
   // implement an instruction cache for simulator performance
   icache_entry_t icache[ICACHE_ENTRIES];

--- a/riscv/mmu.h
+++ b/riscv/mmu.h
@@ -199,8 +199,7 @@ public:
 
   void clean_inval(reg_t addr, bool clean, bool inval) {
     convert_load_traps_to_store_traps({
-      const reg_t vaddr = addr & ~(blocksz - 1);
-      const reg_t paddr = translate(vaddr, blocksz, LOAD, 0);
+      const reg_t paddr = translate(addr, blocksz, LOAD, 0) & ~(blocksz - 1);
       if (sim->addr_to_mem(paddr)) {
         if (tracer.interested_in_range(paddr, paddr + PGSIZE, LOAD))
           tracer.clean_invalidate(paddr, blocksz, clean, inval);

--- a/spike_main/spike.cc
+++ b/spike_main/spike.cc
@@ -411,8 +411,11 @@ int main(int argc, char** argv)
   });
   parser.option(0, "blocksz", 1, [&](const char* s){
     blocksz = strtoull(s, 0, 0);
-    if (((blocksz & (blocksz - 1))) != 0) {
-      fprintf(stderr, "--blocksz should be power of 2\n");
+    const unsigned min_blocksz = 16;
+    const unsigned max_blocksz = PGSIZE;
+    if (blocksz < min_blocksz || blocksz > max_blocksz || ((blocksz & (blocksz - 1))) != 0) {
+      fprintf(stderr, "--blocksz must be a power of 2 between %u and %u\n",
+        min_blocksz, max_blocksz);
       exit(-1);
     }
   });


### PR DESCRIPTION
tval was sometimes reported with the base address of the cache block, and other times reported with the value in rs1 (potentially in the middle of the cache block).  @dkruckemyer-ventana is going to clarify the behavior in the spec, but regardless, we shouldn't be self-inconsistent within Spike.

Also, constrain cache-block sizes to between the largest aligned access we support (16 bytes) and the page size (4 KiB).  The latter is actually a bug fix, since we were only performing one permissions check per CBO.