### PR TITLE
fix: dcsr.ebreak(v)[su] hardwired to 0 if unsupport corresponding privilege modes

### DIFF
--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -1304,10 +1304,10 @@ bool dcsr_csr_t::unlogged_write(const reg_t val) noexcept {
   step = get_field(val, DCSR_STEP);
   // TODO: ndreset and fullreset
   ebreakm = get_field(val, DCSR_EBREAKM);
-  ebreaks = get_field(val, DCSR_EBREAKS);
-  ebreaku = get_field(val, DCSR_EBREAKU);
-  ebreakvs = get_field(val, CSR_DCSR_EBREAKVS);
-  ebreakvu = get_field(val, CSR_DCSR_EBREAKVU);
+  ebreaks = proc->extension_enabled('S') ? get_field(val, DCSR_EBREAKS) : false;
+  ebreaku = proc->extension_enabled('U') ? get_field(val, DCSR_EBREAKU) : false;
+  ebreakvs = proc->extension_enabled('H') ? get_field(val, CSR_DCSR_EBREAKVS) : false;
+  ebreakvu = proc->extension_enabled('H') ? get_field(val, CSR_DCSR_EBREAKVU) : false;
   halt = get_field(val, DCSR_HALT);
   v = proc->extension_enabled('H') ? get_field(val, CSR_DCSR_V) : false;
   return true;


### PR DESCRIPTION
The dcsr.ebreak(v)[su] should be read-only-0 if unsupport corresponding privilege modes.

Reference: 
![image](https://github.com/riscv-software-src/riscv-isa-sim/assets/39526191/9280f904-d8bf-47c4-af30-91ced58f5cfa)
