### PR TITLE
Support using sim.h/processor.h as public interfaces

### DIFF
--- a/ci-tests/test-spike
+++ b/ci-tests/test-spike
@@ -20,3 +20,7 @@ cd run
 wget https://github.com/riscv-software-src/riscv-isa-sim/releases/download/dummy-tag-for-ci-storage/spike-ci.tar
 tar xf spike-ci.tar
 time ../install/bin/spike --isa=rv64gc pk hello | grep "Hello, world!  Pi is approximately 3.141588."
+
+# check that including sim.h in an external project works
+g++ -std=c++17 -I../install/include -L../install/lib $DIR/testlib.c -lriscv -o test-libriscv
+LD_LIBRARY_PATH=../install/lib ./test-libriscv | grep "Hello, world!  Pi is approximately 3.141588."

--- a/ci-tests/testlib.c
+++ b/ci-tests/testlib.c
@@ -1,0 +1,54 @@
+#include <riscv/sim.h>
+
+// Copied from spike main.
+// TODO: This should really be provided in libriscv
+static std::vector<std::pair<reg_t, mem_t*>> make_mems(const std::vector<mem_cfg_t> &layout)
+{
+  std::vector<std::pair<reg_t, mem_t*>> mems;
+  mems.reserve(layout.size());
+  for (const auto &cfg : layout) {
+    mems.push_back(std::make_pair(cfg.base, new mem_t(cfg.size)));
+  }
+  return mems;
+}
+
+int main()
+{
+  std::vector<mem_cfg_t> mem_cfg { mem_cfg_t(0x80000000, 0x10000000) };
+  std::vector<int> hartids = {0};
+  cfg_t cfg(std::make_pair(0, 0),
+	    nullptr,
+	    "rv64gcv",
+	    "MSU",
+	    "vlen:128,elen:64",
+	    endianness_little,
+	    16,
+	    mem_cfg,
+	    hartids,
+	    false);
+  std::vector<std::pair<reg_t, abstract_device_t*>> plugin_devices;
+  std::vector<std::string> htif_args {"pk", "hello"};
+  debug_module_config_t dm_config = {
+    .progbufsize = 2,
+    .max_sba_data_width = 0,
+    .require_authentication = false,
+    .abstract_rti = 0,
+    .support_hasel = true,
+    .support_abstract_csr_access = true,
+    .support_abstract_fpr_access = true,
+    .support_haltgroups = true,
+    .support_impebreak = true
+  };
+  std::vector<std::pair<reg_t, mem_t*>> mems = make_mems(cfg.mem_layout());
+  sim_t sim(&cfg, false,
+	    mems,
+	    plugin_devices,
+	    htif_args,
+	    dm_config,
+	    nullptr,
+	    true,
+	    nullptr,
+	    false,
+	    nullptr);
+  sim.run();
+}

--- a/fesvr/elfloader.cc
+++ b/fesvr/elfloader.cc
@@ -1,5 +1,6 @@
 // See LICENSE for license details.
 
+#include "config.h"
 #include "elf.h"
 #include "memif.h"
 #include "byteorder.h"

--- a/fesvr/htif.cc
+++ b/fesvr/htif.cc
@@ -1,5 +1,6 @@
 // See LICENSE for license details.
 
+#include "config.h"
 #include "htif.h"
 #include "rfb.h"
 #include "elfloader.h"

--- a/fesvr/memif.h
+++ b/fesvr/memif.h
@@ -7,7 +7,7 @@
 #include <stddef.h>
 #include <stdexcept>
 #include "byteorder.h"
-#include "cfg.h"
+#include "../riscv/cfg.h"
 
 typedef uint64_t reg_t;
 typedef int64_t sreg_t;

--- a/fesvr/syscall.cc
+++ b/fesvr/syscall.cc
@@ -1,5 +1,6 @@
 // See LICENSE for license details.
 
+#include "config.h"
 #include "syscall.h"
 #include "htif.h"
 #include "byteorder.h"

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -1,5 +1,6 @@
 // See LICENSE for license details.
 
+#include "config.h"
 // For std::any_of
 #include <algorithm>
 

--- a/riscv/debug_module.h
+++ b/riscv/debug_module.h
@@ -3,12 +3,13 @@
 #define _RISCV_DEBUG_MODULE_H
 
 #include <set>
+#include <vector>
 
 #include "abstract_device.h"
-#include "mmu.h"
 
 class sim_t;
 class bus_t;
+class processor_t;
 
 typedef struct {
   // Size of program_buffer in 32-bit words, as exposed to the rest of the

--- a/riscv/decode.h
+++ b/riscv/decode.h
@@ -7,7 +7,7 @@
 # error spike requires a two''s-complement c++ implementation
 #endif
 
-#include "softfloat_types.h"
+#include "../softfloat/softfloat_types.h"
 #include <algorithm>
 #include <cstdint>
 #include <string.h>

--- a/riscv/dts.cc
+++ b/riscv/dts.cc
@@ -1,5 +1,6 @@
 // See LICENSE for license details.
 
+#include "config.h"
 #include "dts.h"
 #include "libfdt.h"
 #include "platform.h"

--- a/riscv/entropy_source.h
+++ b/riscv/entropy_source.h
@@ -2,7 +2,6 @@
 #include <fstream>
 #include <iostream>
 
-#include "internals.h"
 #include "common.h"
 
 //

--- a/riscv/execute.cc
+++ b/riscv/execute.cc
@@ -1,5 +1,6 @@
 // See LICENSE for license details.
 
+#include "config.h"
 #include "processor.h"
 #include "mmu.h"
 #include "disasm.h"

--- a/riscv/mmu.cc
+++ b/riscv/mmu.cc
@@ -1,5 +1,6 @@
 // See LICENSE for license details.
 
+#include "config.h"
 #include "mmu.h"
 #include "arith.h"
 #include "simif.h"

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -16,7 +16,7 @@
 #include "csrs.h"
 #include "isa_parser.h"
 #include "triggers.h"
-#include "memif.h"
+#include "../fesvr/memif.h"
 #include "vector_unit.h"
 
 #define N_HPMCOUNTERS 29

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -3,7 +3,6 @@
 #define _RISCV_PROCESSOR_H
 
 #include "decode.h"
-#include "config.h"
 #include "trap.h"
 #include "abstract_device.h"
 #include <string>

--- a/riscv/riscv.mk.in
+++ b/riscv/riscv.mk.in
@@ -15,6 +15,7 @@ riscv_install_prog_srcs = \
 
 riscv_hdrs = \
 	abstract_device.h \
+	abstract_interrupt_controller.h \
 	common.h \
 	decode.h \
 	decode_macros.h \
@@ -48,6 +49,7 @@ riscv_hdrs = \
 
 riscv_install_hdrs = \
 	abstract_device.h \
+	abstract_interrupt_controller.h \
 	cachesim.h \
 	cfg.h \
 	common.h \

--- a/riscv/riscv.mk.in
+++ b/riscv/riscv.mk.in
@@ -70,7 +70,8 @@ riscv_install_hdrs = \
 	sim.h \
 	simif.h \
 	trap.h \
-	triggers.h
+	triggers.h \
+	vector_unit.h \
 
 riscv_precompiled_hdrs = \
 	insn_template.h \

--- a/riscv/riscv.mk.in
+++ b/riscv/riscv.mk.in
@@ -63,14 +63,12 @@ riscv_install_hdrs = \
 	memtracer.h \
 	mmio_plugin.h \
 	mmu.h \
-	p_ext_macros.h \
 	platform.h \
 	processor.h \
 	sim.h \
 	simif.h \
 	trap.h \
-	triggers.h \
-	v_ext_macros.h \
+	triggers.h
 
 riscv_precompiled_hdrs = \
 	insn_template.h \

--- a/riscv/sim.h
+++ b/riscv/sim.h
@@ -3,7 +3,6 @@
 #ifndef _RISCV_SIM_H
 #define _RISCV_SIM_H
 
-#include "config.h"
 #include "cfg.h"
 #include "debug_module.h"
 #include "devices.h"

--- a/spike_dasm/spike-dasm.cc
+++ b/spike_dasm/spike-dasm.cc
@@ -6,6 +6,7 @@
 // enclosed hexadecimal number, interpreted as a RISC-V
 // instruction.
 
+#include "config.h"
 #include "disasm.h"
 #include "extension.h"
 #include <iostream>

--- a/spike_main/spike-log-parser.cc
+++ b/spike_main/spike-log-parser.cc
@@ -5,6 +5,7 @@
 // in its inputs, then output the RISC-V instruction with the disassembly
 // enclosed hexadecimal number.
 
+#include "config.h"
 #include <iostream>
 #include <string>
 #include <cstdint>

--- a/spike_main/spike.cc
+++ b/spike_main/spike.cc
@@ -1,5 +1,6 @@
 // See LICENSE for license details.
 
+#include "config.h"
 #include "cfg.h"
 #include "sim.h"
 #include "mmu.h"


### PR DESCRIPTION
This is the final set of patches towards enabling usage of sim.h and processor.h as public interfaces. Resolves #1168.

The primary danger with this change is dropping `config.h` off the include list in a file which references one of those variables, as the bug might only appear when a specific feature is enabled or disabled. To avoid this, I first add `#include "config.h"` directly to any source file which references any variables in `config.h`

The rest of these patches fix the installed headers list, change to relative include paths, and finally remove the config.h dependencies out of processor.h and sim.h. A new test in the `test-spike` script is also added.