### PR TITLE
Avoid use of sprintf

### DIFF
--- a/disasm/disasm.cc
+++ b/disasm/disasm.cc
@@ -1289,14 +1289,12 @@ void disassembler_t::add_instructions(const isa_parser_t* isa)
                          0x10000000, 0x10005000, 0x10006000, 0x10007000};
 
       for (unsigned nf = 0; nf <= 7; ++nf) {
-        char seg_str[8] = "";
-        if (nf)
-          sprintf(seg_str, "seg%u", nf + 1);
+        const auto seg_str = nf ? "seg" + std::to_string(nf + 1) : "";
 
         for (auto item : template_insn) {
           const reg_t match_nf = nf << 29;
           char buf[128];
-          sprintf(buf, item.fmt, seg_str, 8 << elt);
+          snprintf(buf, sizeof(buf), item.fmt, seg_str.c_str(), 8 << elt);
           add_insn(new disasm_insn_t(
             buf,
             ((item.match | match_nf) & ~mask_vldst) | elt_map[elt],
@@ -1314,7 +1312,7 @@ void disassembler_t::add_instructions(const isa_parser_t* isa)
         for (auto item : template_insn2) {
           const reg_t match_nf = nf << 29;
           char buf[128];
-          sprintf(buf, item.fmt, nf + 1, 8 << elt);
+          snprintf(buf, sizeof(buf), item.fmt, nf + 1, 8 << elt);
           add_insn(new disasm_insn_t(
             buf,
             item.match | match_nf | elt_map[elt],
@@ -1675,7 +1673,7 @@ void disassembler_t::add_instructions(const isa_parser_t* isa)
       for (size_t idx = 0; idx < sizeof(amo_map) / sizeof(amo_map[0]); ++idx) {
         for (auto item : template_insn) {
           char buf[128];
-          sprintf(buf, item.fmt, amo_map[idx].first, 8 << elt);
+          snprintf(buf, sizeof(buf), item.fmt, amo_map[idx].first, 8 << elt);
           add_insn(new disasm_insn_t(buf,
                     item.match | amo_map[idx].second | elt_map[elt],
                     item.mask,

--- a/riscv/trap.h
+++ b/riscv/trap.h
@@ -4,7 +4,6 @@
 #define _RISCV_TRAP_H
 
 #include "decode.h"
-#include <cstdio>
 #include <string>
 
 struct state_t;
@@ -29,15 +28,14 @@ class trap_t
 
   virtual std::string name()
   {
-    const char* fmt = uint8_t(which) == which ? "trap #%u" : "interrupt #%u";
-    sprintf(_name, fmt, uint8_t(which));
-    return _name;
+    const uint8_t code = uint8_t(which);
+    const bool is_interrupt = code != which;
+    return (is_interrupt ? "interrupt #" : "trap #") + std::to_string(code);
   }
 
   virtual ~trap_t() = default;
 
  private:
-  char _name[16];
   reg_t which;
 };
 

--- a/riscv/trap.h
+++ b/riscv/trap.h
@@ -5,6 +5,7 @@
 
 #include "decode.h"
 #include <cstdio>
+#include <string>
 
 struct state_t;
 
@@ -26,7 +27,7 @@ class trap_t
   virtual reg_t get_tinst() { return 0; }
   reg_t cause() { return which; }
 
-  virtual const char* name()
+  virtual std::string name()
   {
     const char* fmt = uint8_t(which) == which ? "trap #%u" : "interrupt #%u";
     sprintf(_name, fmt, uint8_t(which));
@@ -73,31 +74,31 @@ class mem_trap_t : public trap_t
 #define DECLARE_TRAP(n, x) class trap_##x : public trap_t { \
  public: \
   trap_##x() : trap_t(n) {} \
-  const char* name() { return "trap_"#x; } \
+  std::string name() { return "trap_"#x; } \
 };
 
 #define DECLARE_INST_TRAP(n, x) class trap_##x : public insn_trap_t { \
  public: \
   trap_##x(reg_t tval) : insn_trap_t(n, /*gva*/false, tval) {} \
-  const char* name() { return "trap_"#x; } \
+  std::string name() { return "trap_"#x; } \
 };
 
 #define DECLARE_INST_WITH_GVA_TRAP(n, x) class trap_##x : public insn_trap_t {  \
  public: \
   trap_##x(bool gva, reg_t tval) : insn_trap_t(n, gva, tval) {} \
-  const char* name() { return "trap_"#x; } \
+  std::string name() { return "trap_"#x; } \
 };
 
 #define DECLARE_MEM_TRAP(n, x) class trap_##x : public mem_trap_t { \
  public: \
   trap_##x(bool gva, reg_t tval, reg_t tval2, reg_t tinst) : mem_trap_t(n, gva, tval, tval2, tinst) {} \
-  const char* name() { return "trap_"#x; } \
+  std::string name() { return "trap_"#x; } \
 };
 
 #define DECLARE_MEM_GVA_TRAP(n, x) class trap_##x : public mem_trap_t { \
  public: \
   trap_##x(reg_t tval, reg_t tval2, reg_t tinst) : mem_trap_t(n, true, tval, tval2, tinst) {} \
-  const char* name() { return "trap_"#x; } \
+  std::string name() { return "trap_"#x; } \
 };
 
 DECLARE_MEM_TRAP(CAUSE_MISALIGNED_FETCH, instruction_address_misaligned)


### PR DESCRIPTION
clang 14 declares `sprintf` unsafe, which causes the build to fail.  We should just fall in line and avoid using `sprintf`.

None of our uses were perf-critical, so I switched over to using STL strings when appropriate.  In the cases that were harder to refactor, I switched to `snprintf`.