### PR TITLE
Run Spike and HTIF in a single thread, rather than two

### DIFF
--- a/riscv/sim.h
+++ b/riscv/sim.h
@@ -11,7 +11,6 @@
 #include "simif.h"
 
 #include <fesvr/htif.h>
-#include <fesvr/context.h>
 #include <vector>
 #include <string>
 #include <memory>
@@ -137,11 +136,6 @@ private:
   friend class debug_module_t;
 
   // htif
-  friend void sim_thread_main(void*);
-  void main();
-
-  context_t* host;
-  context_t target;
   void reset();
   void idle();
   void read_chunk(addr_t taddr, size_t len, void* dst);


### PR DESCRIPTION
The two-thread approach was originally motivated by making Spike look as similar as possible to other HTIF targets.  But we can get the same semantics without threading by running the simulator inside of the HTIF host's idle loop instead of performing a context switch.

This was motivated by speeding up the simulator on Mac OS (it's worth around 20% because using pthread condition variables to force strict alternation is very slow).  But I think it also simplifies the control flow enough to justify it on that basis, too.