### PR TITLE
PKBB32, PKTT32 removed (Replaced by PACK and PACKU of Zbp respectively)

### DIFF
--- a/disasm/disasm.cc
+++ b/disasm/disasm.cc
@@ -2109,10 +2109,8 @@ void disassembler_t::add_instructions(const isa_parser_t* isa)
       DEFINE_RTYPE(smdrs32);
       DEFINE_RTYPE(smxds32);
       DEFINE_PI5TYPE(sraiw_u);
-      DEFINE_RTYPE(pkbb32);
       DEFINE_RTYPE(pkbt32);
       DEFINE_RTYPE(pktb32);
-      DEFINE_RTYPE(pktt32);
     }
   }
 


### PR DESCRIPTION
reference: [from spec](https://github.com/riscv/riscv-p-spec/blob/c3409c8edb7df262cb3db0ff323077120e5f7f04/P-ext-proposal.adoc#822-pkbb32-pkbt32-pktt32-pktb32)

Merging this PR will allow reverting - https://github.com/riscv/riscv-opcodes/pull/158 in riscv-opcodes