### PR TITLE
Add legalize_timing() for tdata1.timing

### DIFF
--- a/riscv/triggers.cc
+++ b/riscv/triggers.cc
@@ -221,7 +221,7 @@ std::optional<match_result_t> mcontrol_common_t::detect_memory_access_match(proc
   return std::nullopt;
 }
 
-mcontrol_common_t::match_t mcontrol_common_t::legalize_match(reg_t val) const noexcept
+mcontrol_common_t::match_t mcontrol_common_t::legalize_match(reg_t val) noexcept
 {
   switch (val) {
     case MATCH_EQUAL:

--- a/riscv/triggers.cc
+++ b/riscv/triggers.cc
@@ -148,7 +148,7 @@ void mcontrol_t::tdata1_write(processor_t * const proc, const reg_t val, const b
   dmode = get_field(val, CSR_MCONTROL_DMODE(xlen));
   hit = get_field(val, CSR_MCONTROL_HIT);
   select = get_field(val, MCONTROL_SELECT);
-  timing = get_field(val, MCONTROL_TIMING);
+  timing = legalize_timing(val, MCONTROL_TIMING, MCONTROL_EXECUTE);
   action = legalize_action(get_field(val, MCONTROL_ACTION));
   chain = allow_chain ? get_field(val, MCONTROL_CHAIN) : 0;
   match = legalize_match(get_field(val, MCONTROL_MATCH));
@@ -159,8 +159,6 @@ void mcontrol_t::tdata1_write(processor_t * const proc, const reg_t val, const b
   store = get_field(val, MCONTROL_STORE);
   load = get_field(val, MCONTROL_LOAD);
   // Assume we're here because of csrw.
-  if (execute)
-    timing = 0;
 }
 
 bool mcontrol_common_t::simple_match(unsigned xlen, reg_t value) const {
@@ -238,6 +236,12 @@ mcontrol_common_t::match_t mcontrol_common_t::legalize_match(reg_t val) const no
   }
 }
 
+bool mcontrol_common_t::legalize_timing(reg_t val, reg_t timing_mask, reg_t execute_mask) noexcept {
+  if (get_field(val, execute_mask))
+    return TIMING_BEFORE;
+  return get_field(val, timing_mask);
+}
+
 reg_t mcontrol6_t::tdata1_read(const processor_t * const proc) const noexcept {
   unsigned xlen = proc->get_const_xlen();
   reg_t tdata1 = 0;
@@ -268,7 +272,7 @@ void mcontrol6_t::tdata1_write(processor_t * const proc, const reg_t val, const 
   vu = get_field(val, CSR_MCONTROL6_VU);
   hit = get_field(val, CSR_MCONTROL6_HIT);
   select = get_field(val, CSR_MCONTROL6_SELECT);
-  timing = get_field(val, CSR_MCONTROL6_TIMING);
+  timing = legalize_timing(val, CSR_MCONTROL6_TIMING, CSR_MCONTROL6_EXECUTE);
   action = legalize_action(get_field(val, CSR_MCONTROL6_ACTION));
   chain = allow_chain ? get_field(val, CSR_MCONTROL6_CHAIN) : 0;
   match = legalize_match(get_field(val, CSR_MCONTROL6_MATCH));
@@ -278,8 +282,6 @@ void mcontrol6_t::tdata1_write(processor_t * const proc, const reg_t val, const 
   execute = get_field(val, CSR_MCONTROL6_EXECUTE);
   store = get_field(val, CSR_MCONTROL6_STORE);
   load = get_field(val, CSR_MCONTROL6_LOAD);
-  if (execute)
-    timing = 0;
 }
 
 reg_t itrigger_t::tdata1_read(const processor_t * const proc) const noexcept

--- a/riscv/triggers.cc
+++ b/riscv/triggers.cc
@@ -25,7 +25,7 @@ void trigger_t::tdata2_write(processor_t UNUSED * const proc, const reg_t UNUSED
   tdata2 = val;
 }
 
-action_t trigger_t::legalize_action(reg_t val, reg_t action_mask, reg_t dmode_mask) const noexcept {
+action_t trigger_t::legalize_action(reg_t val, reg_t action_mask, reg_t dmode_mask) noexcept {
   reg_t act = get_field(val, action_mask);
   return (act > ACTION_MAXVAL || (act == ACTION_DEBUG_MODE && get_field(val, dmode_mask) == 0)) ? ACTION_DEBUG_EXCEPTION : (action_t)act;
 }

--- a/riscv/triggers.cc
+++ b/riscv/triggers.cc
@@ -148,7 +148,7 @@ void mcontrol_t::tdata1_write(processor_t * const proc, const reg_t val, const b
   dmode = get_field(val, CSR_MCONTROL_DMODE(xlen));
   hit = get_field(val, CSR_MCONTROL_HIT);
   select = get_field(val, MCONTROL_SELECT);
-  timing = legalize_timing(val, MCONTROL_TIMING, MCONTROL_EXECUTE);
+  timing = legalize_timing(val, MCONTROL_TIMING, MCONTROL_SELECT, MCONTROL_EXECUTE, MCONTROL_LOAD);
   action = legalize_action(get_field(val, MCONTROL_ACTION));
   chain = allow_chain ? get_field(val, MCONTROL_CHAIN) : 0;
   match = legalize_match(get_field(val, MCONTROL_MATCH));
@@ -235,7 +235,10 @@ mcontrol_common_t::match_t mcontrol_common_t::legalize_match(reg_t val) const no
   }
 }
 
-bool mcontrol_common_t::legalize_timing(reg_t val, reg_t timing_mask, reg_t execute_mask) noexcept {
+bool mcontrol_common_t::legalize_timing(reg_t val, reg_t timing_mask, reg_t select_mask, reg_t execute_mask, reg_t load_mask) noexcept {
+  // For load data triggers, force timing=after to avoid debugger having to repeat loads which may have side effects.
+  if (get_field(val, select_mask) && get_field(val, load_mask))
+    return TIMING_AFTER;
   if (get_field(val, execute_mask))
     return TIMING_BEFORE;
   return get_field(val, timing_mask);
@@ -271,7 +274,7 @@ void mcontrol6_t::tdata1_write(processor_t * const proc, const reg_t val, const 
   vu = get_field(val, CSR_MCONTROL6_VU);
   hit = get_field(val, CSR_MCONTROL6_HIT);
   select = get_field(val, CSR_MCONTROL6_SELECT);
-  timing = legalize_timing(val, CSR_MCONTROL6_TIMING, CSR_MCONTROL6_EXECUTE);
+  timing = legalize_timing(val, CSR_MCONTROL6_TIMING, CSR_MCONTROL6_SELECT, CSR_MCONTROL6_EXECUTE, CSR_MCONTROL6_LOAD);
   action = legalize_action(get_field(val, CSR_MCONTROL6_ACTION));
   chain = allow_chain ? get_field(val, CSR_MCONTROL6_CHAIN) : 0;
   match = legalize_match(get_field(val, CSR_MCONTROL6_MATCH));

--- a/riscv/triggers.cc
+++ b/riscv/triggers.cc
@@ -158,7 +158,6 @@ void mcontrol_t::tdata1_write(processor_t * const proc, const reg_t val, const b
   execute = get_field(val, MCONTROL_EXECUTE);
   store = get_field(val, MCONTROL_STORE);
   load = get_field(val, MCONTROL_LOAD);
-  // Assume we're here because of csrw.
 }
 
 bool mcontrol_common_t::simple_match(unsigned xlen, reg_t value) const {

--- a/riscv/triggers.h
+++ b/riscv/triggers.h
@@ -208,7 +208,7 @@ private:
 
 protected:
   match_t legalize_match(reg_t val) const noexcept;
-  static bool legalize_timing(reg_t val, reg_t timing_mask, reg_t execute_mask) noexcept;
+  static bool legalize_timing(reg_t val, reg_t timing_mask, reg_t select_mask, reg_t execute_mask, reg_t load_mask) noexcept;
   bool dmode = false;
   action_t action = ACTION_DEBUG_EXCEPTION;
   bool hit = false;

--- a/riscv/triggers.h
+++ b/riscv/triggers.h
@@ -208,6 +208,7 @@ private:
 
 protected:
   match_t legalize_match(reg_t val) const noexcept;
+  static bool legalize_timing(reg_t val, reg_t timing_mask, reg_t execute_mask) noexcept;
   bool dmode = false;
   action_t action = ACTION_DEBUG_EXCEPTION;
   bool hit = false;

--- a/riscv/triggers.h
+++ b/riscv/triggers.h
@@ -85,7 +85,7 @@ public:
   virtual std::optional<match_result_t> detect_trap_match(processor_t UNUSED * const proc, const trap_t UNUSED & t) noexcept { return std::nullopt; }
 
 protected:
-  action_t legalize_action(reg_t val) const noexcept;
+  action_t legalize_action(reg_t val, reg_t action_mask, reg_t dmode_mask) const noexcept;
   bool common_match(processor_t * const proc) const noexcept;
   reg_t tdata2;
 

--- a/riscv/triggers.h
+++ b/riscv/triggers.h
@@ -207,7 +207,7 @@ private:
   bool simple_match(unsigned xlen, reg_t value) const;
 
 protected:
-  match_t legalize_match(reg_t val) const noexcept;
+  static match_t legalize_match(reg_t val) noexcept;
   static bool legalize_timing(reg_t val, reg_t timing_mask, reg_t select_mask, reg_t execute_mask, reg_t load_mask) noexcept;
   bool dmode = false;
   action_t action = ACTION_DEBUG_EXCEPTION;

--- a/riscv/triggers.h
+++ b/riscv/triggers.h
@@ -85,7 +85,7 @@ public:
   virtual std::optional<match_result_t> detect_trap_match(processor_t UNUSED * const proc, const trap_t UNUSED & t) noexcept { return std::nullopt; }
 
 protected:
-  action_t legalize_action(reg_t val, reg_t action_mask, reg_t dmode_mask) const noexcept;
+  static action_t legalize_action(reg_t val, reg_t action_mask, reg_t dmode_mask) noexcept;
   bool common_match(processor_t * const proc) const noexcept;
   reg_t tdata2;
 


### PR DESCRIPTION
The load data trigger can only be after executing the instruction. This PR adds legalize_timing() to enforce the legal timing value of the load data trigger.

The legalize_timing() implicitly depends on select, execution, load, and store. So, reordering the statement in the tdata1_write() may break the functionality. I need help finding a good way to avoid this and seeking suggestions.

Additionally, I cannot find the reference in debug spec for legalizing timing=0(before) of execution triggers. Although this implementation conforms to the debug spec, should we consider removing the legalization of execution triggers' timing for a more general implementation? (The test suite https://github.com/riscv-software-src/riscv-tests/tree/master/debug is still passed after removing the legalization.)