### PR TITLE
mcontrol/mcontrol6 on CBO

### DIFF
--- a/riscv/mmu.cc
+++ b/riscv/mmu.cc
@@ -169,7 +169,7 @@ bool mmu_t::mmio(reg_t paddr, size_t len, uint8_t* bytes, access_type type)
   return true;
 }
 
-void mmu_t::check_triggers(triggers::operation_t operation, reg_t address, bool virt, std::optional<reg_t> data)
+void mmu_t::check_triggers(triggers::operation_t operation, reg_t address, bool virt, reg_t tval, std::optional<reg_t> data)
 {
   if (matched_trigger || !proc)
     return;
@@ -179,13 +179,13 @@ void mmu_t::check_triggers(triggers::operation_t operation, reg_t address, bool 
   if (match.has_value())
     switch (match->timing) {
       case triggers::TIMING_BEFORE:
-        throw triggers::matched_t(operation, address, match->action, virt);
+        throw triggers::matched_t(operation, tval, match->action, virt);
 
       case triggers::TIMING_AFTER:
         // We want to take this exception on the next instruction.  We check
         // whether to do so in the I$ refill path, so flush the I$.
         flush_icache();
-        matched_trigger = new triggers::matched_t(operation, address, match->action, virt);
+        matched_trigger = new triggers::matched_t(operation, tval, match->action, virt);
     }
 }
 

--- a/riscv/mmu.h
+++ b/riscv/mmu.h
@@ -226,6 +226,9 @@ public:
   }
 
   void clean_inval(reg_t addr, bool clean, bool inval) {
+    auto base = addr & ~(blocksz - 1);
+    for (size_t offset = 0; offset < blocksz; offset += 1)
+      check_triggers(triggers::OPERATION_STORE, base + offset, false, addr, std::nullopt);
     convert_load_traps_to_store_traps({
       const reg_t paddr = translate(generate_access_info(addr, LOAD, {false, false, false}), 1);
       if (sim->reservable(paddr)) {

--- a/riscv/mmu.h
+++ b/riscv/mmu.h
@@ -219,8 +219,10 @@ public:
 
   void cbo_zero(reg_t addr) {
     auto base = addr & ~(blocksz - 1);
-    for (size_t offset = 0; offset < blocksz; offset += 1)
+    for (size_t offset = 0; offset < blocksz; offset += 1) {
+      check_triggers(triggers::OPERATION_STORE, base + offset, false, addr, std::nullopt);
       store<uint8_t>(base + offset, 0);
+    }
   }
 
   void clean_inval(reg_t addr, bool clean, bool inval) {

--- a/riscv/mmu.h
+++ b/riscv/mmu.h
@@ -402,7 +402,10 @@ private:
   bool mmio_store(reg_t paddr, size_t len, const uint8_t* bytes);
   bool mmio(reg_t paddr, size_t len, uint8_t* bytes, access_type type);
   bool mmio_ok(reg_t paddr, access_type type);
-  void check_triggers(triggers::operation_t operation, reg_t address, bool virt, std::optional<reg_t> data = std::nullopt);
+  void check_triggers(triggers::operation_t operation, reg_t address, bool virt, std::optional<reg_t> data = std::nullopt) {
+    check_triggers(operation, address, virt, address, data);
+  }
+  void check_triggers(triggers::operation_t operation, reg_t address, bool virt, reg_t tval, std::optional<reg_t> data);
   reg_t translate(mem_access_info_t access_info, reg_t len);
 
   reg_t pte_load(reg_t pte_paddr, reg_t addr, bool virt, access_type trap_type, size_t ptesize) {


### PR DESCRIPTION
This PR fixes two mcontrol/mcontrol6 trigger issues on cbo instructions.

1. The tval should capture the effective address when a (trigger) exception on cbo.zero. (https://github.com/riscv/riscv-isa-manual/issues/1317). The previous implementation does not pass the effective address on checking_triggers(). This PR proposes extending the checking_triggers() with an additional parameter "tval" and passing the effective address.
2. The mcontrol/mcontrol6 trigger must match cbo.clean/inval as stores. This PR checks all addresses in the cache block appointed by the cbo instruction.