### PR TITLE
Support all 64 PMP regions

### DIFF
--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -583,7 +583,7 @@ void processor_t::set_pmp_num(reg_t n)
 {
   // check the number of pmp is in a reasonable range
   if (n > state.max_pmp) {
-    fprintf(stderr, "error: bad number of pmp regions: '%ld' from the dtb\n", (unsigned long)n);
+    fprintf(stderr, "error: number of PMP regions requested (%" PRIu64 ") exceeds maximum (%d)\n", n, state.max_pmp);
     abort();
   }
   n_pmp = n;
@@ -592,8 +592,9 @@ void processor_t::set_pmp_num(reg_t n)
 void processor_t::set_pmp_granularity(reg_t gran)
 {
   // check the pmp granularity is set from dtb(!=0) and is power of 2
-  if (gran < (1 << PMP_SHIFT) || (gran & (gran - 1)) != 0) {
-    fprintf(stderr, "error: bad pmp granularity '%ld' from the dtb\n", (unsigned long)gran);
+  unsigned min = 1 << PMP_SHIFT;
+  if (gran < min || (gran & (gran - 1)) != 0) {
+    fprintf(stderr, "error: PMP granularity (%" PRIu64 ") must be a power of two and at least %u\n", gran, min);
     abort();
   }
 

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -136,7 +136,7 @@ struct state_t
 
   mseccfg_csr_t_p mseccfg;
 
-  static const int max_pmp = 16;
+  static const int max_pmp = 64;
   pmpaddr_csr_t_p pmpaddr[max_pmp];
 
   float_csr_t_p fflags;

--- a/riscv/sim.cc
+++ b/riscv/sim.cc
@@ -156,20 +156,10 @@ sim_t::sim_t(const cfg_t *cfg, bool halted,
       break;
 
     //handle pmp
-    reg_t pmp_num = 0, pmp_granularity = 0;
-    if (fdt_parse_pmp_num(fdt, cpu_offset, &pmp_num) == 0) {
-      if (pmp_num <= 64) {
-        procs[cpu_idx]->set_pmp_num(pmp_num);
-      } else {
-        std::cerr << "core ("
-                  << cpu_idx
-                  << ") doesn't have valid 'riscv,pmpregions'"
-                  << pmp_num << ").\n";
-        exit(1);
-      }
-    } else {
-      procs[cpu_idx]->set_pmp_num(0);
-    }
+    reg_t pmp_num, pmp_granularity;
+    if (fdt_parse_pmp_num(fdt, cpu_offset, &pmp_num) != 0)
+      pmp_num = 0;
+    procs[cpu_idx]->set_pmp_num(pmp_num);
 
     if (fdt_parse_pmp_alignment(fdt, cpu_offset, &pmp_granularity) == 0) {
       procs[cpu_idx]->set_pmp_granularity(pmp_granularity);


### PR DESCRIPTION
The DTB parser supported all 64, but processor_t only supported 16.

The default of 16, which is specified in `main()`, has not changed.  But note there _is_ a functional change: the additional PMP CSRs will now be present (but by default hardwired to 0).  This is a legal implementation, and the deviation from the old behavior seems so minor that conditionalizing this property doesn't seem worthwhile.