### PR TITLE
riscv: sim.cc: Consider cpu-map node in cpus node

### DIFF
--- a/riscv/sim.cc
+++ b/riscv/sim.cc
@@ -149,14 +149,18 @@ sim_t::sim_t(const cfg_t *cfg, bool halted,
   }
 
   //per core attribute
-  int cpu_offset = 0, rc;
+  int cpu_offset = 0, cpu_map_offset, rc;
   size_t cpu_idx = 0;
   cpu_offset = fdt_get_offset(fdt, "/cpus");
+  cpu_map_offset = fdt_get_offset(fdt, "/cpus/cpu-map");
   if (cpu_offset < 0)
     return;
 
   for (cpu_offset = fdt_get_first_subnode(fdt, cpu_offset); cpu_offset >= 0;
        cpu_offset = fdt_get_next_subnode(fdt, cpu_offset)) {
+
+    if (!(cpu_map_offset < 0) && cpu_offset == cpu_map_offset)
+      continue;
 
     if (cpu_idx >= nprocs())
       break;


### PR DESCRIPTION
cpu-map node may be present in cpus node.
https://github.com/torvalds/linux/commit/124e46a86580c71e0eee8459c5da7649318118db
So this commit adds logic to cater that.