### PR TITLE
csrrw/csrrwi should NOT read CSR when rd is zero

### DIFF
--- a/riscv/insns/csrrw.h
+++ b/riscv/insns/csrrw.h
@@ -1,5 +1,9 @@
 int csr = validate_csr(insn.csr(), true);
-reg_t old = p->get_csr(csr, insn, true);
+bool read = insn.rd() != 0;
+reg_t old = 0;
+if (read) {
+  old = p->get_csr(csr, insn, true);
+}
 p->put_csr(csr, RS1);
 WRITE_RD(sext_xlen(old));
 serialize();

--- a/riscv/insns/csrrwi.h
+++ b/riscv/insns/csrrwi.h
@@ -1,5 +1,9 @@
 int csr = validate_csr(insn.csr(), true);
-reg_t old = p->get_csr(csr, insn, true);
+bool read = insn.rd() != 0;
+reg_t old = 0;
+if (read) {
+  old = p->get_csr(csr, insn, true);
+}
 p->put_csr(csr, insn.rs1());
 WRITE_RD(sext_xlen(old));
 serialize();


### PR DESCRIPTION
According to the RISC-V spec, csrrw/csrrwi shouldn't read CSR when rd is zero, otherwise may cause side effects on user-customized registers