### PR TITLE
Minor trigger cleanup

### DIFF
--- a/riscv/execute.cc
+++ b/riscv/execute.cc
@@ -302,9 +302,9 @@ void processor_t::step(size_t n)
       n = instret;
 
       // Trigger action takes priority over single step
-      triggers::match_result_t match = TM.detect_trap_match(t);
-      if (match.fire)
-        take_trigger_action(match.action, 0, state.pc);
+      auto match = TM.detect_trap_match(t);
+      if (match.has_value())
+        take_trigger_action(match->action, 0, state.pc);
       else if (unlikely(state.single_step == state.STEP_STEPPED)) {
         state.single_step = state.STEP_NONE;
         enter_debug_mode(DCSR_CAUSE_STEP);

--- a/riscv/mmu.cc
+++ b/riscv/mmu.cc
@@ -157,18 +157,18 @@ void mmu_t::check_triggers(triggers::operation_t operation, reg_t address, std::
   if (matched_trigger || !proc)
     return;
 
-  triggers::match_result_t match = proc->TM.detect_memory_access_match(operation, address, data);
+  auto match = proc->TM.detect_memory_access_match(operation, address, data);
 
-  if (match.fire)
-    switch (match.timing) {
+  if (match.has_value())
+    switch (match->timing) {
       case triggers::TIMING_BEFORE:
-        throw triggers::matched_t(operation, address, match.action);
+        throw triggers::matched_t(operation, address, match->action);
 
       case triggers::TIMING_AFTER:
         // We want to take this exception on the next instruction.  We check
         // whether to do so in the I$ refill path, so flush the I$.
         flush_icache();
-        matched_trigger = new triggers::matched_t(operation, address, match.action);
+        matched_trigger = new triggers::matched_t(operation, address, match->action);
     }
 }
 

--- a/riscv/triggers.cc
+++ b/riscv/triggers.cc
@@ -5,11 +5,11 @@
 
 namespace triggers {
 
-reg_t trigger_with_tdata2_t::tdata2_read(const processor_t UNUSED * const proc) const noexcept {
+reg_t trigger_t::tdata2_read(const processor_t UNUSED * const proc) const noexcept {
   return tdata2;
 }
 
-void trigger_with_tdata2_t::tdata2_write(processor_t UNUSED * const proc, const reg_t UNUSED val) noexcept {
+void trigger_t::tdata2_write(processor_t UNUSED * const proc, const reg_t UNUSED val) noexcept {
   tdata2 = val;
 }
 

--- a/riscv/triggers.cc
+++ b/riscv/triggers.cc
@@ -360,18 +360,18 @@ std::optional<match_result_t> module_t::detect_memory_access_match(operation_t o
   return std::nullopt;
 }
 
-match_result_t module_t::detect_trap_match(const trap_t& t) noexcept
+std::optional<match_result_t> module_t::detect_trap_match(const trap_t& t) noexcept
 {
   state_t * const state = proc->get_state();
   if (state->debug_mode)
-    return match_result_t(false);
+    return std::nullopt;
 
   for (auto trigger: triggers) {
     match_result_t result = trigger->detect_trap_match(proc, t);
     if (result.fire)
       return result;
   }
-  return match_result_t(false);
+  return std::nullopt;
 }
 
 reg_t module_t::tinfo_read(UNUSED const processor_t * const proc, unsigned UNUSED index) const noexcept

--- a/riscv/triggers.cc
+++ b/riscv/triggers.cc
@@ -13,6 +13,10 @@ void trigger_t::tdata2_write(processor_t UNUSED * const proc, const reg_t UNUSED
   tdata2 = val;
 }
 
+action_t trigger_t::legalize_action(reg_t val) const noexcept {
+  return (val > ACTION_MAXVAL || (val == ACTION_DEBUG_MODE && get_dmode() == 0)) ? ACTION_DEBUG_EXCEPTION : (action_t)val;
+}
+
 reg_t disabled_trigger_t::tdata1_read(const processor_t * const proc) const noexcept
 {
   auto xlen = proc->get_xlen();
@@ -57,9 +61,7 @@ void mcontrol_t::tdata1_write(processor_t * const proc, const reg_t val, const b
   hit = get_field(val, CSR_MCONTROL_HIT);
   select = get_field(val, MCONTROL_SELECT);
   timing = get_field(val, MCONTROL_TIMING);
-  action = (triggers::action_t) get_field(val, MCONTROL_ACTION);
-  if (action > ACTION_MAXVAL || (action==ACTION_DEBUG_MODE && dmode==0))
-    action = ACTION_DEBUG_EXCEPTION;
+  action = legalize_action(get_field(val, MCONTROL_ACTION));
   chain = allow_chain ? get_field(val, MCONTROL_CHAIN) : 0;
   unsigned match_value = get_field(val, MCONTROL_MATCH);
   switch (match_value) {
@@ -179,9 +181,7 @@ void itrigger_t::tdata1_write(processor_t * const proc, const reg_t val, const b
   m = get_field(val, CSR_ITRIGGER_M);
   s = proc->extension_enabled_const('S') ? get_field(val, CSR_ITRIGGER_S) : 0;
   u = proc->extension_enabled_const('U') ? get_field(val, CSR_ITRIGGER_U) : 0;
-  action = (action_t)get_field(val, CSR_ITRIGGER_ACTION);
-  if (action > ACTION_MAXVAL || (action==ACTION_DEBUG_MODE && dmode==0))
-    action = ACTION_DEBUG_EXCEPTION;
+  action = legalize_action(get_field(val, CSR_ITRIGGER_ACTION));
 }
 
 match_result_t itrigger_t::detect_trap_match(processor_t * const proc, const trap_t& t) noexcept
@@ -233,9 +233,7 @@ void etrigger_t::tdata1_write(processor_t * const proc, const reg_t val, const b
   m = get_field(val, CSR_ETRIGGER_M);
   s = proc->extension_enabled_const('S') ? get_field(val, CSR_ETRIGGER_S) : 0;
   u = proc->extension_enabled_const('U') ? get_field(val, CSR_ETRIGGER_U) : 0;
-  action = (action_t)get_field(val, CSR_ETRIGGER_ACTION);
-  if (action > ACTION_MAXVAL || (action==ACTION_DEBUG_MODE && dmode==0))
-    action = ACTION_DEBUG_EXCEPTION;
+  action = legalize_action(get_field(val, CSR_ETRIGGER_ACTION));
 }
 
 match_result_t etrigger_t::detect_trap_match(processor_t * const proc, const trap_t& t) noexcept

--- a/riscv/triggers.cc
+++ b/riscv/triggers.cc
@@ -184,7 +184,7 @@ void itrigger_t::tdata1_write(processor_t * const proc, const reg_t val, const b
   action = legalize_action(get_field(val, CSR_ITRIGGER_ACTION));
 }
 
-match_result_t itrigger_t::detect_trap_match(processor_t * const proc, const trap_t& t) noexcept
+std::optional<match_result_t> itrigger_t::detect_trap_match(processor_t * const proc, const trap_t& t) noexcept
 {
   state_t * const state = proc->get_state();
   if ((state->prv == PRV_M && !m) ||
@@ -192,7 +192,7 @@ match_result_t itrigger_t::detect_trap_match(processor_t * const proc, const tra
       (!state->v && state->prv == PRV_U && !u) ||
       (state->v && state->prv == PRV_S && !vs) ||
       (state->v && state->prv == PRV_U && !vu)) {
-    return match_result_t(false);
+    return std::nullopt;
   }
 
   auto xlen = proc->get_xlen();
@@ -203,7 +203,7 @@ match_result_t itrigger_t::detect_trap_match(processor_t * const proc, const tra
     hit = true;
     return match_result_t(true, TIMING_AFTER, action);
   }
-  return match_result_t(false);
+  return std::nullopt;
 }
 
 reg_t etrigger_t::tdata1_read(const processor_t * const proc) const noexcept
@@ -236,7 +236,7 @@ void etrigger_t::tdata1_write(processor_t * const proc, const reg_t val, const b
   action = legalize_action(get_field(val, CSR_ETRIGGER_ACTION));
 }
 
-match_result_t etrigger_t::detect_trap_match(processor_t * const proc, const trap_t& t) noexcept
+std::optional<match_result_t> etrigger_t::detect_trap_match(processor_t * const proc, const trap_t& t) noexcept
 {
   state_t * const state = proc->get_state();
   if ((state->prv == PRV_M && !m) ||
@@ -244,7 +244,7 @@ match_result_t etrigger_t::detect_trap_match(processor_t * const proc, const tra
       (!state->v && state->prv == PRV_U && !u) ||
       (state->v && state->prv == PRV_S && !vs) ||
       (state->v && state->prv == PRV_U && !vu)) {
-    return match_result_t(false);
+    return std::nullopt;
   }
 
   auto xlen = proc->get_xlen();
@@ -255,7 +255,7 @@ match_result_t etrigger_t::detect_trap_match(processor_t * const proc, const tra
     hit = true;
     return match_result_t(true, TIMING_AFTER, action);
   }
-  return match_result_t(false);
+  return std::nullopt;
 }
 
 module_t::module_t(unsigned count) : triggers(count) {
@@ -367,8 +367,8 @@ std::optional<match_result_t> module_t::detect_trap_match(const trap_t& t) noexc
     return std::nullopt;
 
   for (auto trigger: triggers) {
-    match_result_t result = trigger->detect_trap_match(proc, t);
-    if (result.fire)
+    auto result = trigger->detect_trap_match(proc, t);
+    if (result.has_value())
       return result;
   }
   return std::nullopt;

--- a/riscv/triggers.cc
+++ b/riscv/triggers.cc
@@ -341,7 +341,7 @@ std::optional<match_result_t> module_t::detect_memory_access_match(operation_t o
 
   for (auto trigger: triggers) {
     if (!chain_ok) {
-      chain_ok |= !trigger->get_chain();
+      chain_ok = !trigger->get_chain();
       continue;
     }
 

--- a/riscv/triggers.cc
+++ b/riscv/triggers.cc
@@ -113,7 +113,7 @@ bool mcontrol_t::simple_match(unsigned xlen, reg_t value) const {
   assert(0);
 }
 
-match_result_t mcontrol_t::detect_memory_access_match(processor_t * const proc, operation_t operation, reg_t address, std::optional<reg_t> data) {
+match_result_t mcontrol_t::detect_memory_access_match(processor_t * const proc, operation_t operation, reg_t address, std::optional<reg_t> data) noexcept {
   state_t * const state = proc->get_state();
   if ((operation == triggers::OPERATION_EXECUTE && !execute) ||
       (operation == triggers::OPERATION_STORE && !store) ||
@@ -184,7 +184,7 @@ void itrigger_t::tdata1_write(processor_t * const proc, const reg_t val, const b
     action = ACTION_DEBUG_EXCEPTION;
 }
 
-match_result_t itrigger_t::detect_trap_match(processor_t * const proc, const trap_t& t)
+match_result_t itrigger_t::detect_trap_match(processor_t * const proc, const trap_t& t) noexcept
 {
   state_t * const state = proc->get_state();
   if ((state->prv == PRV_M && !m) ||
@@ -238,7 +238,7 @@ void etrigger_t::tdata1_write(processor_t * const proc, const reg_t val, const b
     action = ACTION_DEBUG_EXCEPTION;
 }
 
-match_result_t etrigger_t::detect_trap_match(processor_t * const proc, const trap_t& t)
+match_result_t etrigger_t::detect_trap_match(processor_t * const proc, const trap_t& t) noexcept
 {
   state_t * const state = proc->get_state();
   if ((state->prv == PRV_M && !m) ||
@@ -333,7 +333,7 @@ bool module_t::tdata2_write(processor_t * const proc, unsigned index, const reg_
   return true;
 }
 
-match_result_t module_t::detect_memory_access_match(operation_t operation, reg_t address, std::optional<reg_t> data)
+match_result_t module_t::detect_memory_access_match(operation_t operation, reg_t address, std::optional<reg_t> data) noexcept
 {
   state_t * const state = proc->get_state();
   if (state->debug_mode)
@@ -362,7 +362,7 @@ match_result_t module_t::detect_memory_access_match(operation_t operation, reg_t
   return match_result_t(false);
 }
 
-match_result_t module_t::detect_trap_match(const trap_t& t)
+match_result_t module_t::detect_trap_match(const trap_t& t) noexcept
 {
   state_t * const state = proc->get_state();
   if (state->debug_mode)

--- a/riscv/triggers.cc
+++ b/riscv/triggers.cc
@@ -331,11 +331,11 @@ bool module_t::tdata2_write(processor_t * const proc, unsigned index, const reg_
   return true;
 }
 
-match_result_t module_t::detect_memory_access_match(operation_t operation, reg_t address, std::optional<reg_t> data) noexcept
+std::optional<match_result_t> module_t::detect_memory_access_match(operation_t operation, reg_t address, std::optional<reg_t> data) noexcept
 {
   state_t * const state = proc->get_state();
   if (state->debug_mode)
-    return match_result_t(false);
+    return std::nullopt;
 
   bool chain_ok = true;
 
@@ -357,7 +357,7 @@ match_result_t module_t::detect_memory_access_match(operation_t operation, reg_t
 
     chain_ok = result.fire || !trigger->get_chain();
   }
-  return match_result_t(false);
+  return std::nullopt;
 }
 
 match_result_t module_t::detect_trap_match(const trap_t& t) noexcept

--- a/riscv/triggers.cc
+++ b/riscv/triggers.cc
@@ -147,7 +147,7 @@ std::optional<match_result_t> mcontrol_t::detect_memory_access_match(processor_t
     /* This is OK because this function is only called if the trigger was not
      * inhibited by the previous trigger in the chain. */
     hit = true;
-    return match_result_t(true, timing_t(timing), action);
+    return match_result_t(timing_t(timing), action);
   }
   return std::nullopt;
 }
@@ -201,7 +201,7 @@ std::optional<match_result_t> itrigger_t::detect_trap_match(processor_t * const 
   assert(bit < xlen);
   if (interrupt && ((bit == 0 && nmi) || ((tdata2 >> bit) & 1))) { // Assume NMI's exception code is 0
     hit = true;
-    return match_result_t(true, TIMING_AFTER, action);
+    return match_result_t(TIMING_AFTER, action);
   }
   return std::nullopt;
 }
@@ -253,7 +253,7 @@ std::optional<match_result_t> etrigger_t::detect_trap_match(processor_t * const 
   assert(bit < xlen);
   if (!interrupt && ((tdata2 >> bit) & 1)) {
     hit = true;
-    return match_result_t(true, TIMING_AFTER, action);
+    return match_result_t(TIMING_AFTER, action);
   }
   return std::nullopt;
 }

--- a/riscv/triggers.h
+++ b/riscv/triggers.h
@@ -187,7 +187,7 @@ public:
   unsigned count() const { return triggers.size(); }
 
   std::optional<match_result_t> detect_memory_access_match(operation_t operation, reg_t address, std::optional<reg_t> data) noexcept;
-  match_result_t detect_trap_match(const trap_t& t) noexcept;
+  std::optional<match_result_t> detect_trap_match(const trap_t& t) noexcept;
 
   processor_t *proc;
 private:

--- a/riscv/triggers.h
+++ b/riscv/triggers.h
@@ -68,8 +68,8 @@ public:
   virtual action_t get_action() const { return ACTION_DEBUG_EXCEPTION; }
 
   virtual match_result_t detect_memory_access_match(processor_t UNUSED * const proc,
-      operation_t UNUSED operation, reg_t UNUSED address, std::optional<reg_t> UNUSED data) { return match_result_t(false); }
-  virtual match_result_t detect_trap_match(processor_t UNUSED * const proc, const trap_t UNUSED & t) { return match_result_t(false); }
+      operation_t UNUSED operation, reg_t UNUSED address, std::optional<reg_t> UNUSED data) noexcept { return match_result_t(false); }
+  virtual match_result_t detect_trap_match(processor_t UNUSED * const proc, const trap_t UNUSED & t) noexcept { return match_result_t(false); }
 
 protected:
   reg_t tdata2;
@@ -94,7 +94,7 @@ public:
   bool get_dmode() const override { return dmode; }
   virtual action_t get_action() const override { return action; }
 
-  virtual match_result_t detect_trap_match(processor_t * const proc, const trap_t& t) override;
+  virtual match_result_t detect_trap_match(processor_t * const proc, const trap_t& t) noexcept override;
 
 private:
   bool dmode;
@@ -116,7 +116,7 @@ public:
   bool get_dmode() const override { return dmode; }
   virtual action_t get_action() const override { return action; }
 
-  virtual match_result_t detect_trap_match(processor_t * const proc, const trap_t& t) override;
+  virtual match_result_t detect_trap_match(processor_t * const proc, const trap_t& t) noexcept override;
 
 private:
   bool dmode;
@@ -152,7 +152,7 @@ public:
   virtual action_t get_action() const override { return action; }
 
   virtual match_result_t detect_memory_access_match(processor_t * const proc,
-      operation_t operation, reg_t address, std::optional<reg_t> data) override;
+      operation_t operation, reg_t address, std::optional<reg_t> data) noexcept override;
 
 private:
   bool simple_match(unsigned xlen, reg_t value) const;
@@ -185,8 +185,8 @@ public:
 
   unsigned count() const { return triggers.size(); }
 
-  match_result_t detect_memory_access_match(operation_t operation, reg_t address, std::optional<reg_t> data);
-  match_result_t detect_trap_match(const trap_t& t);
+  match_result_t detect_memory_access_match(operation_t operation, reg_t address, std::optional<reg_t> data) noexcept;
+  match_result_t detect_trap_match(const trap_t& t) noexcept;
 
   processor_t *proc;
 private:

--- a/riscv/triggers.h
+++ b/riscv/triggers.h
@@ -30,12 +30,10 @@ typedef enum {
 } timing_t;
 
 struct match_result_t {
-  match_result_t(const bool f, const timing_t t=TIMING_BEFORE, const action_t a=ACTION_DEBUG_EXCEPTION) {
-    fire = f;
+  match_result_t(const bool UNUSED f, const timing_t t=TIMING_BEFORE, const action_t a=ACTION_DEBUG_EXCEPTION) {
     timing = t;
     action = a;
   }
-  bool fire;
   timing_t timing;
   action_t action;
 };

--- a/riscv/triggers.h
+++ b/riscv/triggers.h
@@ -186,7 +186,7 @@ public:
 
   unsigned count() const { return triggers.size(); }
 
-  match_result_t detect_memory_access_match(operation_t operation, reg_t address, std::optional<reg_t> data) noexcept;
+  std::optional<match_result_t> detect_memory_access_match(operation_t operation, reg_t address, std::optional<reg_t> data) noexcept;
   match_result_t detect_trap_match(const trap_t& t) noexcept;
 
   processor_t *proc;

--- a/riscv/triggers.h
+++ b/riscv/triggers.h
@@ -75,10 +75,7 @@ protected:
   reg_t tdata2;
 };
 
-class trigger_with_tdata2_t : public trigger_t {
-};
-
-class disabled_trigger_t : public trigger_with_tdata2_t {
+class disabled_trigger_t : public trigger_t {
 public:
   virtual reg_t tdata1_read(const processor_t * const proc) const noexcept override;
   virtual void tdata1_write(processor_t * const proc, const reg_t val, const bool allow_chain) noexcept override;
@@ -89,7 +86,7 @@ private:
   bool dmode;
 };
 
-class itrigger_t : public trigger_with_tdata2_t {
+class itrigger_t : public trigger_t {
 public:
   virtual reg_t tdata1_read(const processor_t * const proc) const noexcept override;
   virtual void tdata1_write(processor_t * const proc, const reg_t val, const bool allow_chain) noexcept override;
@@ -111,7 +108,7 @@ private:
   action_t action;
 };
 
-class etrigger_t : public trigger_with_tdata2_t {
+class etrigger_t : public trigger_t {
 public:
   virtual reg_t tdata1_read(const processor_t * const proc) const noexcept override;
   virtual void tdata1_write(processor_t * const proc, const reg_t val, const bool allow_chain) noexcept override;
@@ -132,7 +129,7 @@ private:
   action_t action;
 };
 
-class mcontrol_t : public trigger_with_tdata2_t {
+class mcontrol_t : public trigger_t {
 public:
   typedef enum
   {

--- a/riscv/triggers.h
+++ b/riscv/triggers.h
@@ -67,8 +67,8 @@ public:
   virtual bool get_load() const { return false; }
   virtual action_t get_action() const { return ACTION_DEBUG_EXCEPTION; }
 
-  virtual match_result_t detect_memory_access_match(processor_t UNUSED * const proc,
-      operation_t UNUSED operation, reg_t UNUSED address, std::optional<reg_t> UNUSED data) noexcept { return match_result_t(false); }
+  virtual std::optional<match_result_t> detect_memory_access_match(processor_t UNUSED * const proc,
+      operation_t UNUSED operation, reg_t UNUSED address, std::optional<reg_t> UNUSED data) noexcept { return std::nullopt; }
   virtual match_result_t detect_trap_match(processor_t UNUSED * const proc, const trap_t UNUSED & t) noexcept { return match_result_t(false); }
 
 protected:
@@ -152,7 +152,7 @@ public:
   virtual bool get_load() const override { return load; }
   virtual action_t get_action() const override { return action; }
 
-  virtual match_result_t detect_memory_access_match(processor_t * const proc,
+  virtual std::optional<match_result_t> detect_memory_access_match(processor_t * const proc,
       operation_t operation, reg_t address, std::optional<reg_t> data) noexcept override;
 
 private:

--- a/riscv/triggers.h
+++ b/riscv/triggers.h
@@ -72,6 +72,7 @@ public:
   virtual match_result_t detect_trap_match(processor_t UNUSED * const proc, const trap_t UNUSED & t) noexcept { return match_result_t(false); }
 
 protected:
+  action_t legalize_action(reg_t val) const noexcept;
   reg_t tdata2;
 };
 

--- a/riscv/triggers.h
+++ b/riscv/triggers.h
@@ -57,8 +57,8 @@ public:
 
   virtual reg_t tdata1_read(const processor_t * const proc) const noexcept = 0;
   virtual void tdata1_write(processor_t * const proc, const reg_t val, const bool allow_chain) noexcept = 0;
-  virtual reg_t tdata2_read(const processor_t * const proc) const noexcept = 0;
-  virtual void tdata2_write(processor_t * const proc, const reg_t val) noexcept = 0;
+  reg_t tdata2_read(const processor_t * const proc) const noexcept;
+  void tdata2_write(processor_t * const proc, const reg_t val) noexcept;
 
   virtual bool get_dmode() const = 0;
   virtual bool get_chain() const { return false; }
@@ -70,15 +70,12 @@ public:
   virtual match_result_t detect_memory_access_match(processor_t UNUSED * const proc,
       operation_t UNUSED operation, reg_t UNUSED address, std::optional<reg_t> UNUSED data) { return match_result_t(false); }
   virtual match_result_t detect_trap_match(processor_t UNUSED * const proc, const trap_t UNUSED & t) { return match_result_t(false); }
-};
-
-class trigger_with_tdata2_t : public trigger_t {
-public:
-  reg_t tdata2_read(const processor_t * const proc) const noexcept override;
-  void tdata2_write(processor_t * const proc, const reg_t val) noexcept override;
 
 protected:
   reg_t tdata2;
+};
+
+class trigger_with_tdata2_t : public trigger_t {
 };
 
 class disabled_trigger_t : public trigger_with_tdata2_t {

--- a/riscv/triggers.h
+++ b/riscv/triggers.h
@@ -30,7 +30,7 @@ typedef enum {
 } timing_t;
 
 struct match_result_t {
-  match_result_t(const bool UNUSED f, const timing_t t=TIMING_BEFORE, const action_t a=ACTION_DEBUG_EXCEPTION) {
+  match_result_t(const timing_t t=TIMING_BEFORE, const action_t a=ACTION_DEBUG_EXCEPTION) {
     timing = t;
     action = a;
   }

--- a/riscv/triggers.h
+++ b/riscv/triggers.h
@@ -69,7 +69,7 @@ public:
 
   virtual std::optional<match_result_t> detect_memory_access_match(processor_t UNUSED * const proc,
       operation_t UNUSED operation, reg_t UNUSED address, std::optional<reg_t> UNUSED data) noexcept { return std::nullopt; }
-  virtual match_result_t detect_trap_match(processor_t UNUSED * const proc, const trap_t UNUSED & t) noexcept { return match_result_t(false); }
+  virtual std::optional<match_result_t> detect_trap_match(processor_t UNUSED * const proc, const trap_t UNUSED & t) noexcept { return std::nullopt; }
 
 protected:
   action_t legalize_action(reg_t val) const noexcept;
@@ -95,7 +95,7 @@ public:
   bool get_dmode() const override { return dmode; }
   virtual action_t get_action() const override { return action; }
 
-  virtual match_result_t detect_trap_match(processor_t * const proc, const trap_t& t) noexcept override;
+  virtual std::optional<match_result_t> detect_trap_match(processor_t * const proc, const trap_t& t) noexcept override;
 
 private:
   bool dmode;
@@ -117,7 +117,7 @@ public:
   bool get_dmode() const override { return dmode; }
   virtual action_t get_action() const override { return action; }
 
-  virtual match_result_t detect_trap_match(processor_t * const proc, const trap_t& t) noexcept override;
+  virtual std::optional<match_result_t> detect_trap_match(processor_t * const proc, const trap_t& t) noexcept override;
 
 private:
   bool dmode;


### PR DESCRIPTION
Cleans up a few things in the trigger code. See individual commits for details.

The biggest change is to eliminate dont-care fields in `match_result_t` so that nobody can accidentally use `timing` and `action` when they contain garbage.

cc @YenHaoChen 