### PR TITLE
Remove redundant child process for DTS compilation

### DIFF
--- a/riscv/dts.cc
+++ b/riscv/dts.cc
@@ -136,39 +136,23 @@ std::string make_dts(size_t insns_per_rtc_tick, size_t cpu_hz,
 std::string dts_compile(const std::string& dts)
 {
   // Convert the DTS to DTB
-  int dts_pipe[2];
-  pid_t dts_pid;
 
-  fflush(NULL); // flush stdout/stderr before forking
-  if (pipe(dts_pipe) != 0 || (dts_pid = fork()) < 0) {
-    std::cerr << "Failed to fork dts child: " << strerror(errno) << std::endl;
+  fflush(NULL); // flush stdout/stderr
+
+  int dts_pipe[2];
+  if (pipe(dts_pipe) != 0) {
+    std::cerr << "Failed to create pipe: " << strerror(errno) << std::endl;
     exit(1);
   }
 
-  // Child process to output dts
-  if (dts_pid == 0) {
-    close(dts_pipe[0]);
-    int step, len = dts.length();
-    const char *buf = dts.c_str();
-    for (int done = 0; done < len; done += step) {
-      step = write(dts_pipe[1], buf+done, len-done);
-      if (step == -1) {
-        std::cerr << "Failed to write dts: " << strerror(errno) << std::endl;
-        exit(1);
-      }
-    }
-    close(dts_pipe[1]);
-    exit(0);
-  }
-
-  pid_t dtb_pid;
   int dtb_pipe[2];
+  pid_t dtb_pid;
   if (pipe(dtb_pipe) != 0 || (dtb_pid = fork()) < 0) {
     std::cerr << "Failed to fork dtb child: " << strerror(errno) << std::endl;
     exit(1);
   }
 
-  // Child process to output dtb
+  // Child process to compile DTS
   if (dtb_pid == 0) {
     dup2(dts_pipe[0], 0);
     dup2(dtb_pipe[1], 1);
@@ -181,17 +165,27 @@ std::string dts_compile(const std::string& dts)
     exit(1);
   }
 
-  close(dts_pipe[1]);
   close(dts_pipe[0]);
   close(dtb_pipe[1]);
 
-  // Read-out dtb
-  std::stringstream dtb;
+  // Send DTS
+  int step, len = dts.length();
+  const char *buf = dts.c_str();
+  for (int done = 0; done < len; done += step) {
+    step = write(dts_pipe[1], buf+done, len-done);
+    if (step == -1) {
+      std::cerr << "Failed to write dts: " << strerror(errno) << std::endl;
+      exit(1);
+    }
+  }
+  close(dts_pipe[1]);
 
+  // Read-out DTB
+  std::stringstream dtb;
   int got;
-  char buf[4096];
-  while ((got = read(dtb_pipe[0], buf, sizeof(buf))) > 0) {
-    dtb.write(buf, got);
+  char dtb_buf[4096];
+  while ((got = read(dtb_pipe[0], dtb_buf, sizeof(dtb_buf))) > 0) {
+    dtb.write(dtb_buf, got);
   }
   if (got == -1) {
     std::cerr << "Failed to read dtb: " << strerror(errno) << std::endl;
@@ -199,13 +193,8 @@ std::string dts_compile(const std::string& dts)
   }
   close(dtb_pipe[0]);
 
-  // Reap children
+  // Reap child
   int status;
-  waitpid(dts_pid, &status, 0);
-  if (!WIFEXITED(status) || WEXITSTATUS(status) != 0) {
-    std::cerr << "Child dts process failed" << std::endl;
-    exit(1);
-  }
   waitpid(dtb_pid, &status, 0);
   if (!WIFEXITED(status) || WEXITSTATUS(status) != 0) {
     std::cerr << "Child dtb process failed" << std::endl;


### PR DESCRIPTION
I'm attempting to use Spike w/ Cocotb and Hammer (https://github.com/rivosinc/hammer) to do co-simulation. Hammer provides a convenient Python interface for Spike, however upon attempting to instantiate Spike via Hammer, the cocotb test would hang. 

I narrowed down the issue to DTS compilation where the child process responsible for sending the DTS would never terminate, causing the parent to wait indefinitely. My best guess for why the child never terminates is because when it forks, it gets a copy of the entire parent, including the cocotb test.

My modification has the parent process sending the DTS, eliminating the need for a separate child process. Is there a reason for having a dedicated child process for sending the DTS?

