### PR TITLE
Fix Spike --device option to pass on args to downstream plugins

### DIFF
--- a/ci-tests/testlib.c
+++ b/ci-tests/testlib.c
@@ -29,7 +29,7 @@ int main()
             hartids,
             false,
             4);
-  std::vector<const device_factory_t*> plugin_devices;
+  std::vector<device_factory_t*> plugin_devices;
   std::vector<std::string> htif_args {"pk", "hello"};
   debug_module_config_t dm_config = {
     .progbufsize = 2,

--- a/riscv/abstract_device.h
+++ b/riscv/abstract_device.h
@@ -8,6 +8,7 @@
 #include <string>
 #include <map>
 #include <stdexcept>
+#include <vector>
 
 class sim_t;
 
@@ -26,10 +27,15 @@ public:
   virtual abstract_device_t* parse_from_fdt(const void* fdt, const sim_t* sim, reg_t* base) const = 0;
   virtual std::string generate_dts(const sim_t* sim) const = 0;
   virtual ~device_factory_t() {}
+  void set_sargs(std::vector<std::string> sargs) { this->sargs = sargs; }
+  std::vector<std::string> get_sargs() { return sargs; }
+
+protected:
+  std::vector<std::string> sargs;
 };
 
 // Type for holding all registered MMIO plugins by name.
-using mmio_device_map_t = std::map<std::string, const device_factory_t*>;
+using mmio_device_map_t = std::map<std::string, device_factory_t*>;
 
 mmio_device_map_t& mmio_device_map();
 
@@ -40,8 +46,8 @@ mmio_device_map_t& mmio_device_map();
     std::string str(#name); \
     if (!mmio_device_map().emplace(str, this).second) throw std::runtime_error("Plugin \"" + str + "\" already registered"); \
   }; \
-  name##_t* parse_from_fdt(const void* fdt, const sim_t* sim, reg_t* base) const override { return parse(fdt, sim, base); } \
+  name##_t* parse_from_fdt(const void* fdt, const sim_t* sim, reg_t* base) const override { return parse(fdt, sim, base, sargs); } \
   std::string generate_dts(const sim_t* sim) const override { return generate(sim); } \
-  }; const device_factory_t *name##_factory = new name##_factory_t();
+  }; device_factory_t *name##_factory = new name##_factory_t();
 
 #endif

--- a/riscv/clint.cc
+++ b/riscv/clint.cc
@@ -116,7 +116,8 @@ void clint_t::tick(reg_t rtc_ticks)
   }
 }
 
-clint_t* clint_parse_from_fdt(const void* fdt, const sim_t* sim, reg_t* base) {
+clint_t* clint_parse_from_fdt(const void* fdt, const sim_t* sim, reg_t* base,
+    const std::vector<std::string>& sargs) {
   if (fdt_parse_clint(fdt, base, "riscv,clint0") == 0)
     return new clint_t(sim,
                        sim->CPU_HZ / sim->INSNS_PER_RTC_TICK,

--- a/riscv/ns16550.cc
+++ b/riscv/ns16550.cc
@@ -341,7 +341,7 @@ std::string ns16550_generate_dts(const sim_t* sim)
   return s.str();
 }
 
-ns16550_t* ns16550_parse_from_fdt(const void* fdt, const sim_t* sim, reg_t* base)
+ns16550_t* ns16550_parse_from_fdt(const void* fdt, const sim_t* sim, reg_t* base, const std::vector<std::string>& sargs)
 {
   uint32_t ns16550_shift, ns16550_io_width, ns16550_int_id;
   if (fdt_parse_ns16550(fdt, base,

--- a/riscv/plic.cc
+++ b/riscv/plic.cc
@@ -415,7 +415,7 @@ std::string plic_generate_dts(const sim_t* sim)
   return s.str();
 }
 
-plic_t* plic_parse_from_fdt(const void* fdt, const sim_t* sim, reg_t* base)
+plic_t* plic_parse_from_fdt(const void* fdt, const sim_t* sim, reg_t* base, const std::vector<std::string>& sargs)
 {
   uint32_t plic_ndev;
   if (fdt_parse_plic(fdt, base, &plic_ndev, "riscv,plic0") == 0)

--- a/riscv/sim.cc
+++ b/riscv/sim.cc
@@ -38,7 +38,7 @@ extern device_factory_t* ns16550_factory;
 
 sim_t::sim_t(const cfg_t *cfg, bool halted,
              std::vector<std::pair<reg_t, abstract_mem_t*>> mems,
-             std::vector<const device_factory_t*> plugin_device_factories,
+             std::vector<device_factory_t*> plugin_device_factories,
              const std::vector<std::string>& args,
              const debug_module_config_t &dm_config,
              const char *log_path,

--- a/riscv/sim.h
+++ b/riscv/sim.h
@@ -27,7 +27,7 @@ class sim_t : public htif_t, public simif_t
 public:
   sim_t(const cfg_t *cfg, bool halted,
         std::vector<std::pair<reg_t, abstract_mem_t*>> mems,
-        std::vector<const device_factory_t*> plugin_device_factories,
+        std::vector<device_factory_t*> plugin_device_factories,
         const std::vector<std::string>& args,
         const debug_module_config_t &dm_config, const char *log_path,
         bool dtb_enabled, const char *dtb_file,


### PR DESCRIPTION
Relate to this PR https://github.com/ucb-bar/spike-devices/pull/2.
Basically, as the MMIO devices are suppose to be implemented as plugins, we need a way to pass down arguments to the plugins from the top.
Hence, we change the `--device` option to specify the name of the device along with the arguments.
E.g., `--device="mydevice,arg1=hello"`.