### PR TITLE
fix:Align the BASE field of the tvec register to 4-byte boundaries.

### DIFF
--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -374,7 +374,8 @@ reg_t tvec_csr_t::read() const noexcept {
 }
 
 bool tvec_csr_t::unlogged_write(const reg_t val) noexcept {
-  this->val = val & ~(reg_t)2;
+  //Preserve the MODE field and adhere to a 4-byte aligned BASE field.
+  this->val = val & ~(reg_t)0xe;
   return true;
 }
 


### PR DESCRIPTION
See issue #1518 

![image](https://github.com/riscv-software-src/riscv-isa-sim/assets/62980522/269a9a34-a510-4ae4-84a5-5fe14458f6e9)
![image](https://github.com/riscv-software-src/riscv-isa-sim/assets/62980522/2851a260-545c-4897-9b09-1f6d287c4bdf)

The specification requires the BASE field of the tvec register to be aligned to four-byte boundaries, but in practice, it is possible to write a non-four-byte aligned address.