### PR TITLE
Always support commit-logging without performance penalty

### DIFF
--- a/config.h.in
+++ b/config.h.in
@@ -99,9 +99,6 @@
 /* Define if subproject MCPPBS_SPROJ_NORM is enabled */
 #undef RISCV_ENABLED
 
-/* Enable commit log generation */
-#undef RISCV_ENABLE_COMMITLOG
-
 /* Enable hardware management of PTE accessed and dirty bits */
 #undef RISCV_ENABLE_DIRTY
 

--- a/configure
+++ b/configure
@@ -715,7 +715,6 @@ with_isa
 with_priv
 with_varch
 with_target
-enable_commitlog
 enable_histogram
 enable_dirty
 enable_misaligned
@@ -1362,7 +1361,6 @@ Optional Features:
   --enable-stow           Enable stow-based install
   --enable-optional-subprojects
                           Enable all optional subprojects
-  --enable-commitlog      Enable commit log generation
   --enable-histogram      Enable PC histogram generation
   --enable-dirty          Enable hardware management of PTE accessed and dirty
                           bits
@@ -6051,20 +6049,6 @@ _ACEOF
 
 else
   as_fn_error $? "libpthread is required" "$LINENO" 5
-fi
-
-
-# Check whether --enable-commitlog was given.
-if test "${enable_commitlog+set}" = set; then :
-  enableval=$enable_commitlog;
-fi
-
-if test "x$enable_commitlog" = "xyes"; then :
-
-
-$as_echo "#define RISCV_ENABLE_COMMITLOG /**/" >>confdefs.h
-
-
 fi
 
 # Check whether --enable-histogram was given.

--- a/customext/cflush.cc
+++ b/customext/cflush.cc
@@ -24,9 +24,9 @@ class cflush_t : public extension_t
 
   std::vector<insn_desc_t> get_instructions() {
     std::vector<insn_desc_t> insns;
-    insns.push_back((insn_desc_t){0xFC000073, 0xFFF07FFF, custom_cflush, custom_cflush, custom_cflush, custom_cflush});
-    insns.push_back((insn_desc_t){0xFC200073, 0xFFF07FFF, custom_cflush, custom_cflush, custom_cflush, custom_cflush});
-    insns.push_back((insn_desc_t){0xFC100073, 0xFFF07FFF, custom_cflush, custom_cflush, custom_cflush, custom_cflush});
+    insns.push_back((insn_desc_t){0xFC000073, 0xFFF07FFF, custom_cflush, custom_cflush, custom_cflush, custom_cflush, custom_cflush, custom_cflush, custom_cflush, custom_cflush});
+    insns.push_back((insn_desc_t){0xFC200073, 0xFFF07FFF, custom_cflush, custom_cflush, custom_cflush, custom_cflush, custom_cflush, custom_cflush, custom_cflush, custom_cflush});
+    insns.push_back((insn_desc_t){0xFC100073, 0xFFF07FFF, custom_cflush, custom_cflush, custom_cflush, custom_cflush, custom_cflush, custom_cflush, custom_cflush, custom_cflush});
     return insns;
   }
 

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -1,6 +1,5 @@
 // See LICENSE for license details.
 
-#include "config.h"
 // For std::any_of
 #include <algorithm>
 
@@ -62,9 +61,8 @@ void csr_t::log_write() const noexcept {
 }
 
 void csr_t::log_special_write(const reg_t UNUSED address, const reg_t UNUSED val) const noexcept {
-#if defined(RISCV_ENABLE_COMMITLOG)
-  proc->get_state()->log_reg_write[((address) << 4) | 4] = {val, 0};
-#endif
+  if (proc->get_log_commits_enabled())
+    proc->get_state()->log_reg_write[((address) << 4) | 4] = {val, 0};
 }
 
 reg_t csr_t::written_value() const noexcept {

--- a/riscv/decode_macros.h
+++ b/riscv/decode_macros.h
@@ -23,11 +23,11 @@
 #define RS3 READ_REG(insn.rs3())
 #define WRITE_RD(value) WRITE_REG(insn.rd(), value)
 
-#ifndef RISCV_ENABLE_COMMITLOG
+#if defined(DECODE_MACRO_USAGE_FAST)
 # define WRITE_REG(reg, value) ({ CHECK_REG(reg); STATE.XPR.write(reg, value); })
 # define WRITE_FREG(reg, value) DO_WRITE_FREG(reg, freg(value))
 # define WRITE_VSTATUS {}
-#else
+#elif defined(DECODE_MACRO_USAGE_LOGGED)
    /* 0 : int
     * 1 : floating
     * 2 : vector reg

--- a/riscv/execute.cc
+++ b/riscv/execute.cc
@@ -207,7 +207,7 @@ static inline reg_t execute_insn(processor_t* p, reg_t pc, insn_fetch_t fetch)
 
 bool processor_t::slow_path()
 {
-  return debug || state.single_step != state.STEP_NONE || state.debug_mode;
+  return debug || state.single_step != state.STEP_NONE || state.debug_mode || log_commits_enabled;
 }
 
 // fetch/decode/execute loop

--- a/riscv/execute.cc
+++ b/riscv/execute.cc
@@ -6,7 +6,6 @@
 #include "disasm.h"
 #include <cassert>
 
-#ifdef RISCV_ENABLE_COMMITLOG
 static void commit_log_reset(processor_t* p)
 {
   p->get_state()->log_reg_write.clear();
@@ -150,7 +149,6 @@ static void commit_log_print_insn(processor_t *p, reg_t pc, insn_t insn)
   }
   fprintf(log_file, "\n");
 }
-#endif
 
 inline void processor_t::update_histogram(reg_t UNUSED pc)
 {

--- a/riscv/execute.cc
+++ b/riscv/execute.cc
@@ -60,11 +60,6 @@ static void commit_log_print_value(FILE *log_file, int width, uint64_t val)
   commit_log_print_value(log_file, width, &val);
 }
 
-const char* processor_t::get_symbol(uint64_t addr)
-{
-  return sim->get_symbol(addr);
-}
-
 static void commit_log_print_insn(processor_t *p, reg_t pc, insn_t insn)
 {
   FILE *log_file = p->get_log_file();

--- a/riscv/execute.cc
+++ b/riscv/execute.cc
@@ -157,29 +157,25 @@ inline void processor_t::update_histogram(reg_t UNUSED pc)
 #endif
 }
 
-// This is expected to be inlined by the compiler so each use of execute_insn
-// includes a duplicated body of the function to get separate fetch.func
-// function calls.
-static inline reg_t execute_insn(processor_t* p, reg_t pc, insn_fetch_t fetch)
+// These two functions are expected to be inlined by the compiler separately in
+// the processor_t::step() loop. The logged variant is used in the slow path
+static inline reg_t execute_insn_fast(processor_t* p, reg_t pc, insn_fetch_t fetch) {
+  p->update_histogram(pc);
+  return fetch.func(p, fetch.insn, pc);
+}
+static inline reg_t execute_insn_logged(processor_t* p, reg_t pc, insn_fetch_t fetch)
 {
-#ifdef RISCV_ENABLE_COMMITLOG
   commit_log_reset(p);
   commit_log_stash_privilege(p);
-#endif
   reg_t npc;
 
   try {
     npc = fetch.func(p, fetch.insn, pc);
     if (npc != PC_SERIALIZE_BEFORE) {
-
-#ifdef RISCV_ENABLE_COMMITLOG
       if (p->get_log_commits_enabled()) {
         commit_log_print_insn(p, pc, fetch.insn);
       }
-#endif
-
      }
-#ifdef RISCV_ENABLE_COMMITLOG
   } catch (wait_for_interrupt_t &t) {
       if (p->get_log_commits_enabled()) {
         commit_log_print_insn(p, pc, fetch.insn);
@@ -196,7 +192,6 @@ static inline reg_t execute_insn(processor_t* p, reg_t pc, insn_fetch_t fetch)
         }
       }
       throw;
-#endif
   } catch(...) {
     throw;
   }
@@ -268,7 +263,7 @@ void processor_t::step(size_t n)
           insn_fetch_t fetch = mmu->load_insn(pc);
           if (debug && !state.serialized)
             disasm(fetch.insn);
-          pc = execute_insn(this, pc, fetch);
+          pc = execute_insn_logged(this, pc, fetch);
           advance_pc();
         }
       }
@@ -277,7 +272,7 @@ void processor_t::step(size_t n)
         // Main simulation loop, fast path.
         for (auto ic_entry = _mmu->access_icache(pc); ; ) {
           auto fetch = ic_entry->data;
-          pc = execute_insn(this, pc, fetch);
+          pc = execute_insn_fast(this, pc, fetch);
           ic_entry = ic_entry->next;
           if (unlikely(ic_entry->tag != pc))
             break;

--- a/riscv/execute.cc
+++ b/riscv/execute.cc
@@ -123,10 +123,10 @@ static void commit_log_print_insn(processor_t *p, reg_t pc, insn_t insn)
 
     if (!show_vec && (is_vreg || is_vec)) {
         fprintf(log_file, " e%ld %s%ld l%ld",
-                p->VU.vsew,
+                (long)p->VU.vsew,
                 p->VU.vflmul < 1 ? "mf" : "m",
-                p->VU.vflmul < 1 ? (reg_t)(1 / p->VU.vflmul) : (reg_t)p->VU.vflmul,
-                p->VU.vl->read());
+                p->VU.vflmul < 1 ? (long)(1 / p->VU.vflmul) : (long)p->VU.vflmul,
+                (long)p->VU.vl->read());
         show_vec = true;
     }
 

--- a/riscv/insn_template.cc
+++ b/riscv/insn_template.cc
@@ -1,9 +1,9 @@
 // See LICENSE for license details.
 
-#include "insn_template.h"
+#include "insn_template_TYPE.h"
 #include "insn_macros.h"
 
-reg_t rv32i_NAME(processor_t* p, insn_t insn, reg_t pc)
+reg_t TYPE_rv32i_NAME(processor_t* p, insn_t insn, reg_t pc)
 {
   #define xlen 32
   reg_t npc = sext_xlen(pc + insn_length(OPCODE));
@@ -13,7 +13,7 @@ reg_t rv32i_NAME(processor_t* p, insn_t insn, reg_t pc)
   return npc;
 }
 
-reg_t rv64i_NAME(processor_t* p, insn_t insn, reg_t pc)
+reg_t TYPE_rv64i_NAME(processor_t* p, insn_t insn, reg_t pc)
 {
   #define xlen 64
   reg_t npc = sext_xlen(pc + insn_length(OPCODE));
@@ -26,7 +26,7 @@ reg_t rv64i_NAME(processor_t* p, insn_t insn, reg_t pc)
 #undef CHECK_REG
 #define CHECK_REG(reg) require((reg) < 16)
 
-reg_t rv32e_NAME(processor_t* p, insn_t insn, reg_t pc)
+reg_t TYPE_rv32e_NAME(processor_t* p, insn_t insn, reg_t pc)
 {
   #define xlen 32
   reg_t npc = sext_xlen(pc + insn_length(OPCODE));
@@ -36,7 +36,7 @@ reg_t rv32e_NAME(processor_t* p, insn_t insn, reg_t pc)
   return npc;
 }
 
-reg_t rv64e_NAME(processor_t* p, insn_t insn, reg_t pc)
+reg_t TYPE_rv64e_NAME(processor_t* p, insn_t insn, reg_t pc)
 {
   #define xlen 64
   reg_t npc = sext_xlen(pc + insn_length(OPCODE));

--- a/riscv/insn_template_fast.h
+++ b/riscv/insn_template_fast.h
@@ -1,0 +1,4 @@
+// See LICENSE for license details.
+
+#define DECODE_MACRO_USAGE_FAST
+#include "insn_template.h"

--- a/riscv/insn_template_logged.h
+++ b/riscv/insn_template_logged.h
@@ -1,0 +1,4 @@
+// See LICENSE for license details
+
+#define DECODE_MACRO_USAGE_LOGGED
+#include "insn_template.h"

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -1054,18 +1054,18 @@ void processor_t::register_base_instructions()
   #undef DECLARE_OVERLAP_INSN
 
   #define DEFINE_INSN(name) \
-    extern reg_t rv32i_##name(processor_t*, insn_t, reg_t); \
-    extern reg_t rv64i_##name(processor_t*, insn_t, reg_t); \
-    extern reg_t rv32e_##name(processor_t*, insn_t, reg_t); \
-    extern reg_t rv64e_##name(processor_t*, insn_t, reg_t); \
+    extern reg_t fast_rv32i_##name(processor_t*, insn_t, reg_t); \
+    extern reg_t fast_rv64i_##name(processor_t*, insn_t, reg_t); \
+    extern reg_t fast_rv32e_##name(processor_t*, insn_t, reg_t); \
+    extern reg_t fast_rv64e_##name(processor_t*, insn_t, reg_t); \
     if (name##_supported) { \
       register_insn((insn_desc_t) { \
         name##_match, \
         name##_mask, \
-        rv32i_##name, \
-        rv64i_##name, \
-        rv32e_##name, \
-        rv64e_##name}); \
+        fast_rv32i_##name, \
+        fast_rv64i_##name, \
+        fast_rv32e_##name, \
+        fast_rv64e_##name}); \
     }
   #include "insn_list.h"
   #undef DEFINE_INSN

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -891,20 +891,23 @@ void processor_t::take_trigger_action(triggers::action_t action, reg_t breakpoin
   }
 }
 
+const char* processor_t::get_symbol(uint64_t addr)
+{
+  return sim->get_symbol(addr);
+}
+
 void processor_t::disasm(insn_t insn)
 {
   uint64_t bits = insn.bits();
   if (last_pc != state.pc || last_bits != bits) {
     std::stringstream s;  // first put everything in a string, later send it to output
 
-#ifdef RISCV_ENABLE_COMMITLOG
     const char* sym = get_symbol(state.pc);
     if (sym != nullptr)
     {
       s << "core " << std::dec << std::setfill(' ') << std::setw(3) << id
         << ": >>>>  " << sym << std::endl;
     }
-#endif
 
     if (executions != 1) {
       s << "core " << std::dec << std::setfill(' ') << std::setw(3) << id

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -532,15 +532,7 @@ void processor_t::set_histogram(bool value)
 
 void processor_t::enable_log_commits()
 {
-#ifndef RISCV_ENABLE_COMMITLOG
-  fputs("Commit logging support has not been properly enabled; "
-        "please re-build the riscv-isa-sim project using "
-        "\"configure --enable-commitlog\".\n",
-        stderr);
-  abort();
-#else
   log_commits_enabled = true;
-#endif
 }
 
 void processor_t::reset()

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -502,14 +502,12 @@ void state_t::reset(processor_t* const proc, reg_t max_isa)
 
   serialized = false;
 
-#ifdef RISCV_ENABLE_COMMITLOG
   log_reg_write.clear();
   log_mem_read.clear();
   log_mem_write.clear();
   last_inst_priv = 0;
   last_inst_xlen = 0;
   last_inst_flen = 0;
-#endif
 }
 
 void processor_t::set_debug(bool value)

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -999,12 +999,13 @@ insn_func_t processor_t::decode_insn(insn_t insn)
     opcode_cache[idx].match = insn.bits();
   }
 
-  return desc.func(xlen, rve);
+  return desc.func(xlen, rve, log_commits_enabled);
 }
 
 void processor_t::register_insn(insn_desc_t desc)
 {
-  assert(desc.rv32i && desc.rv64i && desc.rv32e && desc.rv64e);
+  assert(desc.fast_rv32i && desc.fast_rv64i && desc.fast_rv32e && desc.fast_rv64e &&
+         desc.logged_rv32i && desc.logged_rv64i && desc.logged_rv32e && desc.logged_rv64e);
 
   instructions.push_back(desc);
 }
@@ -1058,6 +1059,10 @@ void processor_t::register_base_instructions()
     extern reg_t fast_rv64i_##name(processor_t*, insn_t, reg_t); \
     extern reg_t fast_rv32e_##name(processor_t*, insn_t, reg_t); \
     extern reg_t fast_rv64e_##name(processor_t*, insn_t, reg_t); \
+    extern reg_t logged_rv32i_##name(processor_t*, insn_t, reg_t); \
+    extern reg_t logged_rv64i_##name(processor_t*, insn_t, reg_t); \
+    extern reg_t logged_rv32e_##name(processor_t*, insn_t, reg_t); \
+    extern reg_t logged_rv64e_##name(processor_t*, insn_t, reg_t); \
     if (name##_supported) { \
       register_insn((insn_desc_t) { \
         name##_match, \
@@ -1065,7 +1070,11 @@ void processor_t::register_base_instructions()
         fast_rv32i_##name, \
         fast_rv64i_##name, \
         fast_rv32e_##name, \
-        fast_rv64e_##name}); \
+        fast_rv64e_##name, \
+        logged_rv32i_##name, \
+        logged_rv64i_##name, \
+        logged_rv32e_##name, \
+        logged_rv64e_##name}); \
     }
   #include "insn_list.h"
   #undef DEFINE_INSN

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -34,22 +34,34 @@ struct insn_desc_t
 {
   insn_bits_t match;
   insn_bits_t mask;
-  insn_func_t rv32i;
-  insn_func_t rv64i;
-  insn_func_t rv32e;
-  insn_func_t rv64e;
+  insn_func_t fast_rv32i;
+  insn_func_t fast_rv64i;
+  insn_func_t fast_rv32e;
+  insn_func_t fast_rv64e;
+  insn_func_t logged_rv32i;
+  insn_func_t logged_rv64i;
+  insn_func_t logged_rv32e;
+  insn_func_t logged_rv64e;
 
-  insn_func_t func(int xlen, bool rve)
+  insn_func_t func(int xlen, bool rve, bool logged)
   {
-    if (rve)
-      return xlen == 64 ? rv64e : rv32e;
+    if (logged)
+      if (rve)
+        return xlen == 64 ? logged_rv64e : logged_rv32e;
+      else
+        return xlen == 64 ? logged_rv64i : logged_rv32i;
     else
-      return xlen == 64 ? rv64i : rv32i;
+      if (rve)
+        return xlen == 64 ? fast_rv64e : fast_rv32e;
+      else
+        return xlen == 64 ? fast_rv64i : fast_rv32i;
   }
 
   static insn_desc_t illegal()
   {
-    return {0, 0, &illegal_instruction, &illegal_instruction, &illegal_instruction, &illegal_instruction};
+    return {0, 0,
+            &illegal_instruction, &illegal_instruction, &illegal_instruction, &illegal_instruction,
+            &illegal_instruction, &illegal_instruction, &illegal_instruction, &illegal_instruction};
   }
 };
 

--- a/riscv/riscv.ac
+++ b/riscv/riscv.ac
@@ -39,11 +39,6 @@ AC_SEARCH_LIBS([dlopen], [dl dld], [
 
 AC_CHECK_LIB(pthread, pthread_create, [], [AC_MSG_ERROR([libpthread is required])])
 
-AC_ARG_ENABLE([commitlog], AS_HELP_STRING([--enable-commitlog], [Enable commit log generation]))
-AS_IF([test "x$enable_commitlog" = "xyes"], [
-  AC_DEFINE([RISCV_ENABLE_COMMITLOG],,[Enable commit log generation])
-])
-
 AC_ARG_ENABLE([histogram], AS_HELP_STRING([--enable-histogram], [Enable PC histogram generation]))
 AS_IF([test "x$enable_histogram" = "xyes"], [
   AC_DEFINE([RISCV_ENABLE_HISTOGRAM],,[Enable PC histogram generation])

--- a/riscv/riscv.mk.in
+++ b/riscv/riscv.mk.in
@@ -38,6 +38,8 @@ riscv_hdrs = \
 	extension.h \
 	rocc.h \
 	insn_template.h \
+	insn_template_fast.h \
+	insn_template_logged.h \
 	debug_module.h \
 	debug_rom_defines.h \
 	remote_bitbang.h \
@@ -74,7 +76,8 @@ riscv_install_hdrs = \
 	vector_unit.h \
 
 riscv_precompiled_hdrs = \
-	insn_template.h \
+	insn_template_fast.h \
+	insn_template_logged.h \
 
 riscv_srcs = \
 	isa_parser.cc \
@@ -1358,8 +1361,10 @@ riscv_insn_list = \
 	$(riscv_insn_svinval) \
 	$(riscv_insn_ext_cmo) \
 
-riscv_gen_srcs = \
-	$(addsuffix .cc,$(riscv_insn_list))
+riscv_fast_gen_srcs = $(addsuffix _fast.cc,$(riscv_insn_list))
+riscv_logged_gen_srcs = $(addsuffix _logged.cc,$(riscv_insn_list))
+
+riscv_gen_srcs = $(riscv_fast_gen_srcs) $(riscv_logged_gen_srcs)
 
 insn_list.h: $(src_dir)/riscv/riscv.mk.in
 	for insn in $(foreach insn,$(riscv_insn_list),$(subst .,_,$(insn))) ; do \
@@ -1367,8 +1372,11 @@ insn_list.h: $(src_dir)/riscv/riscv.mk.in
 	done > $@.tmp
 	mv $@.tmp $@
 
-$(riscv_gen_srcs): %.cc: insns/%.h insn_template.cc
-	sed 's/NAME/$(subst .cc,,$@)/' $(src_dir)/riscv/insn_template.cc | sed 's/OPCODE/$(call get_opcode,$(src_dir)/riscv/encoding.h,$(subst .cc,,$@))/' > $@
+$(riscv_fast_gen_srcs): %_fast.cc: insns/%.h insn_template.cc
+	sed 's/NAME/$(subst _fast.cc,,$@)/' $(src_dir)/riscv/insn_template.cc | sed 's/TYPE/fast/' | sed 's/OPCODE/$(call get_opcode,$(src_dir)/riscv/encoding.h,$(subst _fast.cc,,$@))/' > $@
+
+$(riscv_logged_gen_srcs): %_logged.cc: insns/%.h insn_template.cc
+	sed 's/NAME/$(subst _logged.cc,,$@)/' $(src_dir)/riscv/insn_template.cc | sed 's/TYPE/logged/' | sed 's/OPCODE/$(call get_opcode,$(src_dir)/riscv/encoding.h,$(subst _logged.cc,,$@))/' > $@
 
 riscv_junk = \
 	$(riscv_gen_srcs) \

--- a/riscv/rocc.cc
+++ b/riscv/rocc.cc
@@ -1,5 +1,7 @@
 // See LICENSE for license details.
 
+#define DECODE_MACRO_USAGE_LOGGED
+#include "decode_macros.h"
 #include "rocc.h"
 #include "trap.h"
 #include <cstdlib>

--- a/riscv/rocc.cc
+++ b/riscv/rocc.cc
@@ -34,10 +34,18 @@ customX(3)
 std::vector<insn_desc_t> rocc_t::get_instructions()
 {
   std::vector<insn_desc_t> insns;
-  insns.push_back((insn_desc_t){0x0b, 0x7f, &::illegal_instruction, c0, &::illegal_instruction, c0});
-  insns.push_back((insn_desc_t){0x2b, 0x7f, &::illegal_instruction, c1, &::illegal_instruction, c1});
-  insns.push_back((insn_desc_t){0x5b, 0x7f, &::illegal_instruction, c2, &::illegal_instruction, c2});
-  insns.push_back((insn_desc_t){0x7b, 0x7f, &::illegal_instruction, c3, &::illegal_instruction, c3});
+  insns.push_back((insn_desc_t){0x0b, 0x7f,
+                                &::illegal_instruction, c0, &::illegal_instruction, c0,
+                                &::illegal_instruction, c0, &::illegal_instruction, c0});
+  insns.push_back((insn_desc_t){0x2b, 0x7f,
+                                &::illegal_instruction, c1, &::illegal_instruction, c1,
+                                &::illegal_instruction, c1, &::illegal_instruction, c1});
+  insns.push_back((insn_desc_t){0x5b, 0x7f,
+                                &::illegal_instruction, c2, &::illegal_instruction, c2,
+                                &::illegal_instruction, c2, &::illegal_instruction, c2});
+  insns.push_back((insn_desc_t){0x7b, 0x7f,
+                                &::illegal_instruction, c3, &::illegal_instruction, c3,
+                                &::illegal_instruction, c0, &::illegal_instruction, c3});
   return insns;
 }
 

--- a/riscv/sim.h
+++ b/riscv/sim.h
@@ -43,9 +43,7 @@ public:
   // Configure logging
   //
   // If enable_log is true, an instruction trace will be generated. If
-  // enable_commitlog is true, so will the commit results (if this
-  // build was configured without support for commit logging, the
-  // function will print an error message and abort).
+  // enable_commitlog is true, so will the commit results
   void configure_log(bool enable_log, bool enable_commitlog);
 
   void set_procs_debug(bool value);

--- a/riscv/vector_unit.cc
+++ b/riscv/vector_unit.cc
@@ -79,10 +79,8 @@ template<class T> T& vectorUnit_t::elt(reg_t vReg, reg_t n, bool UNUSED is_write
 #endif
   reg_referenced[vReg] = 1;
 
-#ifdef RISCV_ENABLE_COMMITLOG
-  if (is_write)
+  if (unlikely(p->get_log_commits_enabled() && is_write))
     p->get_state()->log_reg_write[((vReg) << 4) | 2] = {0, 0};
-#endif
 
   T *regStart = (T*)((char*)reg_file + vReg * (VLEN >> 3));
   return regStart[n];


### PR DESCRIPTION
This PR changes the commit-log-enable from a compile flag to a always-usable feature, *without* a  performance penalty.

Time to run 10K iterations of CoreMark (x86 host)
- Before this PR with `./configure`: 11s
- Before this PR with `./configure --enable-commitlog` : 71s
- After this PR with `./configure`: 11s

The following changes are made:
- Create new `logged_rvxx_xxxx` variants of the `insn_func_t` templates, which have the `LOGGED_INSTRUCTION` variable set, such that the body of these functions will include the logging code
- New `execute_insn_logged` and `execute_insn_fast`. On the slow path, `execute_insn_logged` is used. Enabling logging will force the fetch-decode-execute loop to use the slow path, which will always grab the `logged_` variant through the slow decode path (bypassing the mmu icache).

Generally, this should result in minimal change to the critical sections when logging is not enabled. There are some new extra branches for CSR writes, vector instructions, and loads/stores. With some additional effort, these can be removed as well, but I did not find the impact of these to be significant.

One risk here is that appending to `log_mem_read` and `log_mem_write` while using `execute_insn_fast` would cause those structures to grow without bounds. I don't think this happens in the current code, but some unrelated change could cause this issue to appear silently in the future.