### PR TITLE
riscv: sim.cc: Parse for "sifive,clint0" if "riscv,clint0" is absent

### DIFF
--- a/riscv/clint.cc
+++ b/riscv/clint.cc
@@ -118,7 +118,7 @@ void clint_t::tick(reg_t rtc_ticks)
 
 clint_t* clint_parse_from_fdt(const void* fdt, const sim_t* sim, reg_t* base,
     const std::vector<std::string>& sargs) {
-  if (fdt_parse_clint(fdt, base, "riscv,clint0") == 0)
+  if (fdt_parse_clint(fdt, base, "riscv,clint0") == 0 || fdt_parse_clint(fdt, base, "sifive,clint0") == 0)
     return new clint_t(sim,
                        sim->CPU_HZ / sim->INSNS_PER_RTC_TICK,
                        sim->get_cfg().real_time_clint());


### PR DESCRIPTION
"riscv,clint0" and "sifive,clint0" in device tree's "compatible" string point to the same driver, as can be seen from drivers/clocksource/timer-clint.c in Linux kernel. https://github.com/torvalds/linux/commit/2ac6795fcc085e8d03649f1bbd0d70aaff612cad