### PR TITLE
Remove dead code in Makefiles

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -330,7 +330,6 @@ clean-$(1) :
 libs += lib$(1).a
 objs += $$($(2)_objs)
 srcs += $$(addprefix $(src_dir)/$(1)/, $$($(2)_srcs)) 
-hdrs += $$(addprefix $(src_dir)/$(1)/, $$($(2)_hdrs)) $$($(2)_gen_hdrs)
 junk += $$($(2)_junk)
 deps += $$($(2)_deps)
 

--- a/Makefile.in
+++ b/Makefile.in
@@ -327,9 +327,6 @@ clean-$(1) :
 
 # Update running variables
 
-libs += lib$(1).a
-objs += $$($(2)_objs)
-srcs += $$(addprefix $(src_dir)/$(1)/, $$($(2)_srcs)) 
 junk += $$($(2)_junk)
 deps += $$($(2)_deps)
 

--- a/fdt/fdt.mk.in
+++ b/fdt/fdt.mk.in
@@ -1,10 +1,5 @@
 fdt_subproject_deps = \
 
-fdt_hdrs = \
-	fdt.h \
-	libfdt.h \
-	libfdt_env.h \
-
 fdt_c_srcs = \
 	fdt.c \
 	fdt_ro.c \

--- a/fesvr/fesvr.mk.in
+++ b/fesvr/fesvr.mk.in
@@ -1,4 +1,4 @@
-fesvr_hdrs = \
+fesvr_install_hdrs = \
   byteorder.h \
   elf.h \
   elfloader.h \
@@ -14,8 +14,6 @@ fesvr_hdrs = \
   device.h \
   rfb.h \
   tsi.h \
-
-fesvr_install_hdrs = $(fesvr_hdrs)
 
 fesvr_install_config_hdr = yes
 

--- a/riscv/riscv.mk.in
+++ b/riscv/riscv.mk.in
@@ -13,40 +13,6 @@ riscv_install_shared_lib = yes
 
 riscv_install_prog_srcs = \
 
-riscv_hdrs = \
-	abstract_device.h \
-	abstract_interrupt_controller.h \
-	common.h \
-	decode.h \
-	decode_macros.h \
-	devices.h \
-	dts.h \
-	isa_parser.h \
-	mmu.h \
-	cfg.h \
-	processor.h \
-	p_ext_macros.h \
-	v_ext_macros.h \
-	sim.h \
-	simif.h \
-	trap.h \
-	encoding.h \
-	cachesim.h \
-	memtracer.h \
-	mmio_plugin.h \
-	tracer.h \
-	extension.h \
-	rocc.h \
-	insn_template.h \
-	debug_module.h \
-	debug_rom_defines.h \
-	remote_bitbang.h \
-	jtag_dtm.h \
-	csrs.h \
-	triggers.h \
-	vector_unit.h \
-	socketif.h \
-
 riscv_install_hdrs = \
 	abstract_device.h \
 	abstract_interrupt_controller.h \

--- a/softfloat/softfloat.mk.in
+++ b/softfloat/softfloat.mk.in
@@ -1,14 +1,5 @@
 softfloat_subproject_deps =
 
-softfloat_hdrs = \
-  internals.h \
-  platform.h \
-  primitives.h \
-  primitiveTypes.h \
-  softfloat.h \
-  softfloat_types.h \
-  specialize.h \
-
 softfloat_c_srcs = \
 	f128_add.c \
 	f128_classify.c \

--- a/spike_main/spike_main.mk.in
+++ b/spike_main/spike_main.mk.in
@@ -11,8 +11,6 @@ spike_main_install_prog_srcs = \
 	xspike.cc \
 	termios-xspike.cc \
 
-spike_main_hdrs = \
-
 spike_main_srcs = \
 
 spike_main_CFLAGS = -fPIC


### PR DESCRIPTION
The primary change is that headers that aren't installed don't need to be explicitly listed.  This was already just dead code, because dependences are auto-generated as `.d` files.