### PR TITLE
Use different tlbs respectively to match riscv spec

### DIFF
--- a/riscv/insns/hfence_gvma.h
+++ b/riscv/insns/hfence_gvma.h
@@ -1,4 +1,4 @@
 require_extension('H');
 require_novirt();
 require_privilege(get_field(STATE.mstatus->read(), MSTATUS_TVM) ? PRV_M : PRV_S);
-MMU.flush_tlb();
+MMU.flush_tlb(G_STAGE);

--- a/riscv/insns/hfence_vvma.h
+++ b/riscv/insns/hfence_vvma.h
@@ -1,4 +1,4 @@
 require_extension('H');
 require_novirt();
 require_privilege(PRV_S);
-MMU.flush_tlb();
+MMU.flush_tlb(VS_STAGE);

--- a/riscv/insns/sfence_vma.h
+++ b/riscv/insns/sfence_vma.h
@@ -6,4 +6,8 @@ if (STATE.v) {
 } else {
   require_privilege(get_field(STATE.mstatus->read(), MSTATUS_TVM) ? PRV_M : PRV_S);
 }
-MMU.flush_tlb();
+if (STATE.v) {
+  MMU.flush_tlb(VS_STAGE);
+} else {
+  MMU.flush_tlb(HS_STAGE);
+}


### PR DESCRIPTION
Tests:
hypervisor hfence.gvma hfence.vvma sfence tlb pass

1. hfence.gvma only flush G-stage tlb
2. hfence.vvma only flush VS-stage tlb
3. when V=0 sfence.vma only flush HS-stage tlb; when V=1 sfence.vma only flush VS-stage tlb

