### PR TITLE
Zfa: fix exception behaviour for fcvtmod.w.d

### DIFF
--- a/riscv/insns/fcvtmod_w_d.h
+++ b/riscv/insns/fcvtmod_w_d.h
@@ -38,12 +38,14 @@ if (exp == 0) {
   } else {
     /* The fraction is shifted out entirely.  */
     frac = 0;
+    inexact = true;
   }
 
-  /* Notice overflow or inexact exceptions.  */
+  /* Handle overflows */
   if (true_exp > 31 || frac > (sign ? 0x80000000ull : 0x7fffffff)) {
     /* Overflow, for which this operation raises invalid.  */
     invalid = true;
+    inexact = false;  /* invalid takes precedence */
   }
 
   /* Honor the sign.  */


### PR DESCRIPTION
Fixup the exception behavior of fcvtmod.w.d:
- if the fraction is shifted out entirely, we need to signal inexact as we will have shifted out the implicit bit
- when signaling invalid, we may not signal inexact

Resolves #1312 