### PR TITLE
Add more hint when searched path is wrong

### DIFF
--- a/fesvr/htif.cc
+++ b/fesvr/htif.cc
@@ -112,6 +112,12 @@ std::map<std::string, uint64_t> htif_t::load_payload(const std::string& payload,
     std::string test_path = PREFIX TARGET_DIR + payload;
     if (access(test_path.c_str(), F_OK) == 0)
       path = test_path;
+    else
+      throw std::runtime_error(
+        "could not open " + payload + "; searched paths:\n" +
+        "\t. (current directory)\n" + 
+        "\t" + PREFIX TARGET_DIR + " (based on configured --prefix and --with-target)"
+      );
   }
 
   if (path.empty())


### PR DESCRIPTION
Delete the old branch and pull a new one, because of a wrong force push. Git is not as easy as I think.

When people type `spike ls`, they will get:
```
terminate called after throwing an instance of 'std::runtime_error'
  what():  could not open ls; searched paths:
        . (current directory)
        /usr/local/riscv64-unknown-elf/bin/ (based on configured --prefix and --with-target)
```

things like `spike /tmp/ls` will still get:
```
terminate called after throwing an instance of 'std::runtime_error'
  what():  could not open /tmp/ls (did you misspell it? If VCS, did you forget +permissive/+permissive-off?)
```

Thanks for help from @scottj97 @jerryz123 @aswaterman .
Signed-off-by: gr816ox <50945677+gr816ox@users.noreply.github.com>