### PR TITLE
zip and unzip of Zbkb require RV32

### DIFF
--- a/riscv/insns/shfli.h
+++ b/riscv/insns/shfli.h
@@ -1,4 +1,5 @@
 // Zbkb contains zip but not general shfli
+require_rv32;
 require(((insn.rs2() == (xlen / 2 - 1)) && p->extension_enabled(EXT_ZBKB)));
 require(SHAMT < (xlen/2));
 reg_t x = RS1;

--- a/riscv/insns/unshfli.h
+++ b/riscv/insns/unshfli.h
@@ -1,4 +1,5 @@
 // Zbkb contains unzip but not general unshfli
+require_rv32;
 require(((insn.rs2() == (xlen / 2 - 1)) && p->extension_enabled(EXT_ZBKB)));
 require(SHAMT < (xlen/2));
 reg_t x = RS1;


### PR DESCRIPTION
The zip (shfli) and unzip (unshfli) of Zbk require RV32.

This commit adds the requirement check with minimal modification. (Given that zip/unzip is a special case of shfli/unshfli.)

Reference: https://five-embeddev.com/riscv-bitmanip/draft/bitmanip.html#zbkb