### PR TITLE
Fix --bootargs default value in spike usage help() function

### DIFF
--- a/riscv/dts.cc
+++ b/riscv/dts.cc
@@ -34,10 +34,10 @@ std::string make_dts(size_t insns_per_rtc_tick, size_t cpu_hz,
     s << "    linux,initrd-start = <" << (size_t)initrd_start << ">;\n"
          "    linux,initrd-end = <" << (size_t)initrd_end << ">;\n";
     if (!bootargs)
-      bootargs = "root=/dev/ram console=ttyS0 earlycon";
+      bootargs = "root=/dev/ram " DEFAULT_KERNEL_BOOTARGS;
   } else {
     if (!bootargs)
-      bootargs = "console=ttyS0 earlycon";
+      bootargs = DEFAULT_KERNEL_BOOTARGS;
   }
     s << "    bootargs = \"";
   for (size_t i = 0; i < strlen(bootargs); i++) {

--- a/riscv/platform.h
+++ b/riscv/platform.h
@@ -2,6 +2,7 @@
 #ifndef _RISCV_PLATFORM_H
 #define _RISCV_PLATFORM_H
 
+#define DEFAULT_KERNEL_BOOTARGS "console=ttyS0 earlycon"
 #define DEFAULT_RSTVEC     0x00001000
 #define CLINT_BASE         0x02000000
 #define CLINT_SIZE         0x000c0000

--- a/spike_main/spike.cc
+++ b/spike_main/spike.cc
@@ -68,7 +68,8 @@ static void help(int exit_code = 1)
   fprintf(stderr, "  --disable-dtb         Don't write the device tree blob into memory\n");
   fprintf(stderr, "  --kernel=<path>       Load kernel flat image into memory\n");
   fprintf(stderr, "  --initrd=<path>       Load kernel initrd into memory\n");
-  fprintf(stderr, "  --bootargs=<args>     Provide custom bootargs for kernel [default: console=hvc0 earlycon=sbi]\n");
+  fprintf(stderr, "  --bootargs=<args>     Provide custom bootargs for kernel [default: %s]\n",
+          DEFAULT_KERNEL_BOOTARGS);
   fprintf(stderr, "  --real-time-clint     Increment clint time at real-time rate\n");
   fprintf(stderr, "  --triggers=<n>        Number of supported triggers [default 4]\n");
   fprintf(stderr, "  --dm-progsize=<words> Progsize for the debug module [default 2]\n");


### PR DESCRIPTION
Commit 191634d285 changed the default kernel boot args from "console=hvc0 earlycon=sbi" to "console=ttyS0 earlycon", but didn't updated the spike usage help() function.

This commit realign the usage help string with the actual value.