### PR TITLE
Fix ignoring dmode=1 write in triggers

### DIFF
--- a/riscv/triggers.cc
+++ b/riscv/triggers.cc
@@ -465,10 +465,7 @@ bool module_t::tdata1_write(unsigned index, const reg_t val) noexcept
   if (index > 0 && !triggers[index-1]->get_dmode() && triggers[index-1]->get_chain() && get_field(val, CSR_TDATA1_DMODE(xlen)))
     return false;
 
-  unsigned type = get_field(val, CSR_TDATA1_TYPE(xlen));
   reg_t tdata1 = val;
-  reg_t tdata2 = triggers[index]->tdata2_read(proc);
-  reg_t tdata3 = triggers[index]->tdata3_read(proc);
 
   // hardware must zero chain in writes that set dmode to 0 if the next trigger has dmode of 1
   const bool allow_chain = !(index+1 < triggers.size() && triggers[index+1]->get_dmode() && !get_field(val, CSR_TDATA1_DMODE(xlen)));
@@ -481,6 +478,9 @@ bool module_t::tdata1_write(unsigned index, const reg_t val) noexcept
     tdata1 = set_field(tdata1, CSR_TDATA1_DMODE(xlen), 0);
   }
 
+  unsigned type = get_field(val, CSR_TDATA1_TYPE(xlen));
+  reg_t tdata2 = triggers[index]->tdata2_read(proc);
+  reg_t tdata3 = triggers[index]->tdata3_read(proc);
   delete triggers[index];
   switch (type) {
     case CSR_TDATA1_TYPE_MCONTROL: triggers[index] = new mcontrol_t(); break;

--- a/riscv/triggers.cc
+++ b/riscv/triggers.cc
@@ -461,10 +461,6 @@ bool module_t::tdata1_write(unsigned index, const reg_t val) noexcept
 
   auto xlen = proc->get_xlen();
 
-  // hardware should ignore writes that set dmode to 1 if the previous trigger has both dmode of 0 and chain of 1
-  if (index > 0 && !triggers[index-1]->get_dmode() && triggers[index-1]->get_chain() && get_field(val, CSR_TDATA1_DMODE(xlen)))
-    return false;
-
   reg_t tdata1 = val;
 
   // hardware must zero chain in writes that set dmode to 0 if the next trigger has dmode of 1
@@ -477,6 +473,10 @@ bool module_t::tdata1_write(unsigned index, const reg_t val) noexcept
     assert(CSR_TDATA1_DMODE(xlen) == CSR_ETRIGGER_DMODE(xlen));
     tdata1 = set_field(tdata1, CSR_TDATA1_DMODE(xlen), 0);
   }
+
+  // hardware should ignore writes that set dmode to 1 if the previous trigger has both dmode of 0 and chain of 1
+  if (index > 0 && !triggers[index-1]->get_dmode() && triggers[index-1]->get_chain() && get_field(tdata1, CSR_TDATA1_DMODE(xlen)))
+    return false;
 
   unsigned type = get_field(val, CSR_TDATA1_TYPE(xlen));
   reg_t tdata2 = triggers[index]->tdata2_read(proc);


### PR DESCRIPTION
@YenHaoChen added [a commit](https://github.com/riscv-software-src/riscv-isa-sim/pull/1128/commits/e0e1f2036f6c9e93d32bf412283859ecf8eedcbb) as part of #1128 to implement the second sentence of the following requirements from the debug spec:

> Because chain affects the next trigger, hardware must zero it in writes to mcontrol that set dmode to 0 if the next trigger has dmode of 1. In addition hardware should ignore writes to mcontrol that set dmode to 1 if the previous trigger has both dmode of 0 and chain of 1. Debuggers must avoid the latter case by checking chain on the previous trigger if they’re writing mcontrol.

However, there is already [code](https://github.com/riscv-software-src/riscv-isa-sim/blob/e7d6aff19a071a059f1b9c2328ee4dac83bc677a/riscv/triggers.cc#L476-L482) just below that to force dmode=0 if this write is not coming from debug mode. From my reading of this spec, such a write should not be considered a "write to mcontrol that sets dmode to 1" and therefore should not be ignored.

Example scenario:
Trigger 0 is first programmed with dmode=0 chain=1. Now an M-mode CSRW tries to write trigger 1's `tdata1` with dmode=1.

Before this PR, the entire write would be ignored.

After this PR, the write will be allowed, with dmode forced to 0.
 