### PR TITLE
Fix vectored VS-level interrupts

### DIFF
--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -878,9 +878,10 @@ void processor_t::take_trap(trap_t& t, reg_t epc)
   }
   if (state.prv <= PRV_S && bit < max_xlen && ((vsdeleg >> bit) & 1)) {
     // Handle the trap in VS-mode
+    const reg_t adjusted_cause = interrupt ? bit - 1 : bit;  // VSSIP -> SSIP, etc
     reg_t vector = (state.vstvec->read() & 1) && interrupt ? 4 * bit : 0;
     state.pc = (state.vstvec->read() & ~(reg_t)1) + vector;
-    state.vscause->write((interrupt) ? (t.cause() - 1) : t.cause());
+    state.vscause->write(adjusted_cause | (interrupt ? interrupt_bit : 0));
     state.vsepc->write(epc);
     state.vstval->write(t.get_tval());
 

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -879,7 +879,7 @@ void processor_t::take_trap(trap_t& t, reg_t epc)
   if (state.prv <= PRV_S && bit < max_xlen && ((vsdeleg >> bit) & 1)) {
     // Handle the trap in VS-mode
     const reg_t adjusted_cause = interrupt ? bit - 1 : bit;  // VSSIP -> SSIP, etc
-    reg_t vector = (state.vstvec->read() & 1) && interrupt ? 4 * bit : 0;
+    reg_t vector = (state.vstvec->read() & 1) && interrupt ? 4 * adjusted_cause : 0;
     state.pc = (state.vstvec->read() & ~(reg_t)1) + vector;
     state.vscause->write(adjusted_cause | (interrupt ? interrupt_bit : 0));
     state.vsepc->write(epc);

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -866,7 +866,8 @@ void processor_t::take_trap(trap_t& t, reg_t epc)
   reg_t vsdeleg, hsdeleg;
   reg_t bit = t.cause();
   bool curr_virt = state.v;
-  bool interrupt = (bit & ((reg_t)1 << (max_xlen - 1))) != 0;
+  const reg_t interrupt_bit = (reg_t)1 << (max_xlen - 1);
+  bool interrupt = (bit & interrupt_bit) != 0;
   if (interrupt) {
     vsdeleg = (curr_virt && state.prv <= PRV_S) ? state.hideleg->read() : 0;
     hsdeleg = (state.prv <= PRV_S) ? state.mideleg->read() : 0;


### PR DESCRIPTION
Interrupts destined for VS-mode (i.e. VSEI, VSTI, and VSSI) are presented to the guest OS as supervisor-level interrupts (i.e. SEI, STI, and SSI), according to the hypervisor spec regarding `hideleg`:

> When a virtual supervisor external interrupt (code 10) is delegated to VS-mode, it is automatically translated by the machine into a supervisor external interrupt (code 9) for VS-mode, including the value written to vscause on an interrupt trap. Likewise, a virtual supervisor timer interrupt (6) is translated into a supervisor timer interrupt (5) for VS-mode, and a virtual supervisor software interrupt (2) is translated into a supervisor software interrupt (1) for VS-mode.

When `vstvec.MODE=Vectored` (i.e. bit 0 is 1), interrupts destined for VS-mode should be vectored according to the cause.

Spike was erroneously using the un-adjusted cause (e.g. 10) for this vectoring, instead of the adjusted cause (e.g. 9).

Fixes #1340.