### PR TITLE
Support passing in htif target-arguments through plusargs

### DIFF
--- a/fesvr/htif.cc
+++ b/fesvr/htif.cc
@@ -327,7 +327,6 @@ void htif_t::parse_arguments(int argc, char ** argv)
         break;
       case HTIF_LONG_OPTIONS_OPTIND + 5:
         line_size = atoi(optarg);
-
         break;
       case '?':
         if (!opterr)
@@ -363,9 +362,9 @@ void htif_t::parse_arguments(int argc, char ** argv)
           c = HTIF_LONG_OPTIONS_OPTIND + 4;
           optarg = optarg + 9;
         }
-        else if(arg.find("+signature-granularity=")==0){
-            c = HTIF_LONG_OPTIONS_OPTIND + 5;
-            optarg = optarg + 23;
+        else if (arg.find("+signature-granularity=") == 0) {
+          c = HTIF_LONG_OPTIONS_OPTIND + 5;
+          optarg = optarg + 23;
         }
         else if (arg.find("+permissive-off") == 0) {
           if (opterr)

--- a/fesvr/htif.cc
+++ b/fesvr/htif.cc
@@ -328,6 +328,9 @@ void htif_t::parse_arguments(int argc, char ** argv)
       case HTIF_LONG_OPTIONS_OPTIND + 5:
         line_size = atoi(optarg);
         break;
+      case HTIF_LONG_OPTIONS_OPTIND + 6:
+        targs.push_back(optarg);
+        break;
       case '?':
         if (!opterr)
           break;
@@ -366,6 +369,10 @@ void htif_t::parse_arguments(int argc, char ** argv)
           c = HTIF_LONG_OPTIONS_OPTIND + 5;
           optarg = optarg + 23;
         }
+	else if (arg.find("+target-argument=") == 0) {
+	  c = HTIF_LONG_OPTIONS_OPTIND + 6;
+	  optarg = optarg + 17;
+	}
         else if (arg.find("+permissive-off") == 0) {
           if (opterr)
             throw std::invalid_argument("Found +permissive-off when not parsing permissively");

--- a/fesvr/htif.h
+++ b/fesvr/htif.h
@@ -145,6 +145,7 @@ TARGET (RISC-V BINARY) OPTIONS\n\
 {"chroot",    required_argument, 0, HTIF_LONG_OPTIONS_OPTIND + 3 },     \
 {"payload",   required_argument, 0, HTIF_LONG_OPTIONS_OPTIND + 4 },     \
 {"signature-granularity",    optional_argument, 0, HTIF_LONG_OPTIONS_OPTIND + 5 },     \
+{"target-argument",          required_argument, 0, HTIF_LONG_OPTIONS_OPTIND + 6 },     \
 {0, 0, 0, 0}
 
 #endif // __HTIF_H

--- a/fesvr/htif.h
+++ b/fesvr/htif.h
@@ -63,7 +63,7 @@ class htif_t : public chunked_memif_t
   virtual void idle() {}
 
   const std::vector<std::string>& host_args() { return hargs; }
-  std::vector<std::string>& target_args() { return targs; }
+  const std::vector<std::string>& target_args() { return targs; }
 
   reg_t get_entry_point() { return entry; }
 

--- a/fesvr/htif.h
+++ b/fesvr/htif.h
@@ -144,7 +144,7 @@ TARGET (RISC-V BINARY) OPTIONS\n\
 {"signature", required_argument, 0, HTIF_LONG_OPTIONS_OPTIND + 2 },     \
 {"chroot",    required_argument, 0, HTIF_LONG_OPTIONS_OPTIND + 3 },     \
 {"payload",   required_argument, 0, HTIF_LONG_OPTIONS_OPTIND + 4 },     \
-{"signature-granularity",    optional_argument, 0, HTIF_LONG_OPTIONS_OPTIND + 5 },     \
+{"signature-granularity",    required_argument, 0, HTIF_LONG_OPTIONS_OPTIND + 5 },     \
 {"target-argument",          required_argument, 0, HTIF_LONG_OPTIONS_OPTIND + 6 },     \
 {0, 0, 0, 0}
 


### PR DESCRIPTION
This partially reverts #1272, and provides an alternative approach towards the problem that PR fixes.

HTIF now supports the `+target-argument=` plusarg as a mechanism for setting target arguments.

Ex: `spike +target-argument=pk +target-argument=hello` is the same as `spike pk hello`

This is only intended to be used in a specific scenario where we are unable to pass non-plusargs to the simulator that drives FESVR. As such, no documentation for this flag is provided in the help message for htif.