### PR TITLE
Make misa.C read-only

### DIFF
--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -601,13 +601,12 @@ bool sstatus_csr_t::enabled(const reg_t which) {
 misa_csr_t::misa_csr_t(processor_t* const proc, const reg_t addr, const reg_t max_isa):
   basic_csr_t(proc, addr, max_isa),
   max_isa(max_isa),
-  write_mask(max_isa & (0  // allow MAFDQCHV bits in MISA to be modified
+  write_mask(max_isa & (0  // allow MAFDQHV bits in MISA to be modified
                         | (1L << ('M' - 'A'))
                         | (1L << ('A' - 'A'))
                         | (1L << ('F' - 'A'))
                         | (1L << ('D' - 'A'))
                         | (1L << ('Q' - 'A'))
-                        | (1L << ('C' - 'A'))
                         | (1L << ('H' - 'A'))
                         | (1L << ('V' - 'A'))
                         )
@@ -619,10 +618,6 @@ reg_t misa_csr_t::dependency(const reg_t val, const char feature, const char dep
 }
 
 bool misa_csr_t::unlogged_write(const reg_t val) noexcept {
-  // the write is ignored if increasing IALIGN would misalign the PC
-  if (!(val & (1L << ('C' - 'A'))) && (state->pc & 2))
-    return false;
-
   reg_t adjusted_val = val;
   adjusted_val = dependency(adjusted_val, 'D', 'F');
   adjusted_val = dependency(adjusted_val, 'Q', 'D');

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -236,7 +236,8 @@ public:
     return impl_table[impl];
   }
   reg_t pc_alignment_mask() {
-    return ~(reg_t)(extension_enabled(EXT_ZCA) ? 0 : 2);
+    const int ialign = extension_enabled(EXT_ZCA) ? 16 : 32;
+    return ~(reg_t)(ialign == 16 ? 0 : 2);
   }
   void check_pc_alignment(reg_t pc) {
     if (unlikely(pc & ~pc_alignment_mask()))


### PR DESCRIPTION
This resolves the issue discussed in https://github.com/riscv-software-src/riscv-isa-sim/pull/1201.

Prior to https://github.com/riscv-software-src/riscv-isa-sim/commit/0adf9307eaef62402c4368d33e88bbb5e1211653, clearing misa.C would disable compressed instructions and increase IALIGN to 32.  Afterwards, clearing misa.C had essentially no effect because Zca and friends would stay enabled.  While AFAICS this isn't technically incorrect, it certainly doesn't follow the principle of least surprise.

Instead, remove the feature to toggle misa.C.  The effect is that misa.C is 1 iff C is included in the ISA string, and IALIGN is independent of misa.C: specifically, IALIGN is 16 iff Zca is present. (And of course C implies Zca.)