### PR TITLE
Add +symbol_elf flag to fesvr to support loading in symbols from other elf files

### DIFF
--- a/fesvr/htif.cc
+++ b/fesvr/htif.cc
@@ -161,26 +161,24 @@ void htif_t::load_program()
   }
 
   // detect torture tests so we can print the memory signature at the end
-  if (symbols.count("begin_signature") && symbols.count("end_signature"))
-  {
+  if (symbols.count("begin_signature") && symbols.count("end_signature")) {
     sig_addr = symbols["begin_signature"];
     sig_len = symbols["end_signature"] - sig_addr;
   }
 
-  for (auto payload : payloads)
-  {
+  for (auto payload : payloads) {
     reg_t dummy_entry;
     load_payload(payload, &dummy_entry);
   }
 
-   for (auto i : symbols)
-   {
-     auto it = addr2symbol.find(i.second);
-     if ( it == addr2symbol.end())
-       addr2symbol[i.second] = i.first;
-   }
 
-   return;
+  for (auto i : symbols) {
+    auto it = addr2symbol.find(i.second);
+    if ( it == addr2symbol.end())
+      addr2symbol[i.second] = i.first;
+  }
+
+  return;
 }
 
 const char* htif_t::get_symbol(uint64_t addr)

--- a/fesvr/htif.cc
+++ b/fesvr/htif.cc
@@ -345,6 +345,9 @@ void htif_t::parse_arguments(int argc, char ** argv)
       case HTIF_LONG_OPTIONS_OPTIND + 6:
         targs.push_back(optarg);
         break;
+      case HTIF_LONG_OPTIONS_OPTIND + 7:
+        symbol_elfs.push_back(optarg);
+        break;
       case '?':
         if (!opterr)
           break;
@@ -387,6 +390,10 @@ void htif_t::parse_arguments(int argc, char ** argv)
 	  c = HTIF_LONG_OPTIONS_OPTIND + 6;
 	  optarg = optarg + 17;
 	}
+        else if (arg.find("+symbol-elf=") == 0) {
+          c = HTIF_LONG_OPTIONS_OPTIND + 7;
+          optarg = optarg + 12;
+        }
         else if (arg.find("+permissive-off") == 0) {
           if (opterr)
             throw std::invalid_argument("Found +permissive-off when not parsing permissively");

--- a/fesvr/htif.h
+++ b/fesvr/htif.h
@@ -128,6 +128,8 @@ class htif_t : public chunked_memif_t
        +chroot=PATH\n\
       --payload=PATH       Load PATH memory as an additional ELF payload\n\
        +payload=PATH\n\
+      --symbol-elf=PATH    Populate the symbol table with the ELF file at PATH\n\
+       +symbol-elf=PATH\n\
 \n\
 HOST OPTIONS (currently unsupported)\n\
       --disk=DISK          Add DISK device. Use a ramdisk since this isn't\n\
@@ -147,6 +149,7 @@ TARGET (RISC-V BINARY) OPTIONS\n\
 {"payload",   required_argument, 0, HTIF_LONG_OPTIONS_OPTIND + 4 },     \
 {"signature-granularity",    required_argument, 0, HTIF_LONG_OPTIONS_OPTIND + 5 },     \
 {"target-argument",          required_argument, 0, HTIF_LONG_OPTIONS_OPTIND + 6 },     \
+{"symbol-elf",               required_argument, 0, HTIF_LONG_OPTIONS_OPTIND + 7 },     \
 {0, 0, 0, 0}
 
 #endif // __HTIF_H

--- a/fesvr/htif.h
+++ b/fesvr/htif.h
@@ -99,6 +99,7 @@ class htif_t : public chunked_memif_t
   std::vector<device_t*> dynamic_devices;
   std::vector<std::string> payloads;
 
+  std::vector<std::string> symbol_elfs;
   std::map<uint64_t, std::string> addr2symbol;
 
   friend class memif_t;


### PR DESCRIPTION
Currently, the `addr2symbol` table in `htif` is populated only with the symbols from the target binary. 

This PR adds the `+symbol-elf=` flag to htif, which allows easier debugging of control flow in payload binaries. For example, the Linux payload in OpenSBI.