### PR TITLE
Fix hvip.VSEIP and hvip.VSTIP so they don't observe platform-specific interrupts

### DIFF
--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -728,6 +728,10 @@ mip_csr_t::mip_csr_t(processor_t* const proc, const reg_t addr):
   mip_or_mie_csr_t(proc, addr) {
 }
 
+reg_t mip_csr_t::read() const noexcept {
+  return val | state->hvip->basic_csr_t::read();
+}
+
 void mip_csr_t::backdoor_write_with_mask(const reg_t mask, const reg_t val) noexcept {
   this->val = (this->val & ~mask) | (val & mask);
 }
@@ -1716,4 +1720,17 @@ void srmcfg_csr_t::verify_permissions(insn_t insn, bool write) const {
 
   if (state->v)
       throw trap_virtual_instruction(insn.bits());
+}
+
+hvip_csr_t::hvip_csr_t(processor_t* const proc, const reg_t addr, const reg_t init):
+  basic_csr_t(proc, addr, init) {
+}
+
+reg_t hvip_csr_t::read() const noexcept {
+  return basic_csr_t::read() | (state->mip->read() & MIP_VSSIP); // hvip.VSSIP is an alias of mip.VSSIP
+}
+
+bool hvip_csr_t::unlogged_write(const reg_t val) noexcept {
+  state->mip->write_with_mask(MIP_VSSIP, val); // hvip.VSSIP is an alias of mip.VSSIP
+  return basic_csr_t::unlogged_write(val & (MIP_VSEIP | MIP_VSTIP));
 }

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -349,7 +349,7 @@ typedef std::shared_ptr<misa_csr_t> misa_csr_t_p;
 class mip_or_mie_csr_t: public csr_t {
  public:
   mip_or_mie_csr_t(processor_t* const proc, const reg_t addr);
-  virtual reg_t read() const noexcept override final;
+  virtual reg_t read() const noexcept override;
 
   void write_with_mask(const reg_t mask, const reg_t val) noexcept;
 
@@ -364,6 +364,7 @@ class mip_or_mie_csr_t: public csr_t {
 class mip_csr_t: public mip_or_mie_csr_t {
  public:
   mip_csr_t(processor_t* const proc, const reg_t addr);
+  virtual reg_t read() const noexcept override final;
 
   // Does not log. Used by external things (clint) that wiggle bits in mip.
   void backdoor_write_with_mask(const reg_t mask, const reg_t val) noexcept;
@@ -850,4 +851,14 @@ class srmcfg_csr_t: public masked_csr_t {
   srmcfg_csr_t(processor_t* const proc, const reg_t addr, const reg_t mask, const reg_t init);
   virtual void verify_permissions(insn_t insn, bool write) const override;
 };
+
+class hvip_csr_t : public basic_csr_t {
+ public:
+  hvip_csr_t(processor_t* const proc, const reg_t addr, const reg_t init);
+  reg_t read() const noexcept override;
+ protected:
+  virtual bool unlogged_write(const reg_t val) noexcept override;
+};
+
+typedef std::shared_ptr<hvip_csr_t> hvip_csr_t_p;
 #endif

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -304,15 +304,6 @@ void state_t::reset(processor_t* const proc, reg_t max_isa)
     0              // shiftamt
   );
 
-  auto hvip_accr = std::make_shared<generic_int_accessor_t>(
-    this,
-    MIP_VS_MASK,   // read_mask
-    MIP_VS_MASK,   // ip_write_mask
-    MIP_VS_MASK,   // ie_write_mask
-    generic_int_accessor_t::mask_mode_t::NONE,
-    0              // shiftamt
-  );
-
   auto vsip_vsie_accr = std::make_shared<generic_int_accessor_t>(
     this,
     MIP_VS_MASK,   // read_mask
@@ -327,7 +318,7 @@ void state_t::reset(processor_t* const proc, reg_t max_isa)
   csrmap[CSR_VSIP] = vsip;
   csrmap[CSR_SIP] = std::make_shared<virtualized_csr_t>(proc, nonvirtual_sip, vsip);
   csrmap[CSR_HIP] = std::make_shared<mip_proxy_csr_t>(proc, CSR_HIP, hip_hie_accr);
-  csrmap[CSR_HVIP] = std::make_shared<mip_proxy_csr_t>(proc, CSR_HVIP, hvip_accr);
+  csrmap[CSR_HVIP] = hvip = std::make_shared<hvip_csr_t>(proc, CSR_HVIP, 0);
 
   auto nonvirtual_sie = std::make_shared<mie_proxy_csr_t>(proc, CSR_SIE, sip_sie_accr);
   auto vsie = std::make_shared<mie_proxy_csr_t>(proc, CSR_VSIE, vsip_vsie_accr);

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -128,6 +128,7 @@ struct state_t
   csr_t_p htval;
   csr_t_p htinst;
   csr_t_p hgatp;
+  hvip_csr_t_p hvip;
   sstatus_csr_t_p sstatus;
   vsstatus_csr_t_p vsstatus;
   csr_t_p vstvec;


### PR DESCRIPTION
The H extension defines that bit VSEIP, VSTIP, and VSSIP of hvip are writable. (The other bits of hvip are read-only 0.) Only the VSSIP of hip (mip) is an alias of the same bit of hvip. The VSEIP and VSTIP of hip are the logical-OR of ones of hvip and other sources.

The current aliasing (proxy) implementation does not provide the desired behavior. An ISA-level behavior difference is that any platform-specific external and timer interrupt signals directed to VS-level should not be observable through the hvip. For instance, the hvip should not observe the virtual timer interrupt signal from the Sstc extension (vstimecmp CSR), which isn't true in the current implementation.

This commit fixes the issue by giving the hvip a specialized class, hvip_csr_t. The hvip_csr_t aliases the hvip.VSSIP to the mip.VSSIP but decouples the hvip.VSEIP and hvip.VSTIP from mip.VSEIP and mip.VSTIP. Additionally, the commit updates the read value of mip to be the logical-OR of hvip.VSEIP and hvip.VSTIP and other sources.

![image](https://github.com/riscv-software-src/riscv-isa-sim/assets/39526191/9c23e823-417b-4bcb-b68d-b10f6008a01f)
![image](https://github.com/riscv-software-src/riscv-isa-sim/assets/39526191/6ed55790-efbc-400d-bf9b-fe67b3d0183d)
