### PR TITLE
Make methods of `mem_t` virtual to allow overriding

### DIFF
--- a/ci-tests/testlib.c
+++ b/ci-tests/testlib.c
@@ -2,9 +2,9 @@
 
 // Copied from spike main.
 // TODO: This should really be provided in libriscv
-static std::vector<std::pair<reg_t, mem_t*>> make_mems(const std::vector<mem_cfg_t> &layout)
+static std::vector<std::pair<reg_t, abstract_mem_t*>> make_mems(const std::vector<mem_cfg_t> &layout)
 {
-  std::vector<std::pair<reg_t, mem_t*>> mems;
+  std::vector<std::pair<reg_t, abstract_mem_t*>> mems;
   mems.reserve(layout.size());
   for (const auto &cfg : layout) {
     mems.push_back(std::make_pair(cfg.get_base(), new mem_t(cfg.get_size())));
@@ -41,7 +41,8 @@ int main()
     .support_haltgroups = true,
     .support_impebreak = true
   };
-  std::vector<std::pair<reg_t, mem_t*>> mems = make_mems(cfg.mem_layout());
+  std::vector<std::pair<reg_t, abstract_mem_t*>> mems =
+      make_mems(cfg.mem_layout());
   sim_t sim(&cfg, false,
             mems,
             plugin_devices,

--- a/riscv/devices.h
+++ b/riscv/devices.h
@@ -36,17 +36,26 @@ class rom_device_t : public abstract_device_t {
   std::vector<char> data;
 };
 
-class mem_t : public abstract_device_t {
+class abstract_mem_t : public abstract_device_t {
+ public:
+  virtual ~abstract_mem_t() = default;
+
+  virtual char* contents(reg_t addr) = 0;
+  virtual reg_t size() = 0;
+  virtual void dump(std::ostream& o) = 0;
+};
+
+class mem_t : public abstract_mem_t {
  public:
   mem_t(reg_t size);
   mem_t(const mem_t& that) = delete;
-  ~mem_t();
+  ~mem_t() override;
 
   bool load(reg_t addr, size_t len, uint8_t* bytes) override { return load_store(addr, len, bytes, false); }
   bool store(reg_t addr, size_t len, const uint8_t* bytes) override { return load_store(addr, len, const_cast<uint8_t*>(bytes), true); }
-  char* contents(reg_t addr);
-  reg_t size() { return sz; }
-  void dump(std::ostream& o);
+  char* contents(reg_t addr) override;
+  reg_t size() override { return sz; }
+  void dump(std::ostream& o) override;
 
  private:
   bool load_store(reg_t addr, size_t len, uint8_t* bytes, bool store);

--- a/riscv/dts.cc
+++ b/riscv/dts.cc
@@ -17,7 +17,7 @@ std::string make_dts(size_t insns_per_rtc_tick, size_t cpu_hz,
                      const char* bootargs,
                      size_t pmpregions,
                      std::vector<processor_t*> procs,
-                     std::vector<std::pair<reg_t, mem_t*>> mems,
+                     std::vector<std::pair<reg_t, abstract_mem_t*>> mems,
                      std::string device_nodes)
 {
   std::stringstream s;

--- a/riscv/dts.h
+++ b/riscv/dts.h
@@ -11,7 +11,7 @@ std::string make_dts(size_t insns_per_rtc_tick, size_t cpu_hz,
                      const char* bootargs,
                      size_t pmpregions,
                      std::vector<processor_t*> procs,
-                     std::vector<std::pair<reg_t, mem_t*>> mems,
+                     std::vector<std::pair<reg_t, abstract_mem_t*>> mems,
                      std::string device_nodes);
 
 std::string dts_compile(const std::string& dts);

--- a/riscv/sim.cc
+++ b/riscv/sim.cc
@@ -37,7 +37,7 @@ extern device_factory_t* plic_factory;
 extern device_factory_t* ns16550_factory;
 
 sim_t::sim_t(const cfg_t *cfg, bool halted,
-             std::vector<std::pair<reg_t, mem_t*>> mems,
+             std::vector<std::pair<reg_t, abstract_mem_t*>> mems,
              std::vector<const device_factory_t*> plugin_device_factories,
              const std::vector<std::string>& args,
              const debug_module_config_t &dm_config,
@@ -380,7 +380,7 @@ char* sim_t::addr_to_mem(reg_t paddr) {
   if (!paddr_ok(paddr))
     return NULL;
   auto desc = bus.find_device(paddr);
-  if (auto mem = dynamic_cast<mem_t*>(desc.second))
+  if (auto mem = dynamic_cast<abstract_mem_t*>(desc.second))
     if (paddr - desc.first < mem->size())
       return mem->contents(paddr - desc.first);
   return NULL;

--- a/riscv/sim.h
+++ b/riscv/sim.h
@@ -26,7 +26,7 @@ class sim_t : public htif_t, public simif_t
 {
 public:
   sim_t(const cfg_t *cfg, bool halted,
-        std::vector<std::pair<reg_t, mem_t*>> mems,
+        std::vector<std::pair<reg_t, abstract_mem_t*>> mems,
         std::vector<const device_factory_t*> plugin_device_factories,
         const std::vector<std::string>& args,
         const debug_module_config_t &dm_config, const char *log_path,
@@ -68,7 +68,7 @@ public:
 private:
   isa_parser_t isa;
   const cfg_t * const cfg;
-  std::vector<std::pair<reg_t, mem_t*>> mems;
+  std::vector<std::pair<reg_t, abstract_mem_t*>> mems;
   std::vector<processor_t*> procs;
   std::map<size_t, processor_t*> harts;
   std::pair<reg_t, reg_t> initrd_range;

--- a/spike_main/spike.cc
+++ b/spike_main/spike.cc
@@ -104,7 +104,7 @@ static std::ifstream::pos_type get_file_size(const char *filename)
 }
 
 static void read_file_bytes(const char *filename,size_t fileoff,
-                            mem_t* mem, size_t memoff, size_t read_sz)
+                            abstract_mem_t* mem, size_t memoff, size_t read_sz)
 {
   std::ifstream in(filename, std::ios::in | std::ios::binary);
   in.seekg(fileoff, std::ios::beg);
@@ -260,9 +260,9 @@ static std::vector<mem_cfg_t> parse_mem_layout(const char* arg)
   return merged_mem;
 }
 
-static std::vector<std::pair<reg_t, mem_t*>> make_mems(const std::vector<mem_cfg_t> &layout)
+static std::vector<std::pair<reg_t, abstract_mem_t*>> make_mems(const std::vector<mem_cfg_t> &layout)
 {
-  std::vector<std::pair<reg_t, mem_t*>> mems;
+  std::vector<std::pair<reg_t, abstract_mem_t*>> mems;
   mems.reserve(layout.size());
   for (const auto &cfg : layout) {
     mems.push_back(std::make_pair(cfg.get_base(), new mem_t(cfg.get_size())));
@@ -473,7 +473,8 @@ int main(int argc, char** argv)
   if (!*argv1)
     help();
 
-  std::vector<std::pair<reg_t, mem_t*>> mems = make_mems(cfg.mem_layout());
+  std::vector<std::pair<reg_t, abstract_mem_t*>> mems =
+      make_mems(cfg.mem_layout());
 
   if (kernel && check_file_exists(kernel)) {
     const char *isa = cfg.isa();


### PR DESCRIPTION
This allows the users to provide their own custom implementations of `mem_t` when constructing `sim_t`.

Fixes #1408.