### PR TITLE
Disassemble Zicond by default

### DIFF
--- a/disasm/disasm.cc
+++ b/disasm/disasm.cc
@@ -2329,7 +2329,7 @@ disassembler_t::disassembler_t(const isa_parser_t *isa)
 
   // next-highest priority: other instructions in same base ISA
   std::string fallback_isa_string = std::string("rv") + std::to_string(isa->get_max_xlen()) +
-    "gqchv_zfh_zba_zbb_zbc_zbs_zcb_zicbom_zicboz_zkn_zkr_zks_svinval";
+    "gqchv_zfh_zba_zbb_zbc_zbs_zcb_zicbom_zicboz_zicond_zkn_zkr_zks_svinval";
   isa_parser_t fallback_isa(fallback_isa_string.c_str(), DEFAULT_PRIV);
   add_instructions(&fallback_isa);
 


### PR DESCRIPTION
In general, the strategy has been that the disassembler enables a maximal set of non-conflicting extensions, thereby doing the right thing for the largest number of users.