### PR TITLE
Prevent processor_t from retiring instructions after a WFI

### DIFF
--- a/riscv/execute.cc
+++ b/riscv/execute.cc
@@ -242,6 +242,10 @@ void processor_t::step(size_t n)
     try
     {
       take_pending_interrupt();
+      if (unlikely(in_wfi)) {
+        // No unmasked pending interrupt, so remain in wfi
+        throw wait_for_interrupt_t();
+      }
 
       if (unlikely(slow_path()))
       {
@@ -321,6 +325,7 @@ void processor_t::step(size_t n)
       // allows us to switch to other threads only once per idle loop in case
       // there is activity.
       n = ++instret;
+      in_wfi = true;
     }
 
     state.minstret->bump(instret);

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -35,6 +35,7 @@ processor_t::processor_t(const isa_parser_t *isa, const char* varch,
   : debug(false), halt_request(HR_NONE), isa(isa), sim(sim), id(id), xlen(0),
   histogram_enabled(false), log_commits_enabled(false),
   log_file(log_file), sout_(sout_.rdbuf()), halt_on_reset(halt_on_reset),
+  in_wfi(false),
   impl_table(256, false), last_pc(1), executions(1), TM(4)
 {
   VU.p = this;
@@ -626,6 +627,9 @@ void processor_t::take_interrupt(reg_t pending_interrupts)
   if (!pending_interrupts) {
     return;
   }
+
+  // Exit WFI if there are any pending interrupts
+  in_wfi = false;
 
   // M-ints have higher priority over HS-ints and VS-ints
   const reg_t mie = get_field(state.mstatus->read(), MSTATUS_MIE);

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -292,6 +292,7 @@ private:
   FILE *log_file;
   std::ostream sout_; // needed for socket command interface -s, also used for -d and -l, but not for --log
   bool halt_on_reset;
+  bool in_wfi;
   std::vector<bool> impl_table;
 
   std::vector<insn_desc_t> instructions;


### PR DESCRIPTION
Previously, after a WFI, the next call to `proc->step(n)` would always retire another instruction. With this PR, no instructions will retire until a pending interrupt is seen, regardless of how many times `proc->step(n)` is called.

The primary motivation for this change is for use-cases where `proc->step(n)` is called with small `n`. 