### PR TITLE
SC Instruction Returns Incorrect Value on Trap.

### DIFF
--- a/riscv/insns/sc_d.h
+++ b/riscv/insns/sc_d.h
@@ -1,6 +1,8 @@
 require_extension('A');
 require_rv64;
 
+WRITE_RD(!false);
+
 bool have_reservation = MMU.store_conditional<uint64_t>(RS1, RS2);
 
 WRITE_RD(!have_reservation);

--- a/riscv/insns/sc_w.h
+++ b/riscv/insns/sc_w.h
@@ -1,5 +1,7 @@
 require_extension('A');
 
+WRITE_RD(!false);
+
 bool have_reservation = MMU.store_conditional<uint32_t>(RS1, RS2);
 
 WRITE_RD(!have_reservation);


### PR DESCRIPTION
_See issue #1495._
### Description
According to the RISC-V ISA specification for the A extension, the SC (Store Conditional ) instruction requires that the address in rs1 be naturally aligned to the size of the operand. This means that for a 64-bit SC.D instruction, the address must be 8-byte aligned. If the address is not naturally aligned, an address misaligned exception or an access-fault exception should be raised.

However, during testing with the Spike simulator, it has been observed that when the SC.D instruction is executed with a misaligned address in rs1, an exception is raised. Additionally, the RD register does not accurately reflect the success or failure of the SC execution. For instance, if the RD register is initially set to 0, it remains 0 even when the SC instruction encounters a trap, suggesting successful execution, which contradicts the expected behavior.

### Expected Behavior
The SC instruction should not succeed when given a misaligned address and should return a non-zero value in the destination register to indicate failure, in accordance with the specification.

### Actual Behavior
When executing sc, due to traps occurring internally, such as misaligned addresses, a non-zero value will not be written to the rd register, implying that the sc execution has failed. Especially when the rd register is originally 0, it is easy to mislead that the execution has been successful.

### Proposed Solution
When executing SC, the RD register should be set to '!false' before performing MMU operations.