### PR TITLE
Legalize xenvcfg.CBIE

### DIFF
--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -1476,7 +1476,7 @@ void sstateen_csr_t::verify_permissions(insn_t insn, bool write) const {
 // implement class senvcfg_csr_t
 senvcfg_csr_t::senvcfg_csr_t(processor_t* const proc, const reg_t addr, const reg_t mask,
                              const reg_t init):
-  masked_csr_t(proc, addr, mask, init) {
+  envcfg_csr_t(proc, addr, mask, init) {
 }
 
 void senvcfg_csr_t::verify_permissions(insn_t insn, bool write) const {

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -916,7 +916,7 @@ bool envcfg_csr_t::unlogged_write(const reg_t val) noexcept {
 
 // implement class henvcfg_csr_t
 henvcfg_csr_t::henvcfg_csr_t(processor_t* const proc, const reg_t addr, const reg_t mask, const reg_t init, csr_t_p menvcfg):
-  masked_csr_t(proc, addr, mask, init),
+  envcfg_csr_t(proc, addr, mask, init),
   menvcfg(menvcfg) {
 }
 

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -901,6 +901,19 @@ bool masked_csr_t::unlogged_write(const reg_t val) noexcept {
   return basic_csr_t::unlogged_write((read() & ~mask) | (val & mask));
 }
 
+envcfg_csr_t::envcfg_csr_t(processor_t* const proc, const reg_t addr, const reg_t mask,
+                             const reg_t init):
+  masked_csr_t(proc, addr, mask, init) {
+  // In unlogged_write() we WARLize this field for all three of [msh]envcfg
+  assert(MENVCFG_CBIE == SENVCFG_CBIE && MENVCFG_CBIE == HENVCFG_CBIE);
+}
+
+bool envcfg_csr_t::unlogged_write(const reg_t val) noexcept {
+  const reg_t cbie_reserved = 2; // Reserved value of xenvcfg.CBIE
+  const reg_t adjusted_val = get_field(val, MENVCFG_CBIE) != cbie_reserved ? val : set_field(val, MENVCFG_CBIE, 0);
+  return masked_csr_t::unlogged_write(adjusted_val);
+}
+
 // implement class henvcfg_csr_t
 henvcfg_csr_t::henvcfg_csr_t(processor_t* const proc, const reg_t addr, const reg_t mask, const reg_t init, csr_t_p menvcfg):
   masked_csr_t(proc, addr, mask, init),

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -468,7 +468,7 @@ class envcfg_csr_t: public masked_csr_t {
 // henvcfg.pbmte is read_only 0 when menvcfg.pbmte = 0
 // henvcfg.stce is read_only 0 when menvcfg.stce = 0
 // henvcfg.hade is read_only 0 when menvcfg.hade = 0
-class henvcfg_csr_t final: public masked_csr_t {
+class henvcfg_csr_t final: public envcfg_csr_t {
  public:
   henvcfg_csr_t(processor_t* const proc, const reg_t addr, const reg_t mask, const reg_t init, csr_t_p menvcfg);
 

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -458,6 +458,13 @@ class masked_csr_t: public basic_csr_t {
   const reg_t mask;
 };
 
+class envcfg_csr_t: public masked_csr_t {
+ public:
+  envcfg_csr_t(processor_t* const proc, const reg_t addr, const reg_t mask, const reg_t init);
+ protected:
+  virtual bool unlogged_write(const reg_t val) noexcept override;
+};
+
 // henvcfg.pbmte is read_only 0 when menvcfg.pbmte = 0
 // henvcfg.stce is read_only 0 when menvcfg.stce = 0
 // henvcfg.hade is read_only 0 when menvcfg.hade = 0

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -759,7 +759,7 @@ class sstateen_csr_t: public hstateen_csr_t {
   virtual bool unlogged_write(const reg_t val) noexcept override;
 };
 
-class senvcfg_csr_t final: public masked_csr_t {
+class senvcfg_csr_t final: public envcfg_csr_t {
  public:
   senvcfg_csr_t(processor_t* const proc, const reg_t addr, const reg_t mask, const reg_t init);
   virtual void verify_permissions(insn_t insn, bool write) const override;

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -445,7 +445,7 @@ void state_t::reset(processor_t* const proc, reg_t max_isa)
                               (proc->extension_enabled(EXT_SVPBMT) ? MENVCFG_PBMTE : 0) |
                               (proc->extension_enabled(EXT_SSTC) ? MENVCFG_STCE : 0);
     const reg_t menvcfg_init = (proc->extension_enabled(EXT_SVPBMT) ? MENVCFG_PBMTE : 0);
-    menvcfg = std::make_shared<masked_csr_t>(proc, CSR_MENVCFG, menvcfg_mask, menvcfg_init);
+    menvcfg = std::make_shared<envcfg_csr_t>(proc, CSR_MENVCFG, menvcfg_mask, menvcfg_init);
     if (xlen == 32) {
       csrmap[CSR_MENVCFG] = std::make_shared<rv32_low_csr_t>(proc, CSR_MENVCFG, menvcfg);
       csrmap[CSR_MENVCFGH] = std::make_shared<rv32_high_csr_t>(proc, CSR_MENVCFGH, menvcfg);


### PR DESCRIPTION
The value 2 of xenvcfg.CBIE is reserved. This PR legalizes it to 0.

The values 2 and 0 of xenvcfg.CBIE do not have corresponding macros. Thus, this PR hard-codes those values.

Reference: https://github.com/riscv/riscv-CMOs/issues/65