### PR TITLE
Change disasm for vset{i}vli with reserved vtypes to display the reserved bits

### DIFF
--- a/disasm/disasm.cc
+++ b/disasm/disasm.cc
@@ -413,27 +413,35 @@ struct : public arg_t {
     int lmul = insn.v_lmul();
     auto vta = insn.v_vta() == 1 ? "ta" : "tu";
     auto vma = insn.v_vma() == 1 ? "ma" : "mu";
-    s << "e" << sew;
-    if(insn.v_frac_lmul()) {
-      std::string lmul_str = "";
-      switch(lmul){
-        case 3:
-          lmul_str = "f2";
-          break;
-        case 2:
-          lmul_str = "f4";
-          break;
-        case 1:
-          lmul_str = "f8";
-          break;
-        default:
-          assert(true && "unsupport fractional LMUL");
-      }
-      s << ", m" << lmul_str;
+    int newType = (insn.bits() & 0x80000000) ? insn.v_zimm10() : insn.v_zimm11();
+    // if bit 31 is set, this is vsetivli and there is a 10-bit vtype, else this is vsetvli and there is an 11-bit vtype
+    // If the provided vtype has reserved bits, display the hex version of the vtype instead
+    if ((newType >> 8) != 0) {
+      s << "0x" << std::hex << newType;
     } else {
-      s << ", m" << (1 << lmul);
+      s << "e" << sew;
+      if(insn.v_frac_lmul()) {
+        std::string lmul_str = "";
+        switch(lmul){
+          case 3:
+            lmul_str = "f2";
+            break;
+          case 2:
+            lmul_str = "f4";
+            break;
+          case 1:
+            lmul_str = "f8";
+            break;
+          default:
+            assert(true && "unsupport fractional LMUL");
+        }
+        s << ", m" << lmul_str;
+      } else {
+        s << ", m" << (1 << lmul);
+      }
+      s << ", " << vta << ", " << vma;
     }
-    s << ", " << vta << ", " << vma;
+
     return s.str();
   }
 } v_vtype;


### PR DESCRIPTION
Currently there is a bug with the disassembly when vsetivli/vsetvli have invalid vtypes (with reserved bits set). Spike correctly detects this and sets vill, but the disassembler integrated into spike ignores those bits being set and prints the instruction as if they weren't. This makes debugging harder, it looks like an otherwise valid vtype was being rejected and can lead down debugging paths like thinking the vector unit is configured incorrectly.

This commit changes the behaviour so that if these reserved bits are set, it prints out the hex value of the vtype. This is understood by the assembler. GCC disassembler prints out the decimal value of the vtype in this case, I think that hex value is clearer but I can change it if desired.