### PR TITLE
dscr.ebreakh is now dcsr.ebreakv[su]

### DIFF
--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -1232,9 +1232,10 @@ dcsr_csr_t::dcsr_csr_t(processor_t* const proc, const reg_t addr):
   prv(0),
   step(false),
   ebreakm(false),
-  ebreakh(false),
   ebreaks(false),
   ebreaku(false),
+  ebreakvs(false),
+  ebreakvu(false),
   halt(false),
   v(false),
   cause(0) {
@@ -1250,9 +1251,10 @@ reg_t dcsr_csr_t::read() const noexcept {
   reg_t result = 0;
   result = set_field(result, DCSR_XDEBUGVER, 1);
   result = set_field(result, DCSR_EBREAKM, ebreakm);
-  result = set_field(result, DCSR_EBREAKH, ebreakh);
   result = set_field(result, DCSR_EBREAKS, ebreaks);
   result = set_field(result, DCSR_EBREAKU, ebreaku);
+  result = set_field(result, CSR_DCSR_EBREAKVS, ebreakvs);
+  result = set_field(result, CSR_DCSR_EBREAKVU, ebreakvu);
   result = set_field(result, DCSR_STOPCYCLE, 0);
   result = set_field(result, DCSR_STOPTIME, 0);
   result = set_field(result, DCSR_CAUSE, cause);
@@ -1267,9 +1269,10 @@ bool dcsr_csr_t::unlogged_write(const reg_t val) noexcept {
   step = get_field(val, DCSR_STEP);
   // TODO: ndreset and fullreset
   ebreakm = get_field(val, DCSR_EBREAKM);
-  ebreakh = get_field(val, DCSR_EBREAKH);
   ebreaks = get_field(val, DCSR_EBREAKS);
   ebreaku = get_field(val, DCSR_EBREAKU);
+  ebreakvs = get_field(val, CSR_DCSR_EBREAKVS);
+  ebreakvu = get_field(val, CSR_DCSR_EBREAKVU);
   halt = get_field(val, DCSR_HALT);
   v = proc->extension_enabled('H') ? get_field(val, CSR_DCSR_V) : false;
   return true;

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -663,9 +663,10 @@ class dcsr_csr_t: public csr_t {
   uint8_t prv;
   bool step;
   bool ebreakm;
-  bool ebreakh;
   bool ebreaks;
   bool ebreaku;
+  bool ebreakvs;
+  bool ebreakvu;
   bool halt;
   bool v;
   uint8_t cause;

--- a/riscv/insns/c_ebreak.h
+++ b/riscv/insns/c_ebreak.h
@@ -1,8 +1,10 @@
 require_extension(EXT_ZCA);
-if (!STATE.debug_mode &&
-    ((STATE.prv == PRV_M && STATE.dcsr->ebreakm) ||
-     (STATE.prv == PRV_S && STATE.dcsr->ebreaks) ||
-     (STATE.prv == PRV_U && STATE.dcsr->ebreaku))) {
+if (!STATE.debug_mode && (
+        (!STATE.v && STATE.prv == PRV_M && STATE.dcsr->ebreakm) ||
+        (!STATE.v && STATE.prv == PRV_S && STATE.dcsr->ebreaks) ||
+        (!STATE.v && STATE.prv == PRV_U && STATE.dcsr->ebreaku) ||
+        (STATE.v && STATE.prv == PRV_S && STATE.dcsr->ebreakvs) ||
+        (STATE.v && STATE.prv == PRV_U && STATE.dcsr->ebreakvu))) {
 	throw trap_debug_mode();
 } else {
 	throw trap_breakpoint(STATE.v, pc);

--- a/riscv/insns/ebreak.h
+++ b/riscv/insns/ebreak.h
@@ -1,7 +1,9 @@
-if (!STATE.debug_mode &&
-    ((STATE.prv == PRV_M && STATE.dcsr->ebreakm) ||
-     (STATE.prv == PRV_S && STATE.dcsr->ebreaks) ||
-     (STATE.prv == PRV_U && STATE.dcsr->ebreaku))) {
+if (!STATE.debug_mode && (
+        (!STATE.v && STATE.prv == PRV_M && STATE.dcsr->ebreakm) ||
+        (!STATE.v && STATE.prv == PRV_S && STATE.dcsr->ebreaks) ||
+        (!STATE.v && STATE.prv == PRV_U && STATE.dcsr->ebreaku) ||
+        (STATE.v && STATE.prv == PRV_S && STATE.dcsr->ebreakvs) ||
+        (STATE.v && STATE.prv == PRV_U && STATE.dcsr->ebreakvu))) {
 	throw trap_debug_mode();
 } else {
 	throw trap_breakpoint(STATE.v, pc);


### PR DESCRIPTION
This change was made ages ago in the spec.

I did not actually test that the new privilege checks in ebreak and c.ebreak are correct, but all the existing debug tests still pass.