### PR TITLE
Initialize MTIP at reset

### DIFF
--- a/riscv/clint.cc
+++ b/riscv/clint.cc
@@ -12,6 +12,7 @@ clint_t::clint_t(sim_t* sim, uint64_t freq_hz, bool real_time)
 
   real_time_ref_secs = base.tv_sec;
   real_time_ref_usecs = base.tv_usec;
+  increment(0);
 }
 
 /* 0000 msip hart 0


### PR DESCRIPTION
Since mtime and mtimecmp both initialize to 0, and "a machine timer interrupt becomes pending whenever mtime contains a value greater than or equal to mtimecmp," `mip.MTIP` should be 1.

Before this change, MTIP would be 0 until the first increment, or until reading/writing from CLINT regs (since `clint_t::load()` and `clint_t::store()` call `increment(0)`).
