### PR TITLE
Use proper include for MCONTROL_ACTION_*

### DIFF
--- a/riscv/triggers.h
+++ b/riscv/triggers.h
@@ -4,7 +4,7 @@
 #include <vector>
 #include <optional>
 
-#include "decode.h"
+#include "encoding.h"
 
 namespace triggers {
 


### PR DESCRIPTION
The include of decode.h was added in
08442c1aad70be858f177e277b02a340a22346ba presumably to get MCONTROL_ACTION_* defines, but those are defined in encoding.h, not decode.h.