### PR TITLE
hypervisor extension does not hardwire misa.H

### DIFF
--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -650,6 +650,10 @@ bool misa_csr_t::unlogged_write(const reg_t val) noexcept {
     state->mie->write_with_mask(MIP_HS_MASK, 0);  // also takes care of hie, sie
     state->mip->write_with_mask(MIP_HS_MASK, 0);  // also takes care of hip, sip, hvip
     state->hstatus->write(0);
+    for (reg_t i = 3; i < N_HPMCOUNTERS + 3; ++i) {
+      const reg_t new_mevent = state->mevent[i - 3]->read() & ~(MHPMEVENT_VUINH | MHPMEVENT_VSINH);
+      state->mevent[i - 3]->write(new_mevent);
+    }
   }
 
   return basic_csr_t::unlogged_write(new_misa);

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -1062,7 +1062,7 @@ bool mevent_csr_t::unlogged_write(const reg_t val) noexcept {
   const reg_t mask = proc->extension_enabled(EXT_SSCOFPMF) ? MHPMEVENT_OF | MHPMEVENT_MINH
     | (proc->extension_enabled_const('U') ? MHPMEVENT_UINH : 0)
     | (proc->extension_enabled_const('S') ? MHPMEVENT_SINH : 0)
-    | (proc->extension_enabled_const('H') ? MHPMEVENT_VUINH | MHPMEVENT_VSINH : 0) : 0;
+    | (proc->extension_enabled('H') ? MHPMEVENT_VUINH | MHPMEVENT_VSINH : 0) : 0;
   return basic_csr_t::unlogged_write((read() & ~mask) | (val & mask));
 }
 

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -1054,6 +1054,18 @@ void counter_proxy_csr_t::verify_permissions(insn_t insn, bool write) const {
   }
 }
 
+mevent_csr_t::mevent_csr_t(processor_t* const proc, const reg_t addr):
+  basic_csr_t(proc, addr, 0) {
+}
+
+bool mevent_csr_t::unlogged_write(const reg_t val) noexcept {
+  const reg_t mask = proc->extension_enabled(EXT_SSCOFPMF) ? MHPMEVENT_OF | MHPMEVENT_MINH
+    | (proc->extension_enabled_const('U') ? MHPMEVENT_UINH : 0)
+    | (proc->extension_enabled_const('S') ? MHPMEVENT_SINH : 0)
+    | (proc->extension_enabled_const('H') ? MHPMEVENT_VUINH | MHPMEVENT_VSINH : 0) : 0;
+  return basic_csr_t::unlogged_write((read() & ~mask) | (val & mask));
+}
+
 hypervisor_csr_t::hypervisor_csr_t(processor_t* const proc, const reg_t addr):
   basic_csr_t(proc, addr, 0) {
 }

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -1472,7 +1472,7 @@ void scountovf_csr_t::verify_permissions(insn_t insn, bool write) const {
 
 reg_t scountovf_csr_t::read() const noexcept {
   reg_t val = 0;
-  for (reg_t i = 3; i <= 31; ++i) {
+  for (reg_t i = 3; i < N_HPMCOUNTERS + 3; ++i) {
     bool of = state->mevent[i - 3]->read() & MHPMEVENT_OF;
     val |= of << i;
   }

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -559,6 +559,13 @@ class counter_proxy_csr_t: public proxy_csr_t {
   bool myenable(csr_t_p counteren) const noexcept;
 };
 
+class mevent_csr_t: public basic_csr_t {
+ public:
+  mevent_csr_t(processor_t* const proc, const reg_t addr);
+ protected:
+  virtual bool unlogged_write(const reg_t val) noexcept override;
+};
+
 // For machine-level CSRs that only exist with Hypervisor
 class hypervisor_csr_t: public basic_csr_t {
  public:

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -238,11 +238,7 @@ void state_t::reset(processor_t* const proc, reg_t max_isa)
     const reg_t which_mcounterh = CSR_MHPMCOUNTER3H + i - 3;
     const reg_t which_counter = CSR_HPMCOUNTER3 + i - 3;
     const reg_t which_counterh = CSR_HPMCOUNTER3H + i - 3;
-    const reg_t mevent_mask = proc->extension_enabled_const(EXT_SSCOFPMF) ? MHPMEVENT_OF | MHPMEVENT_MINH
-      | (proc->extension_enabled_const('U') ? MHPMEVENT_UINH : 0)
-      | (proc->extension_enabled_const('S') ? MHPMEVENT_SINH : 0)
-      | (proc->extension_enabled_const('H') ? MHPMEVENT_VUINH | MHPMEVENT_VSINH : 0) : 0;
-    mevent[i - 3] = std::make_shared<masked_csr_t>(proc, which_mevent, mevent_mask, 0);
+    mevent[i - 3] = std::make_shared<mevent_csr_t>(proc, which_mevent);
     auto mcounter = std::make_shared<const_csr_t>(proc, which_mcounter, 0);
     csrmap[which_mcounter] = mcounter;
 

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -231,7 +231,7 @@ void state_t::reset(processor_t* const proc, reg_t max_isa)
     csrmap[CSR_MINSTRET] = minstret;
     csrmap[CSR_MCYCLE] = mcycle;
   }
-  for (reg_t i = 3; i <= 31; ++i) {
+  for (reg_t i = 3; i < N_HPMCOUNTERS + 3; ++i) {
     const reg_t which_mevent = CSR_MHPMEVENT3 + i - 3;
     const reg_t which_meventh = CSR_MHPMEVENT3H + i - 3;
     const reg_t which_mcounter = CSR_MHPMCOUNTER3 + i - 3;

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -18,6 +18,8 @@
 #include "triggers.h"
 #include "memif.h"
 
+#define N_HPMCOUNTERS 29
+
 class processor_t;
 class mmu_t;
 typedef reg_t (*insn_func_t)(processor_t*, insn_t, reg_t);
@@ -146,7 +148,7 @@ struct state_t
   csr_t_p medeleg;
   csr_t_p mideleg;
   csr_t_p mcounteren;
-  csr_t_p mevent[29];
+  csr_t_p mevent[N_HPMCOUNTERS];
   csr_t_p scounteren;
   csr_t_p sepc;
   csr_t_p stval;


### PR DESCRIPTION
This PR corrects the wrong assumption that misa.H is read-only (hardwired).

Reported by @kwalker27 (https://github.com/riscv-software-src/riscv-isa-sim/pull/1154)