### PR TITLE
triggers: implement {mcontrol,mcontrol6}.match = {not equal,not napot,not mask low,not mask high}

### DIFF
--- a/riscv/triggers.cc
+++ b/riscv/triggers.cc
@@ -199,8 +199,25 @@ bool mcontrol_common_t::simple_match(unsigned xlen, reg_t value) const {
         reg_t mask = tdata2 >> (xlen/2);
         return ((value >> (xlen/2)) & mask) == (tdata2 & mask);
       }
+    case MATCH_NOT_EQUAL:
+      return value != tdata2;
+    case MATCH_NOT_NAPOT:
+      {
+        reg_t mask = ~((1 << (cto(tdata2)+1)) - 1);
+        return (value & mask) != (tdata2 & mask);
+      }
+    case MATCH_NOT_MASK_LOW:
+      {
+        reg_t mask = tdata2 >> (xlen/2);
+        return (value & mask) != (tdata2 & mask);
+      }
+    case MATCH_NOT_MASK_HIGH:
+      {
+        reg_t mask = tdata2 >> (xlen/2);
+        return ((value >> (xlen/2)) & mask) != (tdata2 & mask);
+      }
+    default: assert(false);
   }
-  assert(0);
 }
 
 std::optional<match_result_t> mcontrol_common_t::detect_memory_access_match(processor_t * const proc, operation_t operation, reg_t address, std::optional<reg_t> data) noexcept {
@@ -245,6 +262,10 @@ mcontrol_common_t::match_t mcontrol_common_t::legalize_match(reg_t val) noexcept
     case MATCH_LT:
     case MATCH_MASK_LOW:
     case MATCH_MASK_HIGH:
+    case MATCH_NOT_EQUAL:
+    case MATCH_NOT_NAPOT:
+    case MATCH_NOT_MASK_LOW:
+    case MATCH_NOT_MASK_HIGH:
       return (match_t)val;
     default:
       return MATCH_EQUAL;

--- a/riscv/triggers.h
+++ b/riscv/triggers.h
@@ -194,7 +194,11 @@ public:
     MATCH_GE = MCONTROL_MATCH_GE,
     MATCH_LT = MCONTROL_MATCH_LT,
     MATCH_MASK_LOW = MCONTROL_MATCH_MASK_LOW,
-    MATCH_MASK_HIGH = MCONTROL_MATCH_MASK_HIGH
+    MATCH_MASK_HIGH = MCONTROL_MATCH_MASK_HIGH,
+    MATCH_NOT_EQUAL = 8,
+    MATCH_NOT_NAPOT = 9,
+    MATCH_NOT_MASK_LOW = 12,
+    MATCH_NOT_MASK_HIGH = 13
   } match_t;
 
   virtual bool get_dmode() const override { return dmode; }


### PR DESCRIPTION
This PR implements {mcontrol,mcontrol6}.match = {not equal,not napot,not mask low,not mask high}.