### PR TITLE
triggers: icount: not to decrease on firing icount trigger with Debug Mode action

### DIFF
--- a/riscv/triggers.cc
+++ b/riscv/triggers.cc
@@ -317,7 +317,7 @@ std::optional<match_result_t> icount_t::detect_icount_match(processor_t * const 
     ret = match_result_t(TIMING_BEFORE, action);
   }
 
-  if (count >= 1) {
+  if (count >= 1 && (ret == std::nullopt || action != MCONTROL_ACTION_DEBUG_MODE)) {
     if (count == 1)
       pending = 1;
     count = count - 1;


### PR DESCRIPTION
Firing a icount trigger does not execute current instruction and should not decrease.

Update (2023.06.19) https://github.com/riscv/riscv-debug-spec/issues/842#issuecomment-1533703993: 
The icount decreases on firing trigger action=breakpoint but not on firing trigger action=debug_mode when icount.count=1.