### PR TITLE
update support for Zc* to v1.0.3

### DIFF
--- a/riscv/decode.h
+++ b/riscv/decode.h
@@ -121,8 +121,8 @@ public:
   uint64_t rvc_lbimm() { return (x(5, 1) << 1) + x(6, 1); }
   uint64_t rvc_lhimm() { return (x(5, 1) << 1); }
 
-  uint64_t rvc_sreg1() { return x(7, 3); }
-  uint64_t rvc_sreg2() { return x(2, 3); }
+  uint64_t rvc_r1sc() { return x(7, 3); }
+  uint64_t rvc_r2sc() { return x(2, 3); }
   uint64_t rvc_rlist() { return x(4, 4); }
   uint64_t rvc_spimm() { return x(2, 2) << 4; }
 

--- a/riscv/decode_macros.h
+++ b/riscv/decode_macros.h
@@ -55,8 +55,8 @@
 #define RVC_SP READ_REG(X_SP)
 
 // Zc* macros
-#define RVC_SREG1 (Sn(insn.rvc_sreg1()))
-#define RVC_SREG2 (Sn(insn.rvc_sreg2()))
+#define RVC_R1S (Sn(insn.rvc_r1sc()))
+#define RVC_R2S (Sn(insn.rvc_r2sc()))
 #define SP READ_REG(X_SP)
 #define RA READ_REG(X_RA)
 

--- a/riscv/insns/cm_mva01s.h
+++ b/riscv/insns/cm_mva01s.h
@@ -1,6 +1,6 @@
 require_extension(EXT_ZCMP);
 if (p->extension_enabled('E')) {
-  require((insn.rvc_sreg1() < 2) && (insn.rvc_sreg2() < 2));
+  require((insn.rvc_r1sc() < 2) && (insn.rvc_r2sc() < 2));
 }
-WRITE_REG(X_A0, READ_REG(RVC_SREG1));
-WRITE_REG(X_A1, READ_REG(RVC_SREG2));
+WRITE_REG(X_A0, READ_REG(RVC_R1S));
+WRITE_REG(X_A1, READ_REG(RVC_R2S));

--- a/riscv/insns/cm_mva01s.h
+++ b/riscv/insns/cm_mva01s.h
@@ -1,6 +1,3 @@
 require_extension(EXT_ZCMP);
-if (p->extension_enabled('E')) {
-  require((insn.rvc_r1sc() < 2) && (insn.rvc_r2sc() < 2));
-}
 WRITE_REG(X_A0, READ_REG(RVC_R1S));
 WRITE_REG(X_A1, READ_REG(RVC_R2S));

--- a/riscv/insns/cm_mvsa01.h
+++ b/riscv/insns/cm_mvsa01.h
@@ -1,7 +1,4 @@
 require_extension(EXT_ZCMP);
-if (p->extension_enabled('E')) {
-  require((insn.rvc_r1sc() < 2) && (insn.rvc_r2sc() < 2));
-}
 require(insn.rvc_r1sc() != insn.rvc_r2sc());
 WRITE_REG(RVC_R1S, READ_REG(X_A0));
 WRITE_REG(RVC_R2S, READ_REG(X_A1));

--- a/riscv/insns/cm_mvsa01.h
+++ b/riscv/insns/cm_mvsa01.h
@@ -1,6 +1,6 @@
 require_extension(EXT_ZCMP);
 if (p->extension_enabled('E')) {
-  require((insn.rvc_sreg1() < 2) && (insn.rvc_sreg2() < 2));
+  require((insn.rvc_r1sc() < 2) && (insn.rvc_r2sc() < 2));
 }
-WRITE_REG(RVC_SREG1, READ_REG(X_A0));
-WRITE_REG(RVC_SREG2, READ_REG(X_A1));
+WRITE_REG(RVC_R1S, READ_REG(X_A0));
+WRITE_REG(RVC_R2S, READ_REG(X_A1));

--- a/riscv/insns/cm_mvsa01.h
+++ b/riscv/insns/cm_mvsa01.h
@@ -2,5 +2,6 @@ require_extension(EXT_ZCMP);
 if (p->extension_enabled('E')) {
   require((insn.rvc_r1sc() < 2) && (insn.rvc_r2sc() < 2));
 }
+require(insn.rvc_r1sc() != insn.rvc_r2sc());
 WRITE_REG(RVC_R1S, READ_REG(X_A0));
 WRITE_REG(RVC_R2S, READ_REG(X_A1));

--- a/riscv/isa_parser.cc
+++ b/riscv/isa_parser.cc
@@ -152,6 +152,13 @@ isa_parser_t::isa_parser_t(const char* str, const char *priv)
     } else if (ext_str == "zhinxmin") {
       extension_table[EXT_ZFINX] = true;
       extension_table[EXT_ZHINXMIN] = true;
+    } else if (ext_str == "zce") {
+      extension_table[EXT_ZCA] = true;
+      extension_table[EXT_ZCB] = true;
+      extension_table[EXT_ZCMT] = true;
+      extension_table[EXT_ZCMP] = true;
+      if (extension_table['F'])
+        extension_table[EXT_ZCF] = true;
     } else if (ext_str == "zca") {
       extension_table[EXT_ZCA] = true;
     } else if (ext_str == "zcf") {


### PR DESCRIPTION
The PR does some updates for Zc*:
* add the updates for Zc* v1.0.3:
  - update the field name for sreg1/sreg2 to r1s/r2s
  - add isa flag for zce
* add missed check r1s!=r2s for cm.mvsa01
* remove the redundant check in cm.mva01s/cm.mvsa01