### PR TITLE
explicitly show D(-mode) instead of M(-mode) when in debug mode

### DIFF
--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -722,6 +722,8 @@ void processor_t::set_privilege(reg_t prv)
 
 const char* processor_t::get_privilege_string()
 {
+  if (state.debug_mode)
+    return "D";
   if (state.v) {
     switch (state.prv) {
     case 0x0: return "VU";


### PR DESCRIPTION
Debug mode (D-mode) can be considered an additional privilege mode. This commit proposes printing D(-mode) instead of M(-mode) for D-mode.