### PR TITLE
decode_macros: move 'is_aligned' from 'v_ext_macros.h'

### DIFF
--- a/riscv/decode_macros.h
+++ b/riscv/decode_macros.h
@@ -120,6 +120,10 @@ do { \
               if (rm > 4) throw trap_illegal_instruction(insn.bits()); \
               rm; })
 
+static inline bool is_aligned(const unsigned val, const unsigned pos)
+{
+  return pos ? (val & (pos - 1)) == 0 : true;
+}
 
 #define require_privilege(p) require(STATE.prv >= (p))
 #define require_novirt() (unlikely(STATE.v) ? throw trap_virtual_instruction(insn.bits()) : (void) 0)

--- a/riscv/v_ext_macros.h
+++ b/riscv/v_ext_macros.h
@@ -64,11 +64,6 @@ static inline bool is_overlapped_widen(const int astart, int asize,
   }
 }
 
-static inline bool is_aligned(const unsigned val, const unsigned pos)
-{
-  return pos ? (val & (pos - 1)) == 0 : true;
-}
-
 #define VI_NARROW_CHECK_COMMON \
   require_vector(true); \
   require(P.VU.vflmul <= 4); \


### PR DESCRIPTION
Simple nit: `is_aligned()` is only used in `decode_macros.h` while being defined in `v_ext_macros.h`.
Move it to `decode_macros.h`, that looks more like its place.