### PR TITLE
Add processor_t::is_waiting_for_interrupt accessor

### DIFF
--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -293,6 +293,8 @@ public:
   void set_mmu_capability(int cap);
 
   const char* get_symbol(uint64_t addr);
+  
+  bool is_waiting_for_interrupt() { return in_wfi; };
 
 private:
   const isa_parser_t * const isa;


### PR DESCRIPTION
With a RTL-driven uncore-simulation, I want to fast-forwards mtime to improve simulation performance. This requires a mechanism to determine if processor_t is WFI.

This is the same API suggested for #1198