### PR TITLE
Fix build nondeterminism by deleting archives before recreating

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -242,6 +242,7 @@ $(2)_lib_libarg     := $$(patsubst %, -l%, $$($(2)_lib_libs))
 $(2)_lib_libnames_shared	:= $$(if $$($(2)_install_shared_lib),lib$(1).so,)
 
 lib$(1).a : $$($(2)_objs) $$($(2)_c_objs)
+	rm -f $$@
 	$(AR) rcs $$@ $$^
 lib$(1).so : $$($(2)_objs) $$($(2)_c_objs) $$($(2)_lib_libnames_shared) $$($(2)_lib_libnames)
 	$(LINK) -shared -o $$@ $(if $(filter Darwin,$(shell uname -s)),-install_name $(install_libs_dir)/$$@) $$^ $$($(2)_lib_libnames) $(LIBS)


### PR DESCRIPTION
Otherwise, `ar rcs` will add to the previous archive, creating the possibility of multiple functions with the same name in the archive. The linker might not choose the most recent version, resulting in undefined behavior.