### PR TITLE
fix mevent_mask for Sscofpmf extension

### DIFF
--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -237,8 +237,10 @@ void state_t::reset(processor_t* const proc, reg_t max_isa)
     const reg_t which_mcounterh = CSR_MHPMCOUNTER3H + i - 3;
     const reg_t which_counter = CSR_HPMCOUNTER3 + i - 3;
     const reg_t which_counterh = CSR_HPMCOUNTER3H + i - 3;
-    const reg_t mevent_mask = proc->extension_enabled_const(EXT_SSCOFPMF) ? MHPMEVENT_VUINH | MHPMEVENT_VSINH | MHPMEVENTH_UINH |
-                                                                            MHPMEVENT_UINH | MHPMEVENT_MINH | MHPMEVENT_OF : 0;
+    const reg_t mevent_mask = proc->extension_enabled_const(EXT_SSCOFPMF) ? MHPMEVENT_OF | MHPMEVENT_MINH
+      | (proc->extension_enabled_const('U') ? MHPMEVENT_UINH : 0)
+      | (proc->extension_enabled_const('S') ? MHPMEVENT_SINH : 0)
+      | (proc->extension_enabled_const('H') ? MHPMEVENT_VUINH | MHPMEVENT_VSINH : 0) : 0;
     mevent[i - 3] = std::make_shared<masked_csr_t>(proc, which_mevent, mevent_mask, 0);
     auto mcounter = std::make_shared<const_csr_t>(proc, which_mcounter, 0);
     csrmap[which_mcounter] = mcounter;


### PR DESCRIPTION
The mevent_mask of Sscofpmf depends on the support of privilege modes. The UINH, SINH, VSINH, and VUINH are read-only 0 if unsupporting the corresponding modes.
(https://github.com/riscv/riscv-count-overflow/issues/3#issuecomment-1291247070)

This commit fixes the mevent_mask of Sscofpmf accordingly. The previous MHPMEVENTH_UINH is a typo, which should be MHPMEVENT_SINH instead.