### PR TITLE
Relax VLEN requirement to 65,536 bytes in processor module

### DIFF
--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -172,9 +172,9 @@ void processor_t::parse_varch_string(const char* s)
   if (vlen < elen)
     bad_varch_string(s, "vlen must be >= elen");
 
-  /* spike requirements. */
-  if (vlen > 4096)
-    bad_varch_string(s, "vlen must be <= 4096");
+  /* Vector spec requirements. */
+  if (vlen > 65536)
+    bad_varch_string(s, "vlen must be <= 65536");
 
   VU.VLEN = vlen;
   VU.ELEN = elen;


### PR DESCRIPTION
Related issue: https://github.com/riscv-software-src/riscv-isa-sim/issues/1502