### PR TITLE
Fix syscall gettimeofday in 32-bit emulator

### DIFF
--- a/fesvr/syscall.cc
+++ b/fesvr/syscall.cc
@@ -7,6 +7,7 @@
 #include <unistd.h>
 #include <fcntl.h>
 #include <sys/stat.h>
+#include <sys/time.h>
 #include <limits.h>
 #include <errno.h>
 #include <stdlib.h>
@@ -164,6 +165,7 @@ syscall_t::syscall_t(htif_t* htif)
   table[79] = &syscall_t::sys_fstatat;
   table[80] = &syscall_t::sys_fstat;
   table[93] = &syscall_t::sys_exit;
+  table[169] = &syscall_t::sys_gettimeofday;
   table[291] = &syscall_t::sys_statx;
   table[1039] = &syscall_t::sys_lstat;
   table[2011] = &syscall_t::sys_getmainvars;
@@ -214,6 +216,14 @@ void syscall_t::handle_syscall(command_t cmd)
 reg_t syscall_t::sys_exit(reg_t code, reg_t a1, reg_t a2, reg_t a3, reg_t a4, reg_t a5, reg_t a6)
 {
   htif->exitcode = code << 1 | 1;
+  return 0;
+}
+
+reg_t syscall_t::sys_gettimeofday(reg_t buf, reg_t a1, reg_t a2, reg_t a3, reg_t a4, reg_t a5, reg_t a6)
+{
+  struct timeval tv;
+  gettimeofday(&tv, NULL);
+  memif->write(buf, sizeof(timeval), &tv);
   return 0;
 }
 

--- a/fesvr/syscall.h
+++ b/fesvr/syscall.h
@@ -47,6 +47,7 @@ class syscall_t : public device_t
   std::string undo_chroot(const char* fn);
 
   reg_t sys_exit(reg_t, reg_t, reg_t, reg_t, reg_t, reg_t, reg_t);
+  reg_t sys_gettimeofday(reg_t, reg_t, reg_t, reg_t, reg_t, reg_t, reg_t);
   reg_t sys_openat(reg_t, reg_t, reg_t, reg_t, reg_t, reg_t, reg_t);
   reg_t sys_read(reg_t, reg_t, reg_t, reg_t, reg_t, reg_t, reg_t);
   reg_t sys_pread(reg_t, reg_t, reg_t, reg_t, reg_t, reg_t, reg_t);


### PR DESCRIPTION
When running the 32-bit emulator, we've discovered that the proxy kernel generates inaccurate time results when the `gettimeofday` system call is made. However, the 64-bit emulator doesn't seem to be impacted by this issue. To address this problem, we've made a modification to the system by forwarding the 'gettimeofday' system call to the Spike front-end server. This allows us to receive the correct time results and resolve the problem. The modification includes both the proxy kernel and Spike.

## Issue reproduction
* [dhrystone source code](https://github.com/qwe661234/rv32emu/blob/master/tests/dhrystone.c)
### 1. Compile
```
riscv32-unknown-elf-gcc -march=rv32g -O2 ./dhrystone.c -o dhrystone.elf
```
### 2. Execute
```
/path/to/spike --isa=rv32g /path/to/32-bit_proxy_kernel dhrystone.elf
```

Related: https://github.com/riscv-software-src/riscv-pk/pull/294