### PR TITLE
Adjust wide_counter_csr_t::written_value() to only increment if counting is enabled, Bug Fix for PR 1381

### DIFF
--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -1038,7 +1038,7 @@ bool wide_counter_csr_t::unlogged_write(const reg_t val) noexcept {
 
 reg_t wide_counter_csr_t::written_value() const noexcept {
   // Re-adjust for upcoming bump()
-  return this->val + 1;
+  return val + (is_counting_enabled() ? 1 : 0);
 }
 
 // Returns true if counting is not inhibited by Smcntrpmf.


### PR DESCRIPTION
There looks to be a bug in the `wide_counter_csr_t::written_value()` when `is_counting_enabled() == false`. This bug was introduced in [PR 1381](https://github.com/riscv-software-src/riscv-isa-sim/pull/1381/commits), specifically in c927773dd1584d870dd60a1cf86c0a8f0d138dd4.

The control flow for this is:
```
void csr_t::write(const reg_t val) noexcept {
  const bool success = unlogged_write(val);
  if (success) {
    log_write();
  }
}
```
First calls `unlogged_write()`
```
bool wide_counter_csr_t::unlogged_write(const reg_t val) noexcept {
  this->val = val;
  // The ISA mandates that if an instruction writes instret, the write
  // takes precedence over the increment to instret.  However, Spike
  // unconditionally increments instret after executing an instruction.
  // Correct for this artifact by decrementing instret here.
  // Ensure that Smctrpmf hasn't disabled counting.
  if (is_counting_enabled()) {
    this->val--;
  }
  return true;
}
```
If `!is_counting_enabled()`, then `this->val` is not decremented.

However, `log_write()` calls `written_value()`
```
void csr_t::log_write() const noexcept {
  log_special_write(address, written_value());
}
```
```
reg_t wide_counter_csr_t::written_value() const noexcept {
  // Re-adjust for upcoming bump()
  return val + 1;
}
```
Which reports back an adjust version of `val` regardless.


@atulkharerivos could you please review this change