### PR TITLE
triggers: refactor: add trap_common_t

### DIFF
--- a/riscv/triggers.cc
+++ b/riscv/triggers.cc
@@ -370,11 +370,16 @@ std::optional<match_result_t> etrigger_t::detect_trap_match(processor_t * const 
   bool interrupt = (t.cause() & ((reg_t)1 << (xlen - 1))) != 0;
   reg_t bit = t.cause() & ~((reg_t)1 << (xlen - 1));
   assert(bit < xlen);
-  if (!interrupt && ((tdata2 >> bit) & 1)) {
+  if (simple_match(interrupt, bit)) {
     hit = true;
     return match_result_t(TIMING_AFTER, action);
   }
   return std::nullopt;
+}
+
+bool etrigger_t::simple_match(bool interrupt, reg_t bit) const
+{
+  return !interrupt && ((tdata2 >> bit) & 1);
 }
 
 module_t::module_t(unsigned count) : triggers(count) {

--- a/riscv/triggers.cc
+++ b/riscv/triggers.cc
@@ -310,7 +310,7 @@ void itrigger_t::tdata1_write(processor_t * const proc, const reg_t val, const b
   action = legalize_action(get_field(val, CSR_ITRIGGER_ACTION));
 }
 
-std::optional<match_result_t> itrigger_t::detect_trap_match(processor_t * const proc, const trap_t& t) noexcept
+std::optional<match_result_t> trap_common_t::detect_trap_match(processor_t * const proc, const trap_t& t) noexcept
 {
   if (!mode_match(proc->get_state()))
     return std::nullopt;
@@ -359,22 +359,6 @@ void etrigger_t::tdata1_write(processor_t * const proc, const reg_t val, const b
   s = proc->extension_enabled_const('S') ? get_field(val, CSR_ETRIGGER_S) : 0;
   u = proc->extension_enabled_const('U') ? get_field(val, CSR_ETRIGGER_U) : 0;
   action = legalize_action(get_field(val, CSR_ETRIGGER_ACTION));
-}
-
-std::optional<match_result_t> etrigger_t::detect_trap_match(processor_t * const proc, const trap_t& t) noexcept
-{
-  if (!mode_match(proc->get_state()))
-    return std::nullopt;
-
-  auto xlen = proc->get_xlen();
-  bool interrupt = (t.cause() & ((reg_t)1 << (xlen - 1))) != 0;
-  reg_t bit = t.cause() & ~((reg_t)1 << (xlen - 1));
-  assert(bit < xlen);
-  if (simple_match(interrupt, bit)) {
-    hit = true;
-    return match_result_t(TIMING_AFTER, action);
-  }
-  return std::nullopt;
 }
 
 bool etrigger_t::simple_match(bool interrupt, reg_t bit) const

--- a/riscv/triggers.cc
+++ b/riscv/triggers.cc
@@ -54,6 +54,10 @@ void trigger_t::tdata3_write(processor_t * const proc, const reg_t val) noexcept
   sselect = (sselect_t)((proc->extension_enabled_const('S') && get_field(val, CSR_TEXTRA_SSELECT(xlen)) <= SSELECT_MAXVAL) ? get_field(val, CSR_TEXTRA_SSELECT(xlen)) : SSELECT_IGNORE);
 }
 
+bool trigger_t::common_match(processor_t * const proc) const noexcept {
+  return mode_match(proc->get_state()) && textra_match(proc);
+}
+
 bool trigger_t::mode_match(state_t * const state) const noexcept
 {
   switch (state->prv) {
@@ -190,8 +194,7 @@ std::optional<match_result_t> mcontrol_common_t::detect_memory_access_match(proc
   if ((operation == triggers::OPERATION_EXECUTE && !execute) ||
       (operation == triggers::OPERATION_STORE && !store) ||
       (operation == triggers::OPERATION_LOAD && !load) ||
-      !mode_match(proc->get_state()) ||
-      !textra_match(proc)) {
+      !common_match(proc)) {
     return std::nullopt;
   }
 
@@ -313,7 +316,7 @@ void itrigger_t::tdata1_write(processor_t * const proc, const reg_t val, const b
 
 std::optional<match_result_t> trap_common_t::detect_trap_match(processor_t * const proc, const trap_t& t) noexcept
 {
-  if (!mode_match(proc->get_state()) || !textra_match(proc))
+  if (!common_match(proc))
     return std::nullopt;
 
   auto xlen = proc->get_xlen();

--- a/riscv/triggers.cc
+++ b/riscv/triggers.cc
@@ -190,7 +190,8 @@ std::optional<match_result_t> mcontrol_common_t::detect_memory_access_match(proc
   if ((operation == triggers::OPERATION_EXECUTE && !execute) ||
       (operation == triggers::OPERATION_STORE && !store) ||
       (operation == triggers::OPERATION_LOAD && !load) ||
-      !mode_match(proc->get_state())) {
+      !mode_match(proc->get_state()) ||
+      !textra_match(proc)) {
     return std::nullopt;
   }
 
@@ -477,7 +478,7 @@ std::optional<match_result_t> module_t::detect_memory_access_match(operation_t o
      * entire chain did not match. This is allowed by the spec, because the final
      * trigger in the chain will never get `hit` set unless the entire chain
      * matches. */
-    auto result = trigger->textra_match(proc) ? trigger->detect_memory_access_match(proc, operation, address, data) : std::nullopt;
+    auto result = trigger->detect_memory_access_match(proc, operation, address, data);
     if (result.has_value() && !trigger->get_chain())
       return result;
 

--- a/riscv/triggers.cc
+++ b/riscv/triggers.cc
@@ -319,11 +319,16 @@ std::optional<match_result_t> itrigger_t::detect_trap_match(processor_t * const 
   bool interrupt = (t.cause() & ((reg_t)1 << (xlen - 1))) != 0;
   reg_t bit = t.cause() & ~((reg_t)1 << (xlen - 1));
   assert(bit < xlen);
-  if (interrupt && ((bit == 0 && nmi) || ((tdata2 >> bit) & 1))) { // Assume NMI's exception code is 0
+  if (simple_match(interrupt, bit)) {
     hit = true;
     return match_result_t(TIMING_AFTER, action);
   }
   return std::nullopt;
+}
+
+bool itrigger_t::simple_match(bool interrupt, reg_t bit) const
+{
+  return interrupt && ((bit == 0 && nmi) || ((tdata2 >> bit) & 1)); // Assume NMI's exception code is 0
 }
 
 reg_t etrigger_t::tdata1_read(const processor_t * const proc) const noexcept

--- a/riscv/triggers.cc
+++ b/riscv/triggers.cc
@@ -313,7 +313,7 @@ void itrigger_t::tdata1_write(processor_t * const proc, const reg_t val, const b
 
 std::optional<match_result_t> trap_common_t::detect_trap_match(processor_t * const proc, const trap_t& t) noexcept
 {
-  if (!mode_match(proc->get_state()))
+  if (!mode_match(proc->get_state()) || !textra_match(proc))
     return std::nullopt;
 
   auto xlen = proc->get_xlen();
@@ -494,7 +494,7 @@ std::optional<match_result_t> module_t::detect_trap_match(const trap_t& t) noexc
     return std::nullopt;
 
   for (auto trigger: triggers) {
-    auto result = trigger->textra_match(proc) ? trigger->detect_trap_match(proc, t) : std::nullopt;
+    auto result = trigger->detect_trap_match(proc, t);
     if (result.has_value())
       return result;
   }

--- a/riscv/triggers.h
+++ b/riscv/triggers.h
@@ -156,6 +156,7 @@ public:
   virtual std::optional<match_result_t> detect_trap_match(processor_t * const proc, const trap_t& t) noexcept override;
 
 private:
+  bool simple_match(bool interrupt, reg_t bit) const;
   bool dmode;
   bool hit;
   bool nmi;

--- a/riscv/triggers.h
+++ b/riscv/triggers.h
@@ -83,11 +83,11 @@ public:
   virtual std::optional<match_result_t> detect_memory_access_match(processor_t UNUSED * const proc,
       operation_t UNUSED operation, reg_t UNUSED address, std::optional<reg_t> UNUSED data) noexcept { return std::nullopt; }
   virtual std::optional<match_result_t> detect_trap_match(processor_t UNUSED * const proc, const trap_t UNUSED & t) noexcept { return std::nullopt; }
-  bool textra_match(processor_t * const proc) const noexcept;
 
 protected:
   action_t legalize_action(reg_t val) const noexcept;
   bool mode_match(state_t * const state) const noexcept;
+  bool textra_match(processor_t * const proc) const noexcept;
   reg_t tdata2;
 
   bool vs = false;

--- a/riscv/triggers.h
+++ b/riscv/triggers.h
@@ -150,6 +150,8 @@ public:
   bool get_dmode() const override { return dmode; }
   virtual action_t get_action() const override { return action; }
 
+  virtual std::optional<match_result_t> detect_trap_match(processor_t * const proc, const trap_t& t) noexcept override;
+
 private:
   virtual bool simple_match(bool interrupt, reg_t bit) const = 0;
 
@@ -164,8 +166,6 @@ public:
   virtual reg_t tdata1_read(const processor_t * const proc) const noexcept override;
   virtual void tdata1_write(processor_t * const proc, const reg_t val, const bool allow_chain) noexcept override;
 
-  virtual std::optional<match_result_t> detect_trap_match(processor_t * const proc, const trap_t& t) noexcept override;
-
 private:
   virtual bool simple_match(bool interrupt, reg_t bit) const override;
   bool nmi;
@@ -175,8 +175,6 @@ class etrigger_t : public trap_common_t {
 public:
   virtual reg_t tdata1_read(const processor_t * const proc) const noexcept override;
   virtual void tdata1_write(processor_t * const proc, const reg_t val, const bool allow_chain) noexcept override;
-
-  virtual std::optional<match_result_t> detect_trap_match(processor_t * const proc, const trap_t& t) noexcept override;
 
 private:
   virtual bool simple_match(bool interrupt, reg_t bit) const override;

--- a/riscv/triggers.h
+++ b/riscv/triggers.h
@@ -148,6 +148,7 @@ private:
 class trap_common_t : public trigger_t {
 protected:
   bool dmode;
+  bool hit;
 };
 
 class itrigger_t : public trap_common_t {
@@ -162,7 +163,6 @@ public:
 
 private:
   bool simple_match(bool interrupt, reg_t bit) const;
-  bool hit;
   bool nmi;
   action_t action;
 };
@@ -179,7 +179,6 @@ public:
 
 private:
   bool simple_match(bool interrupt, reg_t bit) const;
-  bool hit;
   action_t action;
 };
 

--- a/riscv/triggers.h
+++ b/riscv/triggers.h
@@ -86,6 +86,7 @@ public:
 
 protected:
   action_t legalize_action(reg_t val) const noexcept;
+  bool common_match(processor_t * const proc) const noexcept;
   bool mode_match(state_t * const state) const noexcept;
   bool textra_match(processor_t * const proc) const noexcept;
   reg_t tdata2;

--- a/riscv/triggers.h
+++ b/riscv/triggers.h
@@ -149,6 +149,7 @@ class trap_common_t : public trigger_t {
 protected:
   bool dmode;
   bool hit;
+  action_t action;
 };
 
 class itrigger_t : public trap_common_t {
@@ -164,7 +165,6 @@ public:
 private:
   bool simple_match(bool interrupt, reg_t bit) const;
   bool nmi;
-  action_t action;
 };
 
 class etrigger_t : public trap_common_t {
@@ -179,7 +179,6 @@ public:
 
 private:
   bool simple_match(bool interrupt, reg_t bit) const;
-  action_t action;
 };
 
 class mcontrol_common_t : public trigger_t {

--- a/riscv/triggers.h
+++ b/riscv/triggers.h
@@ -146,6 +146,9 @@ private:
 };
 
 class trap_common_t : public trigger_t {
+public:
+  bool get_dmode() const override { return dmode; }
+
 protected:
   bool dmode;
   bool hit;
@@ -157,7 +160,6 @@ public:
   virtual reg_t tdata1_read(const processor_t * const proc) const noexcept override;
   virtual void tdata1_write(processor_t * const proc, const reg_t val, const bool allow_chain) noexcept override;
 
-  bool get_dmode() const override { return dmode; }
   virtual action_t get_action() const override { return action; }
 
   virtual std::optional<match_result_t> detect_trap_match(processor_t * const proc, const trap_t& t) noexcept override;
@@ -172,7 +174,6 @@ public:
   virtual reg_t tdata1_read(const processor_t * const proc) const noexcept override;
   virtual void tdata1_write(processor_t * const proc, const reg_t val, const bool allow_chain) noexcept override;
 
-  bool get_dmode() const override { return dmode; }
   virtual action_t get_action() const override { return action; }
 
   virtual std::optional<match_result_t> detect_trap_match(processor_t * const proc, const trap_t& t) noexcept override;

--- a/riscv/triggers.h
+++ b/riscv/triggers.h
@@ -150,6 +150,9 @@ public:
   bool get_dmode() const override { return dmode; }
   virtual action_t get_action() const override { return action; }
 
+private:
+  virtual bool simple_match(bool interrupt, reg_t bit) const = 0;
+
 protected:
   bool dmode;
   bool hit;
@@ -164,7 +167,7 @@ public:
   virtual std::optional<match_result_t> detect_trap_match(processor_t * const proc, const trap_t& t) noexcept override;
 
 private:
-  bool simple_match(bool interrupt, reg_t bit) const;
+  virtual bool simple_match(bool interrupt, reg_t bit) const override;
   bool nmi;
 };
 
@@ -176,7 +179,7 @@ public:
   virtual std::optional<match_result_t> detect_trap_match(processor_t * const proc, const trap_t& t) noexcept override;
 
 private:
-  bool simple_match(bool interrupt, reg_t bit) const;
+  virtual bool simple_match(bool interrupt, reg_t bit) const override;
 };
 
 class mcontrol_common_t : public trigger_t {

--- a/riscv/triggers.h
+++ b/riscv/triggers.h
@@ -148,6 +148,7 @@ private:
 class trap_common_t : public trigger_t {
 public:
   bool get_dmode() const override { return dmode; }
+  virtual action_t get_action() const override { return action; }
 
 protected:
   bool dmode;
@@ -160,8 +161,6 @@ public:
   virtual reg_t tdata1_read(const processor_t * const proc) const noexcept override;
   virtual void tdata1_write(processor_t * const proc, const reg_t val, const bool allow_chain) noexcept override;
 
-  virtual action_t get_action() const override { return action; }
-
   virtual std::optional<match_result_t> detect_trap_match(processor_t * const proc, const trap_t& t) noexcept override;
 
 private:
@@ -173,8 +172,6 @@ class etrigger_t : public trap_common_t {
 public:
   virtual reg_t tdata1_read(const processor_t * const proc) const noexcept override;
   virtual void tdata1_write(processor_t * const proc, const reg_t val, const bool allow_chain) noexcept override;
-
-  virtual action_t get_action() const override { return action; }
 
   virtual std::optional<match_result_t> detect_trap_match(processor_t * const proc, const trap_t& t) noexcept override;
 

--- a/riscv/triggers.h
+++ b/riscv/triggers.h
@@ -174,6 +174,7 @@ public:
   virtual std::optional<match_result_t> detect_trap_match(processor_t * const proc, const trap_t& t) noexcept override;
 
 private:
+  bool simple_match(bool interrupt, reg_t bit) const;
   bool dmode;
   bool hit;
   action_t action;

--- a/riscv/triggers.h
+++ b/riscv/triggers.h
@@ -87,8 +87,6 @@ public:
 protected:
   action_t legalize_action(reg_t val) const noexcept;
   bool common_match(processor_t * const proc) const noexcept;
-  bool mode_match(state_t * const state) const noexcept;
-  bool textra_match(processor_t * const proc) const noexcept;
   reg_t tdata2;
 
   bool vs = false;
@@ -99,6 +97,8 @@ protected:
 
 private:
   unsigned legalize_mhselect(bool h_enabled) const noexcept;
+  bool mode_match(state_t * const state) const noexcept;
+  bool textra_match(processor_t * const proc) const noexcept;
 
   struct mhselect_interpretation {
     const unsigned mhselect;

--- a/riscv/triggers.h
+++ b/riscv/triggers.h
@@ -146,6 +146,8 @@ private:
 };
 
 class trap_common_t : public trigger_t {
+protected:
+  bool dmode;
 };
 
 class itrigger_t : public trap_common_t {
@@ -160,7 +162,6 @@ public:
 
 private:
   bool simple_match(bool interrupt, reg_t bit) const;
-  bool dmode;
   bool hit;
   bool nmi;
   action_t action;
@@ -178,7 +179,6 @@ public:
 
 private:
   bool simple_match(bool interrupt, reg_t bit) const;
-  bool dmode;
   bool hit;
   action_t action;
 };

--- a/riscv/triggers.h
+++ b/riscv/triggers.h
@@ -145,7 +145,10 @@ private:
   bool dmode;
 };
 
-class itrigger_t : public trigger_t {
+class trap_common_t : public trigger_t {
+};
+
+class itrigger_t : public trap_common_t {
 public:
   virtual reg_t tdata1_read(const processor_t * const proc) const noexcept override;
   virtual void tdata1_write(processor_t * const proc, const reg_t val, const bool allow_chain) noexcept override;
@@ -163,7 +166,7 @@ private:
   action_t action;
 };
 
-class etrigger_t : public trigger_t {
+class etrigger_t : public trap_common_t {
 public:
   virtual reg_t tdata1_read(const processor_t * const proc) const noexcept override;
   virtual void tdata1_write(processor_t * const proc, const reg_t val, const bool allow_chain) noexcept override;


### PR DESCRIPTION
This PR depends on https://github.com/riscv-software-src/riscv-isa-sim/pull/1177.
I will rebase this PR after merging https://github.com/riscv-software-src/riscv-isa-sim/pull/1177

This PR adds trap_common_t to clean up itrigger and etrigger.