### PR TITLE
Support more than 65 Z* extensions

### DIFF
--- a/riscv/isa_parser.h
+++ b/riscv/isa_parser.h
@@ -12,7 +12,7 @@ class extension_t;
 
 typedef enum {
   // 65('A') ~ 90('Z') is reserved for standard isa in misa
-  EXT_ZFH,
+  EXT_ZFH = 'Z' + 1,
   EXT_ZFHMIN,
   EXT_ZBA,
   EXT_ZBB,


### PR DESCRIPTION
The isa_extension_t enum already has 44 extensions.  In not too long, the enum will grow in size to 65, when it will collide with the 'A' extension.  Fix that preemptively by starting after 'Z'.

This approach will run out of steam at 165 extensions because we are using `unsigned char` to represent extensions, but opefully we will have retired by that point.

In seriousness, we will probably need to refactor the extension_enabled logic at some point in the future (e.g. when the configuration structure is finally added) and at that point we should lift the `char` limit.