### PR TITLE
Support histogram feature without configure option

### DIFF
--- a/config.h.in
+++ b/config.h.in
@@ -105,9 +105,6 @@
 /* Enable support for running target in either endianness */
 #undef RISCV_ENABLE_DUAL_ENDIAN
 
-/* Enable PC histogram generation */
-#undef RISCV_ENABLE_HISTOGRAM
-
 /* Enable hardware support for misaligned loads and stores */
 #undef RISCV_ENABLE_MISALIGNED
 

--- a/configure
+++ b/configure
@@ -715,7 +715,6 @@ with_isa
 with_priv
 with_varch
 with_target
-enable_histogram
 enable_dirty
 enable_misaligned
 enable_dual_endian
@@ -1361,7 +1360,6 @@ Optional Features:
   --enable-stow           Enable stow-based install
   --enable-optional-subprojects
                           Enable all optional subprojects
-  --enable-histogram      Enable PC histogram generation
   --enable-dirty          Enable hardware management of PTE accessed and dirty
                           bits
   --enable-misaligned     Enable hardware support for misaligned loads and
@@ -6051,18 +6049,6 @@ else
   as_fn_error $? "libpthread is required" "$LINENO" 5
 fi
 
-# Check whether --enable-histogram was given.
-if test "${enable_histogram+set}" = set; then :
-  enableval=$enable_histogram;
-fi
-
-if test "x$enable_histogram" = "xyes"; then :
-
-
-$as_echo "#define RISCV_ENABLE_HISTOGRAM /**/" >>confdefs.h
-
-
-fi
 
 # Check whether --enable-dirty was given.
 if test "${enable_dirty+set}" = set; then :

--- a/riscv/execute.cc
+++ b/riscv/execute.cc
@@ -152,9 +152,7 @@ static void commit_log_print_insn(processor_t *p, reg_t pc, insn_t insn)
 
 inline void processor_t::update_histogram(reg_t UNUSED pc)
 {
-#ifdef RISCV_ENABLE_HISTOGRAM
   pc_histogram[pc]++;
-#endif
 }
 
 // These two functions are expected to be inlined by the compiler separately in

--- a/riscv/execute.cc
+++ b/riscv/execute.cc
@@ -158,7 +158,6 @@ inline void processor_t::update_histogram(reg_t UNUSED pc)
 // These two functions are expected to be inlined by the compiler separately in
 // the processor_t::step() loop. The logged variant is used in the slow path
 static inline reg_t execute_insn_fast(processor_t* p, reg_t pc, insn_fetch_t fetch) {
-  p->update_histogram(pc);
   return fetch.func(p, fetch.insn, pc);
 }
 static inline reg_t execute_insn_logged(processor_t* p, reg_t pc, insn_fetch_t fetch)
@@ -200,7 +199,8 @@ static inline reg_t execute_insn_logged(processor_t* p, reg_t pc, insn_fetch_t f
 
 bool processor_t::slow_path()
 {
-  return debug || state.single_step != state.STEP_NONE || state.debug_mode || log_commits_enabled;
+  return debug || state.single_step != state.STEP_NONE || state.debug_mode ||
+         log_commits_enabled || histogram_enabled;
 }
 
 // fetch/decode/execute loop

--- a/riscv/execute.cc
+++ b/riscv/execute.cc
@@ -162,8 +162,11 @@ static inline reg_t execute_insn_fast(processor_t* p, reg_t pc, insn_fetch_t fet
 }
 static inline reg_t execute_insn_logged(processor_t* p, reg_t pc, insn_fetch_t fetch)
 {
-  commit_log_reset(p);
-  commit_log_stash_privilege(p);
+  if (p->get_log_commits_enabled()) {
+    commit_log_reset(p);
+    commit_log_stash_privilege(p);
+  }
+
   reg_t npc;
 
   try {

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -72,14 +72,12 @@ processor_t::processor_t(const isa_parser_t *isa, const char* varch,
 
 processor_t::~processor_t()
 {
-#ifdef RISCV_ENABLE_HISTOGRAM
   if (histogram_enabled)
   {
     fprintf(stderr, "PC Histogram size:%zu\n", pc_histogram.size());
     for (auto it : pc_histogram)
       fprintf(stderr, "%0" PRIx64 " %" PRIu64 "\n", it.first, it.second);
   }
-#endif
 
   delete mmu;
   delete disassembler;

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -519,13 +519,6 @@ void processor_t::set_debug(bool value)
 void processor_t::set_histogram(bool value)
 {
   histogram_enabled = value;
-#ifndef RISCV_ENABLE_HISTOGRAM
-  if (value) {
-    fprintf(stderr, "PC Histogram support has not been properly enabled;");
-    fprintf(stderr, " please re-build the riscv-isa-sim project using \"configure --enable-histogram\".\n");
-    abort();
-  }
-#endif
 }
 
 void processor_t::enable_log_commits()

--- a/riscv/riscv.ac
+++ b/riscv/riscv.ac
@@ -39,11 +39,6 @@ AC_SEARCH_LIBS([dlopen], [dl dld], [
 
 AC_CHECK_LIB(pthread, pthread_create, [], [AC_MSG_ERROR([libpthread is required])])
 
-AC_ARG_ENABLE([histogram], AS_HELP_STRING([--enable-histogram], [Enable PC histogram generation]))
-AS_IF([test "x$enable_histogram" = "xyes"], [
-  AC_DEFINE([RISCV_ENABLE_HISTOGRAM],,[Enable PC histogram generation])
-])
-
 AC_ARG_ENABLE([dirty], AS_HELP_STRING([--enable-dirty], [Enable hardware management of PTE accessed and dirty bits]))
 AS_IF([test "x$enable_dirty" = "xyes"], [
   AC_DEFINE([RISCV_ENABLE_DIRTY],,[Enable hardware management of PTE accessed and dirty bits])


### PR DESCRIPTION
This builds upon #1189 in the obvious way.

There's no perf impact when not histogramming.  Initially, there was a modest slowdown when histogramming, because we moved it to the slow path.  7831b3e5 removes some of this overhead by speeding up the slow path.