### PR TITLE
Stop unconditionally adding zicntr/zihpm to supported extensions

### DIFF
--- a/config.h.in
+++ b/config.h.in
@@ -33,6 +33,9 @@
 /* define if the Boost::ASIO library is available */
 #undef HAVE_BOOST_ASIO
 
+/* define if the Boost::Regex library is available */
+#undef HAVE_BOOST_REGEX
+
 /* Dynamic library loading is supported */
 #undef HAVE_DLOPEN
 
@@ -114,7 +117,7 @@
 /* Define to 1 if you have the ANSI C header files. */
 #undef STDC_HEADERS
 
-/* Default value for --with-target switch */
+/* Default value for --target switch */
 #undef TARGET_ARCH
 
 /* Define WORDS_BIGENDIAN to 1 if your processor stores words with the most

--- a/configure
+++ b/configure
@@ -715,7 +715,6 @@ with_isa
 with_priv
 with_varch
 with_target
-enable_dirty
 enable_dual_endian
 '
       ac_precious_vars='build_alias
@@ -6043,6 +6042,7 @@ _ACEOF
 else
   as_fn_error $? "libpthread is required" "$LINENO" 5
 fi
+
 
 # Check whether --enable-dual-endian was given.
 if test "${enable_dual_endian+set}" = set; then :

--- a/configure
+++ b/configure
@@ -1381,7 +1381,8 @@ Optional Packages:
                           use the Regex library from boost - it is possible to
                           specify a certain library for the linker e.g.
                           --with-boost-regex=boost_regex-gcc-mt-d-1_33_1
-  --with-isa=RV64IMAFDC   Sets the default RISC-V ISA
+  --with-isa=RV64IMAFDC_zicntr_zihpm
+                          Sets the default RISC-V ISA
   --with-priv=MSU         Sets the default RISC-V privilege modes supported
   --with-varch=vlen:128,elen:64
                           Sets the default vector config
@@ -5876,7 +5877,7 @@ _ACEOF
 else
 
 cat >>confdefs.h <<_ACEOF
-#define DEFAULT_ISA "RV64IMAFDC"
+#define DEFAULT_ISA "RV64IMAFDC_zicntr_zihpm"
 _ACEOF
 
 fi

--- a/riscv/isa_parser.cc
+++ b/riscv/isa_parser.cc
@@ -32,10 +32,6 @@ isa_parser_t::isa_parser_t(const char* str, const char *priv)
   isa_string = strtolower(str);
   const char* all_subsets = "mafdqchpv";
 
-  // enable zicntr and zihpm unconditionally for backward compatibility
-  extension_table[EXT_ZICNTR] = true;
-  extension_table[EXT_ZIHPM] = true;
-
   if (isa_string.compare(0, 4, "rv32") == 0)
     max_xlen = 32;
   else if (isa_string.compare(0, 4, "rv64") == 0)
@@ -229,9 +225,11 @@ isa_parser_t::isa_parser_t(const char* str, const char *priv)
       extension_table[EXT_ZICBOZ] = true;
     } else if (ext_str == "zicbop") {
     } else if (ext_str == "zicntr") {
+      extension_table[EXT_ZICNTR] = true;
     } else if (ext_str == "zicond") {
       extension_table[EXT_ZICOND] = true;
     } else if (ext_str == "zihpm") {
+      extension_table[EXT_ZIHPM] = true;
     } else if (ext_str == "sstc") {
         extension_table[EXT_SSTC] = true;
     } else if (ext_str[0] == 'x') {

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -323,7 +323,7 @@ void state_t::reset(processor_t* const proc, reg_t max_isa)
 
   csrmap[CSR_MEDELEG] = medeleg = std::make_shared<medeleg_csr_t>(proc, CSR_MEDELEG);
   csrmap[CSR_MIDELEG] = mideleg = std::make_shared<mideleg_csr_t>(proc, CSR_MIDELEG);
-  const reg_t counteren_mask = 0xffffffffULL;
+  const reg_t counteren_mask = (proc->extension_enabled_const(EXT_ZICNTR) ? 0x7UL : 0x0) | (proc->extension_enabled_const(EXT_ZIHPM) ? 0xfffffff8ULL : 0x0);
   mcounteren = std::make_shared<masked_csr_t>(proc, CSR_MCOUNTEREN, counteren_mask, 0);
   if (proc->extension_enabled_const('U')) csrmap[CSR_MCOUNTEREN] = mcounteren;
   csrmap[CSR_SCOUNTEREN] = scounteren = std::make_shared<masked_csr_t>(proc, CSR_SCOUNTEREN, counteren_mask, 0);

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -247,7 +247,7 @@ void state_t::reset(processor_t* const proc, reg_t max_isa)
     auto mcounter = std::make_shared<const_csr_t>(proc, which_mcounter, 0);
     csrmap[which_mcounter] = mcounter;
 
-    if (proc->extension_enabled_const(EXT_ZICNTR) && proc->extension_enabled_const(EXT_ZIHPM)) {
+    if (proc->extension_enabled_const(EXT_ZIHPM)) {
       auto counter = std::make_shared<counter_proxy_csr_t>(proc, which_counter, mcounter);
       csrmap[which_counter] = counter;
     }
@@ -255,7 +255,7 @@ void state_t::reset(processor_t* const proc, reg_t max_isa)
       csrmap[which_mevent] = std::make_shared<rv32_low_csr_t>(proc, which_mevent, mevent[i - 3]);;
       auto mcounterh = std::make_shared<const_csr_t>(proc, which_mcounterh, 0);
       csrmap[which_mcounterh] = mcounterh;
-      if (proc->extension_enabled_const(EXT_ZICNTR) && proc->extension_enabled_const(EXT_ZIHPM)) {
+      if (proc->extension_enabled_const(EXT_ZIHPM)) {
         auto counterh = std::make_shared<counter_proxy_csr_t>(proc, which_counterh, mcounterh);
         csrmap[which_counterh] = counterh;
       }

--- a/riscv/riscv.ac
+++ b/riscv/riscv.ac
@@ -9,10 +9,10 @@ AC_CHECK_LIB([boost_system], [main], [], [])
 AC_CHECK_LIB([boost_regex], [main], [], [])
 
 AC_ARG_WITH(isa,
-	[AS_HELP_STRING([--with-isa=RV64IMAFDC],
+	[AS_HELP_STRING([--with-isa=RV64IMAFDC_zicntr_zihpm],
 		[Sets the default RISC-V ISA])],
   AC_DEFINE_UNQUOTED([DEFAULT_ISA], "$withval", [Default value for --isa switch]),
-  AC_DEFINE_UNQUOTED([DEFAULT_ISA], "RV64IMAFDC", [Default value for --isa switch]))
+  AC_DEFINE_UNQUOTED([DEFAULT_ISA], "RV64IMAFDC_zicntr_zihpm", [Default value for --isa switch]))
 
 AC_ARG_WITH(priv,
 	[AS_HELP_STRING([--with-priv=MSU],


### PR DESCRIPTION
See https://github.com/riscv-software-src/riscv-isa-sim/pull/926 for prior discussion.

This makes it possible to model systems w.o zicntr and zihpm. I'm not sure what the backwards compatibility being prioritized is, but I've changed the default ISA str to include zicntr/zihpm
