### PR TITLE
Improve icount trigger implementation

### DIFF
--- a/riscv/execute.cc
+++ b/riscv/execute.cc
@@ -263,7 +263,7 @@ void processor_t::step(size_t n)
             state.single_step = state.STEP_STEPPED;
           }
 
-          if (!state.serialized) {
+          if (!state.serialized && check_triggers_icount) {
             auto match = TM.detect_icount_match();
             if (match.has_value()) {
               assert(match->timing == triggers::TIMING_BEFORE);

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -696,6 +696,7 @@ void processor_t::take_interrupt(reg_t pending_interrupts)
     else
       abort();
 
+    if (check_triggers_icount) TM.detect_icount_match();
     throw trap_t(((reg_t)1 << (isa->get_max_xlen() - 1)) | ctz(enabled_interrupts));
   }
 }

--- a/riscv/triggers.h
+++ b/riscv/triggers.h
@@ -249,11 +249,11 @@ public:
   virtual std::optional<match_result_t> detect_icount_match(processor_t * const proc) noexcept override;
 
 private:
-  bool dmode;
-  bool hit;
-  unsigned count, count_read_value;
-  bool pending, pending_read_value;
-  action_t action;
+  bool dmode = false;
+  bool hit = false;
+  unsigned count = 1, count_read_value = 1;
+  bool pending = false, pending_read_value = false;
+  action_t action = (action_t)0;
 };
 
 class module_t {


### PR DESCRIPTION
* Minor but easy performance improvement
* Initialization of icount fields
* Decrement counters on external interrupts

The current lack of initialization doesn't hurt anything today, because we don't instantiate any `icount_t` except right before calling `tdata1_write()` which then initializes all these fields. But in my design (in my fork of Spike) I have a fixed set of triggers which I initialize at reset, and the fields were coming up with garbage in them.

cc @YenHaoChen 
