### PR TITLE
implement Debug Specification Section 5.4 Native Triggers

### DIFF
--- a/riscv/triggers.h
+++ b/riscv/triggers.h
@@ -90,6 +90,7 @@ public:
 protected:
   static action_t legalize_action(reg_t val, reg_t action_mask, reg_t dmode_mask) noexcept;
   bool common_match(processor_t * const proc) const noexcept;
+  bool allow_action(const state_t * const state) const;
   reg_t tdata2;
 
   bool vs = false;


### PR DESCRIPTION
This commit implements Debug Specification Section 5.4 Native Triggers, which resolves the reentrancy problem.

**Reentrancy problem**
Native triggers, i.e., tdata1.action=0, cause a breakpoint exception when matching. Firing a breakpoint exception in a trap handler may result in reentrancy to the trap handler, which overwrites trap-related CSRs (such as mcause and mepc) and leaves the hart unable to resume normal execution.

To avoid the reentrancy problem, native triggers should prevent causing a breakpoint exception to a trap handler, where the hart is already in. The specification allows two solutions to avoid the reentrancy problem, as shown below. This commit chooses the first solution because the second one targets implementations without S-mode.
![image](https://user-images.githubusercontent.com/39526191/231457614-1f830c99-8b67-4b3d-beb0-7e17a2691d8a.png)
