### PR TITLE
Add method to determine if processor is wfi

### DIFF
--- a/riscv/execute.cc
+++ b/riscv/execute.cc
@@ -321,6 +321,7 @@ void processor_t::step(size_t n)
       // allows us to switch to other threads only once per idle loop in case
       // there is activity.
       n = ++instret;
+      in_wfi = true;
     }
 
     state.minstret->bump(instret);

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -35,6 +35,7 @@ processor_t::processor_t(const isa_parser_t *isa, const char* varch,
   : debug(false), halt_request(HR_NONE), isa(isa), sim(sim), id(id), xlen(0),
   histogram_enabled(false), log_commits_enabled(false),
   log_file(log_file), sout_(sout_.rdbuf()), halt_on_reset(halt_on_reset),
+  in_wfi(false),
   impl_table(256, false), last_pc(1), executions(1), TM(4)
 {
   VU.p = this;
@@ -626,6 +627,8 @@ void processor_t::take_interrupt(reg_t pending_interrupts)
   if (!pending_interrupts) {
     return;
   }
+
+  in_wfi = false;
 
   // M-ints have higher priority over HS-ints and VS-ints
   const reg_t mie = get_field(state.mstatus->read(), MSTATUS_MIE);

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -277,6 +277,8 @@ public:
 
   const char* get_symbol(uint64_t addr);
 
+  bool is_waiting_for_interrupt() { return in_wfi; };
+
 private:
   const isa_parser_t * const isa;
 
@@ -292,6 +294,7 @@ private:
   FILE *log_file;
   std::ostream sout_; // needed for socket command interface -s, also used for -d and -l, but not for --log
   bool halt_on_reset;
+  bool in_wfi;
   std::vector<bool> impl_table;
 
   std::vector<insn_desc_t> instructions;


### PR DESCRIPTION
Alternative to https://github.com/riscv-software-src/riscv-isa-sim/pull/1197, avoids changing simulator behavior

With this method, an alternative platform can determine when it is safe to not call `proc->step()` by checking `is_waiting_for_interrupt()` along with that processor's `mip` and `mie` CSRs.