### PR TITLE
Add default cfg_t and debug_module_config_t constructor to libriscv

### DIFF
--- a/ci-tests/testlib.c
+++ b/ci-tests/testlib.c
@@ -14,21 +14,7 @@ static std::vector<std::pair<reg_t, abstract_mem_t*>> make_mems(const std::vecto
 
 int main()
 {
-  std::vector<mem_cfg_t> mem_cfg { mem_cfg_t(0x80000000, 0x10000000) };
-  std::vector<size_t> hartids = {0};
-  cfg_t cfg(std::make_pair(0, 0),
-            nullptr,
-            "rv64gcv",
-            "MSU",
-            "vlen:128,elen:64",
-            false,
-            endianness_little,
-            16,
-            (1 << PMP_SHIFT),
-            mem_cfg,
-            hartids,
-            false,
-            4);
+  cfg_t cfg;
   std::vector<device_factory_t*> plugin_devices;
   std::vector<std::string> htif_args {"pk", "hello"};
   debug_module_config_t dm_config = {

--- a/ci-tests/testlib.c
+++ b/ci-tests/testlib.c
@@ -43,7 +43,7 @@ int main()
     .support_impebreak = true
   };
   std::vector<std::pair<reg_t, abstract_mem_t*>> mems =
-      make_mems(cfg.mem_layout());
+      make_mems(cfg.mem_layout);
   sim_t sim(&cfg, false,
             mems,
             plugin_devices,

--- a/ci-tests/testlib.c
+++ b/ci-tests/testlib.c
@@ -17,17 +17,7 @@ int main()
   cfg_t cfg;
   std::vector<device_factory_t*> plugin_devices;
   std::vector<std::string> htif_args {"pk", "hello"};
-  debug_module_config_t dm_config = {
-    .progbufsize = 2,
-    .max_sba_data_width = 0,
-    .require_authentication = false,
-    .abstract_rti = 0,
-    .support_hasel = true,
-    .support_abstract_csr_access = true,
-    .support_abstract_fpr_access = true,
-    .support_haltgroups = true,
-    .support_impebreak = true
-  };
+  debug_module_config_t dm_config;
   std::vector<std::pair<reg_t, abstract_mem_t*>> mems =
       make_mems(cfg.mem_layout);
   sim_t sim(&cfg, false,

--- a/riscv/cfg.cc
+++ b/riscv/cfg.cc
@@ -3,6 +3,8 @@
 #include "cfg.h"
 #include "mmu.h"
 #include "decode.h"
+#include "encoding.h"
+#include "platform.h"
 
 mem_cfg_t::mem_cfg_t(reg_t base, reg_t size) : base(base), size(size)
 {
@@ -24,4 +26,23 @@ bool mem_cfg_t::check_if_supported(reg_t base, reg_t size)
          (base % PGSIZE == 0) &&
          (size > 0) &&
          ((base + size > base) || (base + size == 0));
+}
+
+cfg_t::cfg_t()
+{
+  // The default system configuration
+  initrd_bounds    = std::make_pair((reg_t)0, (reg_t)0);
+  bootargs         = nullptr;
+  isa              = DEFAULT_ISA;
+  priv             = DEFAULT_PRIV;
+  varch            = DEFAULT_VARCH;
+  misaligned       = false;
+  endianness       = endianness_little;
+  pmpregions       = 16;
+  pmpgranularity   = (1 << PMP_SHIFT);
+  mem_layout       = std::vector<mem_cfg_t>({mem_cfg_t(reg_t(DRAM_BASE), (size_t)2048 << 20)});
+  hartids          = std::vector<size_t>({0});
+  explicit_hartids = false;
+  real_time_clint  = false;
+  trigger_count    = 4;
 }

--- a/riscv/cfg.h
+++ b/riscv/cfg.h
@@ -88,6 +88,7 @@ public:
       real_time_clint(default_real_time_clint),
       trigger_count(default_trigger_count)
   {}
+  cfg_t();
 
   std::pair<reg_t, reg_t> initrd_bounds;
   const char *            bootargs;

--- a/riscv/cfg.h
+++ b/riscv/cfg.h
@@ -89,24 +89,24 @@ public:
       trigger_count(default_trigger_count)
   {}
 
-  cfg_arg_t<std::pair<reg_t, reg_t>> initrd_bounds;
-  cfg_arg_t<const char *>            bootargs;
-  cfg_arg_t<const char *>            isa;
-  cfg_arg_t<const char *>            priv;
-  cfg_arg_t<const char *>            varch;
-  bool                               misaligned;
-  endianness_t                       endianness;
-  reg_t                              pmpregions;
-  reg_t                              pmpgranularity;
-  cfg_arg_t<std::vector<mem_cfg_t>>  mem_layout;
-  std::optional<reg_t>               start_pc;
-  cfg_arg_t<std::vector<size_t>>     hartids;
-  bool                               explicit_hartids;
-  cfg_arg_t<bool>                    real_time_clint;
-  reg_t                              trigger_count;
+  std::pair<reg_t, reg_t> initrd_bounds;
+  const char *            bootargs;
+  const char *            isa;
+  const char *            priv;
+  const char *            varch;
+  bool                    misaligned;
+  endianness_t            endianness;
+  reg_t                   pmpregions;
+  reg_t                   pmpgranularity;
+  std::vector<mem_cfg_t>  mem_layout;
+  std::optional<reg_t>    start_pc;
+  std::vector<size_t>     hartids;
+  bool                    explicit_hartids;
+  bool                    real_time_clint;
+  reg_t                   trigger_count;
 
-  size_t nprocs() const { return hartids().size(); }
-  size_t max_hartid() const { return hartids().back(); }
+  size_t nprocs() const { return hartids.size(); }
+  size_t max_hartid() const { return hartids.back(); }
 };
 
 #endif

--- a/riscv/cfg.h
+++ b/riscv/cfg.h
@@ -61,33 +61,6 @@ private:
 class cfg_t
 {
 public:
-  cfg_t(std::pair<reg_t, reg_t> default_initrd_bounds,
-        const char *default_bootargs,
-        const char *default_isa, const char *default_priv,
-        const char *default_varch,
-        const bool default_misaligned,
-        const endianness_t default_endianness,
-        const reg_t default_pmpregions,
-        const reg_t default_pmpgranularity,
-        const std::vector<mem_cfg_t> &default_mem_layout,
-        const std::vector<size_t> default_hartids,
-        bool default_real_time_clint,
-        const reg_t default_trigger_count)
-    : initrd_bounds(default_initrd_bounds),
-      bootargs(default_bootargs),
-      isa(default_isa),
-      priv(default_priv),
-      varch(default_varch),
-      misaligned(default_misaligned),
-      endianness(default_endianness),
-      pmpregions(default_pmpregions),
-      pmpgranularity(default_pmpgranularity),
-      mem_layout(default_mem_layout),
-      hartids(default_hartids),
-      explicit_hartids(false),
-      real_time_clint(default_real_time_clint),
-      trigger_count(default_trigger_count)
-  {}
   cfg_t();
 
   std::pair<reg_t, reg_t> initrd_bounds;

--- a/riscv/clint.cc
+++ b/riscv/clint.cc
@@ -121,7 +121,7 @@ clint_t* clint_parse_from_fdt(const void* fdt, const sim_t* sim, reg_t* base,
   if (fdt_parse_clint(fdt, base, "riscv,clint0") == 0)
     return new clint_t(sim,
                        sim->CPU_HZ / sim->INSNS_PER_RTC_TICK,
-                       sim->get_cfg().real_time_clint());
+                       sim->get_cfg().real_time_clint);
   else
     return nullptr;
 }

--- a/riscv/debug_module.cc
+++ b/riscv/debug_module.cc
@@ -514,7 +514,7 @@ bool debug_module_t::dmi_read(unsigned address, uint32_t *value)
           unsigned base = hawindowsel * 32;
           for (unsigned i = 0; i < 32; i++) {
             unsigned n = base + i;
-            if (n < sim->get_cfg().nprocs() && hart_array_mask[sim->get_cfg().hartids()[n]]) {
+            if (n < sim->get_cfg().nprocs() && hart_array_mask[sim->get_cfg().hartids[n]]) {
               result |= 1 << i;
             }
           }
@@ -916,7 +916,7 @@ bool debug_module_t::dmi_write(unsigned address, uint32_t value)
           for (unsigned i = 0; i < 32; i++) {
             unsigned n = base + i;
             if (n < sim->get_cfg().nprocs()) {
-              hart_array_mask[sim->get_cfg().hartids()[n]] = (value >> i) & 1;
+              hart_array_mask[sim->get_cfg().hartids[n]] = (value >> i) & 1;
             }
           }
         }
@@ -1030,5 +1030,5 @@ hart_debug_state_t& debug_module_t::selected_hart_state()
 
 size_t debug_module_t::selected_hart_id() const
 {
-  return sim->get_cfg().hartids().at(dmcontrol.hartsel);
+  return sim->get_cfg().hartids.at(dmcontrol.hartsel);
 }

--- a/riscv/debug_module.h
+++ b/riscv/debug_module.h
@@ -14,15 +14,15 @@ class processor_t;
 typedef struct {
   // Size of program_buffer in 32-bit words, as exposed to the rest of the
   // world.
-  unsigned progbufsize;
-  unsigned max_sba_data_width;
-  bool require_authentication;
-  unsigned abstract_rti;
-  bool support_hasel;
-  bool support_abstract_csr_access;
-  bool support_abstract_fpr_access;
-  bool support_haltgroups;
-  bool support_impebreak;
+  unsigned progbufsize = 2;
+  unsigned max_sba_data_width = 0;
+  bool require_authentication = false;
+  unsigned abstract_rti = 0;
+  bool support_hasel = true;
+  bool support_abstract_csr_access = true;
+  bool support_abstract_fpr_access = true;
+  bool support_haltgroups = true;
+  bool support_impebreak = true;
 } debug_module_config_t;
 
 typedef struct {

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -54,7 +54,7 @@ processor_t::processor_t(const isa_parser_t *isa, const cfg_t *cfg,
   }
 #endif
 
-  parse_varch_string(cfg->varch());
+  parse_varch_string(cfg->varch);
 
   register_base_instructions();
   mmu = new mmu_t(sim, cfg->endianness, this);

--- a/riscv/sim.cc
+++ b/riscv/sim.cc
@@ -46,7 +46,7 @@ sim_t::sim_t(const cfg_t *cfg, bool halted,
              bool socket_enabled,
              FILE *cmd_file) // needed for command line option --cmd
   : htif_t(args),
-    isa(cfg->isa(), cfg->priv()),
+    isa(cfg->isa, cfg->priv),
     cfg(cfg),
     mems(mems),
     procs(std::max(cfg->nprocs(), size_t(1))),
@@ -99,9 +99,9 @@ sim_t::sim_t(const cfg_t *cfg, bool halted,
   debug_mmu = new mmu_t(this, cfg->endianness, NULL);
 
   for (size_t i = 0; i < cfg->nprocs(); i++) {
-    procs[i] = new processor_t(&isa, cfg, this, cfg->hartids()[i], halted,
+    procs[i] = new processor_t(&isa, cfg, this, cfg->hartids[i], halted,
                                log_file.get(), sout_);
-    harts[cfg->hartids()[i]] = procs[i];
+    harts[cfg->hartids[i]] = procs[i];
   }
 
   // When running without using a dtb, skip the fdt-based configuration steps
@@ -134,13 +134,13 @@ sim_t::sim_t(const cfg_t *cfg, bool halted,
     strstream << fin.rdbuf();
     dtb = strstream.str();
   } else {
-    std::pair<reg_t, reg_t> initrd_bounds = cfg->initrd_bounds();
+    std::pair<reg_t, reg_t> initrd_bounds = cfg->initrd_bounds;
     std::string device_nodes;
     for (const device_factory_t *factory : device_factories)
       device_nodes.append(factory->generate_dts(this));
     dts = make_dts(INSNS_PER_RTC_TICK, CPU_HZ,
                    initrd_bounds.first, initrd_bounds.second,
-                   cfg->bootargs(), cfg->pmpregions, cfg->pmpgranularity,
+                   cfg->bootargs, cfg->pmpregions, cfg->pmpgranularity,
                    procs, mems, device_nodes);
     dtb = dts_compile(dts);
   }

--- a/spike_main/spike-log-parser.cc
+++ b/spike_main/spike-log-parser.cc
@@ -28,19 +28,7 @@ int main(int UNUSED argc, char** argv)
   parser.option(0, "isa", 1, [&](const char* s){isa_string = s;});
   parser.parse(argv);
 
-  cfg_t cfg(/*default_initrd_bounds=*/std::make_pair((reg_t)0, (reg_t)0),
-            /*default_bootargs=*/nullptr,
-            /*default_isa=*/DEFAULT_ISA,
-            /*default_priv=*/DEFAULT_PRIV,
-            /*default_varch=*/DEFAULT_VARCH,
-            /*default_misaligned=*/false,
-            /*default_endianness*/endianness_little,
-            /*default_pmpregions=*/16,
-            /*default_pmpgranularity=*/(1 << PMP_SHIFT),
-            /*default_mem_layout=*/std::vector<mem_cfg_t>(),
-            /*default_hartids=*/std::vector<size_t>(),
-            /*default_real_time_clint=*/false,
-            /*default_trigger_count=*/4);
+  cfg_t cfg;
 
   isa_parser_t isa(isa_string, DEFAULT_PRIV);
   processor_t p(&isa, &cfg, 0, 0, false, nullptr, cerr);

--- a/spike_main/spike.cc
+++ b/spike_main/spike.cc
@@ -493,10 +493,10 @@ int main(int argc, char** argv)
     help();
 
   std::vector<std::pair<reg_t, abstract_mem_t*>> mems =
-      make_mems(cfg.mem_layout());
+      make_mems(cfg.mem_layout);
 
   if (kernel && check_file_exists(kernel)) {
-    const char *isa = cfg.isa();
+    const char *isa = cfg.isa;
     kernel_size = get_file_size(kernel);
     if (isa[2] == '6' && isa[3] == '4')
       kernel_offset = 0x200000;

--- a/spike_main/spike.cc
+++ b/spike_main/spike.cc
@@ -348,17 +348,7 @@ int main(int argc, char** argv)
   bool use_rbb = false;
   unsigned dmi_rti = 0;
   reg_t blocksz = 64;
-  debug_module_config_t dm_config = {
-    .progbufsize = 2,
-    .max_sba_data_width = 0,
-    .require_authentication = false,
-    .abstract_rti = 0,
-    .support_hasel = true,
-    .support_abstract_csr_access = true,
-    .support_abstract_fpr_access = true,
-    .support_haltgroups = true,
-    .support_impebreak = true
-  };
+  debug_module_config_t dm_config;
   cfg_arg_t<size_t> nprocs(1);
 
   cfg_t cfg;

--- a/spike_main/spike.cc
+++ b/spike_main/spike.cc
@@ -361,19 +361,7 @@ int main(int argc, char** argv)
   };
   cfg_arg_t<size_t> nprocs(1);
 
-  cfg_t cfg(/*default_initrd_bounds=*/std::make_pair((reg_t)0, (reg_t)0),
-            /*default_bootargs=*/nullptr,
-            /*default_isa=*/DEFAULT_ISA,
-            /*default_priv=*/DEFAULT_PRIV,
-            /*default_varch=*/DEFAULT_VARCH,
-            /*default_misaligned=*/false,
-            /*default_endianness*/endianness_little,
-            /*default_pmpregions=*/16,
-            /*default_pmpgranularity=*/(1 << PMP_SHIFT),
-            /*default_mem_layout=*/parse_mem_layout("2048"),
-            /*default_hartids=*/std::vector<size_t>(),
-            /*default_real_time_clint=*/false,
-            /*default_trigger_count=*/4);
+  cfg_t cfg;
 
   auto const device_parser = [&plugin_device_factories](const char *s) {
     const std::string device_args(s);


### PR DESCRIPTION
Adding additional config options to cfg_t has, up to now, required propagating the flag to all code which instantiates cfg_t, including projects which use Spike as a library.

Now, the default constructor for `cfg_t` will construct the default spike parameters.

This should be merged after #1522 to avoid merge conflicts.