### PR TITLE
fesvr: elfloader: replace asserts after open and mmap by exceptions

### DIFF
--- a/fesvr/elfloader.cc
+++ b/fesvr/elfloader.cc
@@ -21,13 +21,15 @@ std::map<std::string, uint64_t> load_elf(const char* fn, memif_t* memif, reg_t* 
 {
   int fd = open(fn, O_RDONLY);
   struct stat s;
-  assert(fd != -1);
+  if (fd == -1)
+      throw std::invalid_argument(std::string("Specified ELF can't be opened: ") + strerror(errno));
   if (fstat(fd, &s) < 0)
     abort();
   size_t size = s.st_size;
 
   char* buf = (char*)mmap(NULL, size, PROT_READ, MAP_PRIVATE, fd, 0);
-  assert(buf != MAP_FAILED);
+  if (buf == MAP_FAILED)
+      throw std::invalid_argument(std::string("Specified ELF can't be mapped: ") + strerror(errno));
   close(fd);
 
   assert(size >= sizeof(Elf64_Ehdr));


### PR DESCRIPTION
Asserts (especially without a message) aren't human readable way of error reporting. So, replace them by exceptions with messages with errno string.

Before:
```
spike: ../fesvr/elfloader.cc:30: std::map<std::__cxx11::basic_string<char>, long unsigned int> load_elf(const char*, memif_t*, reg_t*, unsigned int): Assertion `buf != MAP_FAILED' failed.
```
After:
```
terminate called after throwing an instance of 'std::invalid_argument'
  what():  Specified ELF can't be mapped: No such device
```