### PR TITLE
Make misa.C writable again, even in presence of Zc* extensions

### DIFF
--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -1509,6 +1509,9 @@ jvt_csr_t::jvt_csr_t(processor_t* const proc, const reg_t addr, const reg_t init
 void jvt_csr_t::verify_permissions(insn_t insn, bool write) const {
   basic_csr_t::verify_permissions(insn, write);
 
+  if (!proc->extension_enabled(EXT_ZCMT))
+    throw trap_illegal_instruction(insn.bits());
+
   if (proc->extension_enabled(EXT_SMSTATEEN)) {
     if ((state->prv < PRV_M) && !(state->mstateen[0]->read() & SSTATEEN0_JVT))
       throw trap_illegal_instruction(insn.bits());

--- a/riscv/isa_parser.h
+++ b/riscv/isa_parser.h
@@ -91,6 +91,9 @@ public:
   bool extension_enabled(isa_extension_t ext) const {
     return extension_table[ext];
   }
+
+  std::bitset<NUM_ISA_EXTENSIONS> get_extension_table() const { return extension_table; }
+
   const std::unordered_map<std::string, extension_t*> &
   get_extensions() const { return extensions; }
 

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -508,7 +508,7 @@ void state_t::reset(processor_t* const proc, reg_t max_isa)
     }
   }
 
-  if (proc->extension_enabled_const(EXT_ZCMT))
+  if (proc->extension_enabled(EXT_ZCMT))
     csrmap[CSR_JVT] = jvt = std::make_shared<jvt_csr_t>(proc, CSR_JVT, 0);
 
   serialized = false;

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -35,7 +35,8 @@ processor_t::processor_t(const isa_parser_t *isa, const cfg_t *cfg,
   histogram_enabled(false), log_commits_enabled(false),
   log_file(log_file), sout_(sout_.rdbuf()), halt_on_reset(halt_on_reset),
   in_wfi(false), check_triggers_icount(false),
-  impl_table(256, false), last_pc(1), executions(1), TM(cfg->trigger_count)
+  impl_table(256, false), extension_enable_table(isa->get_extension_table()),
+  last_pc(1), executions(1), TM(cfg->trigger_count)
 {
   VU.p = this;
   TM.proc = this;


### PR DESCRIPTION
Builds on and supersedes #1176. See extensive discussion on that PR.  Fixes #1172.

`misa.C` is now writable whenever `C` is included in the ISA string.  When `misa.C` is writable, all Zc* extensions are also under its direct control.  (There is still no mechanism to individually disable Zc* extensions, nor is there a mechanism to disable Zc* extensions when `misa.C` is read-only).

cc @liweiwei90, who authored the first version of this