### PR TITLE
Remove unused parameter for macro in v_ext_macro.h

### DIFF
--- a/riscv/insns/vfncvt_f_f_w.h
+++ b/riscv/insns/vfncvt_f_f_w.h
@@ -1,4 +1,4 @@
-// vfncvt.f.f.v vd, vs2, vm
+// vfncvt.f.f.w vd, vs2, vm
 VI_VFP_NCVT_FP_TO_FP(
   { vd = f32_to_f16(vs2); },           // BODY32
   { vd = f64_to_f32(vs2); },           // BODY64

--- a/riscv/insns/vfncvt_f_f_w.h
+++ b/riscv/insns/vfncvt_f_f_w.h
@@ -1,9 +1,7 @@
 // vfncvt.f.f.v vd, vs2, vm
 VI_VFP_NCVT_FP_TO_FP(
-  {;},                                 // BODY16
   { vd = f32_to_f16(vs2); },           // BODY32
   { vd = f64_to_f32(vs2); },           // BODY64
-  {;},                                 // CHECK16
   { require_extension(EXT_ZVFHMIN); }, // CHECK32
   { require_extension('D'); }          // CHECK64
 )

--- a/riscv/insns/vfncvt_f_x_w.h
+++ b/riscv/insns/vfncvt_f_x_w.h
@@ -1,9 +1,7 @@
 // vfncvt.f.x.v vd, vs2, vm
 VI_VFP_NCVT_INT_TO_FP(
-  {;},                              // BODY16
   { vd = i32_to_f16(vs2); },        // BODY32
   { vd = i64_to_f32(vs2); },        // BODY64
-  {;},                              // CHECK16
   { require_extension(EXT_ZVFH); }, // CHECK32
   { require_extension('F'); },      // CHECK64
   int                               // sign

--- a/riscv/insns/vfncvt_f_x_w.h
+++ b/riscv/insns/vfncvt_f_x_w.h
@@ -1,4 +1,4 @@
-// vfncvt.f.x.v vd, vs2, vm
+// vfncvt.f.x.w vd, vs2, vm
 VI_VFP_NCVT_INT_TO_FP(
   { vd = i32_to_f16(vs2); },        // BODY32
   { vd = i64_to_f32(vs2); },        // BODY64

--- a/riscv/insns/vfncvt_f_xu_w.h
+++ b/riscv/insns/vfncvt_f_xu_w.h
@@ -1,4 +1,4 @@
-// vfncvt.f.xu.v vd, vs2, vm
+// vfncvt.f.xu.w vd, vs2, vm
 VI_VFP_NCVT_INT_TO_FP(
   { vd = ui32_to_f16(vs2); },       // BODY32
   { vd = ui64_to_f32(vs2); },       // BODY64

--- a/riscv/insns/vfncvt_f_xu_w.h
+++ b/riscv/insns/vfncvt_f_xu_w.h
@@ -1,9 +1,7 @@
 // vfncvt.f.xu.v vd, vs2, vm
 VI_VFP_NCVT_INT_TO_FP(
-  {;},                              // BODY16
   { vd = ui32_to_f16(vs2); },       // BODY32
   { vd = ui64_to_f32(vs2); },       // BODY64
-  {;},                              // CHECK16
   { require_extension(EXT_ZVFH); }, // CHECK32
   { require_extension('F'); },      // CHECK64
   uint                              // sign

--- a/riscv/insns/vfncvt_rod_f_f_w.h
+++ b/riscv/insns/vfncvt_rod_f_f_w.h
@@ -1,4 +1,4 @@
-// vfncvt.rod.f.f.v vd, vs2, vm
+// vfncvt.rod.f.f.w vd, vs2, vm
 VI_VFP_NCVT_FP_TO_FP(
   {                                 // BODY32
     softfloat_roundingMode = softfloat_round_odd;

--- a/riscv/insns/vfncvt_rod_f_f_w.h
+++ b/riscv/insns/vfncvt_rod_f_f_w.h
@@ -1,6 +1,5 @@
 // vfncvt.rod.f.f.v vd, vs2, vm
 VI_VFP_NCVT_FP_TO_FP(
-  {;},                              // BODY16
   {                                 // BODY32
     softfloat_roundingMode = softfloat_round_odd;
     vd = f32_to_f16(vs2);
@@ -9,7 +8,6 @@ VI_VFP_NCVT_FP_TO_FP(
     softfloat_roundingMode = softfloat_round_odd;
     vd = f64_to_f32(vs2);
   },
-  {;},                              // CHECK16
   { require_extension(EXT_ZVFH); }, // CHECK32
   { require_extension('F'); }       // CHECK64
 )

--- a/riscv/insns/vfwcvt_f_f_v.h
+++ b/riscv/insns/vfwcvt_f_f_v.h
@@ -1,9 +1,7 @@
 // vfwcvt.f.f.v vd, vs2, vm
 VI_VFP_WCVT_FP_TO_FP(
-  {;},                                 // BODY8
   { vd = f16_to_f32(vs2); },           // BODY16
   { vd = f32_to_f64(vs2); },           // BODY32
-  {;},                                 // CHECK8
   { require_extension(EXT_ZVFHMIN); }, // CHECK16
   { require_extension('D'); }          // CHECK32
 )

--- a/riscv/insns/vfwcvt_rtz_x_f_v.h
+++ b/riscv/insns/vfwcvt_rtz_x_f_v.h
@@ -1,9 +1,7 @@
 // vfwcvt.rtz.x.f.v vd, vs2, vm
 VI_VFP_WCVT_FP_TO_INT(
-  {;},                                                     // BODY8
   { vd = f16_to_i32(vs2, softfloat_round_minMag, true); }, // BODY16
   { vd = f32_to_i64(vs2, softfloat_round_minMag, true); }, // BODY32
-  {;},                                                     // CHECK8
   { require_extension(EXT_ZVFH); },                        // CHECK16
   { require_extension('F'); },                             // CHECK32
   int                                                      // sign

--- a/riscv/insns/vfwcvt_rtz_xu_f_v.h
+++ b/riscv/insns/vfwcvt_rtz_xu_f_v.h
@@ -1,9 +1,7 @@
 // vfwcvt.rtz,xu.f.v vd, vs2, vm
 VI_VFP_WCVT_FP_TO_INT(
-  {;},                                                      // BODY8
   { vd = f16_to_ui32(vs2, softfloat_round_minMag, true); }, // BODY16
   { vd = f32_to_ui64(vs2, softfloat_round_minMag, true); }, // BODY32
-  {;},                                                      // CHECK8
   { require_extension(EXT_ZVFH); },                         // CHECK16
   { require_extension('F'); },                              // CHECK32
   uint                                                      // sign

--- a/riscv/insns/vfwcvt_x_f_v.h
+++ b/riscv/insns/vfwcvt_x_f_v.h
@@ -1,9 +1,7 @@
 // vfwcvt.x.f.v vd, vs2, vm
 VI_VFP_WCVT_FP_TO_INT(
-  {;},                                                     // BODY8
   { vd = f16_to_i32(vs2, softfloat_roundingMode, true); }, // BODY16
   { vd = f32_to_i64(vs2, softfloat_roundingMode, true); }, // BODY32
-  {;},                                                     // CHECK8
   { require_extension(EXT_ZVFH); },                        // CHECK16
   { require_extension('F'); },                             // CHECK32
   int                                                      // sign

--- a/riscv/insns/vfwcvt_xu_f_v.h
+++ b/riscv/insns/vfwcvt_xu_f_v.h
@@ -1,9 +1,7 @@
 // vfwcvt.xu.f.v vd, vs2, vm
 VI_VFP_WCVT_FP_TO_INT(
-  {;},                                                      // BODY8
   { vd = f16_to_ui32(vs2, softfloat_roundingMode, true); }, // BODY16
   { vd = f32_to_ui64(vs2, softfloat_roundingMode, true); }, // BODY32
-  {;},                                                      // CHECK8
   { require_extension(EXT_ZVFH); },                         // CHECK16
   { require_extension('F'); },                              // CHECK32
   uint                                                      // sign

--- a/riscv/v_ext_macros.h
+++ b/riscv/v_ext_macros.h
@@ -2014,50 +2014,50 @@ reg_t index[P.VU.vlmax]; \
       break; \
   }
 
-#define VI_VFP_NCVT_FP_TO_FP(BODY16, BODY32, \
-                             CHECK16, CHECK32) \
+#define VI_VFP_NCVT_FP_TO_FP(BODY32, BODY64, \
+                             CHECK32, CHECK64) \
   VI_CHECK_SDS(false); \
   switch (P.VU.vsew) { \
     case e16: \
-      { VI_VFP_CVT_LOOP(CVT_FP_TO_FP_PARAMS(32, 16), CHECK16, BODY16); } \
+      { VI_VFP_CVT_LOOP(CVT_FP_TO_FP_PARAMS(32, 16), CHECK32, BODY32); } \
       break; \
     case e32: \
-      { VI_VFP_CVT_LOOP(CVT_FP_TO_FP_PARAMS(64, 32), CHECK32, BODY32); } \
+      { VI_VFP_CVT_LOOP(CVT_FP_TO_FP_PARAMS(64, 32), CHECK64, BODY64); } \
       break; \
     default: \
       require(0); \
       break; \
   }
 
-#define VI_VFP_NCVT_INT_TO_FP(BODY16, BODY32, \
-                              CHECK16, CHECK32, \
+#define VI_VFP_NCVT_INT_TO_FP(BODY32, BODY64, \
+                              CHECK32, CHECK64, \
                               sign) \
   VI_CHECK_SDS(false); \
   switch (P.VU.vsew) { \
     case e16: \
-      { VI_VFP_CVT_LOOP(CVT_INT_TO_FP_PARAMS(32, 16, sign), CHECK16, BODY16); } \
+      { VI_VFP_CVT_LOOP(CVT_INT_TO_FP_PARAMS(32, 16, sign), CHECK32, BODY32); } \
       break; \
     case e32: \
-      { VI_VFP_CVT_LOOP(CVT_INT_TO_FP_PARAMS(64, 32, sign), CHECK32, BODY32); } \
+      { VI_VFP_CVT_LOOP(CVT_INT_TO_FP_PARAMS(64, 32, sign), CHECK64, BODY64); } \
       break; \
     default: \
       require(0); \
       break; \
   }
 
-#define VI_VFP_NCVT_FP_TO_INT(BODY8, BODY16, BODY32, \
-                              CHECK8, CHECK16, CHECK32, \
+#define VI_VFP_NCVT_FP_TO_INT(BODY16, BODY32, BODY64, \
+                              CHECK16, CHECK32, CHECK64, \
                               sign) \
   VI_CHECK_SDS(false); \
   switch (P.VU.vsew) { \
     case e8: \
-      { VI_VFP_CVT_LOOP(CVT_FP_TO_INT_PARAMS(16, 8, sign), CHECK8, BODY8); } \
+      { VI_VFP_CVT_LOOP(CVT_FP_TO_INT_PARAMS(16, 8, sign), CHECK16, BODY16); } \
       break; \
     case e16: \
-      { VI_VFP_CVT_LOOP(CVT_FP_TO_INT_PARAMS(32, 16, sign), CHECK16, BODY16); } \
+      { VI_VFP_CVT_LOOP(CVT_FP_TO_INT_PARAMS(32, 16, sign), CHECK32, BODY32); } \
       break; \
     case e32: \
-      { VI_VFP_CVT_LOOP(CVT_FP_TO_INT_PARAMS(64, 32, sign), CHECK32, BODY32); } \
+      { VI_VFP_CVT_LOOP(CVT_FP_TO_INT_PARAMS(64, 32, sign), CHECK64, BODY64); } \
       break; \
     default: \
       require(0); \

--- a/riscv/v_ext_macros.h
+++ b/riscv/v_ext_macros.h
@@ -1964,8 +1964,8 @@ reg_t index[P.VU.vlmax]; \
       break; \
   }
 
-#define VI_VFP_WCVT_FP_TO_FP(BODY8, BODY16, BODY32, \
-                             CHECK8, CHECK16, CHECK32) \
+#define VI_VFP_WCVT_FP_TO_FP(BODY16, BODY32, \
+                             CHECK16, CHECK32) \
   VI_CHECK_DSS(false); \
   switch (P.VU.vsew) { \
     case e16: \
@@ -1998,8 +1998,8 @@ reg_t index[P.VU.vlmax]; \
       break; \
   }
 
-#define VI_VFP_WCVT_FP_TO_INT(BODY8, BODY16, BODY32, \
-                              CHECK8, CHECK16, CHECK32, \
+#define VI_VFP_WCVT_FP_TO_INT(BODY16, BODY32, \
+                              CHECK16, CHECK32, \
                               sign) \
   VI_CHECK_DSS(false); \
   switch (P.VU.vsew) { \
@@ -2014,8 +2014,8 @@ reg_t index[P.VU.vlmax]; \
       break; \
   }
 
-#define VI_VFP_NCVT_FP_TO_FP(BODY8, BODY16, BODY32, \
-                             CHECK8, CHECK16, CHECK32) \
+#define VI_VFP_NCVT_FP_TO_FP(BODY16, BODY32, \
+                             CHECK16, CHECK32) \
   VI_CHECK_SDS(false); \
   switch (P.VU.vsew) { \
     case e16: \
@@ -2029,8 +2029,8 @@ reg_t index[P.VU.vlmax]; \
       break; \
   }
 
-#define VI_VFP_NCVT_INT_TO_FP(BODY8, BODY16, BODY32, \
-                              CHECK8, CHECK16, CHECK32, \
+#define VI_VFP_NCVT_INT_TO_FP(BODY16, BODY32, \
+                              CHECK16, CHECK32, \
                               sign) \
   VI_CHECK_SDS(false); \
   switch (P.VU.vsew) { \


### PR DESCRIPTION
BODY8/16 and CHECK8/16 are unused in these cases.