### PR TITLE
fesvr: fix compilation with gcc 13

### DIFF
--- a/fesvr/device.h
+++ b/fesvr/device.h
@@ -6,6 +6,7 @@
 #include <cstring>
 #include <string>
 #include <functional>
+#include <cstdint>
 
 class memif_t;
 


### PR DESCRIPTION
Compiling spike with gcc 13 (for example, included in Fedora 38 prerelease) fails with error:

    In file included from fesvr/syscall.h:6,
                     from fesvr/syscall.cc:4:
    fesvr/device.h:15:30: error: ‘uint64_t’ was not declared in this scope
       15 |   typedef std::function<void(uint64_t)> callback_t;
          |                              ^~~~~~~~

This is due to a gcc header dependency change. See for reference: https://gcc.gnu.org/gcc-13/porting_to.html#header-dep-changes

This commit explicitly adds the missing <cstdint> header inclusion to fix this build failure.