### PR TITLE
Reduce compile time increase introduced by #1189

### DIFF
--- a/riscv/decode_macros.h
+++ b/riscv/decode_macros.h
@@ -23,30 +23,24 @@
 #define RS3 READ_REG(insn.rs3())
 #define WRITE_RD(value) WRITE_REG(insn.rd(), value)
 
-#if defined(DECODE_MACRO_USAGE_FAST)
-# define WRITE_REG(reg, value) ({ CHECK_REG(reg); STATE.XPR.write(reg, value); })
-# define WRITE_FREG(reg, value) DO_WRITE_FREG(reg, freg(value))
-# define WRITE_VSTATUS {}
-#elif defined(DECODE_MACRO_USAGE_LOGGED)
-   /* 0 : int
-    * 1 : floating
-    * 2 : vector reg
-    * 3 : vector hint
-    * 4 : csr
-    */
-# define WRITE_REG(reg, value) ({ \
+/* 0 : int
+ * 1 : floating
+ * 2 : vector reg
+ * 3 : vector hint
+ * 4 : csr
+ */
+#define WRITE_REG(reg, value) ({ \
     reg_t wdata = (value); /* value may have side effects */ \
-    STATE.log_reg_write[(reg) << 4] = {wdata, 0}; \
+    if (DECODE_MACRO_USAGE_LOGGED) STATE.log_reg_write[(reg) << 4] = {wdata, 0}; \
     CHECK_REG(reg); \
     STATE.XPR.write(reg, wdata); \
   })
-# define WRITE_FREG(reg, value) ({ \
+#define WRITE_FREG(reg, value) ({ \
     freg_t wdata = freg(value); /* value may have side effects */ \
-    STATE.log_reg_write[((reg) << 4) | 1] = wdata; \
+    if (DECODE_MACRO_USAGE_LOGGED) STATE.log_reg_write[((reg) << 4) | 1] = wdata; \
     DO_WRITE_FREG(reg, wdata); \
   })
-# define WRITE_VSTATUS STATE.log_reg_write[3] = {0, 0};
-#endif
+#define WRITE_VSTATUS STATE.log_reg_write[3] = {0, 0};
 
 // RVC macros
 #define WRITE_RVC_RS1S(value) WRITE_REG(insn.rvc_rs1s(), value)

--- a/riscv/insn_template.cc
+++ b/riscv/insn_template.cc
@@ -1,9 +1,11 @@
 // See LICENSE for license details.
 
-#include "insn_template_TYPE.h"
+#include "insn_template.h"
 #include "insn_macros.h"
 
-reg_t TYPE_rv32i_NAME(processor_t* p, insn_t insn, reg_t pc)
+#define DECODE_MACRO_USAGE_LOGGED 0
+
+reg_t fast_rv32i_NAME(processor_t* p, insn_t insn, reg_t pc)
 {
   #define xlen 32
   reg_t npc = sext_xlen(pc + insn_length(OPCODE));
@@ -13,7 +15,30 @@ reg_t TYPE_rv32i_NAME(processor_t* p, insn_t insn, reg_t pc)
   return npc;
 }
 
-reg_t TYPE_rv64i_NAME(processor_t* p, insn_t insn, reg_t pc)
+reg_t fast_rv64i_NAME(processor_t* p, insn_t insn, reg_t pc)
+{
+  #define xlen 64
+  reg_t npc = sext_xlen(pc + insn_length(OPCODE));
+  #include "insns/NAME.h"
+  trace_opcode(p, OPCODE, insn);
+  #undef xlen
+  return npc;
+}
+
+#undef DECODE_MACRO_USAGE_LOGGED
+#define DECODE_MACRO_USAGE_LOGGED 1
+
+reg_t logged_rv32i_NAME(processor_t* p, insn_t insn, reg_t pc)
+{
+  #define xlen 32
+  reg_t npc = sext_xlen(pc + insn_length(OPCODE));
+  #include "insns/NAME.h"
+  trace_opcode(p, OPCODE, insn);
+  #undef xlen
+  return npc;
+}
+
+reg_t logged_rv64i_NAME(processor_t* p, insn_t insn, reg_t pc)
 {
   #define xlen 64
   reg_t npc = sext_xlen(pc + insn_length(OPCODE));
@@ -26,7 +51,10 @@ reg_t TYPE_rv64i_NAME(processor_t* p, insn_t insn, reg_t pc)
 #undef CHECK_REG
 #define CHECK_REG(reg) require((reg) < 16)
 
-reg_t TYPE_rv32e_NAME(processor_t* p, insn_t insn, reg_t pc)
+#undef DECODE_MACRO_USAGE_LOGGED
+#define DECODE_MACRO_USAGE_LOGGED 0
+
+reg_t fast_rv32e_NAME(processor_t* p, insn_t insn, reg_t pc)
 {
   #define xlen 32
   reg_t npc = sext_xlen(pc + insn_length(OPCODE));
@@ -36,7 +64,30 @@ reg_t TYPE_rv32e_NAME(processor_t* p, insn_t insn, reg_t pc)
   return npc;
 }
 
-reg_t TYPE_rv64e_NAME(processor_t* p, insn_t insn, reg_t pc)
+reg_t fast_rv64e_NAME(processor_t* p, insn_t insn, reg_t pc)
+{
+  #define xlen 64
+  reg_t npc = sext_xlen(pc + insn_length(OPCODE));
+  #include "insns/NAME.h"
+  trace_opcode(p, OPCODE, insn);
+  #undef xlen
+  return npc;
+}
+
+#undef DECODE_MACRO_USAGE_LOGGED
+#define DECODE_MACRO_USAGE_LOGGED 1
+
+reg_t logged_rv32e_NAME(processor_t* p, insn_t insn, reg_t pc)
+{
+  #define xlen 32
+  reg_t npc = sext_xlen(pc + insn_length(OPCODE));
+  #include "insns/NAME.h"
+  trace_opcode(p, OPCODE, insn);
+  #undef xlen
+  return npc;
+}
+
+reg_t logged_rv64e_NAME(processor_t* p, insn_t insn, reg_t pc)
 {
   #define xlen 64
   reg_t npc = sext_xlen(pc + insn_length(OPCODE));

--- a/riscv/insn_template_fast.h
+++ b/riscv/insn_template_fast.h
@@ -1,4 +1,0 @@
-// See LICENSE for license details.
-
-#define DECODE_MACRO_USAGE_FAST
-#include "insn_template.h"

--- a/riscv/insn_template_logged.h
+++ b/riscv/insn_template_logged.h
@@ -1,4 +1,0 @@
-// See LICENSE for license details
-
-#define DECODE_MACRO_USAGE_LOGGED
-#include "insn_template.h"

--- a/riscv/riscv.mk.in
+++ b/riscv/riscv.mk.in
@@ -38,8 +38,6 @@ riscv_hdrs = \
 	extension.h \
 	rocc.h \
 	insn_template.h \
-	insn_template_fast.h \
-	insn_template_logged.h \
 	debug_module.h \
 	debug_rom_defines.h \
 	remote_bitbang.h \
@@ -76,8 +74,7 @@ riscv_install_hdrs = \
 	vector_unit.h \
 
 riscv_precompiled_hdrs = \
-	insn_template_fast.h \
-	insn_template_logged.h \
+	insn_template.h \
 
 riscv_srcs = \
 	isa_parser.cc \
@@ -1361,10 +1358,7 @@ riscv_insn_list = \
 	$(riscv_insn_svinval) \
 	$(riscv_insn_ext_cmo) \
 
-riscv_fast_gen_srcs = $(addsuffix _fast.cc,$(riscv_insn_list))
-riscv_logged_gen_srcs = $(addsuffix _logged.cc,$(riscv_insn_list))
-
-riscv_gen_srcs = $(riscv_fast_gen_srcs) $(riscv_logged_gen_srcs)
+riscv_gen_srcs = $(addsuffix .cc,$(riscv_insn_list))
 
 insn_list.h: $(src_dir)/riscv/riscv.mk.in
 	for insn in $(foreach insn,$(riscv_insn_list),$(subst .,_,$(insn))) ; do \
@@ -1372,11 +1366,8 @@ insn_list.h: $(src_dir)/riscv/riscv.mk.in
 	done > $@.tmp
 	mv $@.tmp $@
 
-$(riscv_fast_gen_srcs): %_fast.cc: insns/%.h insn_template.cc
-	sed 's/NAME/$(subst _fast.cc,,$@)/' $(src_dir)/riscv/insn_template.cc | sed 's/TYPE/fast/' | sed 's/OPCODE/$(call get_opcode,$(src_dir)/riscv/encoding.h,$(subst _fast.cc,,$@))/' > $@
-
-$(riscv_logged_gen_srcs): %_logged.cc: insns/%.h insn_template.cc
-	sed 's/NAME/$(subst _logged.cc,,$@)/' $(src_dir)/riscv/insn_template.cc | sed 's/TYPE/logged/' | sed 's/OPCODE/$(call get_opcode,$(src_dir)/riscv/encoding.h,$(subst _logged.cc,,$@))/' > $@
+$(riscv_gen_srcs): %.cc: insns/%.h insn_template.cc
+	sed 's/NAME/$(subst .cc,,$@)/' $(src_dir)/riscv/insn_template.cc | sed 's/OPCODE/$(call get_opcode,$(src_dir)/riscv/encoding.h,$(subst .cc,,$@))/' > $@
 
 riscv_junk = \
 	$(riscv_gen_srcs) \

--- a/riscv/rocc.cc
+++ b/riscv/rocc.cc
@@ -1,6 +1,6 @@
 // See LICENSE for license details.
 
-#define DECODE_MACRO_USAGE_LOGGED
+#define DECODE_MACRO_USAGE_LOGGED 1
 #include "decode_macros.h"
 #include "rocc.h"
 #include "trap.h"


### PR DESCRIPTION
Partially reverts and reimplements 2493734383e17b27467a12130f9f8e2498d11103

Generate one object file per instruction, as we used to do, rather than two.

On my 2020 Macbook M1, with `make -j12` on 8 cores, this reduces wall-clock time from 185s to 93s.  By contrast, before #1189, it took 67s.