### PR TITLE
Slightly improve histogram feature

### DIFF
--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -75,8 +75,12 @@ processor_t::~processor_t()
 #ifdef RISCV_ENABLE_HISTOGRAM
   if (histogram_enabled)
   {
-    fprintf(stderr, "PC Histogram size:%zu\n", pc_histogram.size());
-    for (auto it : pc_histogram)
+    std::vector<std::pair<reg_t, uint64_t>> ordered_histo(pc_histogram.begin(), pc_histogram.end());
+    std::sort(ordered_histo.begin(), ordered_histo.end(),
+              [](auto& lhs, auto& rhs) { return lhs.second < rhs.second; });
+
+    fprintf(stderr, "PC Histogram size:%zu\n", ordered_histo.size());
+    for (auto it : ordered_histo)
       fprintf(stderr, "%0" PRIx64 " %" PRIu64 "\n", it.first, it.second);
   }
 #endif

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -295,7 +295,7 @@ private:
   std::vector<bool> impl_table;
 
   std::vector<insn_desc_t> instructions;
-  std::map<reg_t,uint64_t> pc_histogram;
+  std::unordered_map<reg_t,uint64_t> pc_histogram;
 
   static const size_t OPCODE_CACHE_SIZE = 8191;
   insn_desc_t opcode_cache[OPCODE_CACHE_SIZE];


### PR DESCRIPTION
In creating #1191, I noticed the histogram prints in order of PC, rather than order of frequency.  This isn't terribly useful, so swap that around.  After doing so, we can switch to `unordered_map` without a functional change, for a significant speedup.