### PR TITLE
Fix build broken by #1170 and #1180

### DIFF
--- a/riscv/cfg.h
+++ b/riscv/cfg.h
@@ -3,6 +3,7 @@
 #define _RISCV_CFG_H
 
 #include <optional>
+#include <vector>
 #include "decode.h"
 #include <cassert>
 


### PR DESCRIPTION
It looks like #1170 and #1180 conflict, so they individually pass CI but collectively don't.  Trivially fix by #including vector.