### PR TITLE
Make htif->get_to/fromhost_addr methods public

### DIFF
--- a/fesvr/htif.h
+++ b/fesvr/htif.h
@@ -45,6 +45,9 @@ class htif_t : public chunked_memif_t
     return endianness == endianness_big? target_endian<T>::to_be(n) : target_endian<T>::to_le(n);
   }
 
+  addr_t get_tohost_addr() { return tohost_addr; }
+  addr_t get_fromhost_addr() { return fromhost_addr; }
+
  protected:
   virtual void reset() = 0;
 
@@ -69,9 +72,6 @@ class htif_t : public chunked_memif_t
 
   // Given an address, return symbol from addr2symbol map
   const char* get_symbol(uint64_t addr);
-  
-  addr_t get_tohost_addr() { return tohost_addr; }
-  addr_t get_fromhost_addr() { return fromhost_addr; }
 
  private:
   void parse_arguments(int argc, char ** argv);


### PR DESCRIPTION
In #1232 I accidentally made the methods protected, not public, as intended