### PR TITLE
Fix ctrl-c responsiveness when running in interactive mode

### DIFF
--- a/riscv/interactive.cc
+++ b/riscv/interactive.cc
@@ -407,7 +407,7 @@ void sim_t::interactive_run(const std::string& cmd, const std::vector<std::strin
   for (size_t i = 0; i < actual_steps && !ctrlc_pressed && !done(); i++)
     step(1);
 
-  if (actual_steps < steps) {
+  if (actual_steps < steps && !ctrlc_pressed) {
     next_interactive_action = [=](){ interactive_run(cmd, {std::to_string(steps - actual_steps)}, noisy); };
     return;
   }


### PR DESCRIPTION
Fixes a bug introduced in #1264 which caused ctrl-c to be ignored in interactive runs.

Break out of the interactive_run->interactive_run loop when ctrlc_pressed