### PR TITLE
Fix Zc* support for writable misa

### DIFF
--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -628,6 +628,11 @@ bool misa_csr_t::unlogged_write(const reg_t val) noexcept {
   const reg_t new_misa = (adjusted_val & write_mask) | (old_misa & ~write_mask);
   const bool new_h = new_misa & (1L << ('H' - 'A'));
 
+  proc->set_extension_enable(EXT_ZCF, (new_misa & (1L << ('F' - 'A'))) &&
+                                      proc->extension_enabled(EXT_ZCA));
+  proc->set_extension_enable(EXT_ZCD, (new_misa & (1L << ('D' - 'A'))) &&
+                                      proc->extension_enabled(EXT_ZCA));
+
   // update the hypervisor-only bits in MEDELEG and other CSRs
   if (!new_h && prev_h) {
     reg_t hypervisor_exceptions = 0

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -601,12 +601,13 @@ bool sstatus_csr_t::enabled(const reg_t which) {
 misa_csr_t::misa_csr_t(processor_t* const proc, const reg_t addr, const reg_t max_isa):
   basic_csr_t(proc, addr, max_isa),
   max_isa(max_isa),
-  write_mask(max_isa & (0  // allow MAFDQHV bits in MISA to be modified
+  write_mask(max_isa & (0  // allow MAFDQCHV bits in MISA to be modified
                         | (1L << ('M' - 'A'))
                         | (1L << ('A' - 'A'))
                         | (1L << ('F' - 'A'))
                         | (1L << ('D' - 'A'))
                         | (1L << ('Q' - 'A'))
+                        | (1L << ('C' - 'A'))
                         | (1L << ('H' - 'A'))
                         | (1L << ('V' - 'A'))
                         )
@@ -618,6 +619,11 @@ reg_t misa_csr_t::dependency(const reg_t val, const char feature, const char dep
 }
 
 bool misa_csr_t::unlogged_write(const reg_t val) noexcept {
+  // the write is ignored if increasing IALIGN would misalign the PC
+  if (!(val & (1L << ('C' - 'A'))) && (state->pc & 2) &&
+      proc->extension_changeable(EXT_ZCA))
+    return false;
+
   reg_t adjusted_val = val;
   adjusted_val = dependency(adjusted_val, 'D', 'F');
   adjusted_val = dependency(adjusted_val, 'Q', 'D');
@@ -628,6 +634,7 @@ bool misa_csr_t::unlogged_write(const reg_t val) noexcept {
   const reg_t new_misa = (adjusted_val & write_mask) | (old_misa & ~write_mask);
   const bool new_h = new_misa & (1L << ('H' - 'A'));
 
+  proc->set_extension_enable(EXT_ZCA, (new_misa & (1L << ('C' - 'A'))));
   proc->set_extension_enable(EXT_ZCF, (new_misa & (1L << ('F' - 'A'))) &&
                                       proc->extension_enabled(EXT_ZCA));
   proc->set_extension_enable(EXT_ZCD, (new_misa & (1L << ('D' - 'A'))) &&

--- a/riscv/isa_parser.h
+++ b/riscv/isa_parser.h
@@ -91,6 +91,9 @@ public:
   bool extension_enabled(isa_extension_t ext) const {
     return extension_table[ext];
   }
+
+  std::bitset<NUM_ISA_EXTENSIONS> get_extension_table() const { return extension_table; }
+
   const std::unordered_map<std::string, extension_t*> &
   get_extensions() const { return extensions; }
 

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -35,7 +35,8 @@ processor_t::processor_t(const isa_parser_t *isa, const cfg_t *cfg,
   histogram_enabled(false), log_commits_enabled(false),
   log_file(log_file), sout_(sout_.rdbuf()), halt_on_reset(halt_on_reset),
   in_wfi(false), check_triggers_icount(false),
-  impl_table(256, false), last_pc(1), executions(1), TM(cfg->trigger_count)
+  impl_table(256, false), extension_enable_table(isa->get_extension_table()),
+  last_pc(1), executions(1), TM(cfg->trigger_count)
 {
   VU.p = this;
   TM.proc = this;

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -223,7 +223,7 @@ public:
     if (ext >= 'A' && ext <= 'Z')
       return state.misa->extension_enabled(ext);
     else
-      return isa->extension_enabled(ext);
+      return extension_enable_table[ext];
   }
   // Is this extension enabled? and abort if this extension can
   // possibly be disabled dynamically. Useful for documenting
@@ -303,6 +303,8 @@ private:
   bool in_wfi;
   bool check_triggers_icount;
   std::vector<bool> impl_table;
+
+  std::bitset<NUM_ISA_EXTENSIONS> extension_enable_table;
 
   std::vector<insn_desc_t> instructions;
   std::unordered_map<reg_t,uint64_t> pc_histogram;

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -218,7 +218,12 @@ public:
   }
   // Only the extensions supported in isa string can be changeable
   bool extension_changeable(unsigned char ext) const {
-    return isa->extension_enabled(ext) && (ext == EXT_ZCF || ext == EXT_ZCD);
+    return isa->extension_enabled(ext) &&
+           (ext == EXT_ZCF || ext == EXT_ZCD ||
+            (ext == EXT_ZCA && isa->extension_enabled('C') &&
+             !(isa->extension_enabled(EXT_ZCB) ||
+               isa->extension_enabled(EXT_ZCMP) ||
+               isa->extension_enabled(EXT_ZCMT))));
   }
   bool extension_enabled(unsigned char ext) const {
     return extension_enabled(isa_extension_t(ext));

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -216,15 +216,6 @@ public:
   bool any_custom_extensions() const {
     return !custom_extensions.empty();
   }
-  // Only the extensions supported in isa string can be changeable
-  bool extension_changeable(unsigned char ext) const {
-    return isa->extension_enabled(ext) &&
-           (ext == EXT_ZCF || ext == EXT_ZCD ||
-            (ext == EXT_ZCA && isa->extension_enabled('C') &&
-             !(isa->extension_enabled(EXT_ZCB) ||
-               isa->extension_enabled(EXT_ZCMP) ||
-               isa->extension_enabled(EXT_ZCMT))));
-  }
   bool extension_enabled(unsigned char ext) const {
     return extension_enabled(isa_extension_t(ext));
   }
@@ -244,14 +235,11 @@ public:
     if (ext >= 'A' && ext <= 'Z')
       return state.misa->extension_enabled_const(ext);
     else {
-      assert(!extension_changeable(ext));
       return isa->extension_enabled(ext);
     }
   }
-  // Only the changeable extensions can be disabled/enabled
   void set_extension_enable(unsigned char ext, bool enable) {
-    if (extension_changeable(ext))
-      extension_enable_table[ext] = enable;
+    extension_enable_table[ext] = enable && isa->extension_enabled(ext);
   }
   void set_impl(uint8_t impl, bool val) { impl_table[impl] = val; }
   bool supports_impl(uint8_t impl) const {

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -216,6 +216,10 @@ public:
   bool any_custom_extensions() const {
     return !custom_extensions.empty();
   }
+  // Only the extensions supported in isa string can be changeable
+  bool extension_changeable(unsigned char ext) const {
+    return isa->extension_enabled(ext) && (ext == EXT_ZCF || ext == EXT_ZCD);
+  }
   bool extension_enabled(unsigned char ext) const {
     return extension_enabled(isa_extension_t(ext));
   }
@@ -234,8 +238,15 @@ public:
   bool extension_enabled_const(isa_extension_t ext) const {
     if (ext >= 'A' && ext <= 'Z')
       return state.misa->extension_enabled_const(ext);
-    else
-      return isa->extension_enabled(ext);  // assume this can't change
+    else {
+      assert(!extension_changeable(ext));
+      return isa->extension_enabled(ext);
+    }
+  }
+  // Only the changeable extensions can be disabled/enabled
+  void set_extension_enable(unsigned char ext, bool enable) {
+    if (extension_changeable(ext))
+      extension_enable_table[ext] = enable;
   }
   void set_impl(uint8_t impl, bool val) { impl_table[impl] = val; }
   bool supports_impl(uint8_t impl) const {


### PR DESCRIPTION
Fix https://github.com/riscv-software-src/riscv-isa-sim/issues/1172
- Disable Zca/Zcf/Zcd when misa.C is cleared if Zcb/Zcmt/Zcmp is not supported
- Enable Zca/Zcf/Zcd when misa.C is enabled
- Make Zcf/Zcd only work when misa.F/D enabled