### PR TITLE
[vector-crypto] Fixing Zvkb/Zvbb distinction

### DIFF
--- a/disasm/disasm.cc
+++ b/disasm/disasm.cc
@@ -2125,7 +2125,7 @@ void disassembler_t::add_instructions(const isa_parser_t* isa)
     DEFINE_R1TYPE(sm3p1);
   }
 
-  if (isa->extension_enabled(EXT_ZVKB) || isa->extension_enabled(EXT_ZVBB)) {
+  if (isa->extension_enabled(EXT_ZVKB)) {
 #define DEFINE_VECTOR_VIU_ZIMM6(code) \
   add_vector_viu_z6_insn(this, #code, match_##code, mask_##code)
 #define DISASM_VECTOR_VV_VX(name) \

--- a/disasm/disasm.cc
+++ b/disasm/disasm.cc
@@ -2125,36 +2125,41 @@ void disassembler_t::add_instructions(const isa_parser_t* isa)
     DEFINE_R1TYPE(sm3p1);
   }
 
-  if (isa->extension_enabled(EXT_ZVBB)) {
+  if (isa->extension_enabled(EXT_ZVKB) || isa->extension_enabled(EXT_ZVBB)) {
 #define DEFINE_VECTOR_VIU_ZIMM6(code) \
   add_vector_viu_z6_insn(this, #code, match_##code, mask_##code)
 #define DISASM_VECTOR_VV_VX(name) \
   DEFINE_VECTOR_VV(name##_vv); \
   DEFINE_VECTOR_VX(name##_vx)
-#define DISASM_VECTOR_VV_VX_VIU(name) \
-  DEFINE_VECTOR_VV(name##_vv); \
-  DEFINE_VECTOR_VX(name##_vx); \
-  DEFINE_VECTOR_VIU(name##_vi)
 #define DISASM_VECTOR_VV_VX_VIU_ZIMM6(name) \
   DEFINE_VECTOR_VV(name##_vv); \
   DEFINE_VECTOR_VX(name##_vx); \
   DEFINE_VECTOR_VIU_ZIMM6(name##_vi)
 
     DISASM_VECTOR_VV_VX(vandn);
-    DEFINE_VECTOR_V(vbrev_v);
     DEFINE_VECTOR_V(vbrev8_v);
     DEFINE_VECTOR_V(vrev8_v);
-    DEFINE_VECTOR_V(vclz_v);
-    DEFINE_VECTOR_V(vctz_v);
-    DEFINE_VECTOR_V(vcpop_v);
     DISASM_VECTOR_VV_VX(vrol);
     DISASM_VECTOR_VV_VX_VIU_ZIMM6(vror);
-    DISASM_VECTOR_VV_VX_VIU(vwsll);
 
 #undef DEFINE_VECTOR_VIU_ZIMM6
 #undef DISASM_VECTOR_VV_VX
-#undef DISASM_VECTOR_VV_VX_VIU
 #undef DISASM_VECTOR_VV_VX_VIU_ZIMM6
+    }
+
+  if (isa->extension_enabled(EXT_ZVBB)) {
+#define DISASM_VECTOR_VV_VX_VIU(name) \
+  DEFINE_VECTOR_VV(name##_vv); \
+  DEFINE_VECTOR_VX(name##_vx); \
+  DEFINE_VECTOR_VIU(name##_vi)
+
+    DEFINE_VECTOR_V(vbrev_v);
+    DEFINE_VECTOR_V(vclz_v);
+    DEFINE_VECTOR_V(vctz_v);
+    DEFINE_VECTOR_V(vcpop_v);
+    DISASM_VECTOR_VV_VX_VIU(vwsll);
+
+#undef DISASM_VECTOR_VV_VX_VIU
     }
 
   if (isa->extension_enabled(EXT_ZVBC)) {

--- a/disasm/isa_parser.cc
+++ b/disasm/isa_parser.cc
@@ -250,6 +250,7 @@ isa_parser_t::isa_parser_t(const char* str, const char *priv)
     } else if (ext_str == "zcmlsd") {
       extension_table[EXT_ZCMLSD] = true;
     } else if (ext_str == "zvbb") {
+      extension_table[EXT_ZVBB] = true;
       extension_table[EXT_ZVKB] = true;
     } else if (ext_str == "zvbc") {
       extension_table[EXT_ZVBC] = true;

--- a/disasm/isa_parser.cc
+++ b/disasm/isa_parser.cc
@@ -257,6 +257,8 @@ isa_parser_t::isa_parser_t(const char* str, const char *priv)
       extension_table[EXT_ZVFBFMIN] = true;
     } else if (ext_str == "zvfbfwma") {
       extension_table[EXT_ZVFBFWMA] = true;
+    } else if (ext_str == "zvkb") {
+      extension_table[EXT_ZVKB] = true;
     } else if (ext_str == "zvkg") {
       extension_table[EXT_ZVKG] = true;
     } else if (ext_str == "zvkn") {

--- a/disasm/isa_parser.cc
+++ b/disasm/isa_parser.cc
@@ -250,7 +250,7 @@ isa_parser_t::isa_parser_t(const char* str, const char *priv)
     } else if (ext_str == "zcmlsd") {
       extension_table[EXT_ZCMLSD] = true;
     } else if (ext_str == "zvbb") {
-      extension_table[EXT_ZVBB] = true;
+      extension_table[EXT_ZVKB] = true;
     } else if (ext_str == "zvbc") {
       extension_table[EXT_ZVBC] = true;
     } else if (ext_str == "zvfbfmin") {
@@ -262,16 +262,16 @@ isa_parser_t::isa_parser_t(const char* str, const char *priv)
     } else if (ext_str == "zvkg") {
       extension_table[EXT_ZVKG] = true;
     } else if (ext_str == "zvkn") {
-      extension_table[EXT_ZVBB] = true;
+      extension_table[EXT_ZVKB] = true;
       extension_table[EXT_ZVKNED] = true;
       extension_table[EXT_ZVKNHB] = true;
     } else if (ext_str == "zvknc") {
-      extension_table[EXT_ZVBB] = true;
+      extension_table[EXT_ZVKB] = true;
       extension_table[EXT_ZVBC] = true;
       extension_table[EXT_ZVKNED] = true;
       extension_table[EXT_ZVKNHB] = true;
     } else if (ext_str == "zvkng") {
-      extension_table[EXT_ZVBB] = true;
+      extension_table[EXT_ZVKB] = true;
       extension_table[EXT_ZVKG] = true;
       extension_table[EXT_ZVKNED] = true;
       extension_table[EXT_ZVKNHB] = true;
@@ -282,16 +282,16 @@ isa_parser_t::isa_parser_t(const char* str, const char *priv)
     } else if (ext_str == "zvknhb") {
       extension_table[EXT_ZVKNHB] = true;
     } else if (ext_str == "zvks") {
-      extension_table[EXT_ZVBB] = true;
+      extension_table[EXT_ZVKB] = true;
       extension_table[EXT_ZVKSED] = true;
       extension_table[EXT_ZVKSH] = true;
     } else if (ext_str == "zvksc") {
-      extension_table[EXT_ZVBB] = true;
+      extension_table[EXT_ZVKB] = true;
       extension_table[EXT_ZVBC] = true;
       extension_table[EXT_ZVKSED] = true;
       extension_table[EXT_ZVKSH] = true;
     } else if (ext_str == "zvksg") {
-      extension_table[EXT_ZVBB] = true;
+      extension_table[EXT_ZVKB] = true;
       extension_table[EXT_ZVKG] = true;
       extension_table[EXT_ZVKSED] = true;
       extension_table[EXT_ZVKSH] = true;

--- a/riscv/insns/vandn_vv.h
+++ b/riscv/insns/vandn_vv.h
@@ -2,7 +2,7 @@
 
 #include "zvk_ext_macros.h"
 
-require_zvbb;
+require_zvkb;
 
 VI_VV_LOOP
 ({

--- a/riscv/insns/vandn_vx.h
+++ b/riscv/insns/vandn_vx.h
@@ -2,7 +2,7 @@
 
 #include "zvk_ext_macros.h"
 
-require_zvbb;
+require_zvkb;
 
 VI_VX_LOOP
 ({

--- a/riscv/insns/vbrev8_v.h
+++ b/riscv/insns/vbrev8_v.h
@@ -2,7 +2,7 @@
 
 #include "zvk_ext_macros.h"
 
-require_zvbb;
+require_zvkb;
 
 VI_V_ULOOP
 ({

--- a/riscv/insns/vrev8_v.h
+++ b/riscv/insns/vrev8_v.h
@@ -2,7 +2,7 @@
 
 #include "zvk_ext_macros.h"
 
-require_zvbb;
+require_zvkb;
 
 VI_V_ULOOP
 ({

--- a/riscv/insns/vrol_vv.h
+++ b/riscv/insns/vrol_vv.h
@@ -2,7 +2,7 @@
 
 #include "zvk_ext_macros.h"
 
-require_zvbb;
+require_zvkb;
 
 // 'mask' selects the low log2(vsew) bits of the shift amount,
 // to limit the maximum shift to "vsew - 1" bits.

--- a/riscv/insns/vrol_vx.h
+++ b/riscv/insns/vrol_vx.h
@@ -2,7 +2,7 @@
 
 #include "zvk_ext_macros.h"
 
-require_zvbb;
+require_zvkb;
 
 // 'mask' selects the low log2(vsew) bits of the shift amount,
 // to limit the maximum shift to "vsew - 1" bits.

--- a/riscv/insns/vror_vi.h
+++ b/riscv/insns/vror_vi.h
@@ -2,7 +2,7 @@
 
 #include "zvk_ext_macros.h"
 
-require_zvbb;
+require_zvkb;
 
 // 'mask' selects the low log2(vsew) bits of the shift amount,
 // to limit the maximum shift to "vsew - 1" bits.

--- a/riscv/insns/vror_vv.h
+++ b/riscv/insns/vror_vv.h
@@ -2,7 +2,7 @@
 
 #include "zvk_ext_macros.h"
 
-require_zvbb;
+require_zvkb;
 
 // 'mask' selects the low log2(vsew) bits of the shift amount,
 // to limit the maximum shift to "vsew - 1" bits.

--- a/riscv/insns/vror_vx.h
+++ b/riscv/insns/vror_vx.h
@@ -2,7 +2,7 @@
 
 #include "zvk_ext_macros.h"
 
-require_zvbb;
+require_zvkb;
 
 // 'mask' selects the low log2(vsew) bits of the shift amount,
 // to limit the maximum shift to "vsew - 1" bits.

--- a/riscv/isa_parser.h
+++ b/riscv/isa_parser.h
@@ -59,6 +59,7 @@ typedef enum {
   EXT_ZVBC,
   EXT_ZVFBFMIN,
   EXT_ZVFBFWMA,
+  EXT_ZVKB,
   EXT_ZVKG,
   EXT_ZVKNED,
   EXT_ZVKNHA,

--- a/riscv/riscv.mk.in
+++ b/riscv/riscv.mk.in
@@ -1017,7 +1017,7 @@ riscv_insn_ext_zvkb = \
 	vror_vx \
 
 riscv_insn_ext_zvbb = \
-    $(riscv_insn_ext_zvkb) \
+	$(riscv_insn_ext_zvkb) \
 	vbrev_v \
 	vclz_v \
 	vcpop_v \

--- a/riscv/riscv.mk.in
+++ b/riscv/riscv.mk.in
@@ -1005,20 +1005,23 @@ riscv_insn_ext_zalasr = \
 	sw_rl \
 	sd_rl \
 
-riscv_insn_ext_zvbb = \
+riscv_insn_ext_zvkb = \
 	vandn_vv \
 	vandn_vx \
 	vbrev8_v \
-	vbrev_v \
-	vclz_v \
-	vcpop_v \
-	vctz_v \
 	vrev8_v \
 	vrol_vv \
 	vrol_vx \
 	vror_vi \
 	vror_vv \
 	vror_vx \
+
+riscv_insn_ext_zvbb = \
+    $(riscv_insn_ext_zvkb) \
+	vbrev_v \
+	vclz_v \
+	vcpop_v \
+	vctz_v \
 	vwsll_vi \
 	vwsll_vv \
 	vwsll_vx \

--- a/riscv/zvk_ext_macros.h
+++ b/riscv/zvk_ext_macros.h
@@ -13,7 +13,7 @@
 // Predicate Macros
 //
 
-// Ensures that the ZVBB extension (vector crypto bitmanip) is present,
+// Ensures that the ZVBB extension (vector basic bitmanip) is present,
 // and the vector unit is enabled and in a valid state.
 #define require_zvbb \
   do { \
@@ -27,6 +27,14 @@
   do { \
     require_vector(true); \
     require_extension(EXT_ZVBC); \
+  } while (0)
+
+// Ensures that the ZVKB extension (vector crypto bitmanip) is present,
+// and the vector unit is enabled and in a valid state.
+#define require_zvkb \
+  do { \
+    require_vector(true); \
+    require_extension(EXT_ZVKB); \
   } while (0)
 
 // Ensures that the ZVKG extension (vector Galois Field Multiplication)


### PR DESCRIPTION
It looks like vector crypto support introduced in https://github.com/riscv-software-src/riscv-isa-sim/pull/1303 was made before the `Zvkb` was re-introduced as a subset of `Zvbb`.

Working on fixing this here.