### PR TITLE
Use 'C' in misa for PC-alignment mask calculation

### DIFF
--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -236,7 +236,7 @@ public:
     return impl_table[impl];
   }
   reg_t pc_alignment_mask() {
-    return ~(reg_t)(extension_enabled(EXT_ZCA) ? 0 : 2);
+    return ~(reg_t)(extension_enabled('C') ? 0 : 2);
   }
   void check_pc_alignment(reg_t pc) {
     if (unlikely(pc & ~pc_alignment_mask()))


### PR DESCRIPTION
https://github.com/riscv/riscv-isa-manual/blob/cb3b9d1dcdacefbde6602ada7a0050f5c723ddee/src/machine.tex#L1969-L1973 states that misa.C should control the PC-alignment mask.

The regression was originally introduced in 0adf9307eaef62402c4368d33e88bbb5e1211653

This fixes the behavior on the `rv64mi-p-ma_fetch` test.