### PR TITLE
Add tinfo register.

### DIFF
--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -1137,6 +1137,14 @@ bool tdata2_csr_t::unlogged_write(const reg_t val) noexcept {
   return proc->TM.tdata2_write(proc, state->tselect->read(), val);
 }
 
+tinfo_csr_t::tinfo_csr_t(processor_t* const proc, const reg_t addr) :
+  csr_t(proc, addr) {
+}
+
+reg_t tinfo_csr_t::read() const noexcept {
+  return proc->TM.tinfo_read(proc, state->tselect->read());
+}
+
 debug_mode_csr_t::debug_mode_csr_t(processor_t* const proc, const reg_t addr):
   basic_csr_t(proc, addr, 0) {
 }

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -605,6 +605,14 @@ class tdata2_csr_t: public csr_t {
   virtual bool unlogged_write(const reg_t val) noexcept override;
 };
 
+class tinfo_csr_t: public csr_t {
+ public:
+  tinfo_csr_t(processor_t* const proc, const reg_t addr);
+  virtual reg_t read() const noexcept override;
+ protected:
+  virtual bool unlogged_write(const reg_t UNUSED val) noexcept override { return false; };
+};
+
 // For CSRs that are only writable from debug mode
 class debug_mode_csr_t: public basic_csr_t {
  public:

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -395,6 +395,7 @@ void state_t::reset(processor_t* const proc, reg_t max_isa)
   csrmap[CSR_TDATA1] = std::make_shared<tdata1_csr_t>(proc, CSR_TDATA1);
   csrmap[CSR_TDATA2] = tdata2 = std::make_shared<tdata2_csr_t>(proc, CSR_TDATA2);
   csrmap[CSR_TDATA3] = std::make_shared<const_csr_t>(proc, CSR_TDATA3, 0);
+  csrmap[CSR_TINFO] = std::make_shared<tinfo_csr_t>(proc, CSR_TINFO);
   debug_mode = false;
   single_step = STEP_NONE;
 

--- a/riscv/triggers.cc
+++ b/riscv/triggers.cc
@@ -208,4 +208,10 @@ bool module_t::tdata2_write(processor_t * const proc, unsigned index, const reg_
   return result;
 }
 
+reg_t module_t::tinfo_read(UNUSED const processor_t * const proc, unsigned UNUSED index) const noexcept
+{
+  /* In spike, every trigger supports the same types. */
+  return 1<<MCONTROL_TYPE_MATCH;
+}
+
 };

--- a/riscv/triggers.h
+++ b/riscv/triggers.h
@@ -121,6 +121,7 @@ public:
   bool tdata1_write(processor_t * const proc, unsigned index, const reg_t val) noexcept;
   reg_t tdata2_read(const processor_t * const proc, unsigned index) const noexcept;
   bool tdata2_write(processor_t * const proc, unsigned index, const reg_t val) noexcept;
+  reg_t tinfo_read(const processor_t * const proc, unsigned index) const noexcept;
 
   processor_t *proc;
 private:


### PR DESCRIPTION
Not very interesting while spike only supports one trigger type, but #1128 is about to change that. Without tinfo, it can become quite slow for a debugger to discover which types are supported.