### PR TITLE
Adjust cache stats printout

### DIFF
--- a/riscv/cachesim.cc
+++ b/riscv/cachesim.cc
@@ -76,9 +76,6 @@ cache_sim_t::~cache_sim_t()
 
 void cache_sim_t::print_stats()
 {
-  if (read_accesses + write_accesses == 0)
-    return;
-
   float mr = 100.0f*(read_misses+write_misses)/(read_accesses+write_accesses);
 
   std::cout << std::setprecision(3) << std::fixed;

--- a/riscv/cachesim.h
+++ b/riscv/cachesim.h
@@ -100,6 +100,10 @@ class cache_memtracer_t : public memtracer_t
   {
     cache->set_log(log);
   }
+  void print_stats(void)
+  {
+    cache->print_stats();
+  }
 
  protected:
   cache_sim_t* cache;
@@ -108,7 +112,8 @@ class cache_memtracer_t : public memtracer_t
 class icache_sim_t : public cache_memtracer_t
 {
  public:
-  icache_sim_t(const char* config) : cache_memtracer_t(config, "I$") {}
+  icache_sim_t(const char* config, const char* name = "I$")
+	  : cache_memtracer_t(config, name) {}
   bool interested_in_range(uint64_t UNUSED begin, uint64_t UNUSED end, access_type type)
   {
     return type == FETCH;
@@ -122,7 +127,8 @@ class icache_sim_t : public cache_memtracer_t
 class dcache_sim_t : public cache_memtracer_t
 {
  public:
-  dcache_sim_t(const char* config) : cache_memtracer_t(config, "D$") {}
+  dcache_sim_t(const char* config, const char* name = "D$")
+	  : cache_memtracer_t(config, name) {}
   bool interested_in_range(uint64_t UNUSED begin, uint64_t UNUSED end, access_type type)
   {
     return type == LOAD || type == STORE;


### PR DESCRIPTION
With this change the statistics can be printed on demand and there is no longer need to wait for destructor to trigger this action.
It is also possible to finetune naming for various caches keeping backward API compatibility.
Finally, stats are printed regardless whether any accesses have been requested or not. This is for better insight and potential scripting input.