### PR TITLE
vcpop.m, vfirst.m: delete unnecessary VSTART write.

### DIFF
--- a/riscv/insns/vcpop_m.h
+++ b/riscv/insns/vcpop_m.h
@@ -17,5 +17,4 @@ for (reg_t i=P.VU.vstart->read(); i<vl; ++i) {
     popcount += (vs2_lsb && do_mask);
   }
 }
-P.VU.vstart->write(0);
 WRITE_RD(popcount);

--- a/riscv/insns/vfirst_m.h
+++ b/riscv/insns/vfirst_m.h
@@ -14,5 +14,4 @@ for (reg_t i=P.VU.vstart->read(); i < vl; ++i) {
     break;
   }
 }
-P.VU.vstart->write(0);
 WRITE_RD(pos);


### PR DESCRIPTION
An updated PR of previous closed [#1570](https://github.com/riscv-software-src/riscv-isa-sim/pull/1570)