### PR TITLE
riscv: sim.cc: Parse for other compatible strings if "riscv,plic0" is absent

### DIFF
--- a/riscv/plic.cc
+++ b/riscv/plic.cc
@@ -418,7 +418,8 @@ std::string plic_generate_dts(const sim_t* sim)
 plic_t* plic_parse_from_fdt(const void* fdt, const sim_t* sim, reg_t* base, const std::vector<std::string>& sargs)
 {
   uint32_t plic_ndev;
-  if (fdt_parse_plic(fdt, base, &plic_ndev, "riscv,plic0") == 0)
+  if (fdt_parse_plic(fdt, base, &plic_ndev, "riscv,plic0") == 0 ||
+      fdt_parse_plic(fdt, base, &plic_ndev, "sifive,plic-1.0.0") == 0)
     return new plic_t(sim, plic_ndev);
   else
     return nullptr;


### PR DESCRIPTION
There are three more compatible strings in device tree that point to the same driver,
- "sifive,plic-1.0.0"
- "andestech,nceplic100"
- "thead,c900-plic" 

as can be seen from drivers/irqchip/irq-sifive-plic.c in Linux kernel. https://github.com/torvalds/linux/commit/5873ba559101fa37ad9764e79856f71bf54021aa