### PR TITLE
fix condition of executing cbo.inval as a flush operation

### DIFF
--- a/riscv/insns/cbo_inval.h
+++ b/riscv/insns/cbo_inval.h
@@ -3,7 +3,7 @@ DECLARE_XENVCFG_VARS(CBIE);
 require_envcfg(CBIE);
 if (((STATE.prv != PRV_M) && (mCBIE == 1)) ||
     ((!STATE.v && (STATE.prv == PRV_U)) && (sCBIE = 1)) ||
-    (STATE.v && ((hCBIE == 1) || ((STATE.prv == PRV_U) && (sCBIE== 0)))))
+    (STATE.v && ((hCBIE == 1) || ((STATE.prv == PRV_U) && (sCBIE== 1)))))
   MMU.clean_inval(RS1, true, true);
 else
   MMU.clean_inval(RS1, false, true);


### PR DESCRIPTION
As CMO spec described in Chapter 3, page 13:

> if (((priv_mode != M) && (menvcfg.CBIE == 01)) ||
> ((priv_mode == U) && (senvcfg.CBIE == 01)) ||
> ((priv_mode == VS) && (henvcfg.CBIE == 01)) ||
> ((priv_mode == VU) && ((henvcfg.CBIE == 01) || (senvcfg.CBIE == 01))))
> {
> <execute CBO.INVAL and perform flush operation>

the condition of executing cbo.inval as a flush operation has a clerical error. Please help to check that.