### PR TITLE
Pull mmu.h out of cfg.h

### DIFF
--- a/fesvr/dtm.cc
+++ b/fesvr/dtm.cc
@@ -44,9 +44,6 @@
 #define CLEAR 3
 #define CSRRx(type, dst, csr, src) (0x73 | ((type) << 12) | ((dst) << 7) | ((src) << 15) | (uint32_t)((csr) << 20))
 
-#define get_field(reg, mask) (((reg) & (mask)) / ((mask) & ~((mask) << 1)))
-#define set_field(reg, mask, val) (((reg) & ~(mask)) | (((val) * ((mask) & ~((mask) << 1))) & (mask)))
-
 #define RUN_AC_OR_DIE(a, b, c, d, e) { \
     uint32_t cmderr = run_abstract_command(a, b, c, d, e);      \
     if (cmderr) {                                               \

--- a/fesvr/elfloader.cc
+++ b/fesvr/elfloader.cc
@@ -98,7 +98,7 @@ std::map<std::string, uint64_t> load_elf(const char* fn, memif_t* memif, reg_t* 
   } while (0)
 
   if (IS_ELFLE(*eh64)) {
-    if (memif->get_target_endianness() != memif_endianness_little) {
+    if (memif->get_target_endianness() != endianness_little) {
       throw std::invalid_argument("Specified ELF is little endian, but system uses a big-endian memory system. Rerun without --big-endian");
     }
     if (IS_ELF32(*eh64))
@@ -109,7 +109,7 @@ std::map<std::string, uint64_t> load_elf(const char* fn, memif_t* memif, reg_t* 
 #ifndef RISCV_ENABLE_DUAL_ENDIAN
     throw std::invalid_argument("Specified ELF is big endian.  Configure with --enable-dual-endian to enable support");
 #else
-    if (memif->get_target_endianness() != memif_endianness_big) {
+    if (memif->get_target_endianness() != endianness_big) {
       throw std::invalid_argument("Specified ELF is big endian, but system uses a little-endian memory system. Rerun with --big-endian");
     }
     if (IS_ELF32(*eh64))

--- a/fesvr/htif.h
+++ b/fesvr/htif.h
@@ -31,18 +31,18 @@ class htif_t : public chunked_memif_t
 
   template<typename T> inline T from_target(target_endian<T> n) const
   {
-    memif_endianness_t endianness = get_target_endianness();
-    assert(endianness == memif_endianness_little || endianness == memif_endianness_big);
+    endianness_t endianness = get_target_endianness();
+    assert(endianness == endianness_little || endianness == endianness_big);
 
-    return endianness == memif_endianness_big? n.from_be() : n.from_le();
+    return endianness == endianness_big? n.from_be() : n.from_le();
   }
 
   template<typename T> inline target_endian<T> to_target(T n) const
   {
-    memif_endianness_t endianness = get_target_endianness();
-    assert(endianness == memif_endianness_little || endianness == memif_endianness_big);
+    endianness_t endianness = get_target_endianness();
+    assert(endianness == endianness_little || endianness == endianness_big);
 
-    return endianness == memif_endianness_big? target_endian<T>::to_be(n) : target_endian<T>::to_le(n);
+    return endianness == endianness_big? target_endian<T>::to_be(n) : target_endian<T>::to_le(n);
   }
 
  protected:

--- a/fesvr/memif.h
+++ b/fesvr/memif.h
@@ -7,15 +7,11 @@
 #include <stddef.h>
 #include <stdexcept>
 #include "byteorder.h"
+#include "cfg.h"
 
 typedef uint64_t reg_t;
 typedef int64_t sreg_t;
 typedef reg_t addr_t;
-
-typedef enum {
-  memif_endianness_little,
-  memif_endianness_big
-} memif_endianness_t;
 
 class chunked_memif_t
 {

--- a/fesvr/memif.h
+++ b/fesvr/memif.h
@@ -23,8 +23,8 @@ public:
   virtual size_t chunk_align() = 0;
   virtual size_t chunk_max_size() = 0;
 
-  virtual memif_endianness_t get_target_endianness() const {
-    return memif_endianness_little;
+  virtual endianness_t get_target_endianness() const {
+    return endianness_little;
   }
 
   virtual ~chunked_memif_t() = default;
@@ -65,7 +65,7 @@ public:
   virtual void write_int64(addr_t addr, target_endian<int64_t> val);
 
   // endianness
-  virtual memif_endianness_t get_target_endianness() const {
+  virtual endianness_t get_target_endianness() const {
     return cmemif->get_target_endianness();
   }
 

--- a/riscv/cfg.cc
+++ b/riscv/cfg.cc
@@ -1,0 +1,23 @@
+// See LICENSE for license details.
+
+#include "cfg.h"
+#include "mmu.h"
+#include "decode.h"
+
+mem_cfg_t::mem_cfg_t(reg_t base, reg_t size) : base(base), size(size)
+{
+  assert(mem_cfg_t::check_if_supported(base, size));
+}
+
+bool mem_cfg_t::check_if_supported(reg_t base, reg_t size)
+{
+  // The truth of these conditions should be ensured by whatever is creating
+  // the regions in the first place, but we have them here to make sure that
+  // we can't end up describing memory regions that don't make sense. They
+  // ask that the page size is a multiple of the minimum page size, that the
+  // page is aligned to the minimum page size, that the page is non-empty and
+  // that the top address is still representable in a reg_t.
+  return (size % PGSIZE == 0) &&
+         (base % PGSIZE == 0) &&
+         (base + size > base);
+}

--- a/riscv/cfg.h
+++ b/riscv/cfg.h
@@ -7,9 +7,9 @@
 #include <cassert>
 
 typedef enum {
-  memif_endianness_little,
-  memif_endianness_big
-} memif_endianness_t;
+  endianness_little,
+  endianness_big
+} endianness_t;
 
 template <typename T>
 class cfg_arg_t {
@@ -51,7 +51,7 @@ public:
         const char *default_bootargs,
         const char *default_isa, const char *default_priv,
         const char *default_varch,
-        const memif_endianness_t default_endianness,
+        const endianness_t default_endianness,
         const reg_t default_pmpregions,
         const std::vector<mem_cfg_t> &default_mem_layout,
         const std::vector<int> default_hartids,
@@ -74,7 +74,7 @@ public:
   cfg_arg_t<const char *>            isa;
   cfg_arg_t<const char *>            priv;
   cfg_arg_t<const char *>            varch;
-  memif_endianness_t                 endianness;
+  endianness_t                       endianness;
   reg_t                              pmpregions;
   cfg_arg_t<std::vector<mem_cfg_t>>  mem_layout;
   std::optional<reg_t>               start_pc;

--- a/riscv/cfg.h
+++ b/riscv/cfg.h
@@ -4,8 +4,12 @@
 
 #include <optional>
 #include "decode.h"
-#include "mmu.h"
 #include <cassert>
+
+typedef enum {
+  memif_endianness_little,
+  memif_endianness_big
+} memif_endianness_t;
 
 template <typename T>
 class cfg_arg_t {

--- a/riscv/cfg.h
+++ b/riscv/cfg.h
@@ -32,23 +32,9 @@ private:
 class mem_cfg_t
 {
 public:
-  static bool check_if_supported(reg_t base, reg_t size) {
-    // The truth of these conditions should be ensured by whatever is creating
-    // the regions in the first place, but we have them here to make sure that
-    // we can't end up describing memory regions that don't make sense. They
-    // ask that the page size is a multiple of the minimum page size, that the
-    // page is aligned to the minimum page size, that the page is non-empty and
-    // that the top address is still representable in a reg_t.
-    return (size % PGSIZE == 0) &&
-           (base % PGSIZE == 0) &&
-           (base + size > base);
-  }
+  static bool check_if_supported(reg_t base, reg_t size);
 
-  mem_cfg_t(reg_t base, reg_t size)
-    : base(base), size(size)
-  {
-    assert(mem_cfg_t::check_if_supported(base, size));
-  }
+  mem_cfg_t(reg_t base, reg_t size);
 
   reg_t base;
   reg_t size;

--- a/riscv/mmu.cc
+++ b/riscv/mmu.cc
@@ -5,10 +5,10 @@
 #include "simif.h"
 #include "processor.h"
 
-mmu_t::mmu_t(simif_t* sim, memif_endianness_t endianness, processor_t* proc)
+mmu_t::mmu_t(simif_t* sim, endianness_t endianness, processor_t* proc)
  : sim(sim), proc(proc),
 #ifdef RISCV_ENABLE_DUAL_ENDIAN
-  target_big_endian(endianness == memif_endianness_big),
+  target_big_endian(endianness == endianness_big),
 #endif
   check_triggers_fetch(false),
   check_triggers_load(false),
@@ -16,7 +16,7 @@ mmu_t::mmu_t(simif_t* sim, memif_endianness_t endianness, processor_t* proc)
   matched_trigger(NULL)
 {
 #ifndef RISCV_ENABLE_DUAL_ENDIAN
-  assert(endianness == memif_endianness_little);
+  assert(endianness == endianness_little);
 #endif
   flush_tlb();
   yield_load_reservation();

--- a/riscv/mmu.h
+++ b/riscv/mmu.h
@@ -47,7 +47,7 @@ private:
   std::map<reg_t, reg_t> alloc_cache;
   std::vector<std::pair<reg_t, reg_t >> addr_tbl;
 public:
-  mmu_t(simif_t* sim, memif_endianness_t endianness, processor_t* proc);
+  mmu_t(simif_t* sim, endianness_t endianness, processor_t* proc);
   ~mmu_t();
 
 #define RISCV_XLATE_VIRT      (1U << 0)

--- a/riscv/mmu.h
+++ b/riscv/mmu.h
@@ -12,6 +12,7 @@
 #include "memtracer.h"
 #include "byteorder.h"
 #include "triggers.h"
+#include "cfg.h"
 #include <stdlib.h>
 #include <vector>
 

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -30,7 +30,7 @@
 
 processor_t::processor_t(const isa_parser_t *isa, const char* varch,
                          simif_t* sim, uint32_t id, bool halt_on_reset,
-                         memif_endianness_t endianness,
+                         endianness_t endianness,
                          FILE* log_file, std::ostream& sout_)
   : debug(false), halt_request(HR_NONE), isa(isa), sim(sim), id(id), xlen(0),
   histogram_enabled(false), log_commits_enabled(false),

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -170,7 +170,7 @@ class processor_t : public abstract_device_t
 public:
   processor_t(const isa_parser_t *isa, const char* varch,
               simif_t* sim, uint32_t id, bool halt_on_reset,
-              memif_endianness_t endianness,
+              endianness_t endianness,
               FILE *log_file, std::ostream& sout_); // because of command line option --log and -s we need both
   ~processor_t();
 

--- a/riscv/riscv.mk.in
+++ b/riscv/riscv.mk.in
@@ -98,6 +98,7 @@ riscv_srcs = \
 	triggers.cc \
 	vector_unit.cc \
 	socketif.cc \
+	cfg.cc \
 	$(riscv_gen_srcs) \
 
 riscv_test_srcs =

--- a/riscv/sim.cc
+++ b/riscv/sim.cc
@@ -86,7 +86,7 @@ sim_t::sim_t(const cfg_t *cfg, bool halted,
 #endif
 
 #ifndef RISCV_ENABLE_DUAL_ENDIAN
-  if (cfg->endianness != memif_endianness_little) {
+  if (cfg->endianness != endianness_little) {
     fputs("Big-endian support has not been prroperly enabled; "
 	  "please rebuild the riscv-isa-sim project using "
 	  "\"configure --enable-dual-endian\".\n",
@@ -375,7 +375,7 @@ void sim_t::set_rom()
     (uint32_t) (start_pc & 0xffffffff),
     (uint32_t) (start_pc >> 32)
   };
-  if (get_target_endianness() == memif_endianness_big) {
+  if (get_target_endianness() == endianness_big) {
     int i;
     // Instuctions are little endian
     for (i = 0; reset_vec[i] != 0; i++)
@@ -445,9 +445,9 @@ void sim_t::write_chunk(addr_t taddr, size_t len, const void* src)
   debug_mmu->store<uint64_t>(taddr, debug_mmu->from_target(data));
 }
 
-memif_endianness_t sim_t::get_target_endianness() const
+endianness_t sim_t::get_target_endianness() const
 {
-  return debug_mmu->is_target_big_endian()? memif_endianness_big : memif_endianness_little;
+  return debug_mmu->is_target_big_endian()? endianness_big : endianness_little;
 }
 
 void sim_t::proc_reset(unsigned id)

--- a/riscv/sim.h
+++ b/riscv/sim.h
@@ -151,7 +151,7 @@ private:
   void write_chunk(addr_t taddr, size_t len, const void* src);
   size_t chunk_align() { return 8; }
   size_t chunk_max_size() { return 8; }
-  memif_endianness_t get_target_endianness() const;
+  endianness_t get_target_endianness() const;
 
 public:
   // Initialize this after procs, because in debug_module_t::reset() we

--- a/spike_main/spike-log-parser.cc
+++ b/spike_main/spike-log-parser.cc
@@ -28,7 +28,7 @@ int main(int UNUSED argc, char** argv)
   parser.parse(argv);
 
   isa_parser_t isa(isa_string, DEFAULT_PRIV);
-  processor_t p(&isa, DEFAULT_VARCH, 0, 0, false, memif_endianness_little, nullptr, cerr);
+  processor_t p(&isa, DEFAULT_VARCH, 0, 0, false, endianness_little, nullptr, cerr);
   if (extension) {
     p.register_extension(extension());
   }

--- a/spike_main/spike.cc
+++ b/spike_main/spike.cc
@@ -326,7 +326,7 @@ int main(int argc, char** argv)
             /*default_isa=*/DEFAULT_ISA,
             /*default_priv=*/DEFAULT_PRIV,
             /*default_varch=*/DEFAULT_VARCH,
-            /*default_endianness*/memif_endianness_little,
+            /*default_endianness*/endianness_little,
             /*default_pmpregions=*/16,
             /*default_mem_layout=*/parse_mem_layout("2048"),
             /*default_hartids=*/std::vector<int>(),
@@ -397,7 +397,7 @@ int main(int argc, char** argv)
   parser.option(0, "ic", 1, [&](const char* s){ic.reset(new icache_sim_t(s));});
   parser.option(0, "dc", 1, [&](const char* s){dc.reset(new dcache_sim_t(s));});
   parser.option(0, "l2", 1, [&](const char* s){l2.reset(cache_sim_t::construct(s, "L2$"));});
-  parser.option(0, "big-endian", 0, [&](const char UNUSED *s){cfg.endianness = memif_endianness_big;});
+  parser.option(0, "big-endian", 0, [&](const char UNUSED *s){cfg.endianness = endianness_big;});
   parser.option(0, "log-cache-miss", 0, [&](const char UNUSED *s){log_cache = true;});
   parser.option(0, "isa", 1, [&](const char* s){cfg.isa = s;});
   parser.option(0, "pmpregions", 1, [&](const char* s){cfg.pmpregions = atoul_safe(s);});


### PR DESCRIPTION
My reasoning is that `cfg.h` should not pull in headers defining simulator components, it should just contain definitions of config config-related classes. 

Now cfg.h contains endianness_t, cfg_arg_t, mem_cfg_t, and cfg_t