### PR TITLE
PLIC and CLINT fixes for heterogeneous harts/discontiguous hart IDs

### DIFF
--- a/riscv/devices.h
+++ b/riscv/devices.h
@@ -79,6 +79,11 @@ class clint_t : public abstract_device_t {
 #define PLIC_MAX_DEVICES 1024
 
 struct plic_context_t {
+  plic_context_t(processor_t* proc, bool mmode)
+    : proc(proc), mmode(mmode), priority_threshold(0), enable{}, pending{},
+      pending_priority{}, claimed{}
+  {}
+
 	processor_t *proc;
 	bool mmode;
 

--- a/riscv/devices.h
+++ b/riscv/devices.h
@@ -58,7 +58,7 @@ class mem_t : public abstract_device_t {
 
 class clint_t : public abstract_device_t {
  public:
-  clint_t(std::vector<processor_t*>&, uint64_t freq_hz, bool real_time);
+  clint_t(sim_t*, uint64_t freq_hz, bool real_time);
   bool load(reg_t addr, size_t len, uint8_t* bytes);
   bool store(reg_t addr, size_t len, const uint8_t* bytes);
   size_t size() { return CLINT_SIZE; }
@@ -69,13 +69,13 @@ class clint_t : public abstract_device_t {
   typedef uint64_t mtime_t;
   typedef uint64_t mtimecmp_t;
   typedef uint32_t msip_t;
-  std::vector<processor_t*>& procs;
+  sim_t* sim;
   uint64_t freq_hz;
   bool real_time;
   uint64_t real_time_ref_secs;
   uint64_t real_time_ref_usecs;
   mtime_t mtime;
-  std::vector<mtimecmp_t> mtimecmp;
+  std::map<size_t, mtimecmp_t> mtimecmp;
 };
 
 #define PLIC_MAX_DEVICES 1024

--- a/riscv/devices.h
+++ b/riscv/devices.h
@@ -79,7 +79,6 @@ class clint_t : public abstract_device_t {
 #define PLIC_MAX_DEVICES 1024
 
 struct plic_context_t {
-	uint32_t num;
 	processor_t *proc;
 	bool mmode;
 

--- a/riscv/devices.h
+++ b/riscv/devices.h
@@ -10,6 +10,7 @@
 #include <queue>
 #include <vector>
 #include <utility>
+#include <cassert>
 
 class processor_t;
 class sim_t;
@@ -169,5 +170,27 @@ class mmio_plugin_device_t : public abstract_device_t {
   mmio_plugin_t plugin;
   void* user_data;
 };
+
+template<typename T>
+void write_little_endian_reg(T* word, reg_t addr, size_t len, const uint8_t* bytes)
+{
+  assert(len <= sizeof(T));
+
+  for (size_t i = 0; i < len; i++) {
+    const int shift = 8 * ((addr + i) % sizeof(T));
+    *word = (*word & ~(T(0xFF) << shift)) | (T(bytes[i]) << shift);
+  }
+}
+
+template<typename T>
+void read_little_endian_reg(T word, reg_t addr, size_t len, uint8_t* bytes)
+{
+  assert(len <= sizeof(T));
+
+  for (size_t i = 0; i < len; i++) {
+    const int shift = 8 * ((addr + i) % sizeof(T));
+    bytes[i] = word >> shift;
+  }
+}
 
 #endif

--- a/riscv/devices.h
+++ b/riscv/devices.h
@@ -12,6 +12,7 @@
 #include <utility>
 
 class processor_t;
+class sim_t;
 
 class bus_t : public abstract_device_t {
  public:
@@ -96,7 +97,7 @@ struct plic_context_t {
 
 class plic_t : public abstract_device_t, public abstract_interrupt_controller_t {
  public:
-  plic_t(std::vector<processor_t*>&, bool smode, uint32_t ndev);
+  plic_t(sim_t*, uint32_t ndev);
   bool load(reg_t addr, size_t len, uint8_t* bytes);
   bool store(reg_t addr, size_t len, const uint8_t* bytes);
   void set_interrupt_level(uint32_t id, int lvl);

--- a/riscv/devices.h
+++ b/riscv/devices.h
@@ -98,7 +98,6 @@ class plic_t : public abstract_device_t, public abstract_interrupt_controller_t 
   void set_interrupt_level(uint32_t id, int lvl);
   size_t size() { return PLIC_SIZE; }
  private:
-  std::vector<processor_t*>& procs;
   std::vector<plic_context_t> contexts;
   uint32_t num_ids;
   uint32_t num_ids_word;

--- a/riscv/plic.cc
+++ b/riscv/plic.cc
@@ -1,6 +1,7 @@
 #include <sys/time.h>
 #include "devices.h"
 #include "processor.h"
+#include "sim.h"
 
 #define PLIC_MAX_CONTEXTS 15872
 
@@ -66,15 +67,17 @@
 
 #define REG_SIZE                0x1000000
 
-plic_t::plic_t(std::vector<processor_t*>& procs, bool smode, uint32_t ndev)
+plic_t::plic_t(sim_t* sim, uint32_t ndev)
   : num_ids(ndev + 1), num_ids_word(((ndev + 1) + (32 - 1)) / 32),
   max_prio((1UL << PLIC_PRIO_BITS) - 1), priority{}, level{}
 {
-  size_t contexts_per_hart = smode ? 2 : 1;
-  size_t num_contexts = procs.size() * (smode ? 2 : 1);
+  // PLIC contexts are contiguous in memory even if harts are discontiguous.
+  for (const auto& [hart_id, hart] : sim->get_harts()) {
+    contexts.push_back(plic_context_t(hart, true));
 
-  for (size_t i = 0; i < num_contexts; i++) {
-    contexts.push_back(plic_context_t(procs[i / contexts_per_hart], i % contexts_per_hart == 0));
+    if (hart->extension_enabled_const('S')) {
+      contexts.push_back(plic_context_t(hart, false));
+    }
   }
 }
 

--- a/riscv/plic.cc
+++ b/riscv/plic.cc
@@ -78,7 +78,6 @@ plic_t::plic_t(std::vector<processor_t*>& procs, bool smode, uint32_t ndev)
 
   for (size_t i = 0; i < contexts.size(); i++) {
     plic_context_t* c = &contexts[i];
-    c->num = i;
     c->proc = procs[i / contexts_per_hart];
     if (smode) {
       c->mmode = (i % contexts_per_hart == 0);

--- a/riscv/plic.cc
+++ b/riscv/plic.cc
@@ -329,7 +329,7 @@ bool plic_t::load(reg_t addr, size_t len, uint8_t* bytes)
     }
   }
 
-  memcpy(bytes, (uint8_t *)&val, len);
+  read_little_endian_reg(val, addr, len, bytes);
 
   return ret;
 }
@@ -337,7 +337,7 @@ bool plic_t::load(reg_t addr, size_t len, uint8_t* bytes)
 bool plic_t::store(reg_t addr, size_t len, const uint8_t* bytes)
 {
   bool ret = false;
-  uint32_t val;
+  uint32_t val = 0;
 
   switch (len) {
     case 4:
@@ -350,7 +350,7 @@ bool plic_t::store(reg_t addr, size_t len, const uint8_t* bytes)
       return false;
   }
 
-  memcpy((uint8_t *)&val, bytes, len);
+  write_little_endian_reg(&val, addr, len, bytes);
 
   if (PRIORITY_BASE <= addr && addr < ENABLE_BASE) {
     ret = priority_write(addr, val);

--- a/riscv/plic.cc
+++ b/riscv/plic.cc
@@ -329,9 +329,7 @@ bool plic_t::load(reg_t addr, size_t len, uint8_t* bytes)
     }
   }
 
-  if (ret) {
-    memcpy(bytes, (uint8_t *)&val, len);
-  }
+  memcpy(bytes, (uint8_t *)&val, len);
 
   return ret;
 }

--- a/riscv/plic.cc
+++ b/riscv/plic.cc
@@ -67,7 +67,7 @@
 #define REG_SIZE                0x1000000
 
 plic_t::plic_t(std::vector<processor_t*>& procs, bool smode, uint32_t ndev)
-  : procs(procs), contexts(procs.size() * (smode ? 2 : 1)),
+  : contexts(procs.size() * (smode ? 2 : 1)),
   num_ids(ndev + 1), num_ids_word(((ndev + 1) + (32 - 1)) / 32),
   max_prio((1UL << PLIC_PRIO_BITS) - 1) 
 {

--- a/riscv/sim.cc
+++ b/riscv/sim.cc
@@ -130,7 +130,7 @@ sim_t::sim_t(const cfg_t *cfg, bool halted,
   reg_t plic_base;
   uint32_t plic_ndev;
   if (fdt_parse_plic(fdt, &plic_base, &plic_ndev, "riscv,plic0") == 0) {
-    plic.reset(new plic_t(procs, true, plic_ndev));
+    plic.reset(new plic_t(this, plic_ndev));
     bus.add_device(plic_base, plic.get());
     intctrl = plic.get();
   }

--- a/riscv/sim.cc
+++ b/riscv/sim.cc
@@ -119,7 +119,7 @@ sim_t::sim_t(const cfg_t *cfg, bool halted,
   // setting the dtb_file argument has one.
   reg_t clint_base;
   if (fdt_parse_clint(fdt, &clint_base, "riscv,clint0") == 0) {
-    clint.reset(new clint_t(procs, CPU_HZ / INSNS_PER_RTC_TICK, cfg->real_time_clint()));
+    clint.reset(new clint_t(this, CPU_HZ / INSNS_PER_RTC_TICK, cfg->real_time_clint()));
     bus.add_device(clint_base, clint.get());
   }
 


### PR DESCRIPTION
I went through the PLIC and CLINT to support discontiguous hart IDs.  It turns out the PLIC already supports them, but it wasn't handling the case of some harts having S-mode and some not.

Also, both the PLIC and CLINT were broken on big-endian hosts.  Especially for the CLINT, the fix for that dovetailed with the discontiguous hart ID fix.