### PR TITLE
Support discontiguous hart IDs in debug module

### DIFF
--- a/ci-tests/testlib.c
+++ b/ci-tests/testlib.c
@@ -15,7 +15,7 @@ static std::vector<std::pair<reg_t, mem_t*>> make_mems(const std::vector<mem_cfg
 int main()
 {
   std::vector<mem_cfg_t> mem_cfg { mem_cfg_t(0x80000000, 0x10000000) };
-  std::vector<int> hartids = {0};
+  std::vector<size_t> hartids = {0};
   cfg_t cfg(std::make_pair(0, 0),
             nullptr,
             "rv64gcv",

--- a/riscv/cfg.h
+++ b/riscv/cfg.h
@@ -69,7 +69,7 @@ public:
         const endianness_t default_endianness,
         const reg_t default_pmpregions,
         const std::vector<mem_cfg_t> &default_mem_layout,
-        const std::vector<int> default_hartids,
+        const std::vector<size_t> default_hartids,
         bool default_real_time_clint,
         const reg_t default_trigger_count)
     : initrd_bounds(default_initrd_bounds),
@@ -97,7 +97,7 @@ public:
   reg_t                              pmpregions;
   cfg_arg_t<std::vector<mem_cfg_t>>  mem_layout;
   std::optional<reg_t>               start_pc;
-  cfg_arg_t<std::vector<int>>        hartids;
+  cfg_arg_t<std::vector<size_t>>     hartids;
   bool                               explicit_hartids;
   cfg_arg_t<bool>                    real_time_clint;
   reg_t                              trigger_count;

--- a/riscv/cfg.h
+++ b/riscv/cfg.h
@@ -103,6 +103,7 @@ public:
   reg_t                              trigger_count;
 
   size_t nprocs() const { return hartids().size(); }
+  size_t max_hartid() const { return hartids().back(); }
 };
 
 #endif

--- a/riscv/debug_module.h
+++ b/riscv/debug_module.h
@@ -132,7 +132,6 @@ class debug_module_t : public abstract_device_t
 
   private:
     static const unsigned datasize = 2;
-    unsigned nprocs;
     debug_module_config_t config;
     // Actual size of the program buffer, which is 1 word bigger than we let on
     // to implement the implicit ebreak at the end.
@@ -145,10 +144,6 @@ class debug_module_t : public abstract_device_t
     // R/W this through custom registers, to allow debuggers to test that
     // functionality.
     unsigned custom_base;
-
-    // We only support 1024 harts currently. More requires at least resizing
-    // the arrays below, and their corresponding special memory regions.
-    unsigned hartsellen = 10;
 
     sim_t *sim;
 
@@ -183,13 +178,15 @@ class debug_module_t : public abstract_device_t
     uint32_t challenge;
     const uint32_t secret = 1;
 
-    processor_t *processor(unsigned hartid) const;
     bool hart_selected(unsigned hartid) const;
     void reset();
     bool perform_abstract_command();
 
     bool abstract_command_completed;
     unsigned rti_remaining;
+
+    size_t selected_hart_id() const;
+    hart_debug_state_t& selected_hart_state();
 };
 
 #endif

--- a/riscv/sim.cc
+++ b/riscv/sim.cc
@@ -99,6 +99,7 @@ sim_t::sim_t(const cfg_t *cfg, bool halted,
   for (size_t i = 0; i < cfg->nprocs(); i++) {
     procs[i] = new processor_t(&isa, cfg, this, cfg->hartids()[i], halted,
                                log_file.get(), sout_);
+    harts[cfg->hartids()[i]] = procs[i];
   }
 
   // When running without using a dtb, skip the fdt-based configuration steps

--- a/riscv/sim.h
+++ b/riscv/sim.h
@@ -12,6 +12,7 @@
 
 #include <fesvr/htif.h>
 #include <vector>
+#include <map>
 #include <string>
 #include <memory>
 #include <sys/types.h>
@@ -51,7 +52,10 @@ public:
   }
   const char* get_dts() { return dts.c_str(); }
   processor_t* get_core(size_t i) { return procs.at(i); }
+  const cfg_t &get_cfg() { return *cfg; }
   unsigned nprocs() const { return procs.size(); }
+
+  const std::map<size_t, processor_t*>& get_harts() { return harts; }
 
   // Callback for processors to let the simulation know they were reset.
   void proc_reset(unsigned id);
@@ -63,6 +67,7 @@ private:
   std::vector<std::pair<reg_t, abstract_device_t*>> plugin_devices;
   mmu_t* debug_mmu;  // debug port into main memory
   std::vector<processor_t*> procs;
+  std::map<size_t, processor_t*> harts;
   std::pair<reg_t, reg_t> initrd_range;
   std::string dts;
   std::string dtb;

--- a/spike_main/spike-log-parser.cc
+++ b/spike_main/spike-log-parser.cc
@@ -37,7 +37,7 @@ int main(int UNUSED argc, char** argv)
             /*default_endianness*/endianness_little,
             /*default_pmpregions=*/16,
             /*default_mem_layout=*/std::vector<mem_cfg_t>(),
-            /*default_hartids=*/std::vector<int>(),
+            /*default_hartids=*/std::vector<size_t>(),
             /*default_real_time_clint=*/false,
             /*default_trigger_count=*/4);
 

--- a/spike_main/spike.cc
+++ b/spike_main/spike.cc
@@ -291,11 +291,11 @@ static unsigned long atoul_nonzero_safe(const char* s)
   return res;
 }
 
-static std::vector<int> parse_hartids(const char *s)
+static std::vector<size_t> parse_hartids(const char *s)
 {
   std::string const str(s);
   std::stringstream stream(str);
-  std::vector<int> hartids;
+  std::vector<size_t> hartids;
 
   int n;
   while (stream >> n) {
@@ -353,7 +353,7 @@ int main(int argc, char** argv)
             /*default_endianness*/endianness_little,
             /*default_pmpregions=*/16,
             /*default_mem_layout=*/parse_mem_layout("2048"),
-            /*default_hartids=*/std::vector<int>(),
+            /*default_hartids=*/std::vector<size_t>(),
             /*default_real_time_clint=*/false,
             /*default_trigger_count=*/4);
 
@@ -536,7 +536,7 @@ int main(int argc, char** argv)
     // Set default set of hartids based on nprocs, but don't set the
     // explicit_hartids flag (which means that downstream code can know that
     // we've only set the number of harts, not explicitly chosen their IDs).
-    std::vector<int> default_hartids;
+    std::vector<size_t> default_hartids;
     default_hartids.reserve(nprocs());
     for (size_t i = 0; i < nprocs(); ++i) {
       default_hartids.push_back(i);

--- a/spike_main/spike.cc
+++ b/spike_main/spike.cc
@@ -299,8 +299,26 @@ static std::vector<size_t> parse_hartids(const char *s)
 
   int n;
   while (stream >> n) {
+    if (n < 0) {
+      fprintf(stderr, "Negative hart ID %d is unsupported\n", n);
+      exit(-1);
+    }
+
     hartids.push_back(n);
     if (stream.peek() == ',') stream.ignore();
+  }
+
+  if (hartids.empty()) {
+    fprintf(stderr, "No hart IDs specified\n");
+    exit(-1);
+  }
+
+  std::sort(hartids.begin(), hartids.end());
+
+  const auto dup = std::adjacent_find(hartids.begin(), hartids.end());
+  if (dup != hartids.end()) {
+    fprintf(stderr, "Duplicate hart ID %zu\n", *dup);
+    exit(-1);
   }
 
   return hartids;


### PR DESCRIPTION
Supersedes #1166

@scottj97 I'm backtracking on what I wrote earlier.  I think it's worth the effort to audit all of the places where we assume hart IDs are contiguous, because some of them have bad code smell.  Then we can support discontiguous hart IDs directly, rather than constructing all of them and skipping over some.  Are you OK with this direction?

This PR is sufficient to fix the segfault mentioned in #1166 and to make the debug module tolerate discontiguous hart IDs, but there are still other places where the behavior is surprising, if not incorrect: at minimum, the CLINT and the DeviceTree.  I've already done some of the work to fix them, but I'd like to reach agreement on this PR before continuing down that path.