### PR TITLE
Close file descriptors in destructor of syscall_t

### DIFF
--- a/fesvr/syscall.cc
+++ b/fesvr/syscall.cc
@@ -174,9 +174,16 @@ syscall_t::syscall_t(htif_t* htif)
   if (stdin_fd < 0 || stdout_fd0 < 0 || stdout_fd1 < 0)
     throw std::runtime_error("could not dup stdin/stdout");
 
-  fds.alloc(stdin_fd); // stdin -> stdin
-  fds.alloc(stdout_fd0); // stdout -> stdout
-  fds.alloc(stdout_fd1); // stderr -> stdout
+  fds_index.push_back(fds.alloc(stdin_fd)); // stdin -> stdin
+  fds_index.push_back(fds.alloc(stdout_fd0)); // stdout -> stdout
+  fds_index.push_back(fds.alloc(stdout_fd1)); // stderr -> stdout
+}
+
+syscall_t::~syscall_t() {
+  for (auto i: fds_index) {
+    close(fds.lookup(i));
+    fds.dealloc(i);
+  }
 }
 
 std::string syscall_t::do_chroot(const char* fn)

--- a/fesvr/syscall.h
+++ b/fesvr/syscall.h
@@ -28,6 +28,7 @@ class syscall_t : public device_t
 {
  public:
   syscall_t(htif_t*);
+  ~syscall_t();
 
   void set_chroot(const char* where);
   
@@ -38,6 +39,7 @@ class syscall_t : public device_t
   memif_t* memif;
   std::vector<syscall_func_t> table;
   fds_t fds;
+  std::vector<reg_t> fds_index;
 
   void handle_syscall(command_t cmd);
   void dispatch(addr_t mm);


### PR DESCRIPTION
In the constructor of `syscall_t`, `dup `is called to duplicate the pipes. However, they are not correctly closed when `syscall_t` is destroyed. If we instantiate and delete it multiple times (it's used by `sim_t`, which are normally used to drive the simulation and may be called multiple times), it will cause too many files to be opened and lead to errors.

This PR adds the destructor and calls `close` for the descriptors.