### PR TITLE
Draft: Add virtual/override to sim_t declarations

### DIFF
--- a/riscv/clint.cc
+++ b/riscv/clint.cc
@@ -1,9 +1,9 @@
 #include <sys/time.h>
 #include "devices.h"
 #include "processor.h"
-#include "sim.h"
+#include "simif.h"
 
-clint_t::clint_t(sim_t* sim, uint64_t freq_hz, bool real_time)
+clint_t::clint_t(simif_t* sim, uint64_t freq_hz, bool real_time)
   : sim(sim), freq_hz(freq_hz), real_time(real_time), mtime(0)
 {
   struct timeval base;

--- a/riscv/debug_module.cc
+++ b/riscv/debug_module.cc
@@ -1,6 +1,7 @@
 #include <cassert>
 
-#include "sim.h"
+#include "simif.h"
+#include "devices.h"
 #include "debug_module.h"
 #include "debug_defines.h"
 #include "opcodes.h"
@@ -31,7 +32,7 @@ static unsigned field_width(unsigned n)
 
 ///////////////////////// debug_module_t
 
-debug_module_t::debug_module_t(sim_t *sim, const debug_module_config_t &config) :
+debug_module_t::debug_module_t(simif_t *sim, const debug_module_config_t &config) :
   config(config),
   program_buffer_bytes((config.support_impebreak ? 4 : 0) + 4*config.progbufsize),
   debug_progbuf_start(debug_data_start - program_buffer_bytes),

--- a/riscv/debug_module.h
+++ b/riscv/debug_module.h
@@ -7,7 +7,7 @@
 
 #include "abstract_device.h"
 
-class sim_t;
+class simif_t;
 class bus_t;
 class processor_t;
 
@@ -110,7 +110,7 @@ class debug_module_t : public abstract_device_t
      * abstract_rti is extra run-test/idle cycles that each abstract command
      * takes to execute. Useful for testing OpenOCD.
      */
-    debug_module_t(sim_t *sim, const debug_module_config_t &config);
+    debug_module_t(simif_t *sim, const debug_module_config_t &config);
     ~debug_module_t();
 
     void add_device(bus_t *bus);
@@ -145,7 +145,7 @@ class debug_module_t : public abstract_device_t
     // functionality.
     unsigned custom_base;
 
-    sim_t *sim;
+    simif_t *sim;
 
     uint8_t debug_rom_whereto[4];
     uint8_t debug_abstract[debug_abstract_size * 4];

--- a/riscv/devices.h
+++ b/riscv/devices.h
@@ -13,7 +13,7 @@
 #include <cassert>
 
 class processor_t;
-class sim_t;
+class simif_t;
 
 class bus_t : public abstract_device_t {
  public:
@@ -58,7 +58,7 @@ class mem_t : public abstract_device_t {
 
 class clint_t : public abstract_device_t {
  public:
-  clint_t(sim_t*, uint64_t freq_hz, bool real_time);
+  clint_t(simif_t*, uint64_t freq_hz, bool real_time);
   bool load(reg_t addr, size_t len, uint8_t* bytes);
   bool store(reg_t addr, size_t len, const uint8_t* bytes);
   size_t size() { return CLINT_SIZE; }
@@ -69,7 +69,7 @@ class clint_t : public abstract_device_t {
   typedef uint64_t mtime_t;
   typedef uint64_t mtimecmp_t;
   typedef uint32_t msip_t;
-  sim_t* sim;
+  simif_t* sim;
   uint64_t freq_hz;
   bool real_time;
   uint64_t real_time_ref_secs;
@@ -97,7 +97,7 @@ struct plic_context_t {
 
 class plic_t : public abstract_device_t, public abstract_interrupt_controller_t {
  public:
-  plic_t(sim_t*, uint32_t ndev);
+  plic_t(simif_t*, uint32_t ndev);
   bool load(reg_t addr, size_t len, uint8_t* bytes);
   bool store(reg_t addr, size_t len, const uint8_t* bytes);
   void set_interrupt_level(uint32_t id, int lvl);

--- a/riscv/plic.cc
+++ b/riscv/plic.cc
@@ -1,7 +1,7 @@
 #include <sys/time.h>
 #include "devices.h"
 #include "processor.h"
-#include "sim.h"
+#include "simif.h"
 
 #define PLIC_MAX_CONTEXTS 15872
 
@@ -67,7 +67,7 @@
 
 #define REG_SIZE                0x1000000
 
-plic_t::plic_t(sim_t* sim, uint32_t ndev)
+plic_t::plic_t(simif_t* sim, uint32_t ndev)
   : num_ids(ndev + 1), num_ids_word(((ndev + 1) + (32 - 1)) / 32),
   max_prio((1UL << PLIC_PRIO_BITS) - 1), priority{}, level{}
 {

--- a/riscv/sim.h
+++ b/riscv/sim.h
@@ -65,7 +65,6 @@ private:
   const cfg_t * const cfg;
   std::vector<std::pair<reg_t, mem_t*>> mems;
   std::vector<std::pair<reg_t, abstract_device_t*>> plugin_devices;
-  mmu_t* debug_mmu;  // debug port into main memory
   std::vector<processor_t*> procs;
   std::map<size_t, processor_t*> harts;
   std::pair<reg_t, reg_t> initrd_range;
@@ -138,7 +137,6 @@ private:
 
   friend class processor_t;
   friend class mmu_t;
-  friend class debug_module_t;
 
   // htif
   virtual void reset() override;

--- a/riscv/sim.h
+++ b/riscv/sim.h
@@ -58,7 +58,7 @@ public:
   const std::map<size_t, processor_t*>& get_harts() { return harts; }
 
   // Callback for processors to let the simulation know they were reset.
-  void proc_reset(unsigned id);
+  virtual void proc_reset(unsigned id) override;
 
 private:
   isa_parser_t isa;
@@ -98,13 +98,13 @@ private:
   std::optional<std::function<void()>> next_interactive_action;
 
   // memory-mapped I/O routines
-  char* addr_to_mem(reg_t paddr);
-  bool mmio_load(reg_t paddr, size_t len, uint8_t* bytes);
-  bool mmio_store(reg_t paddr, size_t len, const uint8_t* bytes);
+  virtual char* addr_to_mem(reg_t paddr) override;
+  virtual bool mmio_load(reg_t paddr, size_t len, uint8_t* bytes) override;
+  virtual bool mmio_store(reg_t paddr, size_t len, const uint8_t* bytes) override;
   void make_dtb(const char* dtb_file);
   void set_rom();
 
-  const char* get_symbol(uint64_t paddr);
+  virtual const char* get_symbol(uint64_t paddr) override;
 
   // presents a prompt for introspection into the simulation
   void interactive();
@@ -141,13 +141,13 @@ private:
   friend class debug_module_t;
 
   // htif
-  void reset();
-  void idle();
-  void read_chunk(addr_t taddr, size_t len, void* dst);
-  void write_chunk(addr_t taddr, size_t len, const void* src);
-  size_t chunk_align() { return 8; }
-  size_t chunk_max_size() { return 8; }
-  endianness_t get_target_endianness() const;
+  virtual void reset() override;
+  virtual void idle() override;
+  virtual void read_chunk(addr_t taddr, size_t len, void* dst) override;
+  virtual void write_chunk(addr_t taddr, size_t len, const void* src) override;
+  virtual size_t chunk_align() override { return 8; }
+  virtual size_t chunk_max_size() override { return 8; }
+  virtual endianness_t get_target_endianness() const override;
 
 public:
   // Initialize this after procs, because in debug_module_t::reset() we

--- a/riscv/sim.h
+++ b/riscv/sim.h
@@ -51,11 +51,11 @@ public:
     this->remote_bitbang = remote_bitbang;
   }
   const char* get_dts() { return dts.c_str(); }
-  processor_t* get_core(size_t i) { return procs.at(i); }
-  const cfg_t &get_cfg() { return *cfg; }
-  unsigned nprocs() const { return procs.size(); }
+  virtual processor_t* get_core(size_t i) override { return procs.at(i); }
+  virtual const cfg_t &get_cfg() override { return *cfg; }
+  virtual unsigned nprocs() const override { return procs.size(); }
 
-  const std::map<size_t, processor_t*>& get_harts() { return harts; }
+  virtual const std::map<size_t, processor_t*>& get_harts() override { return harts; }
 
   // Callback for processors to let the simulation know they were reset.
   virtual void proc_reset(unsigned id) override;

--- a/riscv/simif.h
+++ b/riscv/simif.h
@@ -3,7 +3,11 @@
 #ifndef _RISCV_SIMIF_H
 #define _RISCV_SIMIF_H
 
+#include <map>
 #include "decode.h"
+#include "cfg.h"
+
+class processor_t;
 
 // this is the interface to the simulator used by the processors and memory
 class simif_t
@@ -18,6 +22,11 @@ public:
   virtual bool mmio_store(reg_t paddr, size_t len, const uint8_t* bytes) = 0;
   // Callback for processors to let the simulation know they were reset.
   virtual void proc_reset(unsigned id) = 0;
+
+  virtual processor_t* get_core(size_t i) = 0;
+  virtual const cfg_t &get_cfg() = 0;
+  virtual unsigned nprocs() const = 0;
+  virtual const std::map<size_t, processor_t*>& get_harts() = 0;
 
   virtual const char* get_symbol(uint64_t paddr) = 0;
 

--- a/riscv/simif.h
+++ b/riscv/simif.h
@@ -8,6 +8,7 @@
 #include "cfg.h"
 
 class processor_t;
+class mmu_t;
 
 // this is the interface to the simulator used by the processors and memory
 class simif_t
@@ -31,6 +32,8 @@ public:
   virtual const char* get_symbol(uint64_t paddr) = 0;
 
   virtual ~simif_t() = default;
+
+  mmu_t* debug_mmu;  // debug port into main memory, for use by debug_module
 
 };
 


### PR DESCRIPTION
I need to rely on the CI here because my compiler doesn't have `-Winconsistent-missing-override` so I'll be pushing commits here for testing.