### PR TITLE
Fixes towards enabling external compilation of extension libraries

### DIFF
--- a/customext/cflush.cc
+++ b/customext/cflush.cc
@@ -1,5 +1,6 @@
 #include "insn_macros.h"
 #include "extension.h"
+#include "decode_macros.h"
 #include <cstring>
 
 struct : public arg_t {

--- a/disasm/disasm.cc
+++ b/disasm/disasm.cc
@@ -1,6 +1,7 @@
 // See LICENSE for license details.
 
 #include "disasm.h"
+#include "decode_macros.h"
 #include <cassert>
 #include <string>
 #include <vector>

--- a/riscv/disasm.h
+++ b/riscv/disasm.h
@@ -3,7 +3,8 @@
 #ifndef _RISCV_DISASM_H
 #define _RISCV_DISASM_H
 
-#include "decode_macros.h"
+#include "common.h"
+#include "decode.h"
 #include "isa_parser.h"
 #include <string>
 #include <sstream>

--- a/riscv/execute.cc
+++ b/riscv/execute.cc
@@ -4,6 +4,7 @@
 #include "processor.h"
 #include "mmu.h"
 #include "disasm.h"
+#include "decode_macros.h"
 #include <cassert>
 
 static void commit_log_reset(processor_t* p)

--- a/riscv/interactive.cc
+++ b/riscv/interactive.cc
@@ -3,6 +3,7 @@
 #include "config.h"
 #include "sim.h"
 #include "decode.h"
+#include "decode_macros.h"
 #include "disasm.h"
 #include "mmu.h"
 #include "vector_unit.h"

--- a/riscv/mmu.h
+++ b/riscv/mmu.h
@@ -9,7 +9,7 @@
 #include "simif.h"
 #include "processor.h"
 #include "memtracer.h"
-#include "byteorder.h"
+#include "../fesvr/byteorder.h"
 #include "triggers.h"
 #include "cfg.h"
 #include <stdlib.h>

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -5,6 +5,7 @@
 #include "extension.h"
 #include "common.h"
 #include "config.h"
+#include "decode_macros.h"
 #include "simif.h"
 #include "mmu.h"
 #include "disasm.h"

--- a/riscv/riscv.mk.in
+++ b/riscv/riscv.mk.in
@@ -24,8 +24,10 @@ riscv_install_hdrs = \
 	debug_rom_defines.h \
 	decode.h \
 	devices.h \
+	disasm.h \
 	encoding.h \
 	entropy_source.h \
+	extension.h \
 	isa_parser.h \
 	log_file.h \
 	memtracer.h \
@@ -33,6 +35,7 @@ riscv_install_hdrs = \
 	mmu.h \
 	platform.h \
 	processor.h \
+	rocc.h \
 	sim.h \
 	simif.h \
 	trap.h \

--- a/riscv/rocc.h
+++ b/riscv/rocc.h
@@ -37,12 +37,15 @@ class rocc_t : public extension_t
   { \
     type_name* rocc = static_cast<type_name*>(p->get_extension(ext_name_str)); \
     rocc_insn_union_t u; \
-    u.i = insn; \
-    reg_t xs1 = u.r.xs1 ? RS1 : -1; \
-    reg_t xs2 = u.r.xs2 ? RS2 : -1; \
-    reg_t xd = rocc->method_name(u.r, xs1, xs2); \
-    if (u.r.xd) \
-      WRITE_RD(xd); \
+    state_t* state = p->get_state();                          \
+    u.i = insn;                                               \
+    reg_t xs1 = u.r.xs1 ? state->XPR[insn.rs1()] : -1;        \
+    reg_t xs2 = u.r.xs2 ? state->XPR[insn.rs2()] : -1;        \
+    reg_t xd = rocc->method_name(u.r, xs1, xs2);              \
+    if (u.r.xd) {                                                 \
+      state->log_reg_write[insn.rd() << 4] = {xd, 0};             \
+      state->XPR.write(insn.rd(), xd);                            \
+    }                                                             \
     return pc+4; \
   } \
 

--- a/riscv/rocc.h
+++ b/riscv/rocc.h
@@ -47,7 +47,12 @@ class rocc_t : public extension_t
   } \
 
 #define push_custom_insn(insn_list, opcode, opcode_mask, func_name_32, func_name_64) \
-  insn_list.push_back((insn_desc_t){opcode, opcode_mask, func_name_32, func_name_64})
+  insn_list.push_back((insn_desc_t){opcode, opcode_mask,                \
+    func_name_32, func_name_64,                                         \
+    func_name_32, func_name_64,                                         \
+    func_name_32, func_name_64,                                         \
+    func_name_32, func_name_64,                                         \
+  })                                                                    \
 
 #define ILLEGAL_INSN_FUNC &::illegal_instruction
 


### PR DESCRIPTION
These patches make some more headers usable by external libraries, towards enabling easier compilation of libraries containing custom instructions.