### PR TITLE
Upgrade Spike to compile with c++2a and use designated initializers

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -94,7 +94,7 @@ VPATH := $(addprefix $(src_dir)/, $(sprojs_enabled))
 # highest.
 
 default-CFLAGS   := -DPREFIX=\"$(prefix)\" -Wall -Wno-unused -Wno-nonportable-include-path -g -O2 -fPIC
-default-CXXFLAGS := $(default-CFLAGS) -std=c++17
+default-CXXFLAGS := $(default-CFLAGS) -std=c++2a
 
 mcppbs-CPPFLAGS := @CPPFLAGS@
 mcppbs-CFLAGS   := $(default-CFLAGS) @CFLAGS@

--- a/riscv/mmu.cc
+++ b/riscv/mmu.cc
@@ -70,7 +70,7 @@ reg_t mmu_t::translate(mem_access_info_t access_info, reg_t len)
 
 tlb_entry_t mmu_t::fetch_slow_path(reg_t vaddr)
 {
-  auto access_info = generate_access_info(vaddr, FETCH, {false, false, false});
+  auto access_info = generate_access_info(vaddr, FETCH, {});
   check_triggers(triggers::OPERATION_EXECUTE, vaddr, access_info.effective_virt);
 
   tlb_entry_t result;


### PR DESCRIPTION
See discussion here: https://github.com/riscv-software-src/riscv-isa-sim/pull/1560#discussion_r1447285791

This would clobber some of the changes made in [PR:1560](https://github.com/riscv-software-src/riscv-isa-sim/pull/1560) so I was waiting for that PR to merge before posting this. However, might make sense to merge this in before to allow some of the changes there to be cleaned up.

If you want to wait, I can rebase this branch onto master once 1560 is merged.