### PR TITLE
Support processor_t::step without incrementing mcycle

### DIFF
--- a/riscv/execute.cc
+++ b/riscv/execute.cc
@@ -207,7 +207,7 @@ bool processor_t::slow_path()
 }
 
 // fetch/decode/execute loop
-void processor_t::step(size_t n)
+void processor_t::step(size_t n, bool incr_mcycle)
 {
   if (!state.debug_mode) {
     if (halt_request == HR_REGULAR) {
@@ -331,7 +331,8 @@ void processor_t::step(size_t n)
     state.minstret->bump(instret);
 
     // Model a hart whose CPI is 1.
-    state.mcycle->bump(instret);
+    if (incr_mcycle)
+      state.mcycle->bump(instret);
 
     n -= instret;
   }

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -192,7 +192,7 @@ public:
   void enable_log_commits();
   bool get_log_commits_enabled() const { return log_commits_enabled; }
   void reset();
-  void step(size_t n); // run for n cycles
+  void step(size_t n, bool incr_mcycle = true); // run for n cycles
   void put_csr(int which, reg_t val);
   uint32_t get_id() const { return id; }
   reg_t get_csr(int which, insn_t insn, bool write, bool peek = 0);


### PR DESCRIPTION
The use case is in an environment where I want mcycle to reflect uncore simulation cycles, rather than instructions retired.

