### PR TITLE
Don't enforce alignment constraints vwsll.v[xi] rs1 arg

### DIFF
--- a/riscv/zvk_ext_macros.h
+++ b/riscv/zvk_ext_macros.h
@@ -750,7 +750,7 @@
 //  - 'rs1', unsigned, SEW width, by value, constant.
 #define VI_ZVK_VX_WIDENING_ULOOP(BODY) \
   do { \
-    VI_CHECK_DSS(true); \
+    VI_CHECK_DSS(false); \
     VI_LOOP_BASE \
       switch (sew) { \
         case e8: { \
@@ -788,7 +788,7 @@
 //  - 'zimm5', unsigned, SEW width, by value, constant.
 #define VI_ZVK_VI_WIDENING_ULOOP(BODY) \
   do { \
-    VI_CHECK_DSS(true); \
+    VI_CHECK_DSS(false); \
     VI_LOOP_BASE \
       switch (sew) { \
         case e8: { \


### PR DESCRIPTION
rs1 doesn't represent a vector arg in this case, so the instructions were broken for (rs1 % ceil(LMUL)) != 0.

Resolves #1505