### PR TITLE
Expose access type in simif_t mmio_load interface

### DIFF
--- a/riscv/mmu.cc
+++ b/riscv/mmu.cc
@@ -89,7 +89,7 @@ tlb_entry_t mmu_t::fetch_slow_path(reg_t vaddr)
     if (auto host_addr = sim->addr_to_mem(paddr)) {
       result = refill_tlb(vaddr, paddr, host_addr, FETCH);
     } else {
-      if (!mmio_load(paddr, sizeof fetch_temp, (uint8_t*)&fetch_temp))
+      if (!mmio_fetch(paddr, sizeof fetch_temp, (uint8_t*)&fetch_temp))
         throw trap_instruction_access_fault(proc->state.v, vaddr, 0, 0);
       result = {(char*)&fetch_temp - vaddr, paddr - vaddr};
     }
@@ -135,6 +135,14 @@ bool mmu_t::mmio_ok(reg_t addr, access_type UNUSED type)
     return false;
 
   return true;
+}
+
+bool mmu_t::mmio_fetch(reg_t addr, size_t len, uint8_t* bytes)
+{
+  if (!mmio_ok(addr, FETCH))
+    return false;
+
+  return sim->mmio_fetch(addr, len, bytes);
 }
 
 bool mmu_t::mmio_load(reg_t addr, size_t len, uint8_t* bytes)

--- a/riscv/mmu.h
+++ b/riscv/mmu.h
@@ -347,6 +347,7 @@ private:
   void load_slow_path_intrapage(reg_t addr, reg_t len, uint8_t* bytes, uint32_t xlate_flags);
   void store_slow_path(reg_t addr, reg_t len, const uint8_t* bytes, uint32_t xlate_flags, bool actually_store, bool require_alignment);
   void store_slow_path_intrapage(reg_t addr, reg_t len, const uint8_t* bytes, uint32_t xlate_flags, bool actually_store);
+  bool mmio_fetch(reg_t addr, size_t len, uint8_t* bytes);
   bool mmio_load(reg_t addr, size_t len, uint8_t* bytes);
   bool mmio_store(reg_t addr, size_t len, const uint8_t* bytes);
   bool mmio_ok(reg_t addr, access_type type);

--- a/riscv/simif.h
+++ b/riscv/simif.h
@@ -12,6 +12,7 @@ public:
   // should return NULL for MMIO addresses
   virtual char* addr_to_mem(reg_t addr) = 0;
   // used for MMIO addresses
+  virtual bool mmio_fetch(reg_t addr, size_t len, uint8_t* bytes) { return mmio_load(addr, len, bytes); };
   virtual bool mmio_load(reg_t addr, size_t len, uint8_t* bytes) = 0;
   virtual bool mmio_store(reg_t addr, size_t len, const uint8_t* bytes) = 0;
   // Callback for processors to let the simulation know they were reset.


### PR DESCRIPTION
This is useful for alternative implementations of simif_t, which may want to provide different behaviors for fetch/load/store