### PR TITLE
Fix available lmul configuration

### DIFF
--- a/riscv/vector_unit.cc
+++ b/riscv/vector_unit.cc
@@ -39,7 +39,7 @@ reg_t vectorUnit_t::vectorUnit_t::set_vl(int rd, int rs1, reg_t reqVL, reg_t new
     vma = extract64(newType, 7, 1);
 
     vill = !(vflmul >= 0.125 && vflmul <= 8)
-           || vsew > std::min(vflmul, 1.0f) * ELEN
+           || vsew > std::min(vflmul, 1.0f) * VLEN
            || (newType >> 8) != 0;
 
     if (vill) {


### PR DESCRIPTION
It seems that there is no directly description of the relationship between SEW and LMUL, except:

"_In general, the requirement is to support LMUL ≥ SEWmin /ELEN, where SEWmin is the narrowest supported SEW value
and ELEN is the widest supported SEW value. In the standard extensions, SEWmin =8. For standard vector extensions with
ELEN=32, fractional LMULs of 1/2 and 1/4 must be supported. For standard vector extensions with ELEN=64, fractional
LMULs of 1/2, 1/4, and 1/8 must be supported._"

and in the note:

"_When LMUL < SEWmin /ELEN, there is no guarantee an implementation would have enough bits in the fractional vector register to store  at least one element, as VLEN=ELEN is a valid implementation choice. For example, with VLEN=ELEN=32, and SEWmin =8, an LMUL of 1/8 would only provide four bits of storage in a vector register._"

From the description and note, we can find the real limitation for LMUL settings is to provide enough bits of storage for SEWmin elements. So I think this also works for SEW elements.