### PR TITLE
Document implemented trigger configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Spike supports the following RISC-V ISA features:
   - Svpbmt extension, v1.0
   - Svinval extension, v1.0
   - Debug v0.14
+    - 4 triggers fixed to type=2 (mcontrol)
   - Smepmp extension v1.0
   - Smstateen extension, v1.0
   - Sscofpmf v0.5.2


### PR DESCRIPTION
Adds an explanation to the README about what trigger types are supported.

I want this in place because it's about to change with #1128 and this README will change as needed, to document the trigger changes as they're made.