### PR TITLE
For NS16550 UART, poll stdin less often

### DIFF
--- a/riscv/devices.h
+++ b/riscv/devices.h
@@ -148,6 +148,9 @@ class ns16550_t : public abstract_device_t {
   void update_interrupt(void);
   uint8_t rx_byte(void);
   void tx_byte(uint8_t val);
+
+  int backoff_counter;
+  static const int MAX_BACKOFF = 16;
 };
 
 class mmio_plugin_device_t : public abstract_device_t {


### PR DESCRIPTION
On my Mac Mini, calling `poll()` on stdin takes around 10 us, and we are invoking it every 20 us or so.  Reduce the frequency of polling by 16x when not actively receiving data, thereby reducing the fraction of time spent in `poll()` to a trivial amount.