### PR TITLE
fix value printing function: commit_log_print_value()

### DIFF
--- a/riscv/execute.cc
+++ b/riscv/execute.cc
@@ -25,44 +25,26 @@ static void commit_log_print_value(FILE *log_file, int width, const void *data)
 {
   assert(log_file);
 
-  switch (width) {
-    case 8:
-      fprintf(log_file, "0x%02" PRIx8, *(const uint8_t *)data);
-      break;
-    case 16:
-      fprintf(log_file, "0x%04" PRIx16, *(const uint16_t *)data);
-      break;
-    case 24:
-      fprintf(log_file, "0x%06" PRIx32, *(const uint32_t *)data & ((uint32_t(1)<<width)-1));
-      break;
-    case 32:
-      fprintf(log_file, "0x%08" PRIx32, *(const uint32_t *)data);
-      break;
-    case 40:
-      fprintf(log_file, "0x%010" PRIx64, *(const uint64_t *)data & ((uint64_t(1)<<width)-1));
-      break;
-    case 48:
-      fprintf(log_file, "0x%012" PRIx64, *(const uint64_t *)data & ((uint64_t(1)<<width)-1));
-      break;
-    case 56:
-      fprintf(log_file, "0x%014" PRIx64, *(const uint64_t *)data & ((uint64_t(1)<<width)-1));
-      break;
-    case 64:
-      fprintf(log_file, "0x%016" PRIx64, *(const uint64_t *)data);
-      break;
-    default:
-      // max lengh of vector
-      if (((width - 1) & width) == 0) {
-        const uint64_t *arr = (const uint64_t *)data;
+  if ((width&7) == 0 && width <= 64) {
+    // width is 8, 16, 24, 32, 40, 48, 56, or 64
+    const uint8_t *arr = (const uint8_t *)data;
 
-        fprintf(log_file, "0x");
-        for (int idx = width / 64 - 1; idx >= 0; --idx) {
-          fprintf(log_file, "%016" PRIx64, arr[idx]);
-        }
-      } else {
-        abort();
+    fprintf(log_file, "0x");
+    for (int idx = width / 8 - 1; idx >= 0; --idx) {
+      fprintf(log_file, "%02" PRIx8, arr[idx]);
+    }
+  } else {
+    // max lengh of vector
+    if (((width - 1) & width) == 0) {
+      const uint64_t *arr = (const uint64_t *)data;
+
+      fprintf(log_file, "0x");
+      for (int idx = width / 64 - 1; idx >= 0; --idx) {
+        fprintf(log_file, "%016" PRIx64, arr[idx]);
       }
-      break;
+    } else {
+      abort();
+    }
   }
 }
 

--- a/riscv/execute.cc
+++ b/riscv/execute.cc
@@ -25,27 +25,14 @@ static void commit_log_print_value(FILE *log_file, int width, const void *data)
 {
   assert(log_file);
 
-  if ((width&7) == 0 && width <= 64) {
-    // width is 8, 16, 24, 32, 40, 48, 56, or 64
-    const uint8_t *arr = (const uint8_t *)data;
+  if (((width - 1) & width) && ((width & 7) || width > 64))
+    abort(); // disallow non-power-of-2, except 24, 40, 48, 56
 
-    fprintf(log_file, "0x");
-    for (int idx = width / 8 - 1; idx >= 0; --idx) {
-      fprintf(log_file, "%02" PRIx8, arr[idx]);
-    }
-  } else {
-    // max lengh of vector
-    if (((width - 1) & width) == 0) {
-      const uint64_t *arr = (const uint64_t *)data;
+  const uint8_t *arr = (const uint8_t *)data;
 
-      fprintf(log_file, "0x");
-      for (int idx = width / 64 - 1; idx >= 0; --idx) {
-        fprintf(log_file, "%016" PRIx64, arr[idx]);
-      }
-    } else {
-      abort();
-    }
-  }
+  fprintf(log_file, "0x");
+  for (int idx = width / 8 - 1; idx >= 0; --idx)
+    fprintf(log_file, "%02" PRIx8, arr[idx]);
 }
 
 static void commit_log_print_value(FILE *log_file, int width, uint64_t val)

--- a/riscv/execute.cc
+++ b/riscv/execute.cc
@@ -32,8 +32,20 @@ static void commit_log_print_value(FILE *log_file, int width, const void *data)
     case 16:
       fprintf(log_file, "0x%04" PRIx16, *(const uint16_t *)data);
       break;
+    case 24:
+      fprintf(log_file, "0x%06" PRIx32, *(const uint32_t *)data & ((uint32_t(1)<<width)-1));
+      break;
     case 32:
       fprintf(log_file, "0x%08" PRIx32, *(const uint32_t *)data);
+      break;
+    case 40:
+      fprintf(log_file, "0x%010" PRIx64, *(const uint64_t *)data & ((uint64_t(1)<<width)-1));
+      break;
+    case 48:
+      fprintf(log_file, "0x%012" PRIx64, *(const uint64_t *)data & ((uint64_t(1)<<width)-1));
+      break;
+    case 56:
+      fprintf(log_file, "0x%014" PRIx64, *(const uint64_t *)data & ((uint64_t(1)<<width)-1));
       break;
     case 64:
       fprintf(log_file, "0x%016" PRIx64, *(const uint64_t *)data);

--- a/riscv/execute.cc
+++ b/riscv/execute.cc
@@ -25,8 +25,8 @@ static void commit_log_print_value(FILE *log_file, int width, const void *data)
 {
   assert(log_file);
 
-  if (((width - 1) & width) && ((width & 7) || width > 64))
-    abort(); // disallow non-power-of-2, except 24, 40, 48, 56
+  if (width & 7)
+    abort(); // non-byte-addressable
 
   const uint8_t *arr = (const uint8_t *)data;
 

--- a/riscv/execute.cc
+++ b/riscv/execute.cc
@@ -27,7 +27,7 @@ static void commit_log_print_value(FILE *log_file, int width, const void *data)
 
   switch (width) {
     case 8:
-      fprintf(log_file, "0x%01" PRIx8, *(const uint8_t *)data);
+      fprintf(log_file, "0x%02" PRIx8, *(const uint8_t *)data);
       break;
     case 16:
       fprintf(log_file, "0x%04" PRIx16, *(const uint16_t *)data);


### PR DESCRIPTION
This PR includes two commits to the memory value printing function, commit_log_print_value(). The first commit corrects the number of digits of width=8 accesses. The second commit enhances the capability of irregular accesses with width={24,40,48,56}, required by the previous commit (https://github.com/riscv-software-src/riscv-isa-sim/commit/e2e66015af4b5fce4bc958e70398f1fb7af7bcd9).

update 2022.10.24
Another three commits merges the switch cases. Additionally, they correct the abort condition on width={1,2,4}.