### PR TITLE
Control whether misaligned accesses are supported via command line

### DIFF
--- a/ci-tests/testlib.c
+++ b/ci-tests/testlib.c
@@ -21,6 +21,7 @@ int main()
 	    "rv64gcv",
 	    "MSU",
 	    "vlen:128,elen:64",
+	    false,
 	    endianness_little,
 	    16,
 	    mem_cfg,

--- a/config.h.in
+++ b/config.h.in
@@ -105,9 +105,6 @@
 /* Enable support for running target in either endianness */
 #undef RISCV_ENABLE_DUAL_ENDIAN
 
-/* Enable hardware support for misaligned loads and stores */
-#undef RISCV_ENABLE_MISALIGNED
-
 /* Define if subproject MCPPBS_SPROJ_NORM is enabled */
 #undef SOFTFLOAT_ENABLED
 

--- a/configure
+++ b/configure
@@ -716,7 +716,6 @@ with_priv
 with_varch
 with_target
 enable_dirty
-enable_misaligned
 enable_dual_endian
 '
       ac_precious_vars='build_alias
@@ -1362,8 +1361,6 @@ Optional Features:
                           Enable all optional subprojects
   --enable-dirty          Enable hardware management of PTE accessed and dirty
                           bits
-  --enable-misaligned     Enable hardware support for misaligned loads and
-                          stores
   --enable-dual-endian    Enable support for running target in either
                           endianness
 
@@ -6059,19 +6056,6 @@ if test "x$enable_dirty" = "xyes"; then :
 
 
 $as_echo "#define RISCV_ENABLE_DIRTY /**/" >>confdefs.h
-
-
-fi
-
-# Check whether --enable-misaligned was given.
-if test "${enable_misaligned+set}" = set; then :
-  enableval=$enable_misaligned;
-fi
-
-if test "x$enable_misaligned" = "xyes"; then :
-
-
-$as_echo "#define RISCV_ENABLE_MISALIGNED /**/" >>confdefs.h
 
 
 fi

--- a/riscv/cfg.h
+++ b/riscv/cfg.h
@@ -52,6 +52,7 @@ public:
         const char *default_bootargs,
         const char *default_isa, const char *default_priv,
         const char *default_varch,
+        const bool default_misaligned,
         const endianness_t default_endianness,
         const reg_t default_pmpregions,
         const std::vector<mem_cfg_t> &default_mem_layout,
@@ -62,6 +63,7 @@ public:
       isa(default_isa),
       priv(default_priv),
       varch(default_varch),
+      misaligned(default_misaligned),
       endianness(default_endianness),
       pmpregions(default_pmpregions),
       mem_layout(default_mem_layout),
@@ -75,6 +77,7 @@ public:
   cfg_arg_t<const char *>            isa;
   cfg_arg_t<const char *>            priv;
   cfg_arg_t<const char *>            varch;
+  bool                               misaligned;
   endianness_t                       endianness;
   reg_t                              pmpregions;
   cfg_arg_t<std::vector<mem_cfg_t>>  mem_layout;

--- a/riscv/mmu.h
+++ b/riscv/mmu.h
@@ -139,20 +139,20 @@ public:
 
   void store_float128(reg_t addr, float128_t val)
   {
-#ifndef RISCV_ENABLE_MISALIGNED
-    if (unlikely(addr & (sizeof(float128_t)-1)))
+    if (unlikely(addr & (sizeof(float128_t)-1)) && !is_misaligned_enabled()) {
       throw trap_store_address_misaligned((proc) ? proc->state.v : false, addr, 0, 0);
-#endif
+    }
+
     store<uint64_t>(addr, val.v[0]);
     store<uint64_t>(addr + 8, val.v[1]);
   }
 
   float128_t load_float128(reg_t addr)
   {
-#ifndef RISCV_ENABLE_MISALIGNED
-    if (unlikely(addr & (sizeof(float128_t)-1)))
+    if (unlikely(addr & (sizeof(float128_t)-1)) && !is_misaligned_enabled()) {
       throw trap_load_address_misaligned((proc) ? proc->state.v : false, addr, 0, 0);
-#endif
+    }
+
     return (float128_t){load<uint64_t>(addr), load<uint64_t>(addr + 8)};
   }
 
@@ -285,11 +285,7 @@ public:
 
   int is_misaligned_enabled()
   {
-#ifdef RISCV_ENABLE_MISALIGNED
-    return 1;
-#else
-    return 0;
-#endif
+    return proc && proc->get_cfg().misaligned;
   }
 
   bool is_target_big_endian()

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -28,11 +28,10 @@
 #undef STATE
 #define STATE state
 
-processor_t::processor_t(const isa_parser_t *isa, const char* varch,
+processor_t::processor_t(const isa_parser_t *isa, const cfg_t *cfg,
                          simif_t* sim, uint32_t id, bool halt_on_reset,
-                         endianness_t endianness,
                          FILE* log_file, std::ostream& sout_)
-  : debug(false), halt_request(HR_NONE), isa(isa), sim(sim), id(id), xlen(0),
+  : debug(false), halt_request(HR_NONE), isa(isa), cfg(cfg), sim(sim), id(id), xlen(0),
   histogram_enabled(false), log_commits_enabled(false),
   log_file(log_file), sout_(sout_.rdbuf()), halt_on_reset(halt_on_reset),
   in_wfi(false),
@@ -48,10 +47,10 @@ processor_t::processor_t(const isa_parser_t *isa, const char* varch,
   }
 #endif
 
-  parse_varch_string(varch);
+  parse_varch_string(cfg->varch());
 
   register_base_instructions();
-  mmu = new mmu_t(sim, endianness, this);
+  mmu = new mmu_t(sim, cfg->endianness, this);
 
   disassembler = new disassembler_t(isa);
   for (auto e : isa->get_extensions())

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -179,13 +179,13 @@ struct state_t
 class processor_t : public abstract_device_t
 {
 public:
-  processor_t(const isa_parser_t *isa, const char* varch,
+  processor_t(const isa_parser_t *isa, const cfg_t* cfg,
               simif_t* sim, uint32_t id, bool halt_on_reset,
-              endianness_t endianness,
               FILE *log_file, std::ostream& sout_); // because of command line option --log and -s we need both
   ~processor_t();
 
   const isa_parser_t &get_isa() { return *isa; }
+  const cfg_t &get_cfg() { return *cfg; }
 
   void set_debug(bool value);
   void set_histogram(bool value);
@@ -280,6 +280,7 @@ public:
 
 private:
   const isa_parser_t * const isa;
+  const cfg_t * const cfg;
 
   simif_t* sim;
   mmu_t* mmu; // main memory is always accessed via the mmu

--- a/riscv/riscv.ac
+++ b/riscv/riscv.ac
@@ -44,11 +44,6 @@ AS_IF([test "x$enable_dirty" = "xyes"], [
   AC_DEFINE([RISCV_ENABLE_DIRTY],,[Enable hardware management of PTE accessed and dirty bits])
 ])
 
-AC_ARG_ENABLE([misaligned], AS_HELP_STRING([--enable-misaligned], [Enable hardware support for misaligned loads and stores]))
-AS_IF([test "x$enable_misaligned" = "xyes"], [
-  AC_DEFINE([RISCV_ENABLE_MISALIGNED],,[Enable hardware support for misaligned loads and stores])
-])
-
 AC_ARG_ENABLE([dual-endian], AS_HELP_STRING([--enable-dual-endian], [Enable support for running target in either endianness]))
 AS_IF([test "x$enable_dual_endian" = "xyes"], [
   AC_DEFINE([RISCV_ENABLE_DUAL_ENDIAN],,[Enable support for running target in either endianness])

--- a/riscv/sim.cc
+++ b/riscv/sim.cc
@@ -98,8 +98,8 @@ sim_t::sim_t(const cfg_t *cfg, bool halted,
   debug_mmu = new mmu_t(this, cfg->endianness, NULL);
 
   for (size_t i = 0; i < cfg->nprocs(); i++) {
-    procs[i] = new processor_t(&isa, cfg->varch(), this, cfg->hartids()[i], halted,
-                               cfg->endianness, log_file.get(), sout_);
+    procs[i] = new processor_t(&isa, cfg, this, cfg->hartids()[i], halted,
+                               log_file.get(), sout_);
   }
 
   make_dtb();

--- a/spike_main/spike-log-parser.cc
+++ b/spike_main/spike-log-parser.cc
@@ -28,8 +28,19 @@ int main(int UNUSED argc, char** argv)
   parser.option(0, "isa", 1, [&](const char* s){isa_string = s;});
   parser.parse(argv);
 
+  cfg_t cfg(/*default_initrd_bounds=*/std::make_pair((reg_t)0, (reg_t)0),
+            /*default_bootargs=*/nullptr,
+            /*default_isa=*/DEFAULT_ISA,
+            /*default_priv=*/DEFAULT_PRIV,
+            /*default_varch=*/DEFAULT_VARCH,
+            /*default_endianness*/endianness_little,
+            /*default_pmpregions=*/16,
+            /*default_mem_layout=*/std::vector<mem_cfg_t>(),
+            /*default_hartids=*/std::vector<int>(),
+            /*default_real_time_clint=*/false);
+
   isa_parser_t isa(isa_string, DEFAULT_PRIV);
-  processor_t p(&isa, DEFAULT_VARCH, 0, 0, false, endianness_little, nullptr, cerr);
+  processor_t p(&isa, &cfg, 0, 0, false, nullptr, cerr);
   if (extension) {
     p.register_extension(extension());
   }

--- a/spike_main/spike-log-parser.cc
+++ b/spike_main/spike-log-parser.cc
@@ -33,6 +33,7 @@ int main(int UNUSED argc, char** argv)
             /*default_isa=*/DEFAULT_ISA,
             /*default_priv=*/DEFAULT_PRIV,
             /*default_varch=*/DEFAULT_VARCH,
+            /*default_misaligned=*/false,
             /*default_endianness*/endianness_little,
             /*default_pmpregions=*/16,
             /*default_mem_layout=*/std::vector<mem_cfg_t>(),

--- a/spike_main/spike.cc
+++ b/spike_main/spike.cc
@@ -49,6 +49,7 @@ static void help(int exit_code = 1)
   fprintf(stderr, "  --dc=<S>:<W>:<B>        W ways, and B-byte blocks (with S and\n");
   fprintf(stderr, "  --l2=<S>:<W>:<B>        B both powers of 2).\n");
   fprintf(stderr, "  --big-endian          Use a big-endian memory system.\n");
+  fprintf(stderr, "  --misaligned          Support misaligned memory accesses\n");
   fprintf(stderr, "  --device=<P,B,A>      Attach MMIO plugin device from an --extlib library\n");
   fprintf(stderr, "                          P -- Name of the MMIO plugin\n");
   fprintf(stderr, "                          B -- Base memory address of the device\n");
@@ -327,6 +328,7 @@ int main(int argc, char** argv)
             /*default_isa=*/DEFAULT_ISA,
             /*default_priv=*/DEFAULT_PRIV,
             /*default_varch=*/DEFAULT_VARCH,
+            /*default_misaligned=*/false,
             /*default_endianness*/endianness_little,
             /*default_pmpregions=*/16,
             /*default_mem_layout=*/parse_mem_layout("2048"),
@@ -399,6 +401,7 @@ int main(int argc, char** argv)
   parser.option(0, "dc", 1, [&](const char* s){dc.reset(new dcache_sim_t(s));});
   parser.option(0, "l2", 1, [&](const char* s){l2.reset(cache_sim_t::construct(s, "L2$"));});
   parser.option(0, "big-endian", 0, [&](const char UNUSED *s){cfg.endianness = endianness_big;});
+  parser.option(0, "misaligned", 0, [&](const char UNUSED *s){cfg.misaligned = true;});
   parser.option(0, "log-cache-miss", 0, [&](const char UNUSED *s){log_cache = true;});
   parser.option(0, "isa", 1, [&](const char* s){cfg.isa = s;});
   parser.option(0, "pmpregions", 1, [&](const char* s){cfg.pmpregions = atoul_safe(s);});


### PR DESCRIPTION
Command-line option `--misaligned` now controls whether misaligned accesses raise exceptions.

The configure argument `--enable-misaligned` has been removed.