### PR TITLE
Add cache statistics print on demand

### DIFF
--- a/riscv/cachesim.h
+++ b/riscv/cachesim.h
@@ -100,6 +100,10 @@ class cache_memtracer_t : public memtracer_t
   {
     cache->set_log(log);
   }
+  void print_stats()
+  {
+    cache->print_stats();
+  }
 
  protected:
   cache_sim_t* cache;


### PR DESCRIPTION
With this change it is not necessary to wait for
tracer destructor to trigger statistics printout.