### PR TITLE
Fix compilation warning in riscv/execute.cc

### DIFF
--- a/riscv/execute.cc
+++ b/riscv/execute.cc
@@ -85,7 +85,7 @@ static void commit_log_print_insn(processor_t *p, reg_t pc, insn_t insn)
     if (item.first == 0)
       continue;
 
-    char prefix;
+    char prefix = ' ';
     int size;
     int rd = item.first >> 4;
     bool is_vec = false;


### PR DESCRIPTION
../riscv/execute.cc: In function ‘void commit_log_print_insn(processor_t*, reg_t, insn_t)’: ../riscv/execute.cc:132:16: warning: ‘prefix’ may be used uninitialized [-Wmaybe-uninitialized]
  132 |         fprintf(log_file, " %c%-2d ", prefix, rd);
      |         ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../riscv/execute.cc:88:10: note: ‘prefix’ was declared here
   88 |     char prefix;
      |          ^~~~~~