### PR TITLE
Remove vector AMO

### DIFF
--- a/disasm/disasm.cc
+++ b/disasm/disasm.cc
@@ -1795,41 +1795,6 @@ void disassembler_t::add_instructions(const isa_parser_t* isa)
     #undef DISASM_OPIV_S__INSN
     #undef DISASM_OPIV_W__INSN
     #undef DISASM_VFUNARY0_INSN
-
-    // vector amo
-    std::vector<const arg_t *> v_fmt_amo_wd = {&vd, &v_address, &vs2, &vd, opt, &vm};
-    std::vector<const arg_t *> v_fmt_amo = {&x0, &v_address, &vs2, &vd, opt, &vm};
-    for (size_t elt = 0; elt <= 3; ++elt) {
-      const custom_fmt_t template_insn[] = {
-        {match_vamoaddei8_v | mask_wd,   mask_vamoaddei8_v | mask_wd,
-          "%sei%d.v", v_fmt_amo_wd},
-        {match_vamoaddei8_v,   mask_vamoaddei8_v | mask_wd,
-          "%sei%d.v", v_fmt_amo},
-      };
-      std::pair<const char*, reg_t> amo_map[] = {
-          {"vamoswap", 0x01ul << 27},
-          {"vamoadd",  0x00ul << 27},
-          {"vamoxor",  0x04ul << 27},
-          {"vamoand",  0x0cul << 27},
-          {"vamoor",   0x08ul << 27},
-          {"vamomin",  0x10ul << 27},
-          {"vamomax",  0x14ul << 27},
-          {"vamominu", 0x18ul << 27},
-          {"vamomaxu", 0x1cul << 27}};
-      const reg_t elt_map[] = {0x0ul << 12,  0x5ul << 12,
-                               0x6ul <<12, 0x7ul << 12};
-
-      for (size_t idx = 0; idx < sizeof(amo_map) / sizeof(amo_map[0]); ++idx) {
-        for (auto item : template_insn) {
-          char buf[128];
-          snprintf(buf, sizeof(buf), item.fmt, amo_map[idx].first, 8 << elt);
-          add_insn(new disasm_insn_t(buf,
-                    item.match | amo_map[idx].second | elt_map[elt],
-                    item.mask,
-                    item.arg));
-        }
-      }
-    }
   }
 
   if (isa->extension_enabled(EXT_ZVFBFMIN)) {

--- a/riscv/insns/vamoaddei16_v.h
+++ b/riscv/insns/vamoaddei16_v.h
@@ -1,2 +1,0 @@
-//vamoadde.v vd, (rs1), vs2, vd
-VI_AMO({ return lhs + vs3; }, uint, e16);

--- a/riscv/insns/vamoaddei32_v.h
+++ b/riscv/insns/vamoaddei32_v.h
@@ -1,2 +1,0 @@
-//vamoadde.v vd, (rs1), vs2, vd
-VI_AMO({ return lhs + vs3; }, uint, e32);

--- a/riscv/insns/vamoaddei64_v.h
+++ b/riscv/insns/vamoaddei64_v.h
@@ -1,2 +1,0 @@
-//vamoadde.v vd, (rs1), vs2, vd
-VI_AMO({ return lhs + vs3; }, uint, e64);

--- a/riscv/insns/vamoaddei8_v.h
+++ b/riscv/insns/vamoaddei8_v.h
@@ -1,2 +1,0 @@
-//vamoadde.v vd, (rs1), vs2, vd
-VI_AMO({ return lhs + vs3; }, uint, e8);

--- a/riscv/insns/vamoandei16_v.h
+++ b/riscv/insns/vamoandei16_v.h
@@ -1,2 +1,0 @@
-//vamoande.v vd, (rs1), vs2, vd
-VI_AMO({ return lhs & vs3; }, uint, e16);

--- a/riscv/insns/vamoandei32_v.h
+++ b/riscv/insns/vamoandei32_v.h
@@ -1,2 +1,0 @@
-//vamoande.v vd, (rs1), vs2, vd
-VI_AMO({ return lhs & vs3; }, uint, e32);

--- a/riscv/insns/vamoandei64_v.h
+++ b/riscv/insns/vamoandei64_v.h
@@ -1,2 +1,0 @@
-//vamoande.v vd, (rs1), vs2, vd
-VI_AMO({ return lhs & vs3; }, uint, e64);

--- a/riscv/insns/vamoandei8_v.h
+++ b/riscv/insns/vamoandei8_v.h
@@ -1,2 +1,0 @@
-//vamoande.v vd, (rs1), vs2, vd
-VI_AMO({ return lhs & vs3; }, uint, e8);

--- a/riscv/insns/vamomaxei16_v.h
+++ b/riscv/insns/vamomaxei16_v.h
@@ -1,2 +1,0 @@
-//vamomaxe.v vd, (rs1), vs2, vd
-VI_AMO({ return lhs >= vs3 ? lhs : vs3; }, int, e16);

--- a/riscv/insns/vamomaxei32_v.h
+++ b/riscv/insns/vamomaxei32_v.h
@@ -1,2 +1,0 @@
-//vamomaxe.v vd, (rs1), vs2, vd
-VI_AMO({ return lhs >= vs3 ? lhs : vs3; }, int, e32);

--- a/riscv/insns/vamomaxei64_v.h
+++ b/riscv/insns/vamomaxei64_v.h
@@ -1,2 +1,0 @@
-//vamomaxe.v vd, (rs1), vs2, vd
-VI_AMO({ return lhs >= vs3 ? lhs : vs3; }, int, e64);

--- a/riscv/insns/vamomaxei8_v.h
+++ b/riscv/insns/vamomaxei8_v.h
@@ -1,2 +1,0 @@
-//vamomaxe.v vd, (rs1), vs2, vd
-VI_AMO({ return lhs >= vs3 ? lhs : vs3; }, int, e8);

--- a/riscv/insns/vamomaxuei16_v.h
+++ b/riscv/insns/vamomaxuei16_v.h
@@ -1,2 +1,0 @@
-//vamomaxue.v vd, (rs1), vs2, vd
-VI_AMO({ return lhs >= vs3 ? lhs : vs3;; }, uint, e16);

--- a/riscv/insns/vamomaxuei32_v.h
+++ b/riscv/insns/vamomaxuei32_v.h
@@ -1,2 +1,0 @@
-//vamomaxue.v vd, (rs1), vs2, vd
-VI_AMO({ return lhs >= vs3 ? lhs : vs3;; }, uint, e32);

--- a/riscv/insns/vamomaxuei64_v.h
+++ b/riscv/insns/vamomaxuei64_v.h
@@ -1,2 +1,0 @@
-//vamomaxue.v vd, (rs1), vs2, vd
-VI_AMO({ return lhs >= vs3 ? lhs : vs3;; }, uint, e64);

--- a/riscv/insns/vamomaxuei8_v.h
+++ b/riscv/insns/vamomaxuei8_v.h
@@ -1,2 +1,0 @@
-//vamomaxue.v vd, (rs1), vs2, vd
-VI_AMO({ return lhs >= vs3 ? lhs : vs3;; }, uint, e8);

--- a/riscv/insns/vamominei16_v.h
+++ b/riscv/insns/vamominei16_v.h
@@ -1,2 +1,0 @@
-//vamomine.v vd, (rs1), vs2, vd
-VI_AMO({ return lhs < vs3 ? lhs : vs3; }, int, e16);

--- a/riscv/insns/vamominei32_v.h
+++ b/riscv/insns/vamominei32_v.h
@@ -1,2 +1,0 @@
-//vamomine.v vd, (rs1), vs2, vd
-VI_AMO({ return lhs < vs3 ? lhs : vs3; }, int, e32);

--- a/riscv/insns/vamominei64_v.h
+++ b/riscv/insns/vamominei64_v.h
@@ -1,2 +1,0 @@
-//vamomine.v vd, (rs1), vs2, vd
-VI_AMO({ return lhs < vs3 ? lhs : vs3; }, int, e64);

--- a/riscv/insns/vamominei8_v.h
+++ b/riscv/insns/vamominei8_v.h
@@ -1,2 +1,0 @@
-//vamomine.v vd, (rs1), vs2, vd
-VI_AMO({ return lhs < vs3 ? lhs : vs3; }, int, e8);

--- a/riscv/insns/vamominuei16_v.h
+++ b/riscv/insns/vamominuei16_v.h
@@ -1,2 +1,0 @@
-//vamominue.v vd, (rs1), vs2, vd
-VI_AMO({ return lhs < vs3 ? lhs : vs3;; }, uint, e16);

--- a/riscv/insns/vamominuei32_v.h
+++ b/riscv/insns/vamominuei32_v.h
@@ -1,2 +1,0 @@
-//vamominue.v vd, (rs1), vs2, vd
-VI_AMO({ return lhs < vs3 ? lhs : vs3;; }, uint, e32);

--- a/riscv/insns/vamominuei64_v.h
+++ b/riscv/insns/vamominuei64_v.h
@@ -1,2 +1,0 @@
-//vamominue.v vd, (rs1), vs2, vd
-VI_AMO({ return lhs < vs3 ? lhs : vs3;; }, uint, e64);

--- a/riscv/insns/vamominuei8_v.h
+++ b/riscv/insns/vamominuei8_v.h
@@ -1,2 +1,0 @@
-//vamominue.v vd, (rs1), vs2, vd
-VI_AMO({ return lhs < vs3 ? lhs : vs3;; }, uint, e8);

--- a/riscv/insns/vamoorei16_v.h
+++ b/riscv/insns/vamoorei16_v.h
@@ -1,2 +1,0 @@
-//vamoore.v vd, (rs1), vs2, vd
-VI_AMO({ return lhs | vs3; }, uint, e16);

--- a/riscv/insns/vamoorei32_v.h
+++ b/riscv/insns/vamoorei32_v.h
@@ -1,2 +1,0 @@
-//vamoore.v vd, (rs1), vs2, vd
-VI_AMO({ return lhs | vs3; }, uint, e32);

--- a/riscv/insns/vamoorei64_v.h
+++ b/riscv/insns/vamoorei64_v.h
@@ -1,2 +1,0 @@
-//vamoore.v vd, (rs1), vs2, vd
-VI_AMO({ return lhs | vs3; }, uint, e64);

--- a/riscv/insns/vamoorei8_v.h
+++ b/riscv/insns/vamoorei8_v.h
@@ -1,2 +1,0 @@
-//vamoore.v vd, (rs1), vs2, vd
-VI_AMO({ return lhs | vs3; }, uint, e8);

--- a/riscv/insns/vamoswapei16_v.h
+++ b/riscv/insns/vamoswapei16_v.h
@@ -1,2 +1,0 @@
-//vamoswape.v vd, (rs1), vs2, vd
-VI_AMO({ return vs3; }, uint, e16);

--- a/riscv/insns/vamoswapei32_v.h
+++ b/riscv/insns/vamoswapei32_v.h
@@ -1,2 +1,0 @@
-//vamoswape.v vd, (rs1), vs2, vd
-VI_AMO({ return vs3; }, uint, e32);

--- a/riscv/insns/vamoswapei64_v.h
+++ b/riscv/insns/vamoswapei64_v.h
@@ -1,2 +1,0 @@
-//vamoswape.v vd, (rs1), vs2, vd
-VI_AMO({ return vs3; }, uint, e64);

--- a/riscv/insns/vamoswapei8_v.h
+++ b/riscv/insns/vamoswapei8_v.h
@@ -1,2 +1,0 @@
-//vamoswape.v vd, (rs1), vs2, vd
-VI_AMO({ return vs3; }, uint, e8);

--- a/riscv/insns/vamoxorei16_v.h
+++ b/riscv/insns/vamoxorei16_v.h
@@ -1,2 +1,0 @@
-//vamoore.v vd, (rs1), vs2, vd
-VI_AMO({ return lhs ^ vs3; }, uint, e16);

--- a/riscv/insns/vamoxorei32_v.h
+++ b/riscv/insns/vamoxorei32_v.h
@@ -1,2 +1,0 @@
-//vamoore.v vd, (rs1), vs2, vd
-VI_AMO({ return lhs ^ vs3; }, uint, e32);

--- a/riscv/insns/vamoxorei64_v.h
+++ b/riscv/insns/vamoxorei64_v.h
@@ -1,2 +1,0 @@
-//vamoore.v vd, (rs1), vs2, vd
-VI_AMO({ return lhs ^ vs3; }, uint, e64);

--- a/riscv/insns/vamoxorei8_v.h
+++ b/riscv/insns/vamoxorei8_v.h
@@ -1,2 +1,0 @@
-//vamoore.v vd, (rs1), vs2, vd
-VI_AMO({ return lhs ^ vs3; }, uint, e8);

--- a/riscv/riscv.mk.in
+++ b/riscv/riscv.mk.in
@@ -795,44 +795,6 @@ riscv_insn_ext_v_alu_fp = \
 	vmfne_vf \
 	vmfne_vv \
 
-riscv_insn_ext_v_amo = \
-	vamoswapei8_v \
-	vamoaddei8_v \
-	vamoandei8_v \
-	vamomaxei8_v \
-	vamomaxuei8_v \
-	vamominei8_v \
-	vamominuei8_v \
-	vamoorei8_v \
-	vamoxorei8_v \
-	vamoswapei16_v \
-	vamoaddei16_v \
-	vamoandei16_v \
-	vamomaxei16_v \
-	vamomaxuei16_v \
-	vamominei16_v \
-	vamominuei16_v \
-	vamoorei16_v \
-	vamoxorei16_v \
-	vamoswapei32_v \
-	vamoaddei32_v \
-	vamoandei32_v \
-	vamomaxei32_v \
-	vamomaxuei32_v \
-	vamominei32_v \
-	vamominuei32_v \
-	vamoorei32_v \
-	vamoxorei32_v \
-	vamoswapei64_v \
-	vamoaddei64_v \
-	vamoandei64_v \
-	vamomaxei64_v \
-	vamomaxuei64_v \
-	vamominei64_v \
-	vamominuei64_v \
-	vamoorei64_v \
-	vamoxorei64_v \
-
 riscv_insn_ext_v_ldst = \
 	vlm_v \
 	vle8_v \
@@ -901,7 +863,6 @@ riscv_insn_ext_v_ctrl = \
 riscv_insn_ext_v = \
 	$(riscv_insn_ext_v_alu_fp) \
 	$(riscv_insn_ext_v_alu_int) \
-	$(riscv_insn_ext_v_amo) \
 	$(riscv_insn_ext_v_ctrl) \
 	$(riscv_insn_ext_v_ldst) \
 


### PR DESCRIPTION
Not only this is not a part of the vector extension version 1.0, 8-bit vector AMO instructions will conflict to byte-granularity AMO instructions of the `Zabha` extension (containing subword AMO instructions) in the fast track.

The current vector spec (draft) also states that vector AMO encodings are likely to change, making keeping vector AMO as-is less usable.

This commit removes all vector AMO instructions but not `VI_AMO` macro.