### PR TITLE
miselect: support miselect when enabling smcsrind

### DIFF
--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -543,6 +543,9 @@ void state_t::reset(processor_t* const proc, reg_t max_isa)
   sscsrind_reg_csr_t::sscsrind_reg_csr_t_p vsireg[6];
 
   if (proc->extension_enabled_const(EXT_SMCSRIND)) {
+    miselect = std::make_shared<basic_csr_t>(proc, CSR_MISELECT, 0);
+    csrmap[CSR_MISELECT] = miselect;
+
     const reg_t mireg_csrs[] = { CSR_MIREG, CSR_MIREG2, CSR_MIREG3, CSR_MIREG4, CSR_MIREG5, CSR_MIREG6 };
     auto i = 0;
     for (auto csr : mireg_csrs) {

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -535,15 +535,12 @@ void state_t::reset(processor_t* const proc, reg_t max_isa)
 
 
   // Smcsrind / Sscsrind
-  csr_t_p miselect;
-  csr_t_p siselect;
-  csr_t_p vsiselect;
   sscsrind_reg_csr_t::sscsrind_reg_csr_t_p mireg[6];
   sscsrind_reg_csr_t::sscsrind_reg_csr_t_p sireg[6];
   sscsrind_reg_csr_t::sscsrind_reg_csr_t_p vsireg[6];
 
   if (proc->extension_enabled_const(EXT_SMCSRIND)) {
-    miselect = std::make_shared<basic_csr_t>(proc, CSR_MISELECT, 0);
+    csr_t_p miselect = std::make_shared<basic_csr_t>(proc, CSR_MISELECT, 0);
     csrmap[CSR_MISELECT] = miselect;
 
     const reg_t mireg_csrs[] = { CSR_MIREG, CSR_MIREG2, CSR_MIREG3, CSR_MIREG4, CSR_MIREG5, CSR_MIREG6 };
@@ -555,9 +552,9 @@ void state_t::reset(processor_t* const proc, reg_t max_isa)
   }
 
   if (proc->extension_enabled_const(EXT_SSCSRIND)) {
-    vsiselect = std::make_shared<basic_csr_t>(proc, CSR_VSISELECT, 0);
+    csr_t_p vsiselect = std::make_shared<basic_csr_t>(proc, CSR_VSISELECT, 0);
     csrmap[CSR_VSISELECT] = vsiselect;
-    siselect = std::make_shared<basic_csr_t>(proc, CSR_SISELECT, 0);
+    csr_t_p siselect = std::make_shared<basic_csr_t>(proc, CSR_SISELECT, 0);
     csrmap[CSR_SISELECT] = std::make_shared<virtualized_csr_t>(proc, siselect, vsiselect);
 
     const reg_t vsireg_csrs[] = { CSR_VSIREG, CSR_VSIREG2, CSR_VSIREG3, CSR_VSIREG4, CSR_VSIREG5, CSR_VSIREG6 };


### PR DESCRIPTION
This commit adds the missing miselect CSR.