### PR TITLE
Minor fixes (mostly related to __int128 support)

### DIFF
--- a/config.h.in
+++ b/config.h.in
@@ -39,6 +39,9 @@
 /* Dynamic library loading is supported */
 #undef HAVE_DLOPEN
 
+/* __int128_t is supported */
+#undef HAVE_INT128
+
 /* Define to 1 if you have the <inttypes.h> header file. */
 #undef HAVE_INTTYPES_H
 

--- a/configure
+++ b/configure
@@ -4742,6 +4742,9 @@ ac_fn_cxx_check_type "$LINENO" "__int128_t" "ac_cv_type___int128_t" "$ac_include
 if test "x$ac_cv_type___int128_t" = xyes; then :
   HAVE_INT128=yes
 
+
+$as_echo "#define HAVE_INT128 1" >>confdefs.h
+
 fi
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -85,7 +85,9 @@ AC_HEADER_STDC
 # Checks for type
 #-------------------------------------------------------------------------
 
-AC_CHECK_TYPE([__int128_t], AC_SUBST([HAVE_INT128],[yes]))
+AC_CHECK_TYPE([__int128_t],
+              [AC_SUBST([HAVE_INT128],[yes])
+              AC_DEFINE([HAVE_INT128], [1], [__int128_t is supported])])
 
 #-------------------------------------------------------------------------
 # Default compiler flags

--- a/riscv/decode.h
+++ b/riscv/decode.h
@@ -19,11 +19,6 @@ typedef int64_t sreg_t;
 typedef uint64_t reg_t;
 typedef float128_t freg_t;
 
-#ifdef __SIZEOF_INT128__
-typedef __int128 int128_t;
-typedef unsigned __int128 uint128_t;
-#endif
-
 const int NXPR = 32;
 const int NFPR = 32;
 const int NVPR = 32;

--- a/riscv/decode_macros.h
+++ b/riscv/decode_macros.h
@@ -10,6 +10,11 @@
 #include "softfloat_types.h"
 #include "specialize.h"
 
+#ifdef HAVE_INT128
+typedef __int128 int128_t;
+typedef unsigned __int128 uint128_t;
+#endif
+
 // helpful macros, etc
 #define MMU (*p->get_mmu())
 #define STATE (*p->get_state())

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -43,7 +43,7 @@ processor_t::processor_t(const isa_parser_t *isa, const cfg_t *cfg,
   TM.proc = this;
 
 #ifndef HAVE_INT128
-  if (extension_enabled('V')) {
+  if (isa->extension_enabled('V')) {
     fprintf(stderr, "V extension is not supported on platforms without __int128 type\n");
     abort();
   }

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -42,7 +42,7 @@ processor_t::processor_t(const isa_parser_t *isa, const cfg_t *cfg,
   VU.p = this;
   TM.proc = this;
 
-#ifndef __SIZEOF_INT128__
+#ifndef HAVE_INT128
   if (extension_enabled('V')) {
     fprintf(stderr, "V extension is not supported on platforms without __int128 type\n");
     abort();


### PR DESCRIPTION
These are minor fixes related somehow to spike support of uint128_t.

Patch 1&2 use a `configure` defined `HAVE_INT128`  rather than using `__SIZEOF_INT128__`. If anything, the advantage to this is to be able to test `!HAVE_INT128`. Possibly not a fix, this is something that at least IMHO makes things a little bit better.

Patch 3 fixes a crash in spike happening when we do not have `HAVE_INT128` support.