### PR TITLE
Only generate a dtb and bus devices if dtb_enabled

### DIFF
--- a/riscv/dts.cc
+++ b/riscv/dts.cc
@@ -61,7 +61,7 @@ std::string make_dts(size_t insns_per_rtc_tick, size_t cpu_hz,
          "      riscv,isa = \"" << procs[i]->get_isa().get_isa_string() << "\";\n"
          "      mmu-type = \"riscv," << (procs[i]->get_isa().get_max_xlen() <= 32 ? "sv32" : "sv57") << "\";\n"
          "      riscv,pmpregions = <" << pmpregions << ">;\n"
-         "      riscv,pmpgranularity = <4>;\n"
+         "      riscv,pmpgranularity = <" << (1 << PMP_SHIFT) << ">;\n"
          "      clock-frequency = <" << cpu_hz << ">;\n"
          "      CPU" << i << "_intc: interrupt-controller {\n"
          "        #address-cells = <2>;\n"

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -58,7 +58,7 @@ processor_t::processor_t(const isa_parser_t *isa, const cfg_t *cfg,
     register_extension(e.second);
 
   set_pmp_granularity(1 << PMP_SHIFT);
-  set_pmp_num(state.max_pmp);
+  set_pmp_num(cfg->pmpregions);
 
   if (isa->get_max_xlen() == 32)
     set_mmu_capability(IMPL_MMU_SV32);

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -63,7 +63,7 @@ processor_t::processor_t(const isa_parser_t *isa, const cfg_t *cfg,
   if (isa->get_max_xlen() == 32)
     set_mmu_capability(IMPL_MMU_SV32);
   else if (isa->get_max_xlen() == 64)
-    set_mmu_capability(IMPL_MMU_SV48);
+    set_mmu_capability(IMPL_MMU_SV57);
 
   set_impl(IMPL_MMU_ASID, true);
   set_impl(IMPL_MMU_VMID, true);

--- a/riscv/sim.cc
+++ b/riscv/sim.cc
@@ -45,7 +45,6 @@ sim_t::sim_t(const cfg_t *cfg, bool halted,
     mems(mems),
     plugin_devices(plugin_devices),
     procs(std::max(cfg->nprocs(), size_t(1))),
-    dtb_file(dtb_file ? dtb_file : ""),
     dtb_enabled(dtb_enabled),
     log_file(log_path),
     cmd_file(cmd_file),
@@ -102,7 +101,7 @@ sim_t::sim_t(const cfg_t *cfg, bool halted,
                                log_file.get(), sout_);
   }
 
-  make_dtb();
+  make_dtb(dtb_file);
 
   void *fdt = (void *)dtb.c_str();
 
@@ -293,10 +292,10 @@ bool sim_t::mmio_store(reg_t paddr, size_t len, const uint8_t* bytes)
   return bus.store(paddr, len, bytes);
 }
 
-void sim_t::make_dtb()
+void sim_t::make_dtb(const char* dtb_file)
 {
-  if (!dtb_file.empty()) {
-    std::ifstream fin(dtb_file.c_str(), std::ios::binary);
+  if (dtb_file) {
+    std::ifstream fin(dtb_file, std::ios::binary);
     if (!fin.good()) {
       std::cerr << "can't find dtb file: " << dtb_file << std::endl;
       exit(-1);
@@ -317,7 +316,7 @@ void sim_t::make_dtb()
   int fdt_code = fdt_check_header(dtb.c_str());
   if (fdt_code) {
     std::cerr << "Failed to read DTB from ";
-    if (dtb_file.empty()) {
+    if (!dtb_file) {
       std::cerr << "auto-generated DTS string";
     } else {
       std::cerr << "`" << dtb_file << "'";

--- a/riscv/sim.cc
+++ b/riscv/sim.cc
@@ -101,6 +101,10 @@ sim_t::sim_t(const cfg_t *cfg, bool halted,
                                log_file.get(), sout_);
   }
 
+  // When running without using a dtb, skip the fdt-based configuration steps
+  if (!dtb_enabled) return;
+
+  // Load dtb_file if provided, otherwise self-generate a dts/dtb
   make_dtb(dtb_file);
 
   void *fdt = (void *)dtb.c_str();

--- a/riscv/sim.h
+++ b/riscv/sim.h
@@ -49,7 +49,7 @@ public:
   void set_remote_bitbang(remote_bitbang_t* remote_bitbang) {
     this->remote_bitbang = remote_bitbang;
   }
-  const char* get_dts() { if (dts.empty()) reset(); return dts.c_str(); }
+  const char* get_dts() { return dts.c_str(); }
   processor_t* get_core(size_t i) { return procs.at(i); }
   unsigned nprocs() const { return procs.size(); }
 

--- a/riscv/sim.h
+++ b/riscv/sim.h
@@ -66,7 +66,6 @@ private:
   std::pair<reg_t, reg_t> initrd_range;
   std::string dts;
   std::string dtb;
-  std::string dtb_file;
   bool dtb_enabled;
   std::unique_ptr<rom_device_t> boot_rom;
   std::unique_ptr<clint_t> clint;
@@ -96,7 +95,7 @@ private:
   char* addr_to_mem(reg_t paddr);
   bool mmio_load(reg_t paddr, size_t len, uint8_t* bytes);
   bool mmio_store(reg_t paddr, size_t len, const uint8_t* bytes);
-  void make_dtb();
+  void make_dtb(const char* dtb_file);
   void set_rom();
 
   const char* get_symbol(uint64_t paddr);


### PR DESCRIPTION
Previously, spike would generate a dts/dtb even if `!dtb_enabled`, and add devices based on what was generated. This breaks the use case where a spike-as-library user wants to both:
 - provide a custom bootrom+dtb 
 - provide a custom set of bus devices
 
 `!dtb_enabled` now skips both dts/dtb generation and adding the default PLIC/CLINT/UART devices.