### PR TITLE
Fix support for Zc*

### DIFF
--- a/riscv/decode.h
+++ b/riscv/decode.h
@@ -164,7 +164,7 @@ public:
     if (rlist >= 4)
       mask |= 1U << X_RA;
 
-    for (uint i = 5; i <= rlist; i++)
+    for (reg_t i = 5; i <= rlist; i++)
         mask |= 1U << Sn(i - 5);
 
     if (rlist == 15)

--- a/riscv/insns/cm_jalt.h
+++ b/riscv/insns/cm_jalt.h
@@ -2,7 +2,7 @@ require_extension(EXT_ZCMT);
 STATE.jvt->verify_permissions(insn, false);
 reg_t jvt = STATE.jvt->read();
 uint8_t mode = get_field(jvt, JVT_MODE);
-reg_t base = get_field(jvt, JVT_BASE);
+reg_t base = jvt & JVT_BASE;
 reg_t index = insn.rvc_index();
 reg_t target;
 switch (mode) {

--- a/riscv/mmu.h
+++ b/riscv/mmu.h
@@ -227,9 +227,8 @@ public:
 
   template<typename T>
   T ALWAYS_INLINE fetch_jump_table(reg_t addr) {
-    target_endian<T> res;
-    load_slow_path_intrapage(addr, sizeof(T), (uint8_t*)&res, 0);
-    return from_target(res);
+    auto tlb_entry = translate_insn_addr(addr);
+    return from_target(*(target_endian<T>*)(tlb_entry.host_offset + addr));
   }
 
   inline icache_entry_t* refill_icache(reg_t addr, icache_entry_t* entry)


### PR DESCRIPTION
Fix some problems in my previous Zc* support:

- uint type is not available in some platforms
- the base address of jump table is not the field of JVT_BASE, but the the total JVT value with the six LSBs ignored(https://github.com/riscv/riscv-code-size-reduction/issues/201)
- the permission check for jump table remains executable(https://github.com/riscv/riscv-code-size-reduction/issues/195)