### PR TITLE
remote_bitbang: make send_buf class member

### DIFF
--- a/riscv/remote_bitbang.cc
+++ b/riscv/remote_bitbang.cc
@@ -106,7 +106,6 @@ void remote_bitbang_t::tick()
 
 void remote_bitbang_t::execute_commands()
 {
-  static char send_buf[buf_size];
   unsigned total_processed = 0;
   bool quit = false;
   bool in_rti = tap->state() == RUN_TEST_IDLE;

--- a/riscv/remote_bitbang.h
+++ b/riscv/remote_bitbang.h
@@ -22,6 +22,7 @@ private:
   int client_fd;
 
   static const ssize_t buf_size = 64 * 1024;
+  char send_buf[buf_size];
   char recv_buf[buf_size];
   ssize_t recv_start, recv_end;
 


### PR DESCRIPTION
Currently send buffer is static variable in function, which makes it's impossible to have multiple concurrent instances of remote bitbang class, since all of them would share this static buffer. Thus, make send_buf a class member.