### PR TITLE
Install meta pkg-config file for Spike.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -337,7 +337,7 @@ install_hdrs += $$(addprefix $(src_dir)/$(1)/, $$($(2)_install_hdrs))
 install_libs += $$(if $$($(2)_install_lib),lib$(1).a,)
 install_libs += $$(if $$($(2)_install_shared_lib),lib$(1).so,)
 install_exes += $$($(2)_install_prog_exes)
-install_pcs  += $$(if $$($(2)_install_lib),riscv-$(1).pc,)
+install_pcs  += $$(if $$($(2)_install_pcs),riscv-$(1).pc,)
 
 endef
 

--- a/configure
+++ b/configure
@@ -6362,6 +6362,8 @@ ac_config_files="$ac_config_files riscv-fesvr.pc"
 
 ac_config_files="$ac_config_files riscv-disasm.pc"
 
+ac_config_files="$ac_config_files riscv-riscv.pc"
+
 cat >confcache <<\_ACEOF
 # This file is a shell script that caches the results of configure
 # tests run on this system so they can be shared between configure
@@ -7065,6 +7067,7 @@ do
     "Makefile") CONFIG_FILES="$CONFIG_FILES Makefile" ;;
     "riscv-fesvr.pc") CONFIG_FILES="$CONFIG_FILES riscv-fesvr.pc" ;;
     "riscv-disasm.pc") CONFIG_FILES="$CONFIG_FILES riscv-disasm.pc" ;;
+    "riscv-riscv.pc") CONFIG_FILES="$CONFIG_FILES riscv-riscv.pc" ;;
 
   *) as_fn_error $? "invalid argument: \`$ac_config_target'" "$LINENO" 5;;
   esac

--- a/configure.ac
+++ b/configure.ac
@@ -123,4 +123,5 @@ AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_FILES([Makefile])
 AC_CONFIG_FILES([riscv-fesvr.pc])
 AC_CONFIG_FILES([riscv-disasm.pc])
+AC_CONFIG_FILES([riscv-riscv.pc])
 AC_OUTPUT

--- a/disasm/disasm.mk.in
+++ b/disasm/disasm.mk.in
@@ -3,3 +3,5 @@ disasm_srcs = \
   regnames.cc \
 
 disasm_install_lib = yes
+
+disasm_install_pcs = yes

--- a/fesvr/fesvr.mk.in
+++ b/fesvr/fesvr.mk.in
@@ -19,6 +19,8 @@ fesvr_install_config_hdr = yes
 
 fesvr_install_lib = yes
 
+fesvr_install_pcs = yes
+
 fesvr_srcs = \
   elfloader.cc \
   htif.cc \

--- a/riscv-riscv.pc.in
+++ b/riscv-riscv.pc.in
@@ -1,0 +1,11 @@
+prefix=@prefix@
+exec_prefix=@prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: riscv-riscv
+Description: RISC-V
+Version: git
+Libs: -Wl,-rpath,${libdir} -L${libdir} -lriscv
+Cflags: -I${includedir}
+URL: http://riscv.org/download.html#tab_spike

--- a/riscv/riscv.mk.in
+++ b/riscv/riscv.mk.in
@@ -11,6 +11,8 @@ riscv_CFLAGS = -fPIC
 
 riscv_install_shared_lib = yes
 
+riscv_install_pcs = yes
+
 riscv_install_prog_srcs = \
 
 riscv_install_hdrs = \


### PR DESCRIPTION
Using a Spike a stand-alone library is interesting option to develop own solutions based on Spike without the need to directly intake it as source code.
It also creates interface that prevents unrelated changes to Spike itself.