### PR TITLE
Don't issue misaligned or non-power-of-2 MMIO accesses

### DIFF
--- a/riscv/devices.h
+++ b/riscv/devices.h
@@ -82,18 +82,17 @@ class clint_t : public abstract_device_t {
 
 struct plic_context_t {
   plic_context_t(processor_t* proc, bool mmode)
-    : proc(proc), mmode(mmode), priority_threshold(0), enable{}, pending{},
-      pending_priority{}, claimed{}
+    : proc(proc), mmode(mmode)
   {}
 
-	processor_t *proc;
-	bool mmode;
+  processor_t *proc;
+  bool mmode;
 
-	uint8_t priority_threshold;
-	uint32_t enable[PLIC_MAX_DEVICES/32];
-	uint32_t pending[PLIC_MAX_DEVICES/32];
-	uint8_t pending_priority[PLIC_MAX_DEVICES];
-	uint32_t claimed[PLIC_MAX_DEVICES/32];
+  uint8_t priority_threshold {};
+  uint32_t enable[PLIC_MAX_DEVICES/32] {};
+  uint32_t pending[PLIC_MAX_DEVICES/32] {};
+  uint8_t pending_priority[PLIC_MAX_DEVICES] {};
+  uint32_t claimed[PLIC_MAX_DEVICES/32] {};
 };
 
 class plic_t : public abstract_device_t, public abstract_interrupt_controller_t {

--- a/riscv/mmu.h
+++ b/riscv/mmu.h
@@ -339,6 +339,7 @@ private:
   bool mmio_fetch(reg_t paddr, size_t len, uint8_t* bytes);
   bool mmio_load(reg_t paddr, size_t len, uint8_t* bytes);
   bool mmio_store(reg_t paddr, size_t len, const uint8_t* bytes);
+  bool mmio(reg_t paddr, size_t len, uint8_t* bytes, access_type type);
   bool mmio_ok(reg_t paddr, access_type type);
   void check_triggers(triggers::operation_t operation, reg_t address, std::optional<reg_t> data = std::nullopt);
   reg_t translate(reg_t addr, reg_t len, access_type type, uint32_t xlate_flags);


### PR DESCRIPTION
Rather than requiring each MMIO device to support arbitrary sizes and alignments, decompose misaligned loads and stores in such a way as to guarantee their constituent parts are always aligned.  (Specifically, they now always decompose to a sequence of one-byte accesses.)

This is not a semantic change for main-memory accesses, but it is a semantic change for I/O devices.  It makes them more realistic, in that most bus standards don't support non-power-of-2-sized accesses.

Main-memory accesses are not decomposed unless they span page boundaries (in which case they are decomposed into two accesses, possibly of non-power-of-two size).

This fixes misaligned accesses that span a device boundary into the bottom of the CLINT address space, mentioned in https://github.com/riscv-software-src/riscv-isa-sim/pull/1265#discussion_r1123301943

Also make misaligned stores to the CLINT MSIP registers behave more sanely (even though the behavior of misaligned MMIO accesses is unspecified).

Also improve a stylistic comment about initializing `plic_context_t`, https://github.com/riscv-software-src/riscv-isa-sim/pull/1265#discussion_r1123142619