### PR TITLE
PLIC: Implement threshold masking

### DIFF
--- a/riscv/plic.cc
+++ b/riscv/plic.cc
@@ -113,6 +113,15 @@ uint32_t plic_t::context_best_pending(const plic_context_t *c)
     }
   }
 
+  /*
+  From Spec 1.0.0: 6. Priority Thresholds
+  The PLIC will mask all PLIC interrupts of a priority less than or equal to
+  threshold.
+  */
+  if (best_id_prio <= c->priority_threshold) {
+    return 0;
+  }
+
   return best_id;
 }
 


### PR DESCRIPTION
Settings a priority threshold in the PLIC device does currently not mask any interrupts. (The member `priority_threshold` of `plic_context_t` only appears in `plic_t::context_read` and `plic_t::context_write`). This small fix in `plic_t::context_best_pending` fixes the missing threshold masking.