### PR TITLE
Fix: PMP checking region on CBO instructions

### DIFF
--- a/riscv/mmu.h
+++ b/riscv/mmu.h
@@ -214,7 +214,7 @@ public:
 
   void clean_inval(reg_t addr, bool clean, bool inval) {
     convert_load_traps_to_store_traps({
-        const reg_t paddr = translate(generate_access_info(addr, LOAD, {false, false, false}), blocksz) & ~(blocksz - 1);
+      const reg_t paddr = translate(generate_access_info(addr, LOAD, {false, false, false}), 1);
       if (sim->reservable(paddr)) {
         if (tracer.interested_in_range(paddr, paddr + PGSIZE, LOAD))
           tracer.clean_invalidate(paddr, blocksz, clean, inval);


### PR DESCRIPTION
The starting address of the cbo instruction should be implicitly aligned to the cache block. The previous implementation checks the PMP region starting from the misaligned address and crossing the cache block boundary.

This PR corrects the issue by giving the starting address to the translate() function. Additionally, to preserve the desired tval, the clean_inval() function catches the exception from the translate() function and converts the tval.