### PR TITLE
stimecmp: perform menvcfg.STCE permission check when accessing vstimecmp in HS-mode

### DIFF
--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -1535,7 +1535,7 @@ virtualized_stimecmp_csr_t::virtualized_stimecmp_csr_t(processor_t* const proc, 
   virtualized_csr_t(proc, orig, virt) {
 }
 
-void virtualized_stimecmp_csr_t::verify_permissions(insn_t insn, bool write) const {
+void stimecmp_csr_t::verify_permissions(insn_t insn, bool write) const {
   if (!(state->menvcfg->read() & MENVCFG_STCE)) {
     // access to (v)stimecmp with MENVCFG.STCE = 0
     if (state->prv < PRV_M)
@@ -1549,7 +1549,11 @@ void virtualized_stimecmp_csr_t::verify_permissions(insn_t insn, bool write) con
     throw trap_virtual_instruction(insn.bits());
   }
 
-  virtualized_csr_t::verify_permissions(insn, write);
+  basic_csr_t::verify_permissions(insn, write);
+}
+
+void virtualized_stimecmp_csr_t::verify_permissions(insn_t insn, bool write) const {
+  orig_csr->verify_permissions(insn, write);
 }
 
 scountovf_csr_t::scountovf_csr_t(processor_t* const proc, const reg_t addr):

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -780,6 +780,7 @@ class senvcfg_csr_t final: public envcfg_csr_t {
 class stimecmp_csr_t: public basic_csr_t {
  public:
   stimecmp_csr_t(processor_t* const proc, const reg_t addr, const reg_t imask);
+  virtual void verify_permissions(insn_t insn, bool write) const override;
  protected:
   virtual bool unlogged_write(const reg_t val) noexcept override;
  private:


### PR DESCRIPTION
The spec requires menvcfg.STCE=1 on accessing stimecmp or vstimecmp in a mode other than M-mode. The previous implementation does not check the permission on accessing vstimecmp in HS-mode. This commit fixes the issue by moveing the permission check from virtualized_stimecmp_csr_t to stimecmp_csr_t, which implements the vstimecmp.
![image](https://github.com/riscv-software-src/riscv-isa-sim/assets/39526191/47b96261-03d3-4c5d-a91b-87f627c34b57)
