### PR TITLE
build: Dynamically link installed binaries

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -307,7 +307,7 @@ $$($(2)_install_prog_objs) : %.o : %.cc $$($(2)_gen_hdrs)
 	$(COMPILE) -c $$<
 
 $$($(2)_install_prog_exes) : % : %.o $$($(2)_prog_libnames)
-	$(LINK) -o $$@ $$< $$($(2)_prog_libnames) $(LIBS)
+	$(LINK) -o $$@ $$< $$($(2)_prog_libarg) $(LIBS)
 
 $(2)_deps += $$($(2)_install_prog_deps)
 $(2)_junk += \


### PR DESCRIPTION
An alternative solution to the same problem as #1405 

With static linking, some symbols are duplicated when a dynamically loaded extlib/extension plugin loads libriscv.so again. Notably, the default clint/plic/ns16550 extensions will re-register themselves.

Dynamic linking resolves this, since then the dynamic load of the plugin library could freely load symbols from `libriscv.so`.