### PR TITLE
fdt: Install header files `fdt.h` and `libfdt_env.h` as needed by `libfdt.h`

### DIFF
--- a/fdt/fdt.mk.in
+++ b/fdt/fdt.mk.in
@@ -4,6 +4,8 @@ fdt_install_shared_lib = yes
 
 fdt_install_hdrs = \
 	libfdt.h \
+	fdt.h \
+	libfdt_env.h
 
 fdt_c_srcs = \
 	fdt.c \


### PR DESCRIPTION
All three header files `libfdt.h`, `fdt.h` and `libfdt_env.h` need to be installed, for correctly compiling periphery devices, as exemplified in [https://github.com/ucb-bar/spike-devices](https://github.com/ucb-bar/spike-devices).