### PR TITLE
Data trigger breaks AMO atomicity

### DIFF
--- a/riscv/mmu.h
+++ b/riscv/mmu.h
@@ -39,6 +39,7 @@ struct tlb_entry_t {
 };
 
 void throw_access_exception(bool virt, reg_t addr, access_type type);
+reg_t reg_from_bytes(size_t len, const uint8_t* bytes);
 
 // this class implements a processor's port into the virtual memory system.
 // an MMU and instruction cache are maintained for simulator performance.
@@ -138,7 +139,9 @@ public:
       if (likely(tlb_load_hit)) {
         res = *(target_endian<T>*)(tlb_data[vpn % TLB_ENTRIES].host_offset + addr);
       } else {
-        load_slow_path(addr, sizeof(T), (uint8_t*)&res, 0);
+        check_triggers(triggers::OPERATION_LOAD, addr);
+        load_slow_path_intrapage(addr, sizeof(T), (uint8_t*)&res, 0);
+        check_triggers(triggers::OPERATION_LOAD, addr, reg_from_bytes(sizeof(T), (uint8_t*)&res));
       }
 
       if (unlikely(proc && proc->get_log_commits_enabled()))

--- a/riscv/mmu.h
+++ b/riscv/mmu.h
@@ -135,6 +135,7 @@ public:
       target_endian<T> res;
       reg_t vpn = addr >> PGSHIFT;
       bool tlb_load_hit = tlb_load_tag[vpn % TLB_ENTRIES] == vpn;
+      bool tlb_store_hit = tlb_store_tag[vpn % TLB_ENTRIES] == vpn;
 
       if (likely(tlb_load_hit)) {
         res = *(target_endian<T>*)(tlb_data[vpn % TLB_ENTRIES].host_offset + addr);
@@ -144,7 +145,6 @@ public:
       }
 
       auto lhs = from_target(res);
-      bool tlb_store_hit = tlb_store_tag[vpn % TLB_ENTRIES] == vpn;
 
       if (likely(tlb_store_hit)) {
         *(target_endian<T>*)(tlb_data[vpn % TLB_ENTRIES].host_offset + addr) = to_target((T)f(lhs));

--- a/riscv/mmu.h
+++ b/riscv/mmu.h
@@ -154,7 +154,8 @@ public:
         *(target_endian<T>*)(tlb_data[vpn % TLB_ENTRIES].host_offset + addr) = to_target((T)f(lhs));
       } else {
         target_endian<T> target_val = to_target((T)f(lhs));
-        store_slow_path(addr, sizeof(T), (const uint8_t*)&target_val, 0, true, false);
+        check_triggers(triggers::OPERATION_STORE, addr, reg_from_bytes(sizeof(T), (const uint8_t*)&target_val));
+        store_slow_path_intrapage(addr, sizeof(T), (const uint8_t*)&target_val, 0, true);
       }
 
       if (unlikely(proc && proc->get_log_commits_enabled()))


### PR DESCRIPTION
The data trigger breaks AMO's atomicity. (https://github.com/riscv-software-src/riscv-isa-sim/pull/1164)

This PR aims to separate the trigger checking and load/store operation to guarantee the atomicity.