### PR TITLE
Per-commit CI should start from oldest commit

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -29,7 +29,7 @@ jobs:
         run: sudo xargs apt-get install -y < .github/workflows/apt-packages.txt
 
       - run: |
-          for commit in $(git rev-list origin/master..HEAD); do
+          for commit in $(git rev-list origin/master..HEAD | tac); do
             git checkout $commit
             echo "Checking commit $commit"
             ci-tests/build-spike
@@ -49,7 +49,7 @@ jobs:
         run: xargs brew install --overwrite < .github/workflows/brew-packages.txt
 
       - run: |
-          for commit in $(git rev-list origin/master..HEAD); do
+          for commit in $(git rev-list origin/master..HEAD | tail -r); do
             git checkout $commit
             echo "Checking commit $commit"
             ci-tests/build-spike


### PR DESCRIPTION
QoL improvement for debugging the CI logs