### PR TITLE
Fix segfault with non-contiguous hartid

### DIFF
--- a/riscv/sim.cc
+++ b/riscv/sim.cc
@@ -449,5 +449,12 @@ memif_endianness_t sim_t::get_target_endianness() const
 
 void sim_t::proc_reset(unsigned id)
 {
-  debug_module.proc_reset(id);
+  int i;
+  for (int j = 0; j < cfg->nprocs(); j++)
+  {
+    if(cfg->hartids()[j] == id)
+	  i = j;
+  }
+// Each proccessor only knows and could provide it's hartid,so simulator looks up which proc it is and pass it to debug module
+  debug_module.proc_reset(i);
 }


### PR DESCRIPTION
when using --hartid with non-continuous hartids ,spike returns segmentation fault,and finds out that debug module confused hartids with "i" in "procs[i]". when processor resets itself, it won't know which proc it is defined by simulator, it only know it's hartid. therefore adding a logic in sim.cc to lookup "i" according to hartid will fix this bug.