### PR TITLE
Only update histogram when histogramming

### DIFF
--- a/riscv/execute.cc
+++ b/riscv/execute.cc
@@ -152,7 +152,8 @@ static void commit_log_print_insn(processor_t *p, reg_t pc, insn_t insn)
 
 inline void processor_t::update_histogram(reg_t UNUSED pc)
 {
-  pc_histogram[pc]++;
+  if (histogram_enabled)
+    pc_histogram[pc]++;
 }
 
 // These two functions are expected to be inlined by the compiler separately in

--- a/riscv/execute.cc
+++ b/riscv/execute.cc
@@ -150,7 +150,7 @@ static void commit_log_print_insn(processor_t *p, reg_t pc, insn_t insn)
   fprintf(log_file, "\n");
 }
 
-inline void processor_t::update_histogram(reg_t UNUSED pc)
+inline void processor_t::update_histogram(reg_t pc)
 {
   if (histogram_enabled)
     pc_histogram[pc]++;


### PR DESCRIPTION
This is worth a 1.4x speedup on the slow path (when not histogramming).