### PR TITLE
Let debugger control hart availability

### DIFF
--- a/riscv/debug_module.h
+++ b/riscv/debug_module.h
@@ -185,6 +185,12 @@ class debug_module_t : public abstract_device_t
 
     size_t selected_hart_id() const;
     hart_debug_state_t& selected_hart_state();
+
+    /* Whether the first 2 harts are available is controllable through DMCUSTOM,
+     * where bit 0 corresponds to hart 0, etc. When a bit is one the hart
+     * available.  Otherwise it is unavailable. */
+    bool hart_available_state[2];
+    bool hart_available(unsigned hart_id) const;
 };
 
 #endif


### PR DESCRIPTION
This change lets me test OpenOCD's behavior when harts become available. It only affects how things look to the debugger. Harts that are "unavailable" still execute code as usual.

Control is implemented through the 2 LSBs of the DMCUSTOM register in the Debug Module.