### PR TITLE
Include cerrno in fesvr/elfloader.cc

### DIFF
--- a/fesvr/elfloader.cc
+++ b/fesvr/elfloader.cc
@@ -16,6 +16,7 @@
 #include <stdio.h>
 #include <vector>
 #include <map>
+#include <cerrno>
 
 std::map<std::string, uint64_t> load_elf(const char* fn, memif_t* memif, reg_t* entry, unsigned required_xlen = 0)
 {


### PR DESCRIPTION
It caused compile error "use of undeclared identifier 'errno'" at line 26 and 33. 
I Add #include <cerrno> in fesvr/elfloader.cc to fix error and compile successfully.