### PR TITLE
Hit multiple icount triggers with different actions

### DIFF
--- a/riscv/triggers.cc
+++ b/riscv/triggers.cc
@@ -595,11 +595,12 @@ std::optional<match_result_t> module_t::detect_icount_match() noexcept
   std::optional<match_result_t> ret = std::nullopt;
   for (auto trigger: triggers) {
     auto result = trigger->detect_icount_fire(proc);
-    if (result == std::nullopt || result->action != MCONTROL_ACTION_DEBUG_MODE)
-      trigger->detect_icount_decrement(proc);
     if (result.has_value() && (!ret.has_value() || ret->action < result->action))
       ret = result;
   }
+  if (ret == std::nullopt || ret->action != MCONTROL_ACTION_DEBUG_MODE)
+    for (auto trigger: triggers)
+      trigger->detect_icount_decrement(proc);
   return ret;
 }
 

--- a/riscv/triggers.h
+++ b/riscv/triggers.h
@@ -85,7 +85,8 @@ public:
 
   virtual std::optional<match_result_t> detect_memory_access_match(processor_t UNUSED * const proc,
       operation_t UNUSED operation, reg_t UNUSED address, std::optional<reg_t> UNUSED data) noexcept { return std::nullopt; }
-  virtual std::optional<match_result_t> detect_icount_match(processor_t UNUSED * const proc) { return std::nullopt; }
+  virtual std::optional<match_result_t> detect_icount_fire(processor_t UNUSED * const proc) { return std::nullopt; }
+  virtual void detect_icount_decrement(processor_t UNUSED * const proc) {}
   virtual std::optional<match_result_t> detect_trap_match(processor_t UNUSED * const proc, const trap_t UNUSED & t) noexcept { return std::nullopt; }
 
 protected:
@@ -248,7 +249,8 @@ public:
   virtual bool icount_check_needed() const override { return count > 0 || pending; }
   virtual void stash_read_values() override;
 
-  virtual std::optional<match_result_t> detect_icount_match(processor_t * const proc) noexcept override;
+  virtual std::optional<match_result_t> detect_icount_fire(processor_t * const proc) noexcept override;
+  virtual void detect_icount_decrement(processor_t * const proc) noexcept override;
 
 private:
   bool dmode = false;


### PR DESCRIPTION
Entering debug mode does not decrease icount triggers (https://github.com/riscv/riscv-debug-spec/issues/842).
Thus, if any pending icount enters debug mode, all icount triggers shall not decrease.

This PR provides the behavior by decoupling firing and decreasing routines. The revised code checks whether any pending icount enters debug mode before decreasing all icount triggers.