### PR TITLE
mcontrol/mcontrol6 triggers on cbo.flush/clean

### DIFF
--- a/riscv/mmu.h
+++ b/riscv/mmu.h
@@ -224,6 +224,7 @@ public:
   }
 
   void clean_inval(reg_t addr, bool clean, bool inval) {
+    check_triggers(triggers::OPERATION_STORE, addr, false);
     convert_load_traps_to_store_traps({
       const reg_t paddr = translate(generate_access_info(addr, LOAD, {false, false, false}), 1);
       if (sim->reservable(paddr)) {


### PR DESCRIPTION
The mcontrol/mcontrol6 store address before has a higher priority over page faults and access faults. Thus, trigger checking should before the translate().

Reference: Debug spec 1.0, 5.5.3 Cache Operations
Reference: CMO spec 1.0.1, 2.5.4 Breakpoint Exceptions and Debug Mode Entry