### PR TITLE
Link spike main with --whole-archive

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -264,7 +264,7 @@ $$($(2)_test_objs) : %.o : %.cc
 	$(COMPILE) -c $$<
 
 $$($(2)_test_exes) : %-utst : %.t.o $$($(2)_test_libnames)
-	$(LINK) -o $$@ $$< $$($(2)_test_libnames) $(LIBS)
+	$(LINK) $$($(2)_LDFLAGS) -o $$@ $$< $$($(2)_test_libnames) $(LIBS)
 
 $(2)_deps += $$($(2)_test_deps)
 $(2)_junk += \
@@ -292,7 +292,7 @@ $$($(2)_prog_objs) : %.o : %.cc
 	$(COMPILE) -c $$<
 
 $$($(2)_prog_exes) : % : %.o $$($(2)_prog_libnames)
-	$(LINK) -o $$@ $$< $$($(2)_prog_libnames) $(LIBS)
+	$(LINK) $$($(2)_LDFLAGS) -o $$@ $$< $$($(2)_prog_libnames) $(LIBS)
 
 $(2)_deps += $$($(2)_prog_deps)
 $(2)_junk += $$($(2)_prog_objs) $$($(2)_prog_deps) $$($(2)_prog_exes)
@@ -307,7 +307,7 @@ $$($(2)_install_prog_objs) : %.o : %.cc $$($(2)_gen_hdrs)
 	$(COMPILE) -c $$<
 
 $$($(2)_install_prog_exes) : % : %.o $$($(2)_prog_libnames)
-	$(LINK) -o $$@ $$< $$($(2)_prog_libnames) $(LIBS)
+	$(LINK) $$($(2)_LDFLAGS) -o $$@ $$< $$($(2)_prog_libnames) $(LIBS)
 
 $(2)_deps += $$($(2)_install_prog_deps)
 $(2)_junk += \

--- a/spike_main/spike_main.mk.in
+++ b/spike_main/spike_main.mk.in
@@ -14,3 +14,5 @@ spike_main_install_prog_srcs = \
 spike_main_srcs = \
 
 spike_main_CFLAGS = -fPIC
+
+spike_main_LDFLAGS = -Wl,--whole-archive libriscv.a -Wl,--no-whole-archive


### PR DESCRIPTION
The `--extlib` and `--extension` features require runtime dynamic loading of externally compiled libraries. Spike main must make all symbols of `libriscv` available for those libraries. Without `--whole-archive`, some symbols of `libriscv` would not be linked into spike, causing dynamic loader errors when using `--extension/--extlib` with plugins that reference those symbols.

Jamming `libriscv.a` into `LDFLAGS` is a bit of a hack... I don't see a cleaner way to do this with the existing Makefile.
EDIT: It turns out `--whole-archive` isn't available in clang anyways :grimacing: 

An alternative solution would be to dynamically link the library dependencies into the spike main binaries. Not sure which is preferable