### PR TITLE
fesvr/htif: allow exit on SIGINT.

### DIFF
--- a/fesvr/htif.cc
+++ b/fesvr/htif.cc
@@ -253,7 +253,7 @@ int htif_t::run()
     std::bind(enq_func, &fromhost_queue, std::placeholders::_1);
 
   if (tohost_addr == 0) {
-    while (true)
+    while (!signal_exit)
       idle();
   }
 


### PR DESCRIPTION
Currently signal handler would call exit() only on second received signal, this prevents proper program cleanup.
Instead use signal flag to exit loop.