### PR TITLE
A/D updates in G-stage PTE

### DIFF
--- a/riscv/mmu.cc
+++ b/riscv/mmu.cc
@@ -536,6 +536,9 @@ reg_t mmu_t::walk(mem_access_info_t access_info)
 
       if ((pte & ad) != ad) {
         if (hade) {
+          // Check for write permission to the first-stage PT in second-stage
+          // PTE and set the D bit in the second-stage PTE if needed
+          s2xlate(addr, base + idx * vm.ptesize, STORE, type, virt, false);
           // set accessed and possibly dirty bits.
           pte_store(pte_paddr, pte | ad, addr, virt, type, vm.ptesize);
         } else {

--- a/riscv/mmu.h
+++ b/riscv/mmu.h
@@ -391,7 +391,7 @@ private:
   const char* fill_from_mmio(reg_t vaddr, reg_t paddr);
 
   // perform a stage2 translation for a given guest address
-  reg_t s2xlate(reg_t gva, reg_t gpa, access_type type, access_type trap_type, bool virt, bool hlvx);
+  reg_t s2xlate(reg_t gva, reg_t gpa, access_type type, access_type trap_type, bool virt, bool hlvx, bool is_for_vs_pt_addr);
 
   // perform a page table walk for a given VA; set referenced/dirty bits
   reg_t walk(mem_access_info_t access_info);


### PR DESCRIPTION
This PR includes two commits:
1. Invoke G-stage to check write permission to VS-stage page table before setting A and/or D bit in VS-stage PTE. This will also cause A and/or D bit to be set in G-stage PTE mapping the VS-stage PT appropriately.
2. Report the pseudo-instructions specified in "Transformed Instruction or Pseudoinstruction for mtinst or htinst" in Priv specification for guest page fault that may occur when doing an address translation for VS-stage PT address. This PR assumes that HSXLEN == VSXLEN - as spike does not support dynamic XLEN change.