### PR TITLE
Lift artificial limit of 191 extensions; simplify isa_parser_t::extension_enabled

### DIFF
--- a/riscv/isa_parser.cc
+++ b/riscv/isa_parser.cc
@@ -28,7 +28,7 @@ static void bad_priv_string(const char* priv)
 }
 
 isa_parser_t::isa_parser_t(const char* str, const char *priv)
-  : extension_table(256, false)
+  : extension_table(NUM_ISA_EXTENSIONS, false)
 {
   isa_string = strtolower(str);
   const char* all_subsets = "mafdqchpv";

--- a/riscv/isa_parser.cc
+++ b/riscv/isa_parser.cc
@@ -28,7 +28,6 @@ static void bad_priv_string(const char* priv)
 }
 
 isa_parser_t::isa_parser_t(const char* str, const char *priv)
-  : extension_table(NUM_ISA_EXTENSIONS, false)
 {
   isa_string = strtolower(str);
   const char* all_subsets = "mafdqchpv";

--- a/riscv/isa_parser.h
+++ b/riscv/isa_parser.h
@@ -4,7 +4,7 @@
 
 #include "decode.h"
 
-#include <vector>
+#include <bitset>
 #include <string>
 #include <unordered_map>
 
@@ -98,7 +98,7 @@ public:
 protected:
   unsigned max_xlen;
   reg_t max_isa;
-  std::vector<bool> extension_table;
+  std::bitset<NUM_ISA_EXTENSIONS> extension_table;
   std::string isa_string;
   std::unordered_map<std::string, extension_t*> extensions;
 };

--- a/riscv/isa_parser.h
+++ b/riscv/isa_parser.h
@@ -62,6 +62,7 @@ typedef enum {
   EXT_XZBR,
   EXT_XZBT,
   EXT_SSTC,
+  NUM_ISA_EXTENSIONS
 } isa_extension_t;
 
 typedef enum {
@@ -83,6 +84,9 @@ public:
   reg_t get_max_isa() const { return max_isa; }
   std::string get_isa_string() const { return isa_string; }
   bool extension_enabled(unsigned char ext) const {
+    return extension_enabled(isa_extension_t(ext));
+  }
+  bool extension_enabled(isa_extension_t ext) const {
     if (ext >= 'A' && ext <= 'Z')
       return (max_isa >> (ext - 'A')) & 1;
     else

--- a/riscv/isa_parser.h
+++ b/riscv/isa_parser.h
@@ -87,10 +87,7 @@ public:
     return extension_enabled(isa_extension_t(ext));
   }
   bool extension_enabled(isa_extension_t ext) const {
-    if (ext >= 'A' && ext <= 'Z')
-      return (max_isa >> (ext - 'A')) & 1;
-    else
-      return extension_table[ext];
+    return extension_table[ext];
   }
   const std::unordered_map<std::string, extension_t*> &
   get_extensions() const { return extensions; }

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -217,6 +217,9 @@ public:
     return !custom_extensions.empty();
   }
   bool extension_enabled(unsigned char ext) const {
+    return extension_enabled(isa_extension_t(ext));
+  }
+  bool extension_enabled(isa_extension_t ext) const {
     if (ext >= 'A' && ext <= 'Z')
       return state.misa->extension_enabled(ext);
     else
@@ -226,6 +229,9 @@ public:
   // possibly be disabled dynamically. Useful for documenting
   // assumptions about writable misa bits.
   bool extension_enabled_const(unsigned char ext) const {
+    return extension_enabled_const(isa_extension_t(ext));
+  }
+  bool extension_enabled_const(isa_extension_t ext) const {
     if (ext >= 'A' && ext <= 'Z')
       return state.misa->extension_enabled_const(ext);
     else


### PR DESCRIPTION
The isa_extension_t enum is no longer limited by the range of unsigned char.  (I tested this by locally forcing EXT_ZFH to begin at ('A' + 256), so that the Z* extensions would alias the lettered extensions if we accidentally truncated to unsigned char.)

Retain the methods that test for extensions as unsigned chars to reduce churn in the codebase.

Relatedly, simplify isa_parser_t::extension_enabled to access only extension_table, rather than conditionally accessing max_isa as well.