### PR TITLE
add an AMO operation to mcontrol trigger

### DIFF
--- a/riscv/mmu.h
+++ b/riscv/mmu.h
@@ -146,6 +146,7 @@ public:
       store_slow_path(addr, sizeof(T), nullptr, 0, false, true);
       auto lhs = load<T>(addr);
       store<T>(addr, f(lhs));
+      check_triggers(triggers::OPERATION_AMO, addr, f(lhs));
       return lhs;
     })
   }

--- a/riscv/mmu.h
+++ b/riscv/mmu.h
@@ -141,6 +141,7 @@ public:
   // template for functions that perform an atomic memory operation
   template<typename T, typename op>
   T amo(reg_t addr, op f) {
+    check_triggers(triggers::OPERATION_AMO, addr);
     convert_load_traps_to_store_traps({
       store_slow_path(addr, sizeof(T), nullptr, 0, false, true);
       auto lhs = load<T>(addr);

--- a/riscv/triggers.cc
+++ b/riscv/triggers.cc
@@ -120,6 +120,7 @@ std::optional<match_result_t> mcontrol_t::detect_memory_access_match(processor_t
   if ((operation == triggers::OPERATION_EXECUTE && !execute) ||
       (operation == triggers::OPERATION_STORE && !store) ||
       (operation == triggers::OPERATION_LOAD && !load) ||
+      (operation == triggers::OPERATION_AMO && (!store && !load)) ||
       (state->prv == PRV_M && !m) ||
       (state->prv == PRV_S && !s) ||
       (state->prv == PRV_U && !u) ||

--- a/riscv/triggers.h
+++ b/riscv/triggers.h
@@ -12,6 +12,7 @@ typedef enum {
   OPERATION_EXECUTE,
   OPERATION_STORE,
   OPERATION_LOAD,
+  OPERATION_AMO // both LOAD and STORE
 } operation_t;
 
 typedef enum


### PR DESCRIPTION
This commit fixes the following two issues for address trigger on AMO:
1. The address trigger has a higher priority than the misaligned fault and page fault. 
    [riscv-software-src/riscv-isa-sim/issues/971] 
    [riscv-software-src/riscv-isa-sim/pull/1105]
2. AMO can fire on a chain with a load-only trigger and a store-only trigger. 
    [riscv/riscv-debug-spec/issues/780]

This commit does NOT fix the priority for data trigger on AMO.

The fix lies on the critical path of AMO. Is this OK?