### PR TITLE
Let mstatus.MPP initially be M-mode if unsupporting U-mode

### DIFF
--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -510,6 +510,7 @@ reg_t mstatus_csr_t::compute_mstatus_initial_value() const noexcept {
                               | (proc->extension_enabled_const('S') ? MSTATUS_SBE : 0)
                               | MSTATUS_MBE;
   return 0
+         | set_field((reg_t)0, MSTATUS_MPP, proc->extension_enabled_const('U') ? PRV_U : PRV_M)
          | (proc->extension_enabled_const('U') && (proc->get_const_xlen() != 32) ? set_field((reg_t)0, MSTATUS_UXL, xlen_to_uxl(proc->get_const_xlen())) : 0)
          | (proc->extension_enabled_const('S') && (proc->get_const_xlen() != 32) ? set_field((reg_t)0, MSTATUS_SXL, xlen_to_uxl(proc->get_const_xlen())) : 0)
          | (proc->get_mmu()->is_target_big_endian() ? big_endian_bits : 0)


### PR DESCRIPTION
This commit lets the mstatus.MPP be a valid value if unsupporting U-mode. Without this commit, the mret may result in a corrupted state without properly setting the MPP to M-mode (if unsupporting U-mode).