### PR TITLE
Add htif_t tohost/fromhost accessors

### DIFF
--- a/fesvr/htif.h
+++ b/fesvr/htif.h
@@ -69,6 +69,9 @@ class htif_t : public chunked_memif_t
 
   // Given an address, return symbol from addr2symbol map
   const char* get_symbol(uint64_t addr);
+  
+  addr_t get_tohost_addr() { return tohost_addr; }
+  addr_t get_fromhost_addr() { return fromhost_addr; }
 
  private:
   void parse_arguments(int argc, char ** argv);


### PR DESCRIPTION
When using spike as tandem-verification, reads/writes to tohost/fromhost have to be handled specially, since the target HTIF implementation may behave differently from spike's. 
This PR provides accessors for the private members.
