### PR TITLE
Define sim_t::INTERLEAVE so that it can be accessed by reference

### DIFF
--- a/riscv/sim.cc
+++ b/riscv/sim.cc
@@ -30,6 +30,8 @@ static void handle_signal(int sig)
   signal(sig, &handle_signal);
 }
 
+const size_t sim_t::INTERLEAVE;
+
 sim_t::sim_t(const cfg_t *cfg, bool halted,
              std::vector<std::pair<reg_t, mem_t*>> mems,
              std::vector<std::pair<reg_t, abstract_device_t*>> plugin_devices,


### PR DESCRIPTION
`std::min` takes its arguments by reference, so the arguments need to be defined.  An alternative would have been to force the problematic argument into being an rvalue (e.g., by adding 0), but defining `sim_t::INTERLEAVE` seems to me to be more robust.

This fixes compilation under -O0; see https://github.com/riscv-software-src/riscv-isa-sim/pull/1264#issuecomment-1451114717

@scottj97 I posit that this situation is unusual enough that it shouldn't motivate us to test -O0 in CI.