### PR TITLE
[RFC] make XLENs changable

### DIFF
--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -387,11 +387,10 @@ cause_csr_t::cause_csr_t(processor_t* const proc, const reg_t addr, priv_mode_t 
 
 reg_t cause_csr_t::read() const noexcept {
   reg_t val = basic_csr_t::read();
-  // When reading, the interrupt bit needs to adjust to xlen. Spike does
-  // not generally support dynamic xlen, but this code was (partly)
-  // there since at least 2015 (ea58df8 and c4350ef).
-  if (proc->get_isa().get_max_xlen() > proc->get_xlen()) // Move interrupt bit to top of xlen
-    return val | ((val >> (proc->get_isa().get_max_xlen()-1)) << (proc->get_xlen()-1));
+
+  unsigned xlen = proc->get_xlen(prv);
+  if (proc->get_isa().get_max_xlen() > xlen) // Move interrupt bit to top of xlen
+    return val | ((val >> (proc->get_isa().get_max_xlen() - 1)) << (xlen - 1));
   return val;
 }
 

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -872,8 +872,9 @@ henvcfg_csr_t::henvcfg_csr_t(processor_t* const proc, const reg_t addr, const re
 }
 
 // implement class base_atp_csr_t and family
-base_atp_csr_t::base_atp_csr_t(processor_t* const proc, const reg_t addr):
-  basic_csr_t(proc, addr, 0) {
+base_atp_csr_t::base_atp_csr_t(processor_t* const proc, const reg_t addr, priv_mode_t prv):
+  basic_csr_t(proc, addr, 0),
+  prv(prv) {
 }
 
 bool base_atp_csr_t::unlogged_write(const reg_t val) noexcept {
@@ -884,7 +885,7 @@ bool base_atp_csr_t::unlogged_write(const reg_t val) noexcept {
 }
 
 bool base_atp_csr_t::satp_valid(reg_t val) const noexcept {
-  if (proc->get_xlen() == 32) {
+  if (proc->get_xlen(prv) == 32) {
     switch (get_field(val, SATP32_MODE)) {
       case SATP_MODE_SV32: return proc->supports_impl(IMPL_MMU_SV32);
       case SATP_MODE_OFF: return true;
@@ -915,7 +916,7 @@ reg_t base_atp_csr_t::compute_new_satp(reg_t val) const noexcept {
 }
 
 satp_csr_t::satp_csr_t(processor_t* const proc, const reg_t addr):
-  base_atp_csr_t(proc, addr) {
+  base_atp_csr_t(proc, addr, (priv_mode_t){ PRV_S, false }) {
 }
 
 void satp_csr_t::verify_permissions(insn_t insn, bool write) const {

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -905,10 +905,11 @@ bool base_atp_csr_t::satp_valid(reg_t val) const noexcept {
 reg_t base_atp_csr_t::compute_new_satp(reg_t val) const noexcept {
   reg_t rv64_ppn_mask = (reg_t(1) << (MAX_PADDR_BITS - PGSHIFT)) - 1;
 
-  reg_t mode_mask = proc->get_xlen() == 32 ? SATP32_MODE : SATP64_MODE;
-  reg_t asid_mask_if_enabled = proc->get_xlen() == 32 ? SATP32_ASID : SATP64_ASID;
+  reg_t xlen = proc->get_xlen(prv);
+  reg_t mode_mask = xlen == 32 ? SATP32_MODE : SATP64_MODE;
+  reg_t asid_mask_if_enabled = xlen == 32 ? SATP32_ASID : SATP64_ASID;
   reg_t asid_mask = proc->supports_impl(IMPL_MMU_ASID) ? asid_mask_if_enabled : 0;
-  reg_t ppn_mask = proc->get_xlen() == 32 ? SATP32_PPN : SATP64_PPN & rv64_ppn_mask;
+  reg_t ppn_mask = xlen == 32 ? SATP32_PPN : SATP64_PPN & rv64_ppn_mask;
   reg_t new_mask = (satp_valid(val) ? mode_mask : 0) | asid_mask | ppn_mask;
   reg_t old_mask = satp_valid(val) ? 0 : mode_mask;
 
@@ -1102,7 +1103,7 @@ bool hgatp_csr_t::unlogged_write(const reg_t val) noexcept {
   proc->get_mmu()->flush_tlb();
 
   reg_t mask;
-  if (proc->get_const_xlen() == 32) {
+  if (proc->get_xlen((priv_mode_t){ PRV_S, false }) == 32) {
     mask = HGATP32_PPN |
         HGATP32_MODE |
         (proc->supports_impl(IMPL_MMU_VMID) ? HGATP32_VMID : 0);

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -634,6 +634,7 @@ bool misa_csr_t::unlogged_write(const reg_t val) noexcept {
   const bool prev_h = old_misa & (1L << ('H' - 'A'));
   const reg_t new_misa = (adjusted_val & write_mask) | (old_misa & ~write_mask);
   const bool new_h = new_misa & (1L << ('H' - 'A'));
+  unsigned mxlen = proc->get_xlen((priv_mode_t){ PRV_M, false });
 
   // update the hypervisor-only bits in MEDELEG and other CSRs
   if (!new_h && prev_h) {
@@ -647,7 +648,7 @@ bool misa_csr_t::unlogged_write(const reg_t val) noexcept {
     state->medeleg->write(state->medeleg->read() & ~hypervisor_exceptions);
     const reg_t new_mstatus = state->mstatus->read() & ~(MSTATUS_GVA | MSTATUS_MPV);
     state->mstatus->write(new_mstatus);
-    if (state->mstatush) state->mstatush->write(new_mstatus >> 32);  // log mstatush change
+    if (mxlen == 32) state->mstatush->write(new_mstatus >> 32);  // log mstatush change
     state->mie->write_with_mask(MIP_HS_MASK, 0);  // also takes care of hie, sie
     state->mip->write_with_mask(MIP_HS_MASK, 0);  // also takes care of hip, sip, hvip
     state->hstatus->write(0);

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -1073,6 +1073,18 @@ bool mevent_csr_t::unlogged_write(const reg_t val) noexcept {
   return basic_csr_t::unlogged_write((read() & ~mask) | (val & mask));
 }
 
+rv32_counter_proxy_csr_t::rv32_counter_proxy_csr_t(processor_t* const proc, const reg_t addr, csr_t_p delegate,
+                                                   priv_mode_t prv):
+  counter_proxy_csr_t(proc, addr, delegate),
+  prv(prv) {
+}
+
+void rv32_counter_proxy_csr_t::verify_permissions(insn_t insn, bool write) const {
+  if (proc->get_xlen(prv) != 32)
+    throw trap_virtual_instruction(insn.bits());
+  counter_proxy_csr_t::verify_permissions(insn, write);
+}
+
 hypervisor_csr_t::hypervisor_csr_t(processor_t* const proc, const reg_t addr):
   basic_csr_t(proc, addr, 0) {
 }

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -1600,3 +1600,24 @@ void jvt_csr_t::verify_permissions(insn_t insn, bool write) const {
     }
   }
 }
+
+// implement class hstatus_csr_t
+hstatus_csr_t::hstatus_csr_t(processor_t* const proc, const reg_t addr, const reg_t mask, const reg_t init):
+  masked_csr_t(proc, addr, mask, init) {
+}
+
+bool hstatus_csr_t::unlogged_write(const reg_t val) noexcept {
+  reg_t newval = val ;
+  if (proc->get_xlen((priv_mode_t){ PRV_S, false }) != 32) {
+    int new_vsxl = get_field(val, HSTATUS_VSXL);
+    if (is_legal_xl(new_vsxl))
+      proc->update_vsxlen(xl_to_xlen(new_vsxl));
+  }
+  return masked_csr_t::unlogged_write(newval);
+}
+
+reg_t hstatus_csr_t::read() const noexcept {
+  unsigned vsxlen = proc->get_xlen((priv_mode_t){ PRV_S, true } );
+
+  return set_field(masked_csr_t::read(), HSTATUS_VSXL, xlen_to_xl(vsxlen));
+}

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -380,8 +380,9 @@ bool tvec_csr_t::unlogged_write(const reg_t val) noexcept {
 }
 
 // implement class cause_csr_t
-cause_csr_t::cause_csr_t(processor_t* const proc, const reg_t addr):
-  basic_csr_t(proc, addr, 0) {
+cause_csr_t::cause_csr_t(processor_t* const proc, const reg_t addr, priv_mode_t prv):
+  basic_csr_t(proc, addr, 0),
+  prv(prv) {
 }
 
 reg_t cause_csr_t::read() const noexcept {

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -543,9 +543,10 @@ reg_t rv32_low_csr_t::written_value() const noexcept {
 }
 
 // implement class rv32_high_csr_t
-rv32_high_csr_t::rv32_high_csr_t(processor_t* const proc, const reg_t addr, csr_t_p orig):
+rv32_high_csr_t::rv32_high_csr_t(processor_t* const proc, const reg_t addr, csr_t_p orig, priv_mode_t prv):
   csr_t(proc, addr),
-  orig(orig) {
+  orig(orig),
+  prv(prv) {
 }
 
 reg_t rv32_high_csr_t::read() const noexcept {
@@ -553,6 +554,8 @@ reg_t rv32_high_csr_t::read() const noexcept {
 }
 
 void rv32_high_csr_t::verify_permissions(insn_t insn, bool write) const {
+  if (proc->get_xlen(prv) != 32)
+    throw trap_illegal_instruction(insn.bits());
   orig->verify_permissions(insn, write);
 }
 

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -225,6 +225,9 @@ void pmpcfg_csr_t::verify_permissions(insn_t insn, bool write) const {
   // n_pmp can change after reset() is run.
   if (proc->n_pmp == 0)
     throw trap_illegal_instruction(insn.bits());
+
+  if ((address & 1) && proc->get_xlen((priv_mode_t){ PRV_M, false }) != 32)
+    throw trap_illegal_instruction(insn.bits());
 }
 
 reg_t pmpcfg_csr_t::read() const noexcept {

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -577,6 +577,14 @@ class mevent_csr_t: public basic_csr_t {
   virtual bool unlogged_write(const reg_t val) noexcept override;
 };
 
+class rv32_counter_proxy_csr_t: public counter_proxy_csr_t {
+ public:
+  rv32_counter_proxy_csr_t(processor_t* const proc, const reg_t addr, csr_t_p delegate, priv_mode_t prv);
+  virtual void verify_permissions(insn_t insn, bool write) const override;
+ private:
+  priv_mode_t prv;
+};
+
 // For machine-level CSRs that only exist with Hypervisor
 class hypervisor_csr_t: public basic_csr_t {
  public:

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -200,9 +200,11 @@ class tvec_csr_t: public csr_t {
 // For mcause, scause, and vscause
 class cause_csr_t: public basic_csr_t {
  public:
-  cause_csr_t(processor_t* const proc, const reg_t addr);
+  cause_csr_t(processor_t* const proc, const reg_t addr, priv_mode_t prv);
 
   virtual reg_t read() const noexcept override;
+ private:
+  priv_mode_t prv;
 };
 
 // For *status family of CSRs

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -478,12 +478,13 @@ class henvcfg_csr_t final: public masked_csr_t {
 // These are three classes in order to handle the [V]TVM bits permission checks
 class base_atp_csr_t: public basic_csr_t {
  public:
-  base_atp_csr_t(processor_t* const proc, const reg_t addr);
+  base_atp_csr_t(processor_t* const proc, const reg_t addr, priv_mode_t prv);
   bool satp_valid(reg_t val) const noexcept;
  protected:
   virtual bool unlogged_write(const reg_t val) noexcept override;
  private:
   reg_t compute_new_satp(reg_t val) const noexcept;
+  priv_mode_t prv;
 };
 
 class satp_csr_t: public base_atp_csr_t {

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -213,18 +213,16 @@ class base_status_csr_t: public csr_t {
  public:
   base_status_csr_t(processor_t* const proc, const reg_t addr);
 
-  bool field_exists(const reg_t which) {
-    return (sstatus_write_mask & which) != 0;
-  }
+  bool field_exists(const reg_t which);
 
  protected:
-  reg_t adjust_sd(const reg_t val) const noexcept;
+  reg_t adjust_sd(const reg_t val, const unsigned xlen) const noexcept;
   void maybe_flush_tlb(const reg_t newval) noexcept;
   const bool has_page;
-  const reg_t sstatus_write_mask;
-  const reg_t sstatus_read_mask;
+  const reg_t sstatus_const_write_mask;
+  const reg_t sstatus_const_read_mask;
  private:
-  reg_t compute_sstatus_write_mask() const noexcept;
+  reg_t compute_const_sstatus_write_mask() const noexcept;
 };
 
 typedef std::shared_ptr<base_status_csr_t> base_status_csr_t_p;
@@ -235,9 +233,7 @@ class vsstatus_csr_t final: public base_status_csr_t {
  public:
   vsstatus_csr_t(processor_t* const proc, const reg_t addr);
 
-  reg_t read() const noexcept override {
-    return val;
-  }
+  reg_t read() const noexcept override;
 
  protected:
   virtual bool unlogged_write(const reg_t val) noexcept override;
@@ -311,9 +307,7 @@ class sstatus_proxy_csr_t final: public base_status_csr_t {
  public:
   sstatus_proxy_csr_t(processor_t* const proc, const reg_t addr, mstatus_csr_t_p mstatus);
 
-  reg_t read() const noexcept override {
-    return mstatus->read() & sstatus_read_mask;
-  }
+  reg_t read() const noexcept override;
 
  protected:
   virtual bool unlogged_write(const reg_t val) noexcept override;

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -279,7 +279,7 @@ class rv32_low_csr_t: public csr_t {
 
 class rv32_high_csr_t: public csr_t {
  public:
-  rv32_high_csr_t(processor_t* const proc, const reg_t addr, csr_t_p orig);
+  rv32_high_csr_t(processor_t* const proc, const reg_t addr, csr_t_p orig, priv_mode_t prv);
   virtual reg_t read() const noexcept override;
   virtual void verify_permissions(insn_t insn, bool write) const override;
  protected:
@@ -287,6 +287,7 @@ class rv32_high_csr_t: public csr_t {
   virtual reg_t written_value() const noexcept override;
  private:
   csr_t_p orig;
+  priv_mode_t prv;
 };
 
 class sstatus_proxy_csr_t final: public base_status_csr_t {

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -247,9 +247,7 @@ class mstatus_csr_t final: public base_status_csr_t {
  public:
   mstatus_csr_t(processor_t* const proc, const reg_t addr);
 
-  reg_t read() const noexcept override {
-    return val;
-  }
+  reg_t read() const noexcept override;
 
  protected:
   virtual bool unlogged_write(const reg_t val) noexcept override;

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -15,6 +15,11 @@
 class processor_t;
 struct state_t;
 
+struct priv_mode_t {
+  reg_t priv;
+  bool virt;
+};
+
 // Parent, abstract class for all CSRs
 class csr_t {
  public:

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -807,4 +807,14 @@ class jvt_csr_t: public basic_csr_t {
   jvt_csr_t(processor_t* const proc, const reg_t addr, const reg_t init);
   virtual void verify_permissions(insn_t insn, bool write) const override;
 };
+
+class hstatus_csr_t: public masked_csr_t {
+ public:
+  hstatus_csr_t(processor_t* const proc, const reg_t addr, const reg_t mask, const reg_t init);
+  virtual reg_t read() const noexcept override;
+ protected:
+  virtual bool unlogged_write(const reg_t val) noexcept override;
+};
+
+typedef std::shared_ptr<hstatus_csr_t> hstatus_csr_t_p;
 #endif

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -64,6 +64,7 @@ class csr_t {
   // For access to written_value() and unlogged_write():
   friend class rv32_high_csr_t;
   friend class rv32_low_csr_t;
+  friend class rv64_rv32_low_csr_t;
 };
 
 typedef std::shared_ptr<csr_t> csr_t_p;
@@ -287,6 +288,22 @@ class rv32_high_csr_t: public csr_t {
   virtual reg_t written_value() const noexcept override;
  private:
   csr_t_p orig;
+  priv_mode_t prv;
+};
+
+class rv64_rv32_low_csr_t: public csr_t {
+ public:
+  rv64_rv32_low_csr_t(processor_t* const proc, const reg_t addr, csr_t_p orig, priv_mode_t prv);
+
+  virtual reg_t read() const noexcept override;
+  virtual void verify_permissions(insn_t insn, bool write) const override;
+
+ protected:
+  virtual bool unlogged_write(const reg_t val) noexcept override;
+
+ private:
+  csr_t_p orig;
+  csr_t_p low_half;
   priv_mode_t prv;
 };
 

--- a/riscv/mmu.cc
+++ b/riscv/mmu.cc
@@ -367,7 +367,7 @@ reg_t mmu_t::s2xlate(reg_t gva, reg_t gpa, access_type type, access_type trap_ty
   if (!virt)
     return gpa;
 
-  vm_info vm = decode_vm_info(proc->get_const_xlen(), true, 0, proc->get_state()->hgatp->read());
+  vm_info vm = decode_vm_info(proc->get_xlen((priv_mode_t){ PRV_S, true }), true, 0, proc->get_state()->hgatp->read());
   if (vm.levels == 0)
     return gpa;
 
@@ -451,7 +451,7 @@ reg_t mmu_t::walk(reg_t addr, access_type type, reg_t mode, bool virt, bool hlvx
 {
   reg_t page_mask = (reg_t(1) << PGSHIFT) - 1;
   reg_t satp = proc->get_state()->satp->readvirt(virt);
-  vm_info vm = decode_vm_info(proc->get_const_xlen(), false, mode, satp);
+  vm_info vm = decode_vm_info(proc->get_xlen((priv_mode_t){ PRV_S, virt }), false, mode, satp);
   if (vm.levels == 0)
     return s2xlate(addr, addr & ((reg_t(2) << (proc->xlen-1))-1), type, type, virt, hlvx) & ~page_mask; // zero-extend from xlen
 

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -406,7 +406,7 @@ void state_t::reset(processor_t* const proc, reg_t max_isa)
   for (int i = 0; i < max_pmp; ++i) {
     csrmap[CSR_PMPADDR0 + i] = pmpaddr[i] = std::make_shared<pmpaddr_csr_t>(proc, CSR_PMPADDR0 + i);
   }
-  for (int i = 0; i < max_pmp; i += xlen / 8) {
+  for (int i = 0; i < max_pmp; i += 4) {
     reg_t addr = CSR_PMPCFG0 + i / 4;
     csrmap[addr] = std::make_shared<pmpcfg_csr_t>(proc, addr);
   }

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -224,9 +224,9 @@ void state_t::reset(processor_t* const proc, reg_t max_isa)
     csrmap[CSR_MCYCLEH] = mcycleh = std::make_shared<rv32_high_csr_t>(proc, CSR_MCYCLEH, mcycle, (priv_mode_t){ PRV_M, false });
     if (proc->extension_enabled_const(EXT_ZICNTR)) {
       auto timeh = std::make_shared<rv32_high_csr_t>(proc, CSR_TIMEH, time, (priv_mode_t){ PRV_U, false });
-      csrmap[CSR_INSTRETH] = std::make_shared<counter_proxy_csr_t>(proc, CSR_INSTRETH, minstreth);
-      csrmap[CSR_CYCLEH] = std::make_shared<counter_proxy_csr_t>(proc, CSR_CYCLEH, mcycleh);
-      csrmap[CSR_TIMEH] = std::make_shared<counter_proxy_csr_t>(proc, CSR_TIMEH, timeh);
+      csrmap[CSR_INSTRETH] = std::make_shared<rv32_counter_proxy_csr_t>(proc, CSR_INSTRETH, minstreth, (priv_mode_t){ PRV_U, false });
+      csrmap[CSR_CYCLEH] = std::make_shared<rv32_counter_proxy_csr_t>(proc, CSR_CYCLEH, mcycleh, (priv_mode_t){ PRV_U, false });
+      csrmap[CSR_TIMEH] = std::make_shared<rv32_counter_proxy_csr_t>(proc, CSR_TIMEH, timeh, (priv_mode_t){ PRV_U, false });
     }
   } else {
     csrmap[CSR_MINSTRET] = minstret;
@@ -252,7 +252,7 @@ void state_t::reset(processor_t* const proc, reg_t max_isa)
       auto mcounterh = std::make_shared<const_csr_t>(proc, which_mcounterh, 0);
       csrmap[which_mcounterh] = mcounterh;
       if (proc->extension_enabled_const(EXT_ZICNTR) && proc->extension_enabled_const(EXT_ZIHPM)) {
-        auto counterh = std::make_shared<counter_proxy_csr_t>(proc, which_counterh, mcounterh);
+        auto counterh = std::make_shared<rv32_counter_proxy_csr_t>(proc, which_counterh, mcounterh, (priv_mode_t){ PRV_U, false });
         csrmap[which_counterh] = counterh;
       }
       if (proc->extension_enabled_const(EXT_SSCOFPMF)) {

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -873,7 +873,7 @@ void processor_t::take_trap(trap_t& t, reg_t epc)
     s = set_field(s, MSTATUS_MPV, curr_virt);
     s = set_field(s, MSTATUS_GVA, t.has_gva());
     state.mstatus->write(s);
-    if (state.mstatush) state.mstatush->write(s >> 32);  // log mstatush change
+    if (mxlen == 32) state.mstatush->write(s >> 32);  // log mstatush change
     set_privilege(PRV_M);
   }
 }

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -1141,3 +1141,9 @@ void processor_t::trigger_updated(const std::vector<triggers::trigger_t *> &trig
     }
   }
 }
+
+void processor_t::update_vuxlen(unsigned val) {
+  if (val <= vsxlen)
+    vuxlen = val;
+}
+

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -795,7 +795,7 @@ void processor_t::take_trap(trap_t& t, reg_t epc)
     // Handle the trap in VS-mode
     reg_t vector = (state.vstvec->read() & 1) && interrupt ? 4 * bit : 0;
     state.pc = (state.vstvec->read() & ~(reg_t)1) + vector;
-    state.vscause->write((interrupt) ? (t.cause() - 1) : t.cause());
+    state.vscause->write(((interrupt) ? (bit - 1) : bit) | (interrupt << (vsxlen - 1)));
     state.vsepc->write(epc);
     state.vstval->write(t.get_tval());
 
@@ -810,7 +810,7 @@ void processor_t::take_trap(trap_t& t, reg_t epc)
     set_virt(false);
     reg_t vector = (state.stvec->read() & 1) && interrupt ? 4 * bit : 0;
     state.pc = (state.stvec->read() & ~(reg_t)1) + vector;
-    state.scause->write(t.cause());
+    state.scause->write(bit | (interrupt << (sxlen - 1)));
     state.sepc->write(epc);
     state.stval->write(t.get_tval());
     state.htval->write(t.get_tval2());
@@ -836,7 +836,7 @@ void processor_t::take_trap(trap_t& t, reg_t epc)
     reg_t vector = (state.mtvec->read() & 1) && interrupt ? 4 * bit : 0;
     state.pc = (state.mtvec->read() & ~(reg_t)1) + vector;
     state.mepc->write(epc);
-    state.mcause->write(t.cause());
+    state.mcause->write(bit | (interrupt << (mxlen - 1)));
     state.mtval->write(t.get_tval());
     state.mtval2->write(t.get_tval2());
     state.mtinst->write(t.get_tinst());

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -906,13 +906,6 @@ void processor_t::disasm(insn_t insn)
   }
 }
 
-int processor_t::paddr_bits()
-{
-  unsigned max_xlen = isa->get_max_xlen();
-  assert(xlen == max_xlen);
-  return max_xlen == 64 ? 50 : 34;
-}
-
 void processor_t::put_csr(int which, reg_t val)
 {
   val = zext_xlen(val);

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -1167,3 +1167,12 @@ void processor_t::update_vsxlen(unsigned val) {
   }
 }
 
+void processor_t::update_mxlen(unsigned val) {
+  if (val != mxlen) {
+    unsigned old_mxlen = mxlen;
+    mxlen = val;
+    if ((old_mxlen == 32) || (val == 32)) {
+      update_sxlen(val);
+    }
+  }
+}

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -1132,9 +1132,29 @@ void processor_t::trigger_updated(const std::vector<triggers::trigger_t *> &trig
   }
 }
 
+void processor_t::update_uxlen(unsigned val) {
+  if (val <= sxlen)
+    uxlen = val;
+}
+
 void processor_t::update_vuxlen(unsigned val) {
   if (val <= vsxlen)
     vuxlen = val;
+}
+
+void processor_t::update_sxlen(unsigned val) {
+  if (val <= mxlen && val != sxlen) {
+    unsigned old_sxlen = sxlen;
+    sxlen = val;
+    if (old_sxlen == 32 || val == 32) {  /* 32 to wider  or wider to 32 */
+
+      if (extension_enabled('H')) {
+        update_vsxlen(val);
+      }
+
+      update_uxlen(val);
+    }
+  }
 }
 
 void processor_t::update_vsxlen(unsigned val) {

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -207,7 +207,7 @@ void state_t::reset(processor_t* const proc, reg_t max_isa)
   csrmap[CSR_MTVAL] = mtval = std::make_shared<basic_csr_t>(proc, CSR_MTVAL, 0);
   csrmap[CSR_MSCRATCH] = std::make_shared<basic_csr_t>(proc, CSR_MSCRATCH, 0);
   csrmap[CSR_MTVEC] = mtvec = std::make_shared<tvec_csr_t>(proc, CSR_MTVEC);
-  csrmap[CSR_MCAUSE] = mcause = std::make_shared<cause_csr_t>(proc, CSR_MCAUSE);
+  csrmap[CSR_MCAUSE] = mcause = std::make_shared<cause_csr_t>(proc, CSR_MCAUSE, (priv_mode_t){ PRV_M, false });
   minstret = std::make_shared<wide_counter_csr_t>(proc, CSR_MINSTRET);
   mcycle = std::make_shared<wide_counter_csr_t>(proc, CSR_MCYCLE);
   time = std::make_shared<time_counter_csr_t>(proc, CSR_TIME);
@@ -340,8 +340,8 @@ void state_t::reset(processor_t* const proc, reg_t max_isa)
   auto nonvirtual_satp = std::make_shared<satp_csr_t>(proc, CSR_SATP);
   csrmap[CSR_VSATP] = vsatp = std::make_shared<base_atp_csr_t>(proc, CSR_VSATP);
   csrmap[CSR_SATP] = satp = std::make_shared<virtualized_satp_csr_t>(proc, nonvirtual_satp, vsatp);
-  auto nonvirtual_scause = std::make_shared<cause_csr_t>(proc, CSR_SCAUSE);
-  csrmap[CSR_VSCAUSE] = vscause = std::make_shared<cause_csr_t>(proc, CSR_VSCAUSE);
+  auto nonvirtual_scause = std::make_shared<cause_csr_t>(proc, CSR_SCAUSE, (priv_mode_t){ PRV_S, false });
+  csrmap[CSR_VSCAUSE] = vscause = std::make_shared<cause_csr_t>(proc, CSR_VSCAUSE, (priv_mode_t){ PRV_S, true });
   csrmap[CSR_SCAUSE] = scause = std::make_shared<virtualized_csr_t>(proc, nonvirtual_scause, vscause);
   csrmap[CSR_MTVAL2] = mtval2 = std::make_shared<hypervisor_csr_t>(proc, CSR_MTVAL2);
   csrmap[CSR_MTINST] = mtinst = std::make_shared<hypervisor_csr_t>(proc, CSR_MTINST);

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -338,7 +338,7 @@ void state_t::reset(processor_t* const proc, reg_t max_isa)
   csrmap[CSR_VSTVEC] = vstvec = std::make_shared<tvec_csr_t>(proc, CSR_VSTVEC);
   csrmap[CSR_STVEC] = stvec = std::make_shared<virtualized_csr_t>(proc, nonvirtual_stvec, vstvec);
   auto nonvirtual_satp = std::make_shared<satp_csr_t>(proc, CSR_SATP);
-  csrmap[CSR_VSATP] = vsatp = std::make_shared<base_atp_csr_t>(proc, CSR_VSATP);
+  csrmap[CSR_VSATP] = vsatp = std::make_shared<base_atp_csr_t>(proc, CSR_VSATP, (priv_mode_t){ PRV_S, true });
   csrmap[CSR_SATP] = satp = std::make_shared<virtualized_satp_csr_t>(proc, nonvirtual_satp, vsatp);
   auto nonvirtual_scause = std::make_shared<cause_csr_t>(proc, CSR_SCAUSE, (priv_mode_t){ PRV_S, false });
   csrmap[CSR_VSCAUSE] = vscause = std::make_shared<cause_csr_t>(proc, CSR_VSCAUSE, (priv_mode_t){ PRV_S, true });

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -199,7 +199,7 @@ void state_t::reset(processor_t* const proc, reg_t max_isa)
 
   if (xlen == 32) {
     csrmap[CSR_MSTATUS] = std::make_shared<rv32_low_csr_t>(proc, CSR_MSTATUS, mstatus);
-    csrmap[CSR_MSTATUSH] = mstatush = std::make_shared<rv32_high_csr_t>(proc, CSR_MSTATUSH, mstatus);
+    csrmap[CSR_MSTATUSH] = mstatush = std::make_shared<rv32_high_csr_t>(proc, CSR_MSTATUSH, mstatus, (priv_mode_t){ PRV_M, false });
   } else {
     csrmap[CSR_MSTATUS] = mstatus;
   }
@@ -219,11 +219,11 @@ void state_t::reset(processor_t* const proc, reg_t max_isa)
   if (xlen == 32) {
     csr_t_p minstreth, mcycleh;
     csrmap[CSR_MINSTRET] = std::make_shared<rv32_low_csr_t>(proc, CSR_MINSTRET, minstret);
-    csrmap[CSR_MINSTRETH] = minstreth = std::make_shared<rv32_high_csr_t>(proc, CSR_MINSTRETH, minstret);
+    csrmap[CSR_MINSTRETH] = minstreth = std::make_shared<rv32_high_csr_t>(proc, CSR_MINSTRETH, minstret, (priv_mode_t){ PRV_M, false });
     csrmap[CSR_MCYCLE] = std::make_shared<rv32_low_csr_t>(proc, CSR_MCYCLE, mcycle);
-    csrmap[CSR_MCYCLEH] = mcycleh = std::make_shared<rv32_high_csr_t>(proc, CSR_MCYCLEH, mcycle);
+    csrmap[CSR_MCYCLEH] = mcycleh = std::make_shared<rv32_high_csr_t>(proc, CSR_MCYCLEH, mcycle, (priv_mode_t){ PRV_M, false });
     if (proc->extension_enabled_const(EXT_ZICNTR)) {
-      auto timeh = std::make_shared<rv32_high_csr_t>(proc, CSR_TIMEH, time);
+      auto timeh = std::make_shared<rv32_high_csr_t>(proc, CSR_TIMEH, time, (priv_mode_t){ PRV_U, false });
       csrmap[CSR_INSTRETH] = std::make_shared<counter_proxy_csr_t>(proc, CSR_INSTRETH, minstreth);
       csrmap[CSR_CYCLEH] = std::make_shared<counter_proxy_csr_t>(proc, CSR_CYCLEH, mcycleh);
       csrmap[CSR_TIMEH] = std::make_shared<counter_proxy_csr_t>(proc, CSR_TIMEH, timeh);
@@ -256,7 +256,7 @@ void state_t::reset(processor_t* const proc, reg_t max_isa)
         csrmap[which_counterh] = counterh;
       }
       if (proc->extension_enabled_const(EXT_SSCOFPMF)) {
-        auto meventh = std::make_shared<rv32_high_csr_t>(proc, which_meventh, mevent[i - 3]);
+        auto meventh = std::make_shared<rv32_high_csr_t>(proc, which_meventh, mevent[i - 3], (priv_mode_t){ PRV_M, false });
         csrmap[which_meventh] = meventh;
       }
     } else {
@@ -371,7 +371,7 @@ void state_t::reset(processor_t* const proc, reg_t max_isa)
   htimedelta = std::make_shared<basic_csr_t>(proc, CSR_HTIMEDELTA, 0);
   if (xlen == 32) {
     csrmap[CSR_HTIMEDELTA] = std::make_shared<rv32_low_csr_t>(proc, CSR_HTIMEDELTA, htimedelta);
-    csrmap[CSR_HTIMEDELTAH] = std::make_shared<rv32_high_csr_t>(proc, CSR_HTIMEDELTAH, htimedelta);
+    csrmap[CSR_HTIMEDELTAH] = std::make_shared<rv32_high_csr_t>(proc, CSR_HTIMEDELTAH, htimedelta, (priv_mode_t){ PRV_S, false });
   } else {
     csrmap[CSR_HTIMEDELTA] = htimedelta;
   }
@@ -432,7 +432,7 @@ void state_t::reset(processor_t* const proc, reg_t max_isa)
     menvcfg = std::make_shared<masked_csr_t>(proc, CSR_MENVCFG, menvcfg_mask, menvcfg_init);
     if (xlen == 32) {
       csrmap[CSR_MENVCFG] = std::make_shared<rv32_low_csr_t>(proc, CSR_MENVCFG, menvcfg);
-      csrmap[CSR_MENVCFGH] = std::make_shared<rv32_high_csr_t>(proc, CSR_MENVCFGH, menvcfg);
+      csrmap[CSR_MENVCFGH] = std::make_shared<rv32_high_csr_t>(proc, CSR_MENVCFGH, menvcfg, (priv_mode_t){ PRV_M, false });
     } else {
       csrmap[CSR_MENVCFG] = menvcfg;
     }
@@ -447,7 +447,7 @@ void state_t::reset(processor_t* const proc, reg_t max_isa)
     henvcfg = std::make_shared<henvcfg_csr_t>(proc, CSR_HENVCFG, henvcfg_mask, henvcfg_init, menvcfg);
     if (xlen == 32) {
       csrmap[CSR_HENVCFG] = std::make_shared<rv32_low_csr_t>(proc, CSR_HENVCFG, henvcfg);
-      csrmap[CSR_HENVCFGH] = std::make_shared<rv32_high_csr_t>(proc, CSR_HENVCFGH, henvcfg);
+      csrmap[CSR_HENVCFGH] = std::make_shared<rv32_high_csr_t>(proc, CSR_HENVCFGH, henvcfg, (priv_mode_t){ PRV_S, false });
     } else {
       csrmap[CSR_HENVCFG] = henvcfg;
     }
@@ -463,7 +463,7 @@ void state_t::reset(processor_t* const proc, reg_t max_isa)
       mstateen[i] = std::make_shared<masked_csr_t>(proc, CSR_MSTATEEN0 + i, mstateen_mask, 0);
       if (xlen == 32) {
         csrmap[CSR_MSTATEEN0 + i] = std::make_shared<rv32_low_csr_t>(proc, CSR_MSTATEEN0 + i, mstateen[i]);
-        csrmap[CSR_MSTATEEN0H + i] = std::make_shared<rv32_high_csr_t>(proc, CSR_MSTATEEN0H + i, mstateen[i]);
+        csrmap[CSR_MSTATEEN0H + i] = std::make_shared<rv32_high_csr_t>(proc, CSR_MSTATEEN0H + i, mstateen[i], (priv_mode_t){ PRV_M, false });
       } else {
         csrmap[CSR_MSTATEEN0 + i] = mstateen[i];
       }
@@ -472,7 +472,7 @@ void state_t::reset(processor_t* const proc, reg_t max_isa)
       hstateen[i] = std::make_shared<hstateen_csr_t>(proc, CSR_HSTATEEN0 + i, hstateen_mask, 0, i);
       if (xlen == 32) {
         csrmap[CSR_HSTATEEN0 + i] = std::make_shared<rv32_low_csr_t>(proc, CSR_HSTATEEN0 + i, hstateen[i]);
-        csrmap[CSR_HSTATEEN0H + i] = std::make_shared<rv32_high_csr_t>(proc, CSR_HSTATEEN0H + i, hstateen[i]);
+        csrmap[CSR_HSTATEEN0H + i] = std::make_shared<rv32_high_csr_t>(proc, CSR_HSTATEEN0H + i, hstateen[i], (priv_mode_t){ PRV_S, false });
       } else {
         csrmap[CSR_HSTATEEN0 + i] = hstateen[i];
       }
@@ -488,9 +488,9 @@ void state_t::reset(processor_t* const proc, reg_t max_isa)
     auto virtualized_stimecmp = std::make_shared<virtualized_stimecmp_csr_t>(proc, stimecmp, vstimecmp);
     if (xlen == 32) {
       csrmap[CSR_STIMECMP] = std::make_shared<rv32_low_csr_t>(proc, CSR_STIMECMP, virtualized_stimecmp);
-      csrmap[CSR_STIMECMPH] = std::make_shared<rv32_high_csr_t>(proc, CSR_STIMECMPH, virtualized_stimecmp);
+      csrmap[CSR_STIMECMPH] = std::make_shared<rv32_high_csr_t>(proc, CSR_STIMECMPH, virtualized_stimecmp, (priv_mode_t){ PRV_S, false });
       csrmap[CSR_VSTIMECMP] = std::make_shared<rv32_low_csr_t>(proc, CSR_VSTIMECMP, vstimecmp);
-      csrmap[CSR_VSTIMECMPH] = std::make_shared<rv32_high_csr_t>(proc, CSR_VSTIMECMPH, vstimecmp);
+      csrmap[CSR_VSTIMECMPH] = std::make_shared<rv32_high_csr_t>(proc, CSR_VSTIMECMPH, vstimecmp, (priv_mode_t){ PRV_S, true });
     } else {
       csrmap[CSR_STIMECMP] = virtualized_stimecmp;
       csrmap[CSR_VSTIMECMP] = vstimecmp;

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -200,12 +200,7 @@ public:
   mmu_t* get_mmu() { return mmu; }
   state_t* get_state() { return &state; }
   unsigned get_xlen() const { return xlen; }
-  unsigned get_const_xlen() const {
-    // Any code that assumes a const xlen should use this method to
-    // document that assumption. If Spike ever changes to allow
-    // variable xlen, this method should be removed.
-    return xlen;
-  }
+
   unsigned get_flen() const {
     return extension_enabled('Q') ? 128 :
            extension_enabled('D') ? 64 :
@@ -218,7 +213,9 @@ public:
   }
   unsigned get_csr_len(int csr_addr);
 
+  void update_sxlen(unsigned val);
   void update_vsxlen(unsigned val);
+  void update_uxlen(unsigned val);
   void update_vuxlen(unsigned val);
 
   extension_t* get_extension();

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -218,6 +218,8 @@ public:
   }
   unsigned get_csr_len(int csr_addr);
 
+  void update_vuxlen(unsigned val);
+
   extension_t* get_extension();
   extension_t* get_extension(const char* name);
   bool any_custom_extensions() const {

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -211,6 +211,12 @@ public:
            extension_enabled('D') ? 64 :
            extension_enabled('F') ? 32 : 0;
   }
+
+  unsigned get_xlen(const priv_mode_t prv) const;
+  unsigned get_max_xlen() const {
+    return isa->get_max_xlen();
+  }
+
   extension_t* get_extension();
   extension_t* get_extension(const char* name);
   bool any_custom_extensions() const {
@@ -289,6 +295,11 @@ private:
   state_t state;
   uint32_t id;
   unsigned xlen;
+  unsigned mxlen;
+  unsigned sxlen;
+  unsigned uxlen;
+  unsigned vsxlen;
+  unsigned vuxlen;
   bool histogram_enabled;
   bool log_commits_enabled;
   FILE *log_file;

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -321,7 +321,6 @@ private:
   void take_trap(trap_t& t, reg_t epc); // take an exception
   void take_trigger_action(triggers::action_t action, reg_t breakpoint_tval, reg_t epc);
   void disasm(insn_t insn); // disassemble and print an instruction
-  int paddr_bits();
 
   void enter_debug_mode(uint8_t cause);
 

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -213,6 +213,7 @@ public:
   }
   unsigned get_csr_len(int csr_addr);
 
+  void update_mxlen(unsigned val);
   void update_sxlen(unsigned val);
   void update_vsxlen(unsigned val);
   void update_uxlen(unsigned val);

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -108,7 +108,7 @@ struct state_t
 
   csr_t_p mtval2;
   csr_t_p mtinst;
-  csr_t_p hstatus;
+  hstatus_csr_t_p hstatus;
   csr_t_p hideleg;
   csr_t_p hedeleg;
   csr_t_p hcounteren;
@@ -218,6 +218,7 @@ public:
   }
   unsigned get_csr_len(int csr_addr);
 
+  void update_vsxlen(unsigned val);
   void update_vuxlen(unsigned val);
 
   extension_t* get_extension();

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -216,6 +216,7 @@ public:
   unsigned get_max_xlen() const {
     return isa->get_max_xlen();
   }
+  unsigned get_csr_len(int csr_addr);
 
   extension_t* get_extension();
   extension_t* get_extension(const char* name);

--- a/riscv/triggers.cc
+++ b/riscv/triggers.cc
@@ -71,7 +71,7 @@ bool trigger_t::mode_match(state_t * const state) const noexcept
 bool trigger_t::textra_match(processor_t * const proc) const noexcept
 {
   auto xlen = proc->get_xlen();
-  auto hsxlen = proc->get_xlen(); // use xlen since no hsxlen
+  auto hsxlen = proc->get_xlen((priv_mode_t){ PRV_S, false });
   state_t * const state = proc->get_state();
 
   assert(sselect <= SSELECT_MAXVAL);
@@ -239,7 +239,7 @@ mcontrol_common_t::match_t mcontrol_common_t::legalize_match(reg_t val) const no
 }
 
 reg_t mcontrol6_t::tdata1_read(const processor_t * const proc) const noexcept {
-  unsigned xlen = proc->get_const_xlen();
+  unsigned xlen = proc->get_xlen((priv_mode_t){ PRV_M, false });
   reg_t tdata1 = 0;
   tdata1 = set_field(tdata1, CSR_MCONTROL6_TYPE(xlen), 6);
   tdata1 = set_field(tdata1, CSR_MCONTROL6_DMODE(xlen), dmode);
@@ -261,7 +261,7 @@ reg_t mcontrol6_t::tdata1_read(const processor_t * const proc) const noexcept {
 }
 
 void mcontrol6_t::tdata1_write(processor_t * const proc, const reg_t val, const bool allow_chain) noexcept {
-  auto xlen = proc->get_const_xlen();
+  auto xlen = proc->get_xlen((priv_mode_t){ PRV_M, false });
   assert(get_field(val, CSR_MCONTROL6_TYPE(xlen)) == CSR_TDATA1_TYPE_MCONTROL6);
   dmode = get_field(val, CSR_MCONTROL6_DMODE(xlen));
   vs = get_field(val, CSR_MCONTROL6_VS);


### PR DESCRIPTION
This patchset add the support for changable XLENs:
- Instruction functions use different XLENs for different privilege modes
- Make *XL field of *status  CSRs writable
- The length of CSRs  is changed to the XLEN of its related privilege mode
- Limit the *XL to legal value(1 or 2 or unchanged)
- Ensure MXLEN >= SXLEN >=VSXLEN/VUXLEN/UXLEN, and VSXLEN >= VUXLEN

Tests for changable XLENs are lacked currently.