### PR TITLE
arith.h: remove redundant y1 = t; in mulhu(uint64_t, uint64_t)

### DIFF
--- a/riscv/arith.h
+++ b/riscv/arith.h
@@ -20,7 +20,6 @@ inline uint64_t mulhu(uint64_t a, uint64_t b)
   y2 = t >> 32;
 
   t = a0*b1 + y1;
-  y1 = t;
 
   t = a1*b1 + y2 + (t >> 32);
   y2 = t;


### PR DESCRIPTION
local y1 is set to local t
y1 is never accessed in the lines that follow