### PR TITLE
fix: mcontrol/mcontrol6 on fetch

### DIFF
--- a/riscv/mmu.cc
+++ b/riscv/mmu.cc
@@ -70,11 +70,10 @@ reg_t mmu_t::translate(mem_access_info_t access_info, reg_t len)
 
 tlb_entry_t mmu_t::fetch_slow_path(reg_t vaddr)
 {
-  auto access_info = generate_access_info(vaddr, FETCH, {false, false, false});
-
   tlb_entry_t result;
   reg_t vpn = vaddr >> PGSHIFT;
   if (unlikely(tlb_insn_tag[vpn % TLB_ENTRIES] != (vpn | TLB_CHECK_TRIGGERS))) {
+    auto access_info = generate_access_info(vaddr, FETCH, {false, false, false});
     reg_t paddr = translate(access_info, sizeof(fetch_temp));
     if (auto host_addr = sim->addr_to_mem(paddr)) {
       result = refill_tlb(vaddr, paddr, host_addr, FETCH);

--- a/riscv/mmu.cc
+++ b/riscv/mmu.cc
@@ -71,7 +71,6 @@ reg_t mmu_t::translate(mem_access_info_t access_info, reg_t len)
 tlb_entry_t mmu_t::fetch_slow_path(reg_t vaddr)
 {
   auto access_info = generate_access_info(vaddr, FETCH, {false, false, false});
-  check_triggers(triggers::OPERATION_EXECUTE, vaddr, access_info.effective_virt);
 
   tlb_entry_t result;
   reg_t vpn = vaddr >> PGSHIFT;

--- a/riscv/mmu.cc
+++ b/riscv/mmu.cc
@@ -88,8 +88,6 @@ tlb_entry_t mmu_t::fetch_slow_path(reg_t vaddr)
     result = tlb_data[vpn % TLB_ENTRIES];
   }
 
-  check_triggers(triggers::OPERATION_EXECUTE, vaddr, access_info.effective_virt, from_le(*(const uint16_t*)(result.host_offset + vaddr)));
-
   return result;
 }
 

--- a/riscv/mmu.h
+++ b/riscv/mmu.h
@@ -290,6 +290,7 @@ public:
     if (matched_trigger)
       throw *matched_trigger;
 
+    auto access_info = generate_access_info(addr, FETCH, {false, false, false});
     auto tlb_entry = translate_insn_addr(addr);
     insn_bits_t insn = from_le(*(uint16_t*)(tlb_entry.host_offset + addr));
     int length = insn_length(insn);
@@ -307,6 +308,7 @@ public:
       insn |= (insn_bits_t)from_le(*(const uint16_t*)translate_insn_addr_to_host(addr + 4)) << 32;
       insn |= (insn_bits_t)from_le(*(const uint16_t*)translate_insn_addr_to_host(addr + 6)) << 48;
     }
+    check_triggers(triggers::OPERATION_EXECUTE, addr, access_info.effective_virt, insn);
 
     insn_fetch_t fetch = {proc->decode_insn(insn), insn};
     entry->tag = addr;

--- a/riscv/mmu.h
+++ b/riscv/mmu.h
@@ -291,6 +291,7 @@ public:
       throw *matched_trigger;
 
     auto access_info = generate_access_info(addr, FETCH, {false, false, false});
+    check_triggers(triggers::OPERATION_EXECUTE, addr, access_info.effective_virt);
     auto tlb_entry = translate_insn_addr(addr);
     insn_bits_t insn = from_le(*(uint16_t*)(tlb_entry.host_offset + addr));
     int length = insn_length(insn);

--- a/riscv/mmu.h
+++ b/riscv/mmu.h
@@ -290,8 +290,10 @@ public:
     if (matched_trigger)
       throw *matched_trigger;
 
+    reg_t vpn = addr >> PGSHIFT;
     auto access_info = generate_access_info(addr, FETCH, {false, false, false});
-    check_triggers(triggers::OPERATION_EXECUTE, addr, access_info.effective_virt);
+    if (unlikely(tlb_insn_tag[vpn % TLB_ENTRIES] != vpn))
+      check_triggers(triggers::OPERATION_EXECUTE, addr, access_info.effective_virt);
     auto tlb_entry = translate_insn_addr(addr);
     insn_bits_t insn = from_le(*(uint16_t*)(tlb_entry.host_offset + addr));
     int length = insn_length(insn);
@@ -309,7 +311,8 @@ public:
       insn |= (insn_bits_t)from_le(*(const uint16_t*)translate_insn_addr_to_host(addr + 4)) << 32;
       insn |= (insn_bits_t)from_le(*(const uint16_t*)translate_insn_addr_to_host(addr + 6)) << 48;
     }
-    check_triggers(triggers::OPERATION_EXECUTE, addr, access_info.effective_virt, insn);
+    if (unlikely(tlb_insn_tag[vpn % TLB_ENTRIES] != vpn))
+      check_triggers(triggers::OPERATION_EXECUTE, addr, access_info.effective_virt, insn);
 
     insn_fetch_t fetch = {proc->decode_insn(insn), insn};
     entry->tag = addr;


### PR DESCRIPTION
The fetch address and data are in refill_icache() instead of fetch_slow_path(). This commit moves the mcontrol/mcontrol6 checkings from fetch_slow_path() to refill_icache() for correct fetch values (https://github.com/riscv-software-src/riscv-isa-sim/commit/2128daa0e700c0109c1931f997d78ea70d60dbd3).

The last commit (https://github.com/riscv-software-src/riscv-isa-sim/pull/1459/commits/1779c358130b2cd92adef4e9ebe4befcbcba009b) is for performance improvement. I need help verifying the effectiveness.