### PR TITLE
Fix order of H extension in ISA string

### DIFF
--- a/disasm/disasm.cc
+++ b/disasm/disasm.cc
@@ -2390,7 +2390,7 @@ disassembler_t::disassembler_t(const isa_parser_t *isa)
 
   // next-highest priority: other instructions in same base ISA
   std::string fallback_isa_string = std::string("rv") + std::to_string(isa->get_max_xlen()) +
-    "gqchv_zfh_zba_zbb_zbc_zbs_zcb_zicbom_zicboz_zicond_zkn_zkr_zks_svinval_zcmop_zimop";
+    "gqcvh_zfh_zba_zbb_zbc_zbs_zcb_zicbom_zicboz_zicond_zkn_zkr_zks_svinval_zcmop_zimop";
   isa_parser_t fallback_isa(fallback_isa_string.c_str(), DEFAULT_PRIV);
   add_instructions(&fallback_isa);
 

--- a/disasm/isa_parser.cc
+++ b/disasm/isa_parser.cc
@@ -29,7 +29,7 @@ static void bad_priv_string(const char* priv)
 isa_parser_t::isa_parser_t(const char* str, const char *priv)
 {
   isa_string = strtolower(str);
-  const char* all_subsets = "mafdqchpv";
+  const char* all_subsets = "mafdqcpvh";
 
   if (isa_string.compare(0, 4, "rv32") == 0)
     max_xlen = 32;


### PR DESCRIPTION
According to Subset Naming Convention section of ISA Manual Volume I, H extension should be after V extension in ISA string.