### PR TITLE
Remove duplicate compile options

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -98,7 +98,7 @@ default-CXXFLAGS := $(default-CFLAGS) -std=c++17
 
 mcppbs-CPPFLAGS := @CPPFLAGS@
 mcppbs-CFLAGS   := $(default-CFLAGS) @CFLAGS@
-mcppbs-CXXFLAGS := $(mcppbs-CFLAGS) $(default-CXXFLAGS) @CXXFLAGS@
+mcppbs-CXXFLAGS := $(default-CXXFLAGS) @CXXFLAGS@
 
 CC            := @CC@
 CXX           := @CXX@


### PR DESCRIPTION
mcppbs-CXXFLAGS has duplicated default-CFLAGS

In my machine(manjaro and ubuntu 20.04), -g -O2 is default when running configure, but not in github CI.
So revert -g -O2 delete

from autoconf mannual, -g -O2 is default:
If the selected C++ compiler is found to be GNU C++ (regardless of its name), the shell variable GXX will be set to ‘yes’. If the shell variable CXXFLAGS was not already set, it is set to -g -O2 for the GNU C++ compiler (-O2 on systems where G++ does not accept -g), or -g for other compilers. CXXFLAGS is then made an output variable. You can override the default for CXXFLAGS by inserting a shell default assignment between AC_INIT and AC_PROG_CXX: