### PR TITLE
Agnostic: Add support for "write ones" agnostic policy of vector arithmetic instructions.

### DIFF
--- a/riscv/insns/vcompress_vm.h
+++ b/riscv/insns/vcompress_vm.h
@@ -16,7 +16,7 @@ VI_GENERAL_LOOP_BASE(1)
   switch (sew) {
   case e8:
     if (1 == P.VU.vta) {
-      P.VU.elt<uint8_t>(rd_num, i) = 0xFF;
+      P.VU.elt<uint8_t>(rd_num, i, true) = vector_agnostic(P.VU.elt<uint8_t>(rd_num, i, false)); \
     }
     if (do_mask && i < vl) {
       P.VU.elt<uint8_t>(rd_num, pos, true) = P.VU.elt<uint8_t>(rs2_num, i);
@@ -24,19 +24,19 @@ VI_GENERAL_LOOP_BASE(1)
     break;
   case e16:
     if (1 == P.VU.vta)
-      P.VU.elt<uint16_t>(rd_num, i) = 0xFFFF;
+      P.VU.elt<uint16_t>(rd_num, i, true) = vector_agnostic(P.VU.elt<uint16_t>(rd_num, i, false)); \
     if (do_mask && i < vl)
       P.VU.elt<uint16_t>(rd_num, pos, true) = P.VU.elt<uint16_t>(rs2_num, i);
     break;
   case e32:
     if (1 == P.VU.vta)
-      P.VU.elt<uint32_t>(rd_num, i) = 0xFFFFFFFF;
+      P.VU.elt<uint32_t>(rd_num, i, true) = vector_agnostic(P.VU.elt<uint32_t>(rd_num, i, false)); \
     if (do_mask && i < vl)
       P.VU.elt<uint32_t>(rd_num, pos, true) = P.VU.elt<uint32_t>(rs2_num, i);
     break;
   default:
     if (1 == P.VU.vta)
-      P.VU.elt<uint64_t>(rd_num, i) = 0xFFFFFFFFFFFFFFFF;
+      P.VU.elt<uint64_t>(rd_num, i, true) = vector_agnostic(P.VU.elt<uint64_t>(rd_num, i, false)); \
     if (do_mask && i < vl)
       P.VU.elt<uint64_t>(rd_num, pos, true) = P.VU.elt<uint64_t>(rs2_num, i);
     break;

--- a/riscv/insns/vcompress_vm.h
+++ b/riscv/insns/vcompress_vm.h
@@ -12,22 +12,37 @@ VI_GENERAL_LOOP_BASE
   const int mpos = i % 64;
 
   bool do_mask = (P.VU.elt<uint64_t>(rs1_num, midx) >> mpos) & 0x1;
-  if (do_mask) {
-    switch (sew) {
-    case e8:
-      P.VU.elt<uint8_t>(rd_num, pos, true) = P.VU.elt<uint8_t>(rs2_num, i);
-      break;
-    case e16:
-      P.VU.elt<uint16_t>(rd_num, pos, true) = P.VU.elt<uint16_t>(rs2_num, i);
-      break;
-    case e32:
-      P.VU.elt<uint32_t>(rd_num, pos, true) = P.VU.elt<uint32_t>(rs2_num, i);
-      break;
-    default:
-      P.VU.elt<uint64_t>(rd_num, pos, true) = P.VU.elt<uint64_t>(rs2_num, i);
-      break;
-    }
 
-    ++pos;
+  switch (sew) {
+  case e8:
+    if (1 == P.VU.vta) {
+      P.VU.elt<uint8_t>(rd_num, i) = 0xFF;
+    }
+    if (do_mask && i < vl) {
+      P.VU.elt<uint8_t>(rd_num, pos, true) = P.VU.elt<uint8_t>(rs2_num, i);
+    }
+    break;
+  case e16:
+    if (1 == P.VU.vta)
+      P.VU.elt<uint16_t>(rd_num, i) = 0xFFFF;
+    if (do_mask && i < vl)
+      P.VU.elt<uint16_t>(rd_num, pos, true) = P.VU.elt<uint16_t>(rs2_num, i);
+    break;
+  case e32:
+    if (1 == P.VU.vta)
+      P.VU.elt<uint32_t>(rd_num, i) = 0xFFFFFFFF;
+    if (do_mask && i < vl)
+      P.VU.elt<uint32_t>(rd_num, pos, true) = P.VU.elt<uint32_t>(rs2_num, i);
+    break;
+  default:
+    if (1 == P.VU.vta)
+      P.VU.elt<uint64_t>(rd_num, i) = 0xFFFFFFFFFFFFFFFF;
+    if (do_mask && i < vl)
+      P.VU.elt<uint64_t>(rd_num, pos, true) = P.VU.elt<uint64_t>(rs2_num, i);
+    break;
   }
+
+  if(do_mask && i < vl)
+    ++pos;
+
 VI_LOOP_END;

--- a/riscv/insns/vcompress_vm.h
+++ b/riscv/insns/vcompress_vm.h
@@ -7,7 +7,7 @@ require_noover(insn.rd(), P.VU.vflmul, insn.rs1(), 1);
 
 reg_t pos = 0;
 
-VI_GENERAL_LOOP_BASE
+VI_GENERAL_LOOP_BASE(1)
   const int midx = i / 64;
   const int mpos = i % 64;
 

--- a/riscv/insns/vfirst_m.h
+++ b/riscv/insns/vfirst_m.h
@@ -6,7 +6,9 @@ reg_t rs2_num = insn.rs2();
 require(P.VU.vstart->read() == 0);
 reg_t pos = -1;
 for (reg_t i=P.VU.vstart->read(); i < vl; ++i) {
-  VI_LOOP_ELEMENT_SKIP()
+  VI_LOOP_ELEMENT_SKIP_NO_VMA_CHECK()
+  if(skip)
+    continue;
 
   bool vs2_lsb = ((P.VU.elt<uint64_t>(rs2_num, midx ) >> mpos) & 0x1) == 1;
   if (vs2_lsb) {

--- a/riscv/insns/vfmv_s_f.h
+++ b/riscv/insns/vfmv_s_f.h
@@ -31,16 +31,16 @@ if (vl > 0 && P.VU.vstart->read() < vl) {
     for (reg_t i = std::max(P.VU.vstart->read(), (long unsigned int)1); i < P.VU.VLEN/P.VU.vsew; ++i) {
       switch (P.VU.vsew) {
       case e16:
-        P.VU.elt<uint16_t>(rd_num, i, true) = 0xFFFF;
+        P.VU.elt<uint16_t>(rd_num, i, true) = vector_agnostic(P.VU.elt<uint16_t>(rd_num, i, false));
         break;
       case e32:
-        P.VU.elt<uint32_t>(rd_num, i, true) = 0xFFFFFFFF;
+        P.VU.elt<uint32_t>(rd_num, i, true) = vector_agnostic(P.VU.elt<uint32_t>(rd_num, i, false));
         break;
       default:
         if (FLEN == 64)
-          P.VU.elt<uint64_t>(rd_num, i, true) = 0xFFFFFFFFFFFFFFFF;
+          P.VU.elt<uint64_t>(rd_num, i, true) = vector_agnostic(P.VU.elt<uint64_t>(rd_num, i, false));
         else
-          P.VU.elt<uint64_t>(rd_num, i, true) = 0xFFFFFFFF;
+          P.VU.elt<uint64_t>(rd_num, i, true) = vector_agnostic(P.VU.elt<uint64_t>(rd_num, i, false));
         break;
       }
     }

--- a/riscv/insns/vfmv_s_f.h
+++ b/riscv/insns/vfmv_s_f.h
@@ -1,3 +1,4 @@
+#include <algorithm>
 // vfmv_s_f: vd[0] = rs1 (vs2=0)
 require_vector(true);
 require_fp;
@@ -24,6 +25,25 @@ if (vl > 0 && P.VU.vstart->read() < vl) {
       else
         P.VU.elt<uint64_t>(rd_num, 0, true) = f32(FRS1).v;
       break;
+  }
+
+  if(1 == P.VU.vta) {
+    for (reg_t i = std::max(P.VU.vstart->read(), (long unsigned int)1); i < P.VU.VLEN/P.VU.vsew; ++i) {
+      switch (P.VU.vsew) {
+      case e16:
+        P.VU.elt<uint16_t>(rd_num, i, true) = 0xFFFF;
+        break;
+      case e32:
+        P.VU.elt<uint32_t>(rd_num, i, true) = 0xFFFFFFFF;
+        break;
+      default:
+        if (FLEN == 64)
+          P.VU.elt<uint64_t>(rd_num, i, true) = 0xFFFFFFFFFFFFFFFF;
+        else
+          P.VU.elt<uint64_t>(rd_num, i, true) = 0xFFFFFFFF;
+        break;
+      }
+    }
   }
 }
 P.VU.vstart->write(0);

--- a/riscv/insns/vfslide1down_vf.h
+++ b/riscv/insns/vfslide1down_vf.h
@@ -1,7 +1,7 @@
 //vfslide1down.vf vd, vs2, rs1
 VI_CHECK_SLIDE(false);
 
-VI_VFP_LOOP_BASE
+VI_VFP_LOOP_BASE(1)
 if (0 == P.VU.vta && i >= vl) { \
   continue; \
 } \

--- a/riscv/insns/vfslide1down_vf.h
+++ b/riscv/insns/vfslide1down_vf.h
@@ -16,7 +16,7 @@ if (i != vl - 1) {
       if (1 == mata_action) \
         vd = vs2;
       else \
-        *((type_sew_t<e16>::type *)&vd)  = 0xFFFF; \
+        *((type_sew_t<e16>::type *)&vd)  = vector_agnostic(*((type_sew_t<e16>::type *)&vd)); \
     }
     break;
     case e32: {
@@ -24,7 +24,7 @@ if (i != vl - 1) {
       if (1 == mata_action) \
         vd = vs2;
       else \
-        *((type_sew_t<e32>::type *)&vd)  = 0xFFFFFFFF; \
+        *((type_sew_t<e32>::type *)&vd)  = vector_agnostic(*((type_sew_t<e32>::type *)&vd)); \
     }
     break;
     case e64: {
@@ -32,7 +32,7 @@ if (i != vl - 1) {
       if (1 == mata_action) \
         vd = vs2;
       else \
-        *((type_sew_t<e64>::type *)&vd)  = 0xFFFFFFFFFFFFFFFF; \
+        *((type_sew_t<e64>::type *)&vd)  = vector_agnostic(*((type_sew_t<e64>::type *)&vd)); \
     }
     break;
   }
@@ -42,19 +42,19 @@ if (i != vl - 1) {
       if (1 == mata_action) \
         P.VU.elt<float16_t>(rd_num, vl - 1, true) = FRS1_H;\
       else \
-        P.VU.elt<type_sew_t<e16>::type>(rd_num, vl - 1, true) = 0xFFFF; \
+        P.VU.elt<type_sew_t<e16>::type>(rd_num, vl - 1, true)  = vector_agnostic(P.VU.elt<type_sew_t<e16>::type>(rd_num, vl - 1, false)); \
       break;
     case e32:
       if (1 == mata_action) \
         P.VU.elt<float32_t>(rd_num, vl - 1, true) = FRS1_F;
       else \
-        P.VU.elt<type_sew_t<e32>::type>(rd_num, vl - 1, true) = 0xFFFFFFFF; \
+        P.VU.elt<type_sew_t<e32>::type>(rd_num, vl - 1, true)  = vector_agnostic(P.VU.elt<type_sew_t<e32>::type>(rd_num, vl - 1, false)); \
       break;
     case e64:
       if (1 == mata_action) \
         P.VU.elt<float64_t>(rd_num, vl - 1, true) = FRS1_D;
-      else \
-        P.VU.elt<type_sew_t<e64>::type>(rd_num, vl - 1, true) = 0xFFFFFFFFFFFFFFFF; \
+    else \
+        P.VU.elt<type_sew_t<e64>::type>(rd_num, vl - 1, true)  = vector_agnostic(P.VU.elt<type_sew_t<e64>::type>(rd_num, vl - 1, false)); \
       break;
   }
 }

--- a/riscv/insns/vfslide1down_vf.h
+++ b/riscv/insns/vfslide1down_vf.h
@@ -2,34 +2,59 @@
 VI_CHECK_SLIDE(false);
 
 VI_VFP_LOOP_BASE
+if (0 == P.VU.vta && i >= vl) { \
+  continue; \
+} \
+if ((true == skip && 1 == P.VU.vma && i < vl) || (1 == P.VU.vta && i >= vl)) \
+  mata_action = 2; \
+else \
+  mata_action = 1; \
 if (i != vl - 1) {
   switch (P.VU.vsew) {
     case e16: {
       VI_XI_SLIDEDOWN_PARAMS(e16, 1);
-      vd = vs2;
+      if (1 == mata_action) \
+        vd = vs2;
+      else \
+        *((type_sew_t<e16>::type *)&vd)  = 0xFFFF; \
     }
     break;
     case e32: {
       VI_XI_SLIDEDOWN_PARAMS(e32, 1);
-      vd = vs2;
+      if (1 == mata_action) \
+        vd = vs2;
+      else \
+        *((type_sew_t<e32>::type *)&vd)  = 0xFFFFFFFF; \
     }
     break;
     case e64: {
       VI_XI_SLIDEDOWN_PARAMS(e64, 1);
-      vd = vs2;
+      if (1 == mata_action) \
+        vd = vs2;
+      else \
+        *((type_sew_t<e64>::type *)&vd)  = 0xFFFFFFFFFFFFFFFF; \
     }
     break;
   }
 } else {
   switch (P.VU.vsew) {
     case e16:
-      P.VU.elt<float16_t>(rd_num, vl - 1, true) = FRS1_H;
+      if (1 == mata_action) \
+        P.VU.elt<float16_t>(rd_num, vl - 1, true) = FRS1_H;\
+      else \
+        P.VU.elt<type_sew_t<e16>::type>(rd_num, vl - 1, true) = 0xFFFF; \
       break;
     case e32:
-      P.VU.elt<float32_t>(rd_num, vl - 1, true) = FRS1_F;
+      if (1 == mata_action) \
+        P.VU.elt<float32_t>(rd_num, vl - 1, true) = FRS1_F;
+      else \
+        P.VU.elt<type_sew_t<e32>::type>(rd_num, vl - 1, true) = 0xFFFFFFFF; \
       break;
     case e64:
-      P.VU.elt<float64_t>(rd_num, vl - 1, true) = FRS1_D;
+      if (1 == mata_action) \
+        P.VU.elt<float64_t>(rd_num, vl - 1, true) = FRS1_D;
+      else \
+        P.VU.elt<type_sew_t<e64>::type>(rd_num, vl - 1, true) = 0xFFFFFFFFFFFFFFFF; \
       break;
   }
 }

--- a/riscv/insns/vfslide1up_vf.h
+++ b/riscv/insns/vfslide1up_vf.h
@@ -2,34 +2,59 @@
 VI_CHECK_SLIDE(true);
 
 VI_VFP_LOOP_BASE
+if (0 == P.VU.vta && i >= vl) { \
+  continue; \
+} \
+if ((true == skip && 1 == P.VU.vma && i < vl) || (i >= vl)) \
+  mata_action = 2; \
+else \
+  mata_action = 1; \
 if (i != 0) {
   switch (P.VU.vsew) {
     case e16: {
       VI_XI_SLIDEUP_PARAMS(e16, 1);
-      vd = vs2;
+      if (1 == mata_action) \
+        vd = vs2;
+      else \
+        *((type_sew_t<e16>::type *)&vd)  = 0xFFFF; \
     }
     break;
     case e32: {
       VI_XI_SLIDEUP_PARAMS(e32, 1);
-      vd = vs2;
+      if (1 == mata_action) \
+        vd = vs2;
+      else \
+        *((type_sew_t<e32>::type *)&vd)  = 0xFFFFFFFF; \
     }
     break;
     case e64: {
       VI_XI_SLIDEUP_PARAMS(e64, 1);
-      vd = vs2;
+      if (1 == mata_action) \
+        vd = vs2;
+      else \
+        *((type_sew_t<e64>::type *)&vd)  = 0xFFFFFFFFFFFFFFFF; \
     }
     break;
   }
 } else {
   switch (P.VU.vsew) {
     case e16:
-      P.VU.elt<float16_t>(rd_num, 0, true) = FRS1_H;
+      if (1 == mata_action) \
+        P.VU.elt<float16_t>(rd_num, 0, true) = FRS1_H;
+      else \
+        P.VU.elt<type_sew_t<e16>::type>(rd_num, 0, true) = 0xFFFF; \
       break;
     case e32:
-      P.VU.elt<float32_t>(rd_num, 0, true) = FRS1_F;
+      if (1 == mata_action) \
+        P.VU.elt<float32_t>(rd_num, 0, true) = FRS1_F;
+      else \
+        P.VU.elt<type_sew_t<e32>::type>(rd_num, 0, true) = 0xFFFFFFFF; \
       break;
     case e64:
-      P.VU.elt<float64_t>(rd_num, 0, true) = FRS1_D;
+      if (1 == mata_action) \
+        P.VU.elt<float64_t>(rd_num, 0, true) = FRS1_D;
+      else \
+        P.VU.elt<type_sew_t<e64>::type>(rd_num, 0, true) = 0xFFFFFFFFFFFFFFFF; \
       break;
   }
 }

--- a/riscv/insns/vfslide1up_vf.h
+++ b/riscv/insns/vfslide1up_vf.h
@@ -16,7 +16,7 @@ if (i != 0) {
       if (1 == mata_action) \
         vd = vs2;
       else \
-        *((type_sew_t<e16>::type *)&vd)  = 0xFFFF; \
+        vd = vector_agnostic(vd);
     }
     break;
     case e32: {
@@ -24,7 +24,7 @@ if (i != 0) {
       if (1 == mata_action) \
         vd = vs2;
       else \
-        *((type_sew_t<e32>::type *)&vd)  = 0xFFFFFFFF; \
+        vd = vector_agnostic(vd);
     }
     break;
     case e64: {
@@ -32,7 +32,7 @@ if (i != 0) {
       if (1 == mata_action) \
         vd = vs2;
       else \
-        *((type_sew_t<e64>::type *)&vd)  = 0xFFFFFFFFFFFFFFFF; \
+        vd = vector_agnostic(vd);
     }
     break;
   }
@@ -42,19 +42,19 @@ if (i != 0) {
       if (1 == mata_action) \
         P.VU.elt<float16_t>(rd_num, 0, true) = FRS1_H;
       else \
-        P.VU.elt<type_sew_t<e16>::type>(rd_num, 0, true) = 0xFFFF; \
+        P.VU.elt<float16_t>(rd_num, 0, true) = vector_agnostic(P.VU.elt<float16_t>(rd_num, 0, false)); \
       break;
     case e32:
       if (1 == mata_action) \
         P.VU.elt<float32_t>(rd_num, 0, true) = FRS1_F;
       else \
-        P.VU.elt<type_sew_t<e32>::type>(rd_num, 0, true) = 0xFFFFFFFF; \
+        P.VU.elt<float32_t>(rd_num, 0, true) = vector_agnostic(P.VU.elt<float32_t>(rd_num, 0, false)); \
       break;
     case e64:
       if (1 == mata_action) \
         P.VU.elt<float64_t>(rd_num, 0, true) = FRS1_D;
       else \
-        P.VU.elt<type_sew_t<e64>::type>(rd_num, 0, true) = 0xFFFFFFFFFFFFFFFF; \
+        P.VU.elt<float64_t>(rd_num, 0, true) = vector_agnostic(P.VU.elt<float64_t>(rd_num, 0, false)); \
       break;
   }
 }

--- a/riscv/insns/vfslide1up_vf.h
+++ b/riscv/insns/vfslide1up_vf.h
@@ -1,7 +1,7 @@
 //vfslide1up.vf vd, vs2, rs1
 VI_CHECK_SLIDE(true);
 
-VI_VFP_LOOP_BASE
+VI_VFP_LOOP_BASE(1)
 if (0 == P.VU.vta && i >= vl) { \
   continue; \
 } \

--- a/riscv/insns/vid_v.h
+++ b/riscv/insns/vid_v.h
@@ -6,21 +6,42 @@ reg_t rd_num = insn.rd();
 require_align(rd_num, P.VU.vflmul);
 require_vm;
 
-for (reg_t i = P.VU.vstart->read() ; i < P.VU.vl->read(); ++i) {
+V_EXT_VSTART_CHECK;
+for (reg_t i = P.VU.vstart->read() ; i < std::max(P.VU.vlmax, P.VU.VLEN/P.VU.vsew); ++i) {
   VI_LOOP_ELEMENT_SKIP();
+  reg_t vl = P.VU.vl->read();
 
+  if (0 == P.VU.vta && i >= vl) { \
+    continue; \
+  } \
+  if ((true == skip && 1 == P.VU.vma && i < vl) || (1 == P.VU.vta && i >= vl)) \
+    mata_action = 2; \
+  else \
+    mata_action = 1; \
   switch (sew) {
   case e8:
-    P.VU.elt<uint8_t>(rd_num, i, true) = i;
+    if (1 == mata_action)
+      P.VU.elt<uint8_t>(rd_num, i, true) = i;
+    else
+      P.VU.elt<uint8_t>(rd_num, i, true) = 0xFF;
     break;
   case e16:
-    P.VU.elt<uint16_t>(rd_num, i, true) = i;
+    if (1 == mata_action)
+      P.VU.elt<uint16_t>(rd_num, i, true) = i;
+    else
+      P.VU.elt<uint16_t>(rd_num, i, true) = 0xFFFF;
     break;
   case e32:
-    P.VU.elt<uint32_t>(rd_num, i, true) = i;
+    if (1 == mata_action)
+      P.VU.elt<uint32_t>(rd_num, i, true) = i;
+    else
+      P.VU.elt<uint32_t>(rd_num, i, true) = 0xFFFFFFFF;
     break;
   default:
-    P.VU.elt<uint64_t>(rd_num, i, true) = i;
+    if (1 == mata_action)
+      P.VU.elt<uint64_t>(rd_num, i, true) = i;
+    else
+      P.VU.elt<uint64_t>(rd_num, i, true) = 0xFFFFFFFFFFFFFFFF;
     break;
   }
 }

--- a/riscv/insns/vid_v.h
+++ b/riscv/insns/vid_v.h
@@ -23,25 +23,25 @@ for (reg_t i = P.VU.vstart->read() ; i < std::max(P.VU.vlmax, P.VU.VLEN/P.VU.vse
     if (1 == mata_action)
       P.VU.elt<uint8_t>(rd_num, i, true) = i;
     else
-      P.VU.elt<uint8_t>(rd_num, i, true) = 0xFF;
+      P.VU.elt<uint8_t>(rd_num, i, true) = vector_agnostic(P.VU.elt<uint8_t>(rd_num, i, false));
     break;
   case e16:
     if (1 == mata_action)
       P.VU.elt<uint16_t>(rd_num, i, true) = i;
     else
-      P.VU.elt<uint16_t>(rd_num, i, true) = 0xFFFF;
+      P.VU.elt<uint16_t>(rd_num, i, true) = vector_agnostic(P.VU.elt<uint16_t>(rd_num, i, false));
     break;
   case e32:
     if (1 == mata_action)
       P.VU.elt<uint32_t>(rd_num, i, true) = i;
     else
-      P.VU.elt<uint32_t>(rd_num, i, true) = 0xFFFFFFFF;
+      P.VU.elt<uint32_t>(rd_num, i, true) = vector_agnostic(P.VU.elt<uint32_t>(rd_num, i, false));
     break;
   default:
     if (1 == mata_action)
       P.VU.elt<uint64_t>(rd_num, i, true) = i;
     else
-      P.VU.elt<uint64_t>(rd_num, i, true) = 0xFFFFFFFFFFFFFFFF;
+      P.VU.elt<uint64_t>(rd_num, i, true) = vector_agnostic(P.VU.elt<uint64_t>(rd_num, i, false));
     break;
   }
 }

--- a/riscv/insns/viota_m.h
+++ b/riscv/insns/viota_m.h
@@ -41,28 +41,28 @@ for (reg_t i = 0; i < std::max(P.VU.vlmax, P.VU.VLEN/P.VU.vsew); ++i) {
       P.VU.elt<uint8_t>(rd_num, i, true) = use_ori ?
                                      P.VU.elt<uint8_t>(rd_num, i) : cnt;
     } else \
-				P.VU.elt<uint8_t>(rd_num, i, true) = 0xFF;
+				P.VU.elt<uint8_t>(rd_num, i, true) = vector_agnostic(P.VU.elt<uint8_t>(rd_num, i, false));
     break;
   case e16:
     if (1 == mata_action) {
       P.VU.elt<uint16_t>(rd_num, i, true) = use_ori ?
                                       P.VU.elt<uint16_t>(rd_num, i) : cnt;
     } else \
-				P.VU.elt<uint16_t>(rd_num, i, true) = 0xFFFF;
+				P.VU.elt<uint16_t>(rd_num, i, true) = vector_agnostic(P.VU.elt<uint16_t>(rd_num, i, false));
     break;
   case e32:
     if (1 == mata_action) {
       P.VU.elt<uint32_t>(rd_num, i, true) = use_ori ?
                                       P.VU.elt<uint32_t>(rd_num, i) : cnt;
     } else \
-				P.VU.elt<uint32_t>(rd_num, i, true) = 0xFFFFFFFF;
+				P.VU.elt<uint32_t>(rd_num, i, true) = vector_agnostic(P.VU.elt<uint32_t>(rd_num, i, false));
     break;
   default:
     if (1 == mata_action) {
       P.VU.elt<uint64_t>(rd_num, i, true) = use_ori ?
                                       P.VU.elt<uint64_t>(rd_num, i) : cnt;
     } else \
-      P.VU.elt<uint64_t>(rd_num, i, true) = 0xFFFFFFFFFFFFFFFF;
+      P.VU.elt<uint64_t>(rd_num, i, true) = vector_agnostic(P.VU.elt<uint64_t>(rd_num, i, false));
     break;
   }
 

--- a/riscv/insns/viota_m.h
+++ b/riscv/insns/viota_m.h
@@ -11,9 +11,10 @@ require_align(rd_num, P.VU.vflmul);
 require_noover(rd_num, P.VU.vflmul, rs2_num, 1);
 
 int cnt = 0;
-for (reg_t i = 0; i < vl; ++i) {
+for (reg_t i = 0; i < std::max(P.VU.vlmax, P.VU.VLEN/P.VU.vsew); ++i) {
   const int midx = i / 64;
   const int mpos = i % 64;
+  int mata_action = 0; //0:origin, 1:calculate, 2:pad FF
 
   bool vs2_lsb = ((P.VU.elt<uint64_t>(rs2_num, midx) >> mpos) & 0x1) == 1;
   bool do_mask = (P.VU.elt<uint64_t>(0, midx) >> mpos) & 0x1;
@@ -26,22 +27,41 @@ for (reg_t i = 0; i < vl; ++i) {
   }
 
   bool use_ori = (insn.v_vm() == 0) && !do_mask;
+  if (0 == P.VU.vta && i >= vl) { \
+    continue; \
+  } \
+  if ((1 == P.VU.vta && i >= vl) || (insn.v_vm() == 0 && 1 == P.VU.vma && !do_mask && i < vl)) \
+    mata_action = 2; \
+  else \
+    mata_action = 1; \
   switch (sew) {
   case e8:
-    P.VU.elt<uint8_t>(rd_num, i, true) = use_ori ?
-                                   P.VU.elt<uint8_t>(rd_num, i) : cnt;
+    if (1 == mata_action) {
+      P.VU.elt<uint8_t>(rd_num, i, true) = use_ori ?
+                                     P.VU.elt<uint8_t>(rd_num, i) : cnt;
+    } else \
+				P.VU.elt<uint8_t>(rd_num, i, true) = 0xFF;
     break;
   case e16:
-    P.VU.elt<uint16_t>(rd_num, i, true) = use_ori ?
-                                    P.VU.elt<uint16_t>(rd_num, i) : cnt;
+    if (1 == mata_action) {
+      P.VU.elt<uint16_t>(rd_num, i, true) = use_ori ?
+                                      P.VU.elt<uint16_t>(rd_num, i) : cnt;
+    } else \
+				P.VU.elt<uint16_t>(rd_num, i, true) = 0xFFFF;
     break;
   case e32:
-    P.VU.elt<uint32_t>(rd_num, i, true) = use_ori ?
-                                    P.VU.elt<uint32_t>(rd_num, i) : cnt;
+    if (1 == mata_action) {
+      P.VU.elt<uint32_t>(rd_num, i, true) = use_ori ?
+                                      P.VU.elt<uint32_t>(rd_num, i) : cnt;
+    } else \
+				P.VU.elt<uint32_t>(rd_num, i, true) = 0xFFFFFFFF;
     break;
   default:
-    P.VU.elt<uint64_t>(rd_num, i, true) = use_ori ?
-                                    P.VU.elt<uint64_t>(rd_num, i) : cnt;
+    if (1 == mata_action) {
+      P.VU.elt<uint64_t>(rd_num, i, true) = use_ori ?
+                                      P.VU.elt<uint64_t>(rd_num, i) : cnt;
+    } else \
+      P.VU.elt<uint64_t>(rd_num, i, true) = 0xFFFFFFFFFFFFFFFF;
     break;
   }
 

--- a/riscv/insns/viota_m.h
+++ b/riscv/insns/viota_m.h
@@ -11,6 +11,7 @@ require_align(rd_num, P.VU.vflmul);
 require_noover(rd_num, P.VU.vflmul, rs2_num, 1);
 
 int cnt = 0;
+V_EXT_VSTART_CHECK;
 for (reg_t i = 0; i < std::max(P.VU.vlmax, P.VU.VLEN/P.VU.vsew); ++i) {
   const int midx = i / 64;
   const int mpos = i % 64;

--- a/riscv/insns/vmsbf_m.h
+++ b/riscv/insns/vmsbf_m.h
@@ -10,17 +10,20 @@ reg_t rd_num = insn.rd();
 reg_t rs2_num = insn.rs2();
 
 bool has_one = false;
-for (reg_t i = P.VU.vstart->read(); i < vl; ++i) {
+V_EXT_VSTART_CHECK;
+for (reg_t i = P.VU.vstart->read(); i < P.VU.VLEN; ++i) {
   const int midx = i / 64;
   const int mpos = i % 64;
   const uint64_t mmask = UINT64_C(1) << mpos; \
 
   bool vs2_lsb = ((P.VU.elt<uint64_t>(rs2_num, midx) >> mpos) & 0x1) == 1;
   bool do_mask = (P.VU.elt<uint64_t>(0, midx) >> mpos) & 0x1;
+  auto &vd = P.VU.elt<uint64_t>(rd_num, midx, true);
 
-
-  if (insn.v_vm() == 1 || (insn.v_vm() == 0 && do_mask)) {
-    auto &vd = P.VU.elt<uint64_t>(rd_num, midx, true);
+  if ((i >= vl) || (insn.v_vm() == 0 && 1 == P.VU.vma && !do_mask && i < vl)) {
+    vd = (vd & ~mmask) | ((UINT64_C(1) << mpos) & mmask);
+  }
+  if ((insn.v_vm() == 1 || (insn.v_vm() == 0 && do_mask)) && i < vl) {
     uint64_t res = 0;
     if (!has_one && !vs2_lsb) {
       res = 1;

--- a/riscv/insns/vmsbf_m.h
+++ b/riscv/insns/vmsbf_m.h
@@ -18,12 +18,19 @@ for (reg_t i = P.VU.vstart->read(); i < P.VU.VLEN; ++i) {
 
   bool vs2_lsb = ((P.VU.elt<uint64_t>(rs2_num, midx) >> mpos) & 0x1) == 1;
   bool do_mask = (P.VU.elt<uint64_t>(0, midx) >> mpos) & 0x1;
+#ifdef VARITH_AGNOSTIC_WRITE_ONE
   auto &vd = P.VU.elt<uint64_t>(rd_num, midx, true);
 
   if ((i >= vl) || (insn.v_vm() == 0 && 1 == P.VU.vma && !do_mask && i < vl)) {
     vd = (vd & ~mmask) | ((UINT64_C(1) << mpos) & mmask);
   }
   if ((insn.v_vm() == 1 || (insn.v_vm() == 0 && do_mask)) && i < vl) {
+#else
+  if(i >= vl)
+    break;
+  if (insn.v_vm() == 1 || (insn.v_vm() == 0 && do_mask)) {
+    auto &vd = P.VU.elt<uint64_t>(rd_num, midx, true);
+#endif
     uint64_t res = 0;
     if (!has_one && !vs2_lsb) {
       res = 1;

--- a/riscv/insns/vmsif_m.h
+++ b/riscv/insns/vmsif_m.h
@@ -10,16 +10,20 @@ reg_t rd_num = insn.rd();
 reg_t rs2_num = insn.rs2();
 
 bool has_one = false;
-for (reg_t i = P.VU.vstart->read(); i < vl; ++i) {
+V_EXT_VSTART_CHECK;
+for (reg_t i = P.VU.vstart->read(); i < P.VU.VLEN; ++i) {
   const int midx = i / 64;
   const int mpos = i % 64;
   const uint64_t mmask = UINT64_C(1) << mpos; \
 
   bool vs2_lsb = ((P.VU.elt<uint64_t>(rs2_num, midx ) >> mpos) & 0x1) == 1;
   bool do_mask = (P.VU.elt<uint64_t>(0, midx) >> mpos) & 0x1;
+  auto &vd = P.VU.elt<uint64_t>(rd_num, midx, true);
 
-  if (insn.v_vm() == 1 || (insn.v_vm() == 0 && do_mask)) {
-    auto &vd = P.VU.elt<uint64_t>(rd_num, midx, true);
+  if ((i >= vl) || (insn.v_vm() == 0 && 1 == P.VU.vma && !do_mask && i < vl)) {
+    vd = (vd & ~mmask) | ((UINT64_C(1) << mpos) & mmask);
+  }
+  if ((insn.v_vm() == 1 || (insn.v_vm() == 0 && do_mask)) && i < vl) {
     uint64_t res = 0;
     if (!has_one && !vs2_lsb) {
       res = 1;

--- a/riscv/insns/vmsif_m.h
+++ b/riscv/insns/vmsif_m.h
@@ -18,12 +18,19 @@ for (reg_t i = P.VU.vstart->read(); i < P.VU.VLEN; ++i) {
 
   bool vs2_lsb = ((P.VU.elt<uint64_t>(rs2_num, midx ) >> mpos) & 0x1) == 1;
   bool do_mask = (P.VU.elt<uint64_t>(0, midx) >> mpos) & 0x1;
+#ifdef VARITH_AGNOSTIC_WRITE_ONE
   auto &vd = P.VU.elt<uint64_t>(rd_num, midx, true);
 
   if ((i >= vl) || (insn.v_vm() == 0 && 1 == P.VU.vma && !do_mask && i < vl)) {
     vd = (vd & ~mmask) | ((UINT64_C(1) << mpos) & mmask);
   }
   if ((insn.v_vm() == 1 || (insn.v_vm() == 0 && do_mask)) && i < vl) {
+#else
+  if(i >= vl)
+    break;
+  if (insn.v_vm() == 1 || (insn.v_vm() == 0 && do_mask)) {
+    auto &vd = P.VU.elt<uint64_t>(rd_num, midx, true);
+#endif
     uint64_t res = 0;
     if (!has_one && !vs2_lsb) {
       res = 1;

--- a/riscv/insns/vmsof_m.h
+++ b/riscv/insns/vmsof_m.h
@@ -10,16 +10,20 @@ reg_t rd_num = insn.rd();
 reg_t rs2_num = insn.rs2();
 
 bool has_one = false;
-for (reg_t i = P.VU.vstart->read() ; i < vl; ++i) {
+V_EXT_VSTART_CHECK;
+for (reg_t i = P.VU.vstart->read() ; i < P.VU.VLEN; ++i) {
   const int midx = i / 64;
   const int mpos = i % 64;
   const uint64_t mmask = UINT64_C(1) << mpos; \
 
   bool vs2_lsb = ((P.VU.elt<uint64_t>(rs2_num, midx ) >> mpos) & 0x1) == 1;
   bool do_mask = (P.VU.elt<uint64_t>(0, midx) >> mpos) & 0x1;
+  uint64_t &vd = P.VU.elt<uint64_t>(rd_num, midx, true);
 
-  if (insn.v_vm() == 1 || (insn.v_vm() == 0 && do_mask)) {
-    uint64_t &vd = P.VU.elt<uint64_t>(rd_num, midx, true);
+  if ((i >= vl) || (insn.v_vm() == 0 && 1 == P.VU.vma && !do_mask && i < vl)) {
+    vd = (vd & ~mmask) | ((UINT64_C(1) << mpos) & mmask);
+  }
+  if ((insn.v_vm() == 1 || (insn.v_vm() == 0 && do_mask)) && i < vl) {
     uint64_t res = 0;
     if (!has_one && vs2_lsb) {
       has_one = true;

--- a/riscv/insns/vmsof_m.h
+++ b/riscv/insns/vmsof_m.h
@@ -18,12 +18,19 @@ for (reg_t i = P.VU.vstart->read() ; i < P.VU.VLEN; ++i) {
 
   bool vs2_lsb = ((P.VU.elt<uint64_t>(rs2_num, midx ) >> mpos) & 0x1) == 1;
   bool do_mask = (P.VU.elt<uint64_t>(0, midx) >> mpos) & 0x1;
+#ifdef VARITH_AGNOSTIC_WRITE_ONE
   uint64_t &vd = P.VU.elt<uint64_t>(rd_num, midx, true);
 
   if ((i >= vl) || (insn.v_vm() == 0 && 1 == P.VU.vma && !do_mask && i < vl)) {
     vd = (vd & ~mmask) | ((UINT64_C(1) << mpos) & mmask);
   }
   if ((insn.v_vm() == 1 || (insn.v_vm() == 0 && do_mask)) && i < vl) {
+#else
+  if(i >= vl)
+    break;
+  if (insn.v_vm() == 1 || (insn.v_vm() == 0 && do_mask)) {
+    uint64_t &vd = P.VU.elt<uint64_t>(rd_num, midx, true);
+#endif
     uint64_t res = 0;
     if (!has_one && vs2_lsb) {
       has_one = true;

--- a/riscv/insns/vmv_s_x.h
+++ b/riscv/insns/vmv_s_x.h
@@ -28,16 +28,16 @@ if (vl > 0 && P.VU.vstart->read() < vl) {
     for (reg_t i = std::max(P.VU.vstart->read(), (long unsigned int)1); i < P.VU.VLEN/P.VU.vsew; ++i) {
       switch (sew) {
       case e8:
-        P.VU.elt<uint8_t>(rd_num, i, true) = 0xFF;
+        P.VU.elt<uint8_t>(rd_num, i, true) = vector_agnostic(P.VU.elt<uint8_t>(rd_num, i, false));
         break;
       case e16:
-        P.VU.elt<uint16_t>(rd_num, i, true) = 0xFFFF;
+        P.VU.elt<uint16_t>(rd_num, i, true) = vector_agnostic(P.VU.elt<uint16_t>(rd_num, i, false));
         break;
       case e32:
-        P.VU.elt<uint32_t>(rd_num, i, true) = 0xFFFFFFFF;
+        P.VU.elt<uint32_t>(rd_num, i, true) = vector_agnostic(P.VU.elt<uint32_t>(rd_num, i, false));
         break;
       default:
-        P.VU.elt<uint64_t>(rd_num, i, true) = 0xFFFFFFFFFFFFFFFF;
+        P.VU.elt<uint64_t>(rd_num, i, true) = vector_agnostic(P.VU.elt<uint64_t>(rd_num, i, false));
         break;
       }
     }

--- a/riscv/insns/vmv_s_x.h
+++ b/riscv/insns/vmv_s_x.h
@@ -1,3 +1,4 @@
+#include <algorithm>
 // vmv_s_x: vd[0] = rs1
 require_vector(true);
 require(insn.v_vm() == 1);
@@ -21,6 +22,25 @@ if (vl > 0 && P.VU.vstart->read() < vl) {
   default:
     P.VU.elt<uint64_t>(rd_num, 0, true) = RS1;
     break;
+  }
+
+  if(1 == P.VU.vta) {
+    for (reg_t i = std::max(P.VU.vstart->read(), (long unsigned int)1); i < P.VU.VLEN/P.VU.vsew; ++i) {
+      switch (sew) {
+      case e8:
+        P.VU.elt<uint8_t>(rd_num, i, true) = 0xFF;
+        break;
+      case e16:
+        P.VU.elt<uint16_t>(rd_num, i, true) = 0xFFFF;
+        break;
+      case e32:
+        P.VU.elt<uint32_t>(rd_num, i, true) = 0xFFFFFFFF;
+        break;
+      default:
+        P.VU.elt<uint64_t>(rd_num, i, true) = 0xFFFFFFFFFFFFFFFF;
+        break;
+      }
+    }
   }
 
   vl = 0;

--- a/riscv/insns/vrgather_vi.h
+++ b/riscv/insns/vrgather_vi.h
@@ -7,18 +7,37 @@ require_vm;
 reg_t zimm5 = insn.v_zimm5();
 
 VI_LOOP_BASE
+  if (0 == P.VU.vta && i >= vl) { \
+    continue; \
+  } \
+  if ((true == skip && 1 == P.VU.vma && i < vl) || (1 == P.VU.vta && i >= vl)) \
+    mata_action = 2; \
+  else \
+    mata_action = 1; \
   switch (sew) {
   case e8:
-    P.VU.elt<uint8_t>(rd_num, i, true) = zimm5 >= P.VU.vlmax ? 0 : P.VU.elt<uint8_t>(rs2_num, zimm5);
+    if (1 == mata_action) \
+      P.VU.elt<uint8_t>(rd_num, i, true) = zimm5 >= P.VU.vlmax ? 0 : P.VU.elt<uint8_t>(rs2_num, zimm5);
+    else \
+      P.VU.elt<uint8_t>(rd_num, i, true) = 0xFF; \
     break;
   case e16:
-    P.VU.elt<uint16_t>(rd_num, i, true) = zimm5 >= P.VU.vlmax ? 0 : P.VU.elt<uint16_t>(rs2_num, zimm5);
+    if (1 == mata_action) \
+      P.VU.elt<uint16_t>(rd_num, i, true) = zimm5 >= P.VU.vlmax ? 0 : P.VU.elt<uint16_t>(rs2_num, zimm5);
+    else \
+      P.VU.elt<uint16_t>(rd_num, i, true) = 0xFFFF; \
     break;
   case e32:
-    P.VU.elt<uint32_t>(rd_num, i, true) = zimm5 >= P.VU.vlmax ? 0 : P.VU.elt<uint32_t>(rs2_num, zimm5);
+    if (1 == mata_action) \
+      P.VU.elt<uint32_t>(rd_num, i, true) = zimm5 >= P.VU.vlmax ? 0 : P.VU.elt<uint32_t>(rs2_num, zimm5);
+    else \
+      P.VU.elt<uint32_t>(rd_num, i, true) = 0xFFFFFFFF; \
     break;
   default:
-    P.VU.elt<uint64_t>(rd_num, i, true) = zimm5 >= P.VU.vlmax ? 0 : P.VU.elt<uint64_t>(rs2_num, zimm5);
+    if (1 == mata_action) \
+      P.VU.elt<uint64_t>(rd_num, i, true) = zimm5 >= P.VU.vlmax ? 0 : P.VU.elt<uint64_t>(rs2_num, zimm5);
+    else \
+      P.VU.elt<uint64_t>(rd_num, i, true) = 0xFFFFFFFFFFFFFFFF; \
     break;
   }
 VI_LOOP_END;

--- a/riscv/insns/vrgather_vi.h
+++ b/riscv/insns/vrgather_vi.h
@@ -19,25 +19,25 @@ VI_LOOP_BASE(1)
     if (1 == mata_action) \
       P.VU.elt<uint8_t>(rd_num, i, true) = zimm5 >= P.VU.vlmax ? 0 : P.VU.elt<uint8_t>(rs2_num, zimm5);
     else \
-      P.VU.elt<uint8_t>(rd_num, i, true) = 0xFF; \
+      P.VU.elt<uint8_t>(rd_num, i, true) = vector_agnostic(P.VU.elt<uint8_t>(rd_num, i, false)); \
     break;
   case e16:
     if (1 == mata_action) \
       P.VU.elt<uint16_t>(rd_num, i, true) = zimm5 >= P.VU.vlmax ? 0 : P.VU.elt<uint16_t>(rs2_num, zimm5);
     else \
-      P.VU.elt<uint16_t>(rd_num, i, true) = 0xFFFF; \
+      P.VU.elt<uint16_t>(rd_num, i, true) = vector_agnostic(P.VU.elt<uint16_t>(rd_num, i, false)); \
     break;
   case e32:
     if (1 == mata_action) \
       P.VU.elt<uint32_t>(rd_num, i, true) = zimm5 >= P.VU.vlmax ? 0 : P.VU.elt<uint32_t>(rs2_num, zimm5);
     else \
-      P.VU.elt<uint32_t>(rd_num, i, true) = 0xFFFFFFFF; \
+      P.VU.elt<uint32_t>(rd_num, i, true) = vector_agnostic(P.VU.elt<uint32_t>(rd_num, i, false)); \
     break;
   default:
     if (1 == mata_action) \
       P.VU.elt<uint64_t>(rd_num, i, true) = zimm5 >= P.VU.vlmax ? 0 : P.VU.elt<uint64_t>(rs2_num, zimm5);
     else \
-      P.VU.elt<uint64_t>(rd_num, i, true) = 0xFFFFFFFFFFFFFFFF; \
+      P.VU.elt<uint64_t>(rd_num, i, true) = vector_agnostic(P.VU.elt<uint64_t>(rd_num, i, false)); \
     break;
   }
 VI_LOOP_END;

--- a/riscv/insns/vrgather_vi.h
+++ b/riscv/insns/vrgather_vi.h
@@ -6,7 +6,7 @@ require_vm;
 
 reg_t zimm5 = insn.v_zimm5();
 
-VI_LOOP_BASE
+VI_LOOP_BASE(1)
   if (0 == P.VU.vta && i >= vl) { \
     continue; \
   } \

--- a/riscv/insns/vrgather_vv.h
+++ b/riscv/insns/vrgather_vv.h
@@ -6,26 +6,45 @@ require(insn.rd() != insn.rs2() && insn.rd() != insn.rs1());
 require_vm;
 
 VI_LOOP_BASE
+  if (0 == P.VU.vta && i >= vl) { \
+    continue; \
+  } \
+  if ((true == skip && 1 == P.VU.vma && i < vl) || (1 == P.VU.vta && i >= vl)) \
+    mata_action = 2; \
+  else \
+    mata_action = 1; \
   switch (sew) {
   case e8: {
     auto vs1 = P.VU.elt<uint8_t>(rs1_num, i);
     //if (i > 255) continue;
-    P.VU.elt<uint8_t>(rd_num, i, true) = vs1 >= P.VU.vlmax ? 0 : P.VU.elt<uint8_t>(rs2_num, vs1);
+    if (1 == mata_action) \
+      P.VU.elt<uint8_t>(rd_num, i, true) = vs1 >= P.VU.vlmax ? 0 : P.VU.elt<uint8_t>(rs2_num, vs1);
+    else \
+      P.VU.elt<uint8_t>(rd_num, i, true) = 0xFF; \
     break;
   }
   case e16: {
     auto vs1 = P.VU.elt<uint16_t>(rs1_num, i);
-    P.VU.elt<uint16_t>(rd_num, i, true) = vs1 >= P.VU.vlmax ? 0 : P.VU.elt<uint16_t>(rs2_num, vs1);
+    if (1 == mata_action) \
+      P.VU.elt<uint16_t>(rd_num, i, true) = vs1 >= P.VU.vlmax ? 0 : P.VU.elt<uint16_t>(rs2_num, vs1);
+    else \
+      P.VU.elt<uint16_t>(rd_num, i, true) = 0xFFFF; \
     break;
   }
   case e32: {
     auto vs1 = P.VU.elt<uint32_t>(rs1_num, i);
-    P.VU.elt<uint32_t>(rd_num, i, true) = vs1 >= P.VU.vlmax ? 0 : P.VU.elt<uint32_t>(rs2_num, vs1);
+    if (1 == mata_action) \
+      P.VU.elt<uint32_t>(rd_num, i, true) = vs1 >= P.VU.vlmax ? 0 : P.VU.elt<uint32_t>(rs2_num, vs1);
+    else \
+      P.VU.elt<uint32_t>(rd_num, i, true) = 0xFFFFFFFF; \
     break;
   }
   default: {
     auto vs1 = P.VU.elt<uint64_t>(rs1_num, i);
-    P.VU.elt<uint64_t>(rd_num, i, true) = vs1 >= P.VU.vlmax ? 0 : P.VU.elt<uint64_t>(rs2_num, vs1);
+    if (1 == mata_action) \
+      P.VU.elt<uint64_t>(rd_num, i, true) = vs1 >= P.VU.vlmax ? 0 : P.VU.elt<uint64_t>(rs2_num, vs1);
+    else \
+      P.VU.elt<uint64_t>(rd_num, i, true) = 0xFFFFFFFFFFFFFFFF; \
     break;
   }
   }

--- a/riscv/insns/vrgather_vv.h
+++ b/riscv/insns/vrgather_vv.h
@@ -5,7 +5,7 @@ require_align(insn.rs1(), P.VU.vflmul);
 require(insn.rd() != insn.rs2() && insn.rd() != insn.rs1());
 require_vm;
 
-VI_LOOP_BASE
+VI_LOOP_BASE(1)
   if (0 == P.VU.vta && i >= vl) { \
     continue; \
   } \

--- a/riscv/insns/vrgather_vv.h
+++ b/riscv/insns/vrgather_vv.h
@@ -20,7 +20,7 @@ VI_LOOP_BASE(1)
     if (1 == mata_action) \
       P.VU.elt<uint8_t>(rd_num, i, true) = vs1 >= P.VU.vlmax ? 0 : P.VU.elt<uint8_t>(rs2_num, vs1);
     else \
-      P.VU.elt<uint8_t>(rd_num, i, true) = 0xFF; \
+      P.VU.elt<uint8_t>(rd_num, i, true) = vector_agnostic(P.VU.elt<uint8_t>(rd_num, i, false)); \
     break;
   }
   case e16: {
@@ -28,7 +28,7 @@ VI_LOOP_BASE(1)
     if (1 == mata_action) \
       P.VU.elt<uint16_t>(rd_num, i, true) = vs1 >= P.VU.vlmax ? 0 : P.VU.elt<uint16_t>(rs2_num, vs1);
     else \
-      P.VU.elt<uint16_t>(rd_num, i, true) = 0xFFFF; \
+      P.VU.elt<uint16_t>(rd_num, i, true) = vector_agnostic(P.VU.elt<uint16_t>(rd_num, i, false)); \
     break;
   }
   case e32: {
@@ -36,7 +36,7 @@ VI_LOOP_BASE(1)
     if (1 == mata_action) \
       P.VU.elt<uint32_t>(rd_num, i, true) = vs1 >= P.VU.vlmax ? 0 : P.VU.elt<uint32_t>(rs2_num, vs1);
     else \
-      P.VU.elt<uint32_t>(rd_num, i, true) = 0xFFFFFFFF; \
+      P.VU.elt<uint32_t>(rd_num, i, true) = vector_agnostic(P.VU.elt<uint32_t>(rd_num, i, false)); \
     break;
   }
   default: {
@@ -44,7 +44,7 @@ VI_LOOP_BASE(1)
     if (1 == mata_action) \
       P.VU.elt<uint64_t>(rd_num, i, true) = vs1 >= P.VU.vlmax ? 0 : P.VU.elt<uint64_t>(rs2_num, vs1);
     else \
-      P.VU.elt<uint64_t>(rd_num, i, true) = 0xFFFFFFFFFFFFFFFF; \
+      P.VU.elt<uint64_t>(rd_num, i, true) = vector_agnostic(P.VU.elt<uint64_t>(rd_num, i, false)); \
     break;
   }
   }

--- a/riscv/insns/vrgather_vx.h
+++ b/riscv/insns/vrgather_vx.h
@@ -6,7 +6,7 @@ require_vm;
 
 reg_t rs1 = RS1;
 
-VI_LOOP_BASE
+VI_LOOP_BASE(1)
   if (0 == P.VU.vta && i >= vl) { \
     continue; \
   } \

--- a/riscv/insns/vrgather_vx.h
+++ b/riscv/insns/vrgather_vx.h
@@ -7,18 +7,37 @@ require_vm;
 reg_t rs1 = RS1;
 
 VI_LOOP_BASE
+  if (0 == P.VU.vta && i >= vl) { \
+    continue; \
+  } \
+  if ((true == skip && 1 == P.VU.vma && i < vl) || (1 == P.VU.vta && i >= vl)) \
+    mata_action = 2; \
+  else \
+    mata_action = 1; \
   switch (sew) {
   case e8:
-    P.VU.elt<uint8_t>(rd_num, i, true) = rs1 >= P.VU.vlmax ? 0 : P.VU.elt<uint8_t>(rs2_num, rs1);
+    if (1 == mata_action) \
+      P.VU.elt<uint8_t>(rd_num, i, true) = rs1 >= P.VU.vlmax ? 0 : P.VU.elt<uint8_t>(rs2_num, rs1);
+    else \
+      P.VU.elt<uint8_t>(rd_num, i, true) = 0xFF; \
     break;
   case e16:
-    P.VU.elt<uint16_t>(rd_num, i, true) = rs1 >= P.VU.vlmax ? 0 : P.VU.elt<uint16_t>(rs2_num, rs1);
+    if (1 == mata_action) \
+      P.VU.elt<uint16_t>(rd_num, i, true) = rs1 >= P.VU.vlmax ? 0 : P.VU.elt<uint16_t>(rs2_num, rs1);
+    else \
+      P.VU.elt<uint16_t>(rd_num, i, true) = 0xFFFF; \
     break;
   case e32:
-    P.VU.elt<uint32_t>(rd_num, i, true) = rs1 >= P.VU.vlmax ? 0 : P.VU.elt<uint32_t>(rs2_num, rs1);
+    if (1 == mata_action) \
+      P.VU.elt<uint32_t>(rd_num, i, true) = rs1 >= P.VU.vlmax ? 0 : P.VU.elt<uint32_t>(rs2_num, rs1);
+    else \
+      P.VU.elt<uint32_t>(rd_num, i, true) = 0xFFFFFFFF; \
     break;
   default:
-    P.VU.elt<uint64_t>(rd_num, i, true) = rs1 >= P.VU.vlmax ? 0 : P.VU.elt<uint64_t>(rs2_num, rs1);
+    if (1 == mata_action) \
+      P.VU.elt<uint64_t>(rd_num, i, true) = rs1 >= P.VU.vlmax ? 0 : P.VU.elt<uint64_t>(rs2_num, rs1);
+    else \
+      P.VU.elt<uint64_t>(rd_num, i, true) = 0xFFFFFFFFFFFFFFFF; \
     break;
   }
 VI_LOOP_END;

--- a/riscv/insns/vrgather_vx.h
+++ b/riscv/insns/vrgather_vx.h
@@ -19,25 +19,25 @@ VI_LOOP_BASE(1)
     if (1 == mata_action) \
       P.VU.elt<uint8_t>(rd_num, i, true) = rs1 >= P.VU.vlmax ? 0 : P.VU.elt<uint8_t>(rs2_num, rs1);
     else \
-      P.VU.elt<uint8_t>(rd_num, i, true) = 0xFF; \
+      P.VU.elt<uint8_t>(rd_num, i, true) = vector_agnostic(P.VU.elt<uint8_t>(rd_num, i, false)); \
     break;
   case e16:
     if (1 == mata_action) \
       P.VU.elt<uint16_t>(rd_num, i, true) = rs1 >= P.VU.vlmax ? 0 : P.VU.elt<uint16_t>(rs2_num, rs1);
     else \
-      P.VU.elt<uint16_t>(rd_num, i, true) = 0xFFFF; \
+      P.VU.elt<uint16_t>(rd_num, i, true) = vector_agnostic(P.VU.elt<uint16_t>(rd_num, i, false)); \
     break;
   case e32:
     if (1 == mata_action) \
       P.VU.elt<uint32_t>(rd_num, i, true) = rs1 >= P.VU.vlmax ? 0 : P.VU.elt<uint32_t>(rs2_num, rs1);
     else \
-      P.VU.elt<uint32_t>(rd_num, i, true) = 0xFFFFFFFF; \
+      P.VU.elt<uint32_t>(rd_num, i, true) = vector_agnostic(P.VU.elt<uint32_t>(rd_num, i, false)); \
     break;
   default:
     if (1 == mata_action) \
       P.VU.elt<uint64_t>(rd_num, i, true) = rs1 >= P.VU.vlmax ? 0 : P.VU.elt<uint64_t>(rs2_num, rs1);
     else \
-      P.VU.elt<uint64_t>(rd_num, i, true) = 0xFFFFFFFFFFFFFFFF; \
+      P.VU.elt<uint64_t>(rd_num, i, true) = vector_agnostic(P.VU.elt<uint64_t>(rd_num, i, false)); \
     break;
   }
 VI_LOOP_END;

--- a/riscv/insns/vrgatherei16_vv.h
+++ b/riscv/insns/vrgatherei16_vv.h
@@ -9,25 +9,44 @@ require(insn.rd() != insn.rs2());
 require_vm;
 
 VI_LOOP_BASE
+  if (0 == P.VU.vta && i >= vl) { \
+    continue; \
+  } \
+  if ((true == skip && 1 == P.VU.vma && i < vl) || (1 == P.VU.vta && i >= vl)) \
+    mata_action = 2; \
+  else \
+    mata_action = 1; \
   switch (sew) {
   case e8: {
     auto vs1 = P.VU.elt<uint16_t>(rs1_num, i);
-    P.VU.elt<uint8_t>(rd_num, i, true) = vs1 >= P.VU.vlmax ? 0 : P.VU.elt<uint8_t>(rs2_num, vs1);
+    if (1 == mata_action) \
+      P.VU.elt<uint8_t>(rd_num, i, true) = vs1 >= P.VU.vlmax ? 0 : P.VU.elt<uint8_t>(rs2_num, vs1);
+    else \
+      P.VU.elt<uint8_t>(rd_num, i, true) = 0xFF; \
     break;
   }
   case e16: {
     auto vs1 = P.VU.elt<uint16_t>(rs1_num, i);
-    P.VU.elt<uint16_t>(rd_num, i, true) = vs1 >= P.VU.vlmax ? 0 : P.VU.elt<uint16_t>(rs2_num, vs1);
+    if (1 == mata_action) \
+      P.VU.elt<uint16_t>(rd_num, i, true) = vs1 >= P.VU.vlmax ? 0 : P.VU.elt<uint16_t>(rs2_num, vs1);
+    else \
+      P.VU.elt<uint16_t>(rd_num, i, true) = 0xFFFF; \
     break;
   }
   case e32: {
     auto vs1 = P.VU.elt<uint16_t>(rs1_num, i);
-    P.VU.elt<uint32_t>(rd_num, i, true) = vs1 >= P.VU.vlmax ? 0 : P.VU.elt<uint32_t>(rs2_num, vs1);
+    if (1 == mata_action) \
+      P.VU.elt<uint32_t>(rd_num, i, true) = vs1 >= P.VU.vlmax ? 0 : P.VU.elt<uint32_t>(rs2_num, vs1);
+    else \
+      P.VU.elt<uint32_t>(rd_num, i, true) = 0xFFFFFFFF; \
     break;
   }
   default: {
     auto vs1 = P.VU.elt<uint16_t>(rs1_num, i);
-    P.VU.elt<uint64_t>(rd_num, i, true) = vs1 >= P.VU.vlmax ? 0 : P.VU.elt<uint64_t>(rs2_num, vs1);
+    if (1 == mata_action) \
+      P.VU.elt<uint64_t>(rd_num, i, true) = vs1 >= P.VU.vlmax ? 0 : P.VU.elt<uint64_t>(rs2_num, vs1);
+    else \
+      P.VU.elt<uint64_t>(rd_num, i, true) = 0xFFFFFFFFFFFFFFFF; \
     break;
   }
   }

--- a/riscv/insns/vrgatherei16_vv.h
+++ b/riscv/insns/vrgatherei16_vv.h
@@ -8,7 +8,7 @@ require_noover(insn.rd(), P.VU.vflmul, insn.rs1(), vemul);
 require(insn.rd() != insn.rs2());
 require_vm;
 
-VI_LOOP_BASE
+VI_LOOP_BASE(1)
   if (0 == P.VU.vta && i >= vl) { \
     continue; \
   } \

--- a/riscv/insns/vrgatherei16_vv.h
+++ b/riscv/insns/vrgatherei16_vv.h
@@ -22,7 +22,7 @@ VI_LOOP_BASE(1)
     if (1 == mata_action) \
       P.VU.elt<uint8_t>(rd_num, i, true) = vs1 >= P.VU.vlmax ? 0 : P.VU.elt<uint8_t>(rs2_num, vs1);
     else \
-      P.VU.elt<uint8_t>(rd_num, i, true) = 0xFF; \
+      P.VU.elt<uint8_t>(rd_num, i, true) = vector_agnostic(P.VU.elt<uint8_t>(rd_num, i, false)); \
     break;
   }
   case e16: {
@@ -30,7 +30,7 @@ VI_LOOP_BASE(1)
     if (1 == mata_action) \
       P.VU.elt<uint16_t>(rd_num, i, true) = vs1 >= P.VU.vlmax ? 0 : P.VU.elt<uint16_t>(rs2_num, vs1);
     else \
-      P.VU.elt<uint16_t>(rd_num, i, true) = 0xFFFF; \
+      P.VU.elt<uint16_t>(rd_num, i, true) = vector_agnostic(P.VU.elt<uint16_t>(rd_num, i, false)); \
     break;
   }
   case e32: {
@@ -38,7 +38,7 @@ VI_LOOP_BASE(1)
     if (1 == mata_action) \
       P.VU.elt<uint32_t>(rd_num, i, true) = vs1 >= P.VU.vlmax ? 0 : P.VU.elt<uint32_t>(rs2_num, vs1);
     else \
-      P.VU.elt<uint32_t>(rd_num, i, true) = 0xFFFFFFFF; \
+      P.VU.elt<uint32_t>(rd_num, i, true) = vector_agnostic(P.VU.elt<uint32_t>(rd_num, i, false)); \
     break;
   }
   default: {
@@ -46,7 +46,7 @@ VI_LOOP_BASE(1)
     if (1 == mata_action) \
       P.VU.elt<uint64_t>(rd_num, i, true) = vs1 >= P.VU.vlmax ? 0 : P.VU.elt<uint64_t>(rs2_num, vs1);
     else \
-      P.VU.elt<uint64_t>(rd_num, i, true) = 0xFFFFFFFFFFFFFFFF; \
+      P.VU.elt<uint64_t>(rd_num, i, true) = vector_agnostic(P.VU.elt<uint64_t>(rd_num, i, false)); \
     break;
   }
   }

--- a/riscv/insns/vsadd_vi.h
+++ b/riscv/insns/vsadd_vi.h
@@ -15,7 +15,7 @@ case e8: {
   if (1 == mata_action) \
     vd = sat_add<int8_t, uint8_t>(vs2, vsext(simm5, sew), sat);
   else \
-    vd = 0xFF; \
+    vd = vector_agnostic(vd); \
   break;
 }
 case e16: {
@@ -23,7 +23,7 @@ case e16: {
   if (1 == mata_action) \
     vd = sat_add<int16_t, uint16_t>(vs2, vsext(simm5, sew), sat);
   else \
-    vd = 0xFFFF; \
+    vd = vector_agnostic(vd); \
   break;
 }
 case e32: {
@@ -31,7 +31,7 @@ case e32: {
   if (1 == mata_action) \
     vd = sat_add<int32_t, uint32_t>(vs2, vsext(simm5, sew), sat);
   else \
-    vd = 0xFFFFFFFF; \
+    vd = vector_agnostic(vd); \
   break;
 }
 default: {
@@ -39,7 +39,7 @@ default: {
   if (1 == mata_action) \
     vd = sat_add<int64_t, uint64_t>(vs2, vsext(simm5, sew), sat);
   else \
-    vd = 0xFFFFFFFFFFFFFFFF; \
+    vd = vector_agnostic(vd); \
   break;
 }
 }

--- a/riscv/insns/vsadd_vi.h
+++ b/riscv/insns/vsadd_vi.h
@@ -2,25 +2,44 @@
 VI_CHECK_SSS(false);
 VI_LOOP_BASE
 bool sat = false;
+if (0 == P.VU.vta && i >= vl) { \
+  continue; \
+} \
+if ((true == skip && 1 == P.VU.vma && i < vl) || (1 == P.VU.vta && i >= vl)) \
+  mata_action = 2; \
+else \
+  mata_action = 1; \
 switch (sew) {
 case e8: {
   VI_PARAMS(e8);
-  vd = sat_add<int8_t, uint8_t>(vs2, vsext(simm5, sew), sat);
+  if (1 == mata_action) \
+    vd = sat_add<int8_t, uint8_t>(vs2, vsext(simm5, sew), sat);
+  else \
+    vd = 0xFF; \
   break;
 }
 case e16: {
   VI_PARAMS(e16);
-  vd = sat_add<int16_t, uint16_t>(vs2, vsext(simm5, sew), sat);
+  if (1 == mata_action) \
+    vd = sat_add<int16_t, uint16_t>(vs2, vsext(simm5, sew), sat);
+  else \
+    vd = 0xFFFF; \
   break;
 }
 case e32: {
   VI_PARAMS(e32);
-  vd = sat_add<int32_t, uint32_t>(vs2, vsext(simm5, sew), sat);
+  if (1 == mata_action) \
+    vd = sat_add<int32_t, uint32_t>(vs2, vsext(simm5, sew), sat);
+  else \
+    vd = 0xFFFFFFFF; \
   break;
 }
 default: {
   VI_PARAMS(e64);
-  vd = sat_add<int64_t, uint64_t>(vs2, vsext(simm5, sew), sat);
+  if (1 == mata_action) \
+    vd = sat_add<int64_t, uint64_t>(vs2, vsext(simm5, sew), sat);
+  else \
+    vd = 0xFFFFFFFFFFFFFFFF; \
   break;
 }
 }

--- a/riscv/insns/vsadd_vi.h
+++ b/riscv/insns/vsadd_vi.h
@@ -1,6 +1,6 @@
 // vsadd.vi vd, vs2 simm5
 VI_CHECK_SSS(false);
-VI_LOOP_BASE
+VI_LOOP_BASE(1)
 bool sat = false;
 if (0 == P.VU.vta && i >= vl) { \
   continue; \

--- a/riscv/insns/vsadd_vv.h
+++ b/riscv/insns/vsadd_vv.h
@@ -1,6 +1,6 @@
 // vsadd.vv vd, vs2, vs1
 VI_CHECK_SSS(true);
-VI_LOOP_BASE
+VI_LOOP_BASE(1)
 bool sat = false;
 
 if (0 == P.VU.vta && i >= vl) { \

--- a/riscv/insns/vsadd_vv.h
+++ b/riscv/insns/vsadd_vv.h
@@ -16,7 +16,7 @@ case e8: {
   if (1 == mata_action) \
     vd = sat_add<int8_t, uint8_t>(vs2, vs1, sat);
   else \
-    vd = 0xFF; \
+    vd = vector_agnostic(vd); \
   break;
 }
 case e16: {
@@ -24,7 +24,7 @@ case e16: {
   if (1 == mata_action) \
     vd = sat_add<int16_t, uint16_t>(vs2, vs1, sat);
   else \
-    vd = 0xFFFF; \
+    vd = vector_agnostic(vd); \
   break;
 }
 case e32: {
@@ -32,7 +32,7 @@ case e32: {
   if (1 == mata_action) \
     vd = sat_add<int32_t, uint32_t>(vs2, vs1, sat);
   else \
-    vd = 0xFFFFFFFF; \
+    vd = vector_agnostic(vd); \
   break;
 }
 default: {
@@ -40,7 +40,7 @@ default: {
   if (1 == mata_action) \
     vd = sat_add<int64_t, uint64_t>(vs2, vs1, sat);
   else \
-    vd = 0xFFFFFFFFFFFFFFFF; \
+    vd = vector_agnostic(vd); \
   break;
 }
 }

--- a/riscv/insns/vsadd_vv.h
+++ b/riscv/insns/vsadd_vv.h
@@ -2,25 +2,45 @@
 VI_CHECK_SSS(true);
 VI_LOOP_BASE
 bool sat = false;
+
+if (0 == P.VU.vta && i >= vl) { \
+  continue; \
+} \
+if ((true == skip && 1 == P.VU.vma && i < vl) || (1 == P.VU.vta && i >= vl)) \
+  mata_action = 2; \
+else \
+  mata_action = 1; \
 switch (sew) {
 case e8: {
   VV_PARAMS(e8);
-  vd = sat_add<int8_t, uint8_t>(vs2, vs1, sat);
+  if (1 == mata_action) \
+    vd = sat_add<int8_t, uint8_t>(vs2, vs1, sat);
+  else \
+    vd = 0xFF; \
   break;
 }
 case e16: {
   VV_PARAMS(e16);
-  vd = sat_add<int16_t, uint16_t>(vs2, vs1, sat);
+  if (1 == mata_action) \
+    vd = sat_add<int16_t, uint16_t>(vs2, vs1, sat);
+  else \
+    vd = 0xFFFF; \
   break;
 }
 case e32: {
   VV_PARAMS(e32);
-  vd = sat_add<int32_t, uint32_t>(vs2, vs1, sat);
+  if (1 == mata_action) \
+    vd = sat_add<int32_t, uint32_t>(vs2, vs1, sat);
+  else \
+    vd = 0xFFFFFFFF; \
   break;
 }
 default: {
   VV_PARAMS(e64);
-  vd = sat_add<int64_t, uint64_t>(vs2, vs1, sat);
+  if (1 == mata_action) \
+    vd = sat_add<int64_t, uint64_t>(vs2, vs1, sat);
+  else \
+    vd = 0xFFFFFFFFFFFFFFFF; \
   break;
 }
 }

--- a/riscv/insns/vsadd_vx.h
+++ b/riscv/insns/vsadd_vx.h
@@ -15,7 +15,7 @@ case e8: {
   if (1 == mata_action) \
     vd = sat_add<int8_t, uint8_t>(vs2, rs1, sat);
   else \
-    vd = 0xFF; \
+    vd = vector_agnostic(vd); \
   break;
 }
 case e16: {
@@ -23,7 +23,7 @@ case e16: {
   if (1 == mata_action) \
     vd = sat_add<int16_t, uint16_t>(vs2, rs1, sat);
   else \
-    vd = 0xFFFF; \
+    vd = vector_agnostic(vd); \
   break;
 }
 case e32: {
@@ -31,7 +31,7 @@ case e32: {
   if (1 == mata_action) \
     vd = sat_add<int32_t, uint32_t>(vs2, rs1, sat);
   else \
-    vd = 0xFFFFFFFF; \
+    vd = vector_agnostic(vd); \
   break;
 }
 default: {
@@ -39,7 +39,7 @@ default: {
   if (1 == mata_action) \
     vd = sat_add<int64_t, uint64_t>(vs2, rs1, sat);
   else \
-    vd = 0xFFFFFFFFFFFFFFFF; \
+    vd = vector_agnostic(vd); \
   break;
 }
 }

--- a/riscv/insns/vsadd_vx.h
+++ b/riscv/insns/vsadd_vx.h
@@ -1,6 +1,6 @@
 // vsadd.vx vd, vs2, rs1
 VI_CHECK_SSS(false);
-VI_LOOP_BASE
+VI_LOOP_BASE(1)
 bool sat = false;
 if (0 == P.VU.vta && i >= vl) { \
   continue; \

--- a/riscv/insns/vsadd_vx.h
+++ b/riscv/insns/vsadd_vx.h
@@ -2,25 +2,44 @@
 VI_CHECK_SSS(false);
 VI_LOOP_BASE
 bool sat = false;
+if (0 == P.VU.vta && i >= vl) { \
+  continue; \
+} \
+if ((true == skip && 1 == P.VU.vma && i < vl) || (1 == P.VU.vta && i >= vl)) \
+  mata_action = 2; \
+else \
+  mata_action = 1; \
 switch (sew) {
 case e8: {
   VX_PARAMS(e8);
-  vd = sat_add<int8_t, uint8_t>(vs2, rs1, sat);
+  if (1 == mata_action) \
+    vd = sat_add<int8_t, uint8_t>(vs2, rs1, sat);
+  else \
+    vd = 0xFF; \
   break;
 }
 case e16: {
   VX_PARAMS(e16);
-  vd = sat_add<int16_t, uint16_t>(vs2, rs1, sat);
+  if (1 == mata_action) \
+    vd = sat_add<int16_t, uint16_t>(vs2, rs1, sat);
+  else \
+    vd = 0xFFFF; \
   break;
 }
 case e32: {
   VX_PARAMS(e32);
-  vd = sat_add<int32_t, uint32_t>(vs2, rs1, sat);
+  if (1 == mata_action) \
+    vd = sat_add<int32_t, uint32_t>(vs2, rs1, sat);
+  else \
+    vd = 0xFFFFFFFF; \
   break;
 }
 default: {
   VX_PARAMS(e64);
-  vd = sat_add<int64_t, uint64_t>(vs2, rs1, sat);
+  if (1 == mata_action) \
+    vd = sat_add<int64_t, uint64_t>(vs2, rs1, sat);
+  else \
+    vd = 0xFFFFFFFFFFFFFFFF; \
   break;
 }
 }

--- a/riscv/insns/vslide1down_vx.h
+++ b/riscv/insns/vslide1down_vx.h
@@ -16,7 +16,7 @@ if (i != vl - 1) {
     if (1 == mata_action) \
       vd = vs2; \
     else \
-      vd = 0xFF; \
+      vd = vector_agnostic(vd); \
   }
   break;
   case e16: {
@@ -24,7 +24,7 @@ if (i != vl - 1) {
     if (1 == mata_action) \
       vd = vs2; \
     else \
-      vd = 0xFFFF; \
+      vd = vector_agnostic(vd); \
   }
   break;
   case e32: {
@@ -32,7 +32,7 @@ if (i != vl - 1) {
     if (1 == mata_action) \
       vd = vs2; \
     else \
-      vd = 0xFFFFFFFF; \
+      vd = vector_agnostic(vd); \
   }
   break;
   default: {
@@ -40,7 +40,7 @@ if (i != vl - 1) {
     if (1 == mata_action) \
       vd = vs2; \
     else \
-      vd = 0xFFFFFFFFFFFFFFFF; \
+      vd = vector_agnostic(vd); \
   }
   break;
   }
@@ -50,25 +50,25 @@ if (i != vl - 1) {
     if (1 == mata_action) \
       P.VU.elt<uint8_t>(rd_num, vl - 1, true) = RS1; \
     else \
-      P.VU.elt<uint8_t>(rd_num, vl - 1, true) = 0xFF; \
+      P.VU.elt<uint8_t>(rd_num, vl - 1, true) = vector_agnostic(P.VU.elt<uint8_t>(rd_num, vl - 1, false)); \
     break;
   case e16:
     if (1 == mata_action) \
       P.VU.elt<uint16_t>(rd_num, vl - 1, true) = RS1; \
     else \
-      P.VU.elt<uint16_t>(rd_num, vl - 1, true) = 0xFFFF; \
+      P.VU.elt<uint16_t>(rd_num, vl - 1, true) = vector_agnostic(P.VU.elt<uint16_t>(rd_num, vl - 1, false)); \
     break;
   case e32:
     if (1 == mata_action) \
       P.VU.elt<uint32_t>(rd_num, vl - 1, true) = RS1; \
     else \
-      P.VU.elt<uint32_t>(rd_num, vl - 1, true) = 0xFFFFFFFF; \
+      P.VU.elt<uint32_t>(rd_num, vl - 1, true) = vector_agnostic(P.VU.elt<uint32_t>(rd_num, vl - 1, false)); \
     break;
   default:
     if (1 == mata_action) \
       P.VU.elt<uint64_t>(rd_num, vl - 1, true) = RS1; \
     else \
-      P.VU.elt<uint64_t>(rd_num, vl - 1, true) = 0xFFFFFFFFFFFFFFFF; \
+      P.VU.elt<uint64_t>(rd_num, vl - 1, true) = vector_agnostic(P.VU.elt<uint64_t>(rd_num, vl - 1, false)); \
     break;
   }
 }

--- a/riscv/insns/vslide1down_vx.h
+++ b/riscv/insns/vslide1down_vx.h
@@ -1,7 +1,7 @@
 //vslide1down.vx vd, vs2, rs1
 VI_CHECK_SLIDE(false);
 
-VI_LOOP_BASE
+VI_LOOP_BASE(1)
 if (0 == P.VU.vta && i >= vl) { \
   continue; \
 } \

--- a/riscv/insns/vslide1down_vx.h
+++ b/riscv/insns/vslide1down_vx.h
@@ -2,42 +2,73 @@
 VI_CHECK_SLIDE(false);
 
 VI_LOOP_BASE
+if (0 == P.VU.vta && i >= vl) { \
+  continue; \
+} \
+if ((true == skip && 1 == P.VU.vma && i < vl) || (1 == P.VU.vta && i >= vl)) \
+  mata_action = 2; \
+else \
+  mata_action = 1; \
 if (i != vl - 1) {
   switch (sew) {
   case e8: {
     VI_XI_SLIDEDOWN_PARAMS(e8, 1);
-    vd = vs2;
+    if (1 == mata_action) \
+      vd = vs2; \
+    else \
+      vd = 0xFF; \
   }
   break;
   case e16: {
     VI_XI_SLIDEDOWN_PARAMS(e16, 1);
-    vd = vs2;
+    if (1 == mata_action) \
+      vd = vs2; \
+    else \
+      vd = 0xFFFF; \
   }
   break;
   case e32: {
     VI_XI_SLIDEDOWN_PARAMS(e32, 1);
-    vd = vs2;
+    if (1 == mata_action) \
+      vd = vs2; \
+    else \
+      vd = 0xFFFFFFFF; \
   }
   break;
   default: {
     VI_XI_SLIDEDOWN_PARAMS(e64, 1);
-    vd = vs2;
+    if (1 == mata_action) \
+      vd = vs2; \
+    else \
+      vd = 0xFFFFFFFFFFFFFFFF; \
   }
   break;
   }
 } else {
   switch (sew) {
   case e8:
-    P.VU.elt<uint8_t>(rd_num, vl - 1, true) = RS1;
+    if (1 == mata_action) \
+      P.VU.elt<uint8_t>(rd_num, vl - 1, true) = RS1; \
+    else \
+      P.VU.elt<uint8_t>(rd_num, vl - 1, true) = 0xFF; \
     break;
   case e16:
-    P.VU.elt<uint16_t>(rd_num, vl - 1, true) = RS1;
+    if (1 == mata_action) \
+      P.VU.elt<uint16_t>(rd_num, vl - 1, true) = RS1; \
+    else \
+      P.VU.elt<uint16_t>(rd_num, vl - 1, true) = 0xFFFF; \
     break;
   case e32:
-    P.VU.elt<uint32_t>(rd_num, vl - 1, true) = RS1;
+    if (1 == mata_action) \
+      P.VU.elt<uint32_t>(rd_num, vl - 1, true) = RS1; \
+    else \
+      P.VU.elt<uint32_t>(rd_num, vl - 1, true) = 0xFFFFFFFF; \
     break;
   default:
-    P.VU.elt<uint64_t>(rd_num, vl - 1, true) = RS1;
+    if (1 == mata_action) \
+      P.VU.elt<uint64_t>(rd_num, vl - 1, true) = RS1; \
+    else \
+      P.VU.elt<uint64_t>(rd_num, vl - 1, true) = 0xFFFFFFFFFFFFFFFF; \
     break;
   }
 }

--- a/riscv/insns/vslide1up_vx.h
+++ b/riscv/insns/vslide1up_vx.h
@@ -1,7 +1,7 @@
 //vslide1up.vx vd, vs2, rs1
 VI_CHECK_SLIDE(true);
 
-VI_LOOP_BASE
+VI_LOOP_BASE(1)
 if (0 == P.VU.vta && i >= vl) { \
   continue; \
 } \

--- a/riscv/insns/vslide1up_vx.h
+++ b/riscv/insns/vslide1up_vx.h
@@ -15,47 +15,47 @@ if (i != 0) {
     if (1 == mata_action) \
       vd = vs2; \
     else \
-      vd = 0xFF; \
+      vd = vector_agnostic(vd); \
   } else if (sew == e16) {
     VI_XI_SLIDEUP_PARAMS(e16, 1);
     if (1 == mata_action) \
       vd = vs2; \
     else \
-      vd = 0xFFFF; \
+      vd = vector_agnostic(vd); \
   } else if (sew == e32) {
     VI_XI_SLIDEUP_PARAMS(e32, 1);
     if (1 == mata_action) \
       vd = vs2; \
     else \
-      vd = 0xFFFFFFFF; \
+      vd = vector_agnostic(vd); \
   } else if (sew == e64) {
     VI_XI_SLIDEUP_PARAMS(e64, 1);
     if (1 == mata_action) \
       vd = vs2; \
     else \
-      vd = 0xFFFFFFFFFFFFFFFF; \
+      vd = vector_agnostic(vd); \
   }
 } else {
   if (sew == e8) {
     if (1 == mata_action) \
       P.VU.elt<uint8_t>(rd_num, 0, true) = RS1; \
     else \
-      P.VU.elt<uint8_t>(rd_num, 0, true) = 0xFF; \
+      P.VU.elt<uint8_t>(rd_num, 0, true) = vector_agnostic(P.VU.elt<uint8_t>(rd_num, 0, false)); \
   } else if (sew == e16) {
     if (1 == mata_action) \
       P.VU.elt<uint16_t>(rd_num, 0, true) = RS1; \
     else \
-      P.VU.elt<uint16_t>(rd_num, 0, true) = 0xFFFF; \
+      P.VU.elt<uint16_t>(rd_num, 0, true) = vector_agnostic(P.VU.elt<uint16_t>(rd_num, 0, false)); \
   } else if (sew == e32) {
     if (1 == mata_action) \
       P.VU.elt<uint32_t>(rd_num, 0, true) = RS1; \
     else \
-      P.VU.elt<uint32_t>(rd_num, 0, true) = 0xFFFFFFFF; \
+      P.VU.elt<uint32_t>(rd_num, 0, true) = vector_agnostic(P.VU.elt<uint32_t>(rd_num, 0, false)); \
   } else if (sew == e64) {
     if (1 == mata_action) \
       P.VU.elt<uint64_t>(rd_num, 0, true) = RS1; \
     else \
-      P.VU.elt<uint64_t>(rd_num, 0, true) = 0xFFFFFFFFFFFFFFFF; \
+      P.VU.elt<uint64_t>(rd_num, 0, true) = vector_agnostic(P.VU.elt<uint64_t>(rd_num, 0, false)); \
   }
 }
 VI_LOOP_END

--- a/riscv/insns/vslide1up_vx.h
+++ b/riscv/insns/vslide1up_vx.h
@@ -2,29 +2,60 @@
 VI_CHECK_SLIDE(true);
 
 VI_LOOP_BASE
+if (0 == P.VU.vta && i >= vl) { \
+  continue; \
+} \
+if ((true == skip && 1 == P.VU.vma && i < vl) || (i >= vl)) \
+  mata_action = 2; \
+else \
+  mata_action = 1; \
 if (i != 0) {
   if (sew == e8) {
     VI_XI_SLIDEUP_PARAMS(e8, 1);
-    vd = vs2;
+    if (1 == mata_action) \
+      vd = vs2; \
+    else \
+      vd = 0xFF; \
   } else if (sew == e16) {
     VI_XI_SLIDEUP_PARAMS(e16, 1);
-    vd = vs2;
+    if (1 == mata_action) \
+      vd = vs2; \
+    else \
+      vd = 0xFFFF; \
   } else if (sew == e32) {
     VI_XI_SLIDEUP_PARAMS(e32, 1);
-    vd = vs2;
+    if (1 == mata_action) \
+      vd = vs2; \
+    else \
+      vd = 0xFFFFFFFF; \
   } else if (sew == e64) {
     VI_XI_SLIDEUP_PARAMS(e64, 1);
-    vd = vs2;
+    if (1 == mata_action) \
+      vd = vs2; \
+    else \
+      vd = 0xFFFFFFFFFFFFFFFF; \
   }
 } else {
   if (sew == e8) {
-    P.VU.elt<uint8_t>(rd_num, 0, true) = RS1;
+    if (1 == mata_action) \
+      P.VU.elt<uint8_t>(rd_num, 0, true) = RS1; \
+    else \
+      P.VU.elt<uint8_t>(rd_num, 0, true) = 0xFF; \
   } else if (sew == e16) {
-    P.VU.elt<uint16_t>(rd_num, 0, true) = RS1;
+    if (1 == mata_action) \
+      P.VU.elt<uint16_t>(rd_num, 0, true) = RS1; \
+    else \
+      P.VU.elt<uint16_t>(rd_num, 0, true) = 0xFFFF; \
   } else if (sew == e32) {
-    P.VU.elt<uint32_t>(rd_num, 0, true) = RS1;
+    if (1 == mata_action) \
+      P.VU.elt<uint32_t>(rd_num, 0, true) = RS1; \
+    else \
+      P.VU.elt<uint32_t>(rd_num, 0, true) = 0xFFFFFFFF; \
   } else if (sew == e64) {
-    P.VU.elt<uint64_t>(rd_num, 0, true) = RS1;
+    if (1 == mata_action) \
+      P.VU.elt<uint64_t>(rd_num, 0, true) = RS1; \
+    else \
+      P.VU.elt<uint64_t>(rd_num, 0, true) = 0xFFFFFFFFFFFFFFFF; \
   }
 }
 VI_LOOP_END

--- a/riscv/insns/vslidedown_vi.h
+++ b/riscv/insns/vslidedown_vi.h
@@ -2,7 +2,29 @@
 VI_CHECK_SLIDE(false);
 
 const reg_t sh = insn.v_zimm5();
-VI_LOOP_BASE
+//VI_LOOP_BASE
+\
+require(P.VU.vsew >= e8 && P.VU.vsew <= e64); \
+require_vector(true); \
+reg_t vl = P.VU.vl->read(); \
+reg_t UNUSED sew = P.VU.vsew; \
+reg_t rd_num = insn.rd(); \
+reg_t UNUSED rs1_num = insn.rs1(); \
+reg_t rs2_num = insn.rs2(); \
+V_EXT_VSTART_CHECK; \
+for (reg_t i = P.VU.vstart->read(); i < std::max(P.VU.vlmax, P.VU.VLEN/P.VU.vsew); ++i) { \
+\
+VI_MASK_VARS \
+__attribute__((unused)) int mata_action = 0; \
+bool skip = false; \
+mata_action = 0; \
+if (insn.v_vm() == 0) { \
+  skip = ((P.VU.elt<uint64_t>(0, midx) >> mpos) & 0x1) == 0; \
+  if (skip && 0 == P.VU.vma && i < vl) { \
+      continue; \
+  } \
+} \
+\
 
 reg_t offset = 0;
 bool is_valid = (i + sh) < P.VU.vlmax;
@@ -10,26 +32,44 @@ bool is_valid = (i + sh) < P.VU.vlmax;
 if (is_valid) {
   offset = sh;
 }
-
+if (0 == P.VU.vta && i >= vl) { \
+  continue; \
+} \
+if ((true == skip && 1 == P.VU.vma && i < vl) || (1 == P.VU.vta && i >= vl)) \
+  mata_action = 2; \
+else \
+  mata_action = 1; \
 switch (sew) {
 case e8: {
   VI_XI_SLIDEDOWN_PARAMS(e8, offset);
-  vd = is_valid ? vs2 : 0;
+  if (1 == mata_action) \
+    vd = is_valid ? vs2 : 0; \
+  else \
+    vd = 0xFF; \
 }
 break;
 case e16: {
   VI_XI_SLIDEDOWN_PARAMS(e16, offset);
-  vd = is_valid ? vs2 : 0;
+  if (1 == mata_action) \
+    vd = is_valid ? vs2 : 0; \
+  else \
+    vd = 0xFFFF; \
 }
 break;
 case e32: {
   VI_XI_SLIDEDOWN_PARAMS(e32, offset);
-  vd = is_valid ? vs2 : 0;
+  if (1 == mata_action) \
+    vd = is_valid ? vs2 : 0; \
+  else \
+    vd = 0xFFFFFFFF; \
 }
 break;
 default: {
   VI_XI_SLIDEDOWN_PARAMS(e64, offset);
-  vd = is_valid ? vs2 : 0;
+  if (1 == mata_action) \
+    vd = is_valid ? vs2 : 0; \
+  else \
+    vd = 0xFFFFFFFFFFFFFFFF; \
 }
 break;
 }

--- a/riscv/insns/vslidedown_vi.h
+++ b/riscv/insns/vslidedown_vi.h
@@ -45,7 +45,7 @@ case e8: {
   if (1 == mata_action) \
     vd = is_valid ? vs2 : 0; \
   else \
-    vd = 0xFF; \
+    vd = vector_agnostic(vd); \
 }
 break;
 case e16: {
@@ -53,7 +53,7 @@ case e16: {
   if (1 == mata_action) \
     vd = is_valid ? vs2 : 0; \
   else \
-    vd = 0xFFFF; \
+    vd = vector_agnostic(vd); \
 }
 break;
 case e32: {
@@ -61,7 +61,7 @@ case e32: {
   if (1 == mata_action) \
     vd = is_valid ? vs2 : 0; \
   else \
-    vd = 0xFFFFFFFF; \
+    vd = vector_agnostic(vd); \
 }
 break;
 default: {
@@ -69,7 +69,7 @@ default: {
   if (1 == mata_action) \
     vd = is_valid ? vs2 : 0; \
   else \
-    vd = 0xFFFFFFFFFFFFFFFF; \
+    vd = vector_agnostic(vd); \
 }
 break;
 }

--- a/riscv/insns/vslidedown_vx.h
+++ b/riscv/insns/vslidedown_vx.h
@@ -45,7 +45,7 @@ case e8: {
   if (1 == mata_action) \
     vd = is_valid ? vs2 : 0; \
   else \
-    vd = 0xFF; \
+    vd = vector_agnostic(vd); \
 }
 break;
 case e16: {
@@ -53,7 +53,7 @@ case e16: {
   if (1 == mata_action) \
     vd = is_valid ? vs2 : 0; \
   else \
-    vd = 0xFFFF; \
+    vd = vector_agnostic(vd); \
 }
 break;
 case e32: {
@@ -61,7 +61,7 @@ case e32: {
   if (1 == mata_action) \
     vd = is_valid ? vs2 : 0; \
   else \
-    vd = 0xFFFFFFFF; \
+    vd = vector_agnostic(vd); \
 }
 break;
 default: {
@@ -69,7 +69,7 @@ default: {
   if (1 == mata_action) \
     vd = is_valid ? vs2 : 0; \
   else \
-    vd = 0xFFFFFFFFFFFFFFFF; \
+    vd = vector_agnostic(vd); \
 }
 break;
 }

--- a/riscv/insns/vslidedown_vx.h
+++ b/riscv/insns/vslidedown_vx.h
@@ -2,7 +2,29 @@
 VI_CHECK_SLIDE(false);
 
 const uint128_t sh = RS1;
-VI_LOOP_BASE
+//VI_LOOP_BASE
+\
+require(P.VU.vsew >= e8 && P.VU.vsew <= e64); \
+require_vector(true); \
+reg_t vl = P.VU.vl->read(); \
+reg_t UNUSED sew = P.VU.vsew; \
+reg_t rd_num = insn.rd(); \
+reg_t UNUSED rs1_num = insn.rs1(); \
+reg_t rs2_num = insn.rs2(); \
+V_EXT_VSTART_CHECK; \
+for (reg_t i = P.VU.vstart->read(); i < std::max(P.VU.vlmax, P.VU.VLEN/P.VU.vsew); ++i) { \
+\
+VI_MASK_VARS \
+__attribute__((unused)) int mata_action = 0; \
+bool skip = false; \
+mata_action = 0; \
+if (insn.v_vm() == 0) { \
+  skip = ((P.VU.elt<uint64_t>(0, midx) >> mpos) & 0x1) == 0; \
+  if (skip && 0 == P.VU.vma && i < vl) { \
+      continue; \
+  } \
+} \
+\
 
 reg_t offset = 0;
 bool is_valid = (i + sh) < P.VU.vlmax;
@@ -10,26 +32,44 @@ bool is_valid = (i + sh) < P.VU.vlmax;
 if (is_valid) {
   offset = sh;
 }
-
+if (0 == P.VU.vta && i >= vl) { \
+  continue; \
+} \
+if ((true == skip && 1 == P.VU.vma && i < vl) || (1 == P.VU.vta && i >= vl)) \
+  mata_action = 2; \
+else \
+  mata_action = 1; \
 switch (sew) {
 case e8: {
   VI_XI_SLIDEDOWN_PARAMS(e8, offset);
-  vd = is_valid ? vs2 : 0;
+  if (1 == mata_action) \
+    vd = is_valid ? vs2 : 0; \
+  else \
+    vd = 0xFF; \
 }
 break;
 case e16: {
   VI_XI_SLIDEDOWN_PARAMS(e16, offset);
-  vd = is_valid ? vs2 : 0;
+  if (1 == mata_action) \
+    vd = is_valid ? vs2 : 0; \
+  else \
+    vd = 0xFFFF; \
 }
 break;
 case e32: {
   VI_XI_SLIDEDOWN_PARAMS(e32, offset);
-  vd = is_valid ? vs2 : 0;
+  if (1 == mata_action) \
+    vd = is_valid ? vs2 : 0; \
+  else \
+    vd = 0xFFFFFFFF; \
 }
 break;
 default: {
   VI_XI_SLIDEDOWN_PARAMS(e64, offset);
-  vd = is_valid ? vs2 : 0;
+  if (1 == mata_action) \
+    vd = is_valid ? vs2 : 0; \
+  else \
+    vd = 0xFFFFFFFFFFFFFFFF; \
 }
 break;
 }

--- a/riscv/insns/vslideup_vi.h
+++ b/riscv/insns/vslideup_vi.h
@@ -2,29 +2,69 @@
 VI_CHECK_SLIDE(true);
 
 const reg_t offset = insn.v_zimm5();
-VI_LOOP_BASE
+//VI_LOOP_BASE
+\
+require(P.VU.vsew >= e8 && P.VU.vsew <= e64); \
+require_vector(true); \
+reg_t vl = P.VU.vl->read(); \
+reg_t UNUSED sew = P.VU.vsew; \
+reg_t rd_num = insn.rd(); \
+reg_t UNUSED rs1_num = insn.rs1(); \
+reg_t rs2_num = insn.rs2(); \
+V_EXT_VSTART_CHECK; \
+for (reg_t i = P.VU.vstart->read(); i < std::max(P.VU.vlmax, P.VU.VLEN/P.VU.vsew); ++i) { \
+\
+VI_MASK_VARS \
+__attribute__((unused)) int mata_action = 0; \
+bool skip = false; \
+mata_action = 0; \
+if (insn.v_vm() == 0) { \
+  skip = ((P.VU.elt<uint64_t>(0, midx) >> mpos) & 0x1) == 0; \
+  if (skip && 0 == P.VU.vma && i<P.VU.vl->read() && i>= std::max(P.VU.vstart->read(), offset)) { \
+      continue; \
+  } \
+} \
+\
 if (P.VU.vstart->read() < offset && i < offset)
   continue;
-
+if (0 == P.VU.vta && i >= vl) { \
+  continue; \
+} \
+if ((true == skip && 1 == P.VU.vma && i < vl && i >= std::max(P.VU.vstart->read(), offset)) || (1 == P.VU.vta && i >= vl)) \
+  mata_action = 2; \
+else \
+  mata_action = 1; \
 switch (sew) {
 case e8: {
   VI_XI_SLIDEUP_PARAMS(e8, offset);
-  vd = vs2;
+  if (1 == mata_action) \
+    vd = vs2; \
+  else \
+    vd = 0xFF; \
 }
 break;
 case e16: {
   VI_XI_SLIDEUP_PARAMS(e16, offset);
-  vd = vs2;
+  if (1 == mata_action) \
+    vd = vs2; \
+  else \
+    vd = 0xFFFF; \
 }
 break;
 case e32: {
   VI_XI_SLIDEUP_PARAMS(e32, offset);
-  vd = vs2;
+  if (1 == mata_action) \
+    vd = vs2; \
+  else \
+    vd = 0xFFFFFFFF; \
 }
 break;
 default: {
   VI_XI_SLIDEUP_PARAMS(e64, offset);
-  vd = vs2;
+  if (1 == mata_action) \
+    vd = vs2; \
+  else \
+    vd = 0xFFFFFFFFFFFFFFFF; \
 }
 break;
 }

--- a/riscv/insns/vslideup_vi.h
+++ b/riscv/insns/vslideup_vi.h
@@ -40,7 +40,7 @@ case e8: {
   if (1 == mata_action) \
     vd = vs2; \
   else \
-    vd = 0xFF; \
+    vd = vector_agnostic(vd); \
 }
 break;
 case e16: {
@@ -48,7 +48,7 @@ case e16: {
   if (1 == mata_action) \
     vd = vs2; \
   else \
-    vd = 0xFFFF; \
+    vd = vector_agnostic(vd); \
 }
 break;
 case e32: {
@@ -56,7 +56,7 @@ case e32: {
   if (1 == mata_action) \
     vd = vs2; \
   else \
-    vd = 0xFFFFFFFF; \
+    vd = vector_agnostic(vd); \
 }
 break;
 default: {
@@ -64,7 +64,7 @@ default: {
   if (1 == mata_action) \
     vd = vs2; \
   else \
-    vd = 0xFFFFFFFFFFFFFFFF; \
+    vd = vector_agnostic(vd); \
 }
 break;
 }

--- a/riscv/insns/vslideup_vx.h
+++ b/riscv/insns/vslideup_vx.h
@@ -2,29 +2,69 @@
 VI_CHECK_SLIDE(true);
 
 const reg_t offset = RS1;
-VI_LOOP_BASE
+//VI_LOOP_BASE
+\
+require(P.VU.vsew >= e8 && P.VU.vsew <= e64); \
+require_vector(true); \
+reg_t vl = P.VU.vl->read(); \
+reg_t UNUSED sew = P.VU.vsew; \
+reg_t rd_num = insn.rd(); \
+reg_t UNUSED rs1_num = insn.rs1(); \
+reg_t rs2_num = insn.rs2(); \
+V_EXT_VSTART_CHECK; \
+for (reg_t i = P.VU.vstart->read(); i < std::max(P.VU.vlmax, P.VU.VLEN/P.VU.vsew); ++i) { \
+\
+VI_MASK_VARS \
+__attribute__((unused)) int mata_action = 0; \
+bool skip = false; \
+mata_action = 0; \
+if (insn.v_vm() == 0) { \
+  skip = ((P.VU.elt<uint64_t>(0, midx) >> mpos) & 0x1) == 0; \
+  if (skip && 0 == P.VU.vma && i<P.VU.vl->read() && i>= std::max(P.VU.vstart->read(), offset)) { \
+      continue; \
+  } \
+} \
+\
 if (P.VU.vstart->read() < offset && i < offset)
   continue;
-
+if (0 == P.VU.vta && i >= vl) { \
+  continue; \
+} \
+if ((true == skip && 1 == P.VU.vma && i < vl && i >= std::max(P.VU.vstart->read(), offset)) || (1 == P.VU.vta && i >= vl)) \
+  mata_action = 2; \
+else \
+  mata_action = 1; \
 switch (sew) {
 case e8: {
   VI_XI_SLIDEUP_PARAMS(e8, offset);
-  vd = vs2;
+  if (1 == mata_action) \
+    vd = vs2; \
+  else \
+    vd = 0xFF; \
 }
 break;
 case e16: {
   VI_XI_SLIDEUP_PARAMS(e16, offset);
-  vd = vs2;
+  if (1 == mata_action) \
+    vd = vs2; \
+  else \
+    vd = 0xFFFF; \
 }
 break;
 case e32: {
   VI_XI_SLIDEUP_PARAMS(e32, offset);
-  vd = vs2;
+  if (1 == mata_action) \
+    vd = vs2; \
+  else \
+    vd = 0xFFFFFFFF; \
 }
 break;
 default: {
   VI_XI_SLIDEUP_PARAMS(e64, offset);
-  vd = vs2;
+  if (1 == mata_action) \
+    vd = vs2; \
+  else \
+    vd = 0xFFFFFFFFFFFFFFFF; \
 }
 break;
 }

--- a/riscv/insns/vslideup_vx.h
+++ b/riscv/insns/vslideup_vx.h
@@ -40,7 +40,7 @@ case e8: {
   if (1 == mata_action) \
     vd = vs2; \
   else \
-    vd = 0xFF; \
+    vd = vector_agnostic(vd); \
 }
 break;
 case e16: {
@@ -48,7 +48,7 @@ case e16: {
   if (1 == mata_action) \
     vd = vs2; \
   else \
-    vd = 0xFFFF; \
+    vd = vector_agnostic(vd); \
 }
 break;
 case e32: {
@@ -56,7 +56,7 @@ case e32: {
   if (1 == mata_action) \
     vd = vs2; \
   else \
-    vd = 0xFFFFFFFF; \
+    vd = vector_agnostic(vd); \
 }
 break;
 default: {
@@ -64,7 +64,7 @@ default: {
   if (1 == mata_action) \
     vd = vs2; \
   else \
-    vd = 0xFFFFFFFFFFFFFFFF; \
+    vd = vector_agnostic(vd); \
 }
 break;
 }

--- a/riscv/insns/vssub_vv.h
+++ b/riscv/insns/vssub_vv.h
@@ -16,7 +16,7 @@ case e8: {
   if (1 == mata_action) \
     vd = sat_sub<int8_t, uint8_t>(vs2, vs1, sat);
   else \
-    vd = 0xFF; \
+    vd = vector_agnostic(vd); \
   break;
 }
 case e16: {
@@ -24,7 +24,7 @@ case e16: {
   if (1 == mata_action) \
     vd = sat_sub<int16_t, uint16_t>(vs2, vs1, sat);
   else \
-    vd = 0xFFFF; \
+    vd = vector_agnostic(vd); \
   break;
 }
 case e32: {
@@ -32,7 +32,7 @@ case e32: {
   if (1 == mata_action) \
     vd = sat_sub<int32_t, uint32_t>(vs2, vs1, sat);
   else \
-    vd = 0xFFFFFFFF; \
+    vd = vector_agnostic(vd); \
   break;
 }
 default: {
@@ -40,7 +40,7 @@ default: {
   if (1 == mata_action) \
     vd = sat_sub<int64_t, uint64_t>(vs2, vs1, sat);
   else \
-    vd = 0xFFFFFFFFFFFFFFFF; \
+    vd = vector_agnostic(vd); \
   break;
 }
 }

--- a/riscv/insns/vssub_vv.h
+++ b/riscv/insns/vssub_vv.h
@@ -1,6 +1,6 @@
 // vssub.vv vd, vs2, vs1
 VI_CHECK_SSS(true);
-VI_LOOP_BASE
+VI_LOOP_BASE(1)
 bool sat = false;
 
 if (0 == P.VU.vta && i >= vl) { \

--- a/riscv/insns/vssub_vv.h
+++ b/riscv/insns/vssub_vv.h
@@ -3,25 +3,44 @@ VI_CHECK_SSS(true);
 VI_LOOP_BASE
 bool sat = false;
 
+if (0 == P.VU.vta && i >= vl) { \
+  continue; \
+} \
+if ((true == skip && 1 == P.VU.vma && i < vl) || (1 == P.VU.vta && i >= vl)) \
+  mata_action = 2; \
+else \
+  mata_action = 1; \
 switch (sew) {
 case e8: {
   VV_PARAMS(e8);
-  vd = sat_sub<int8_t, uint8_t>(vs2, vs1, sat);
+  if (1 == mata_action) \
+    vd = sat_sub<int8_t, uint8_t>(vs2, vs1, sat);
+  else \
+    vd = 0xFF; \
   break;
 }
 case e16: {
   VV_PARAMS(e16);
-  vd = sat_sub<int16_t, uint16_t>(vs2, vs1, sat);
+  if (1 == mata_action) \
+    vd = sat_sub<int16_t, uint16_t>(vs2, vs1, sat);
+  else \
+    vd = 0xFFFF; \
   break;
 }
 case e32: {
   VV_PARAMS(e32);
-  vd = sat_sub<int32_t, uint32_t>(vs2, vs1, sat);
+  if (1 == mata_action) \
+    vd = sat_sub<int32_t, uint32_t>(vs2, vs1, sat);
+  else \
+    vd = 0xFFFFFFFF; \
   break;
 }
 default: {
   VV_PARAMS(e64);
-  vd = sat_sub<int64_t, uint64_t>(vs2, vs1, sat);
+  if (1 == mata_action) \
+    vd = sat_sub<int64_t, uint64_t>(vs2, vs1, sat);
+  else \
+    vd = 0xFFFFFFFFFFFFFFFF; \
   break;
 }
 }

--- a/riscv/insns/vssub_vx.h
+++ b/riscv/insns/vssub_vx.h
@@ -3,25 +3,44 @@ VI_CHECK_SSS(false);
 VI_LOOP_BASE
 bool sat = false;
 
+if (0 == P.VU.vta && i >= vl) { \
+  continue; \
+} \
+if ((true == skip && 1 == P.VU.vma && i < vl) || (1 == P.VU.vta && i >= vl)) \
+  mata_action = 2; \
+else \
+  mata_action = 1; \
 switch (sew) {
 case e8: {
   VX_PARAMS(e8);
-  vd = sat_sub<int8_t, uint8_t>(vs2, rs1, sat);
+  if (1 == mata_action) \
+    vd = sat_sub<int8_t, uint8_t>(vs2, rs1, sat);
+  else \
+    vd = 0xFF; \
   break;
 }
 case e16: {
   VX_PARAMS(e16);
-  vd = sat_sub<int16_t, uint16_t>(vs2, rs1, sat);
+  if (1 == mata_action) \
+    vd = sat_sub<int16_t, uint16_t>(vs2, rs1, sat);
+  else \
+    vd = 0xFFFF; \
   break;
 }
 case e32: {
   VX_PARAMS(e32);
-  vd = sat_sub<int32_t, uint32_t>(vs2, rs1, sat);
+  if (1 == mata_action) \
+    vd = sat_sub<int32_t, uint32_t>(vs2, rs1, sat);
+  else \
+    vd = 0xFFFFFFFF; \
   break;
 }
 default: {
   VX_PARAMS(e64);
-  vd = sat_sub<int64_t, uint64_t>(vs2, rs1, sat);
+  if (1 == mata_action) \
+    vd = sat_sub<int64_t, uint64_t>(vs2, rs1, sat);
+  else \
+    vd = 0xFFFFFFFFFFFFFFFF; \
   break;
 }
 }

--- a/riscv/insns/vssub_vx.h
+++ b/riscv/insns/vssub_vx.h
@@ -1,6 +1,6 @@
 // vssub.vx vd, vs2, rs1
 VI_CHECK_SSS(false);
-VI_LOOP_BASE
+VI_LOOP_BASE(1)
 bool sat = false;
 
 if (0 == P.VU.vta && i >= vl) { \

--- a/riscv/insns/vssub_vx.h
+++ b/riscv/insns/vssub_vx.h
@@ -16,7 +16,7 @@ case e8: {
   if (1 == mata_action) \
     vd = sat_sub<int8_t, uint8_t>(vs2, rs1, sat);
   else \
-    vd = 0xFF; \
+    vd = vector_agnostic(vd); \
   break;
 }
 case e16: {
@@ -24,7 +24,7 @@ case e16: {
   if (1 == mata_action) \
     vd = sat_sub<int16_t, uint16_t>(vs2, rs1, sat);
   else \
-    vd = 0xFFFF; \
+    vd = vector_agnostic(vd); \
   break;
 }
 case e32: {
@@ -32,7 +32,7 @@ case e32: {
   if (1 == mata_action) \
     vd = sat_sub<int32_t, uint32_t>(vs2, rs1, sat);
   else \
-    vd = 0xFFFFFFFF; \
+    vd = vector_agnostic(vd); \
   break;
 }
 default: {
@@ -40,7 +40,7 @@ default: {
   if (1 == mata_action) \
     vd = sat_sub<int64_t, uint64_t>(vs2, rs1, sat);
   else \
-    vd = 0xFFFFFFFFFFFFFFFF; \
+    vd = vector_agnostic(vd); \
   break;
 }
 }

--- a/riscv/insns/vssubu_vv.h
+++ b/riscv/insns/vssubu_vv.h
@@ -1,6 +1,6 @@
 // vssubu.vv vd, vs2, vs1
 VI_CHECK_SSS(true);
-VI_LOOP_BASE
+VI_LOOP_BASE(1)
 bool sat = false;
 
 if (0 == P.VU.vta && i >= vl) { \

--- a/riscv/insns/vssubu_vv.h
+++ b/riscv/insns/vssubu_vv.h
@@ -16,7 +16,7 @@ case e8: {
   if (1 == mata_action) \
     vd = sat_subu<uint8_t>(vs2, vs1, sat);
   else \
-    vd = 0xFF; \
+    vd = vector_agnostic(vd); \
   break;
 }
 case e16: {
@@ -24,7 +24,7 @@ case e16: {
   if (1 == mata_action) \
     vd = sat_subu<uint16_t>(vs2, vs1, sat);
   else \
-    vd = 0xFFFF; \
+    vd = vector_agnostic(vd); \
   break;
 }
 case e32: {
@@ -32,7 +32,7 @@ case e32: {
   if (1 == mata_action) \
     vd = sat_subu<uint32_t>(vs2, vs1, sat);
   else \
-    vd = 0xFFFFFFFF; \
+    vd = vector_agnostic(vd); \
   break;
 }
 default: {
@@ -40,7 +40,7 @@ default: {
   if (1 == mata_action) \
     vd = sat_subu<uint64_t>(vs2, vs1, sat);
   else \
-    vd = 0xFFFFFFFFFFFFFFFF; \
+    vd = vector_agnostic(vd); \
   break;
 }
 }

--- a/riscv/insns/vssubu_vv.h
+++ b/riscv/insns/vssubu_vv.h
@@ -3,25 +3,44 @@ VI_CHECK_SSS(true);
 VI_LOOP_BASE
 bool sat = false;
 
+if (0 == P.VU.vta && i >= vl) { \
+  continue; \
+} \
+if ((true == skip && 1 == P.VU.vma && i < vl) || (1 == P.VU.vta && i >= vl)) \
+  mata_action = 2; \
+else \
+  mata_action = 1; \
 switch (sew) {
 case e8: {
   VV_U_PARAMS(e8);
-  vd = sat_subu<uint8_t>(vs2, vs1, sat);
+  if (1 == mata_action) \
+    vd = sat_subu<uint8_t>(vs2, vs1, sat);
+  else \
+    vd = 0xFF; \
   break;
 }
 case e16: {
   VV_U_PARAMS(e16);
-  vd = sat_subu<uint16_t>(vs2, vs1, sat);
+  if (1 == mata_action) \
+    vd = sat_subu<uint16_t>(vs2, vs1, sat);
+  else \
+    vd = 0xFFFF; \
   break;
 }
 case e32: {
   VV_U_PARAMS(e32);
-  vd = sat_subu<uint32_t>(vs2, vs1, sat);
+  if (1 == mata_action) \
+    vd = sat_subu<uint32_t>(vs2, vs1, sat);
+  else \
+    vd = 0xFFFFFFFF; \
   break;
 }
 default: {
   VV_U_PARAMS(e64);
-  vd = sat_subu<uint64_t>(vs2, vs1, sat);
+  if (1 == mata_action) \
+    vd = sat_subu<uint64_t>(vs2, vs1, sat);
+  else \
+    vd = 0xFFFFFFFFFFFFFFFF; \
   break;
 }
 }

--- a/riscv/insns/vssubu_vx.h
+++ b/riscv/insns/vssubu_vx.h
@@ -1,6 +1,6 @@
 // vssubu.vx vd, vs2, rs1
 VI_CHECK_SSS(false);
-VI_LOOP_BASE
+VI_LOOP_BASE(1)
 bool sat = false;
 
 if (0 == P.VU.vta && i >= vl) { \

--- a/riscv/insns/vssubu_vx.h
+++ b/riscv/insns/vssubu_vx.h
@@ -16,7 +16,7 @@ case e8: {
   if (1 == mata_action) \
     vd = sat_subu<uint8_t>(vs2, rs1, sat);
   else \
-    vd = 0xFF; \
+    vd = vector_agnostic(vd); \
   break;
 }
 case e16: {
@@ -24,7 +24,7 @@ case e16: {
   if (1 == mata_action) \
     vd = sat_subu<uint16_t>(vs2, rs1, sat);
   else \
-    vd = 0xFFFF; \
+    vd = vector_agnostic(vd); \
   break;
 }
 case e32: {
@@ -32,7 +32,7 @@ case e32: {
   if (1 == mata_action) \
     vd = sat_subu<uint32_t>(vs2, rs1, sat);
   else \
-    vd = 0xFFFFFFFF; \
+    vd = vector_agnostic(vd); \
   break;
 }
 default: {
@@ -40,7 +40,7 @@ default: {
   if (1 == mata_action) \
     vd = sat_subu<uint64_t>(vs2, rs1, sat);
   else \
-    vd = 0xFFFFFFFFFFFFFFFF; \
+    vd = vector_agnostic(vd); \
   break;
 }
 }

--- a/riscv/insns/vssubu_vx.h
+++ b/riscv/insns/vssubu_vx.h
@@ -3,25 +3,44 @@ VI_CHECK_SSS(false);
 VI_LOOP_BASE
 bool sat = false;
 
+if (0 == P.VU.vta && i >= vl) { \
+  continue; \
+} \
+if ((true == skip && 1 == P.VU.vma && i < vl) || (1 == P.VU.vta && i >= vl)) \
+  mata_action = 2; \
+else \
+  mata_action = 1; \
 switch (sew) {
 case e8: {
   VX_U_PARAMS(e8);
-  vd = sat_subu<uint8_t>(vs2, rs1, sat);
+  if (1 == mata_action) \
+    vd = sat_subu<uint8_t>(vs2, rs1, sat);
+  else \
+    vd = 0xFF; \
   break;
 }
 case e16: {
   VX_U_PARAMS(e16);
-  vd = sat_subu<uint16_t>(vs2, rs1, sat);
+  if (1 == mata_action) \
+    vd = sat_subu<uint16_t>(vs2, rs1, sat);
+  else \
+    vd = 0xFFFF; \
   break;
 }
 case e32: {
   VX_U_PARAMS(e32);
-  vd = sat_subu<uint32_t>(vs2, rs1, sat);
+  if (1 == mata_action) \
+    vd = sat_subu<uint32_t>(vs2, rs1, sat);
+  else \
+    vd = 0xFFFFFFFF; \
   break;
 }
 default: {
   VX_U_PARAMS(e64);
-  vd = sat_subu<uint64_t>(vs2, rs1, sat);
+  if (1 == mata_action) \
+    vd = sat_subu<uint64_t>(vs2, rs1, sat);
+  else \
+    vd = 0xFFFFFFFFFFFFFFFF; \
   break;
 }
 }

--- a/riscv/riscv.ac
+++ b/riscv/riscv.ac
@@ -43,3 +43,8 @@ AC_ARG_ENABLE([dual-endian], AS_HELP_STRING([--enable-dual-endian], [Enable supp
 AS_IF([test "x$enable_dual_endian" = "xyes"], [
   AC_DEFINE([RISCV_ENABLE_DUAL_ENDIAN],,[Enable support for running target in either endianness])
 ])
+
+AC_ARG_ENABLE([varith-agnostic-write-ones], AS_HELP_STRING([--enable-varith-agnostic-write-ones], [Change vector arithmetic insns agnostisc policy to writing ones]))
+AS_IF([test "x$enable_varith_agnostic_write_ones" = "xyes"], [
+  AC_DEFINE([VARITH_AGNOSTIC_WRITE_ONE],,[Change vector arithmetic insns agnostisc policy to writing ones])
+])

--- a/riscv/v_ext_macros.h
+++ b/riscv/v_ext_macros.h
@@ -786,12 +786,14 @@ static inline bool is_overlapped_widen(const int astart, int asize,
 
 #define REDUCTION_LOOP(x, BODY) \
   VI_LOOP_REDUCTION_BASE(x) \
-  if(1 == P.VU.vta && i < (P.VU.VLEN/P.VU.vsew)) \
-    P.VU.elt<type_sew_t<x>::type>(rd_num, i, true) = vector_agnostic(P.VU.elt<type_sew_t<x>::type>(rd_num, i, false)); \
   if(false == skip && i < vl) { \
     BODY; \
   } \
-  VI_LOOP_REDUCTION_END(x)
+  VI_LOOP_REDUCTION_END(x) \
+  for (reg_t i = 1; i < (P.VU.VLEN/P.VU.vsew); ++i) { \
+    if(1 == P.VU.vta) \
+      P.VU.elt<type_sew_t<x>::type>(rd_num, i, true) = vector_agnostic(P.VU.elt<type_sew_t<x>::type>(rd_num, i, false)); \
+  }
 
 #define VI_VV_LOOP_REDUCTION(BODY) \
   VI_CHECK_REDUCTION(false); \
@@ -822,12 +824,14 @@ static inline bool is_overlapped_widen(const int astart, int asize,
 
 #define REDUCTION_ULOOP(x, BODY) \
   VI_ULOOP_REDUCTION_BASE(x) \
-  if(1 == P.VU.vta && i < (P.VU.VLEN/P.VU.vsew)) \
-    P.VU.elt<type_sew_t<x>::type>(rd_num, i, true) = vector_agnostic(P.VU.elt<type_sew_t<x>::type>(rd_num, i, false)); \
   if(false == skip && i < vl) { \
     BODY; \
   } \
-  VI_LOOP_REDUCTION_END(x)
+  VI_LOOP_REDUCTION_END(x) \
+  for (reg_t i = 1; i < (P.VU.VLEN/P.VU.vsew); ++i) { \
+    if(1 == P.VU.vta) \
+      P.VU.elt<type_sew_t<x>::type>(rd_num, i, true) = vector_agnostic(P.VU.elt<type_sew_t<x>::type>(rd_num, i, false)); \
+  }
 
 #define VI_VV_ULOOP_REDUCTION(BODY) \
   VI_CHECK_REDUCTION(false); \
@@ -1537,12 +1541,14 @@ static inline bool is_overlapped_widen(const int astart, int asize,
 
 #define WIDE_REDUCTION_LOOP(sew1, sew2, BODY) \
   VI_LOOP_WIDE_REDUCTION_BASE(sew1, sew2) \
-  if(1 == P.VU.vta && i < (reg_t)(P.VU.VLEN/P.VU.vsew*(0.5))) \
-		P.VU.elt<type_sew_t<sew2>::type>(rd_num, i, true) = vector_agnostic(P.VU.elt<type_sew_t<sew2>::type>(rd_num, i, false)); \
 	if(false == skip && i < vl) { \
     BODY; \
   } \
-  VI_LOOP_REDUCTION_END(sew2)
+  VI_LOOP_REDUCTION_END(sew2) \
+  for (reg_t i = 1; i < (reg_t)(P.VU.VLEN/P.VU.vsew*(0.5)); ++i) { \
+    if(1 == P.VU.vta) \
+		P.VU.elt<type_sew_t<sew2>::type>(rd_num, i, true) = vector_agnostic(P.VU.elt<type_sew_t<sew2>::type>(rd_num, i, false)); \
+  }
 
 #define VI_VV_LOOP_WIDE_REDUCTION(BODY) \
   VI_CHECK_REDUCTION(true); \
@@ -1570,12 +1576,14 @@ static inline bool is_overlapped_widen(const int astart, int asize,
 
 #define WIDE_REDUCTION_ULOOP(sew1, sew2, BODY) \
   VI_ULOOP_WIDE_REDUCTION_BASE(sew1, sew2) \
-  if(1 == P.VU.vta && i < (reg_t)(P.VU.VLEN/P.VU.vsew*(0.5))) \
-		P.VU.elt<type_sew_t<sew2>::type>(rd_num, i, true) = vector_agnostic(P.VU.elt<type_sew_t<sew2>::type>(rd_num, i, false)); \
 	if(false == skip && i < vl) { \
     BODY; \
   } \
-  VI_LOOP_REDUCTION_END(sew2)
+  VI_LOOP_REDUCTION_END(sew2) \
+  for (reg_t i = 1; i < (reg_t)(P.VU.VLEN/P.VU.vsew*(0.5)); ++i) { \
+    if(1 == P.VU.vta) \
+      P.VU.elt<type_sew_t<sew2>::type>(rd_num, i, true) = vector_agnostic(P.VU.elt<type_sew_t<sew2>::type>(rd_num, i, false)); \
+  }
 
 #define VI_VV_ULOOP_WIDE_REDUCTION(BODY) \
   VI_CHECK_REDUCTION(true); \
@@ -2308,41 +2316,47 @@ reg_t index[P.VU.vlmax]; \
   switch (P.VU.vsew) { \
     case e16: { \
       VI_VFP_LOOP_REDUCTION_BASE(16) \
-        if(1 == P.VU.vta && i < (P.VU.VLEN/P.VU.vsew) && i > 0) { \
-          P.VU.elt<type_sew_t<16>::type>(rd_num, i, true) = vector_agnostic(P.VU.elt<type_sew_t<16>::type>(rd_num, i, false)); \
-        } \
         if(false == skip && i < vl) { \
           is_active = true; \
           BODY16; \
           set_fp_exceptions; \
         } \
       VI_VFP_LOOP_REDUCTION_END(e16) \
+      for (reg_t i = 1; i < (P.VU.VLEN/P.VU.vsew); ++i) { \
+        if(1 == P.VU.vta) { \
+          P.VU.elt<type_sew_t<16>::type>(rd_num, i, true) = vector_agnostic(P.VU.elt<type_sew_t<16>::type>(rd_num, i, false)); \
+        } \
+      } \
       break; \
     } \
     case e32: { \
       VI_VFP_LOOP_REDUCTION_BASE(32) \
-        if(1 == P.VU.vta && i < (P.VU.VLEN/P.VU.vsew) && i > 0) { \
-          P.VU.elt<type_sew_t<32>::type>(rd_num, i, true) = vector_agnostic(P.VU.elt<type_sew_t<32>::type>(rd_num, i, false)); \
-        } \
         if(false == skip && i < vl) { \
           is_active = true; \
           BODY32; \
           set_fp_exceptions; \
         } \
       VI_VFP_LOOP_REDUCTION_END(e32) \
+      for (reg_t i = 1; i < (P.VU.VLEN/P.VU.vsew); ++i) { \
+        if(1 == P.VU.vta) { \
+          P.VU.elt<type_sew_t<32>::type>(rd_num, i, true) = vector_agnostic(P.VU.elt<type_sew_t<32>::type>(rd_num, i, false)); \
+        } \
+      } \
       break; \
     } \
     case e64: { \
       VI_VFP_LOOP_REDUCTION_BASE(64) \
-        if(1 == P.VU.vta && i < (P.VU.VLEN/P.VU.vsew) && i > 0) { \
-          P.VU.elt<type_sew_t<64>::type>(rd_num, i, true) = vector_agnostic(P.VU.elt<type_sew_t<64>::type>(rd_num, i, false)); \
-        } \
         if(false == skip && i < vl) { \
           is_active = true; \
           BODY64; \
           set_fp_exceptions; \
         } \
       VI_VFP_LOOP_REDUCTION_END(e64) \
+      for (reg_t i = 1; i < (P.VU.VLEN/P.VU.vsew); ++i) { \
+        if(1 == P.VU.vta) { \
+          P.VU.elt<type_sew_t<64>::type>(rd_num, i, true) = vector_agnostic(P.VU.elt<type_sew_t<64>::type>(rd_num, i, false)); \
+        } \
+      } \
       break; \
     } \
     default: \
@@ -2362,9 +2376,6 @@ reg_t index[P.VU.vlmax]; \
       V_EXT_VSTART_CHECK; \
       for (reg_t i = P.VU.vstart->read(); i < std::max(P.VU.vlmax, (reg_t)(P.VU.VLEN/P.VU.vsew*(0.5))); ++i) { \
         VI_LOOP_ELEMENT_SKIP_NO_VMA_CHECK(); \
-        if(1 == P.VU.vta && i < (reg_t)(P.VU.VLEN/P.VU.vsew*(0.5)) && i > 0) { \
-          P.VU.elt<type_sew_t<e32>::type>(rd_num, i, true) = vector_agnostic(P.VU.elt<type_sew_t<e32>::type>(rd_num, i, false)); \
-        } \
         if(false == skip && i < vl) { \
           is_active = true; \
           float32_t vs2 = f16_to_f32(P.VU.elt<float16_t>(rs2_num, i)); \
@@ -2372,6 +2383,11 @@ reg_t index[P.VU.vlmax]; \
           set_fp_exceptions; \
         } \
       VI_VFP_LOOP_REDUCTION_END(e32) \
+      for (reg_t i = 1; i < (reg_t)(P.VU.VLEN/P.VU.vsew*(0.5)); ++i) { \
+        if(1 == P.VU.vta) { \
+          P.VU.elt<type_sew_t<e32>::type>(rd_num, i, true) = vector_agnostic(P.VU.elt<type_sew_t<e32>::type>(rd_num, i, false)); \
+        } \
+      } \
       break; \
     } \
     case e32: { \
@@ -2379,9 +2395,6 @@ reg_t index[P.VU.vlmax]; \
       V_EXT_VSTART_CHECK; \
       for (reg_t i = P.VU.vstart->read(); i < std::max(P.VU.vlmax, (reg_t)(P.VU.VLEN/P.VU.vsew*(0.5))); ++i) { \
         VI_LOOP_ELEMENT_SKIP_NO_VMA_CHECK(); \
-        if(1 == P.VU.vta && i < (reg_t)(P.VU.VLEN/P.VU.vsew*(0.5)) && i > 0) { \
-          P.VU.elt<type_sew_t<e64>::type>(rd_num, i, true) = vector_agnostic(P.VU.elt<type_sew_t<e64>::type>(rd_num, i, false)); \
-        } \
         if(false == skip && i < vl) { \
           is_active = true; \
           float64_t vs2 = f32_to_f64(P.VU.elt<float32_t>(rs2_num, i)); \
@@ -2389,6 +2402,11 @@ reg_t index[P.VU.vlmax]; \
           set_fp_exceptions; \
         } \
       VI_VFP_LOOP_REDUCTION_END(e64) \
+      for (reg_t i = 1; i < ((reg_t)(P.VU.VLEN/P.VU.vsew*(0.5))); ++i) { \
+        if(1 == P.VU.vta) { \
+          P.VU.elt<type_sew_t<e64>::type>(rd_num, i, true) = vector_agnostic(P.VU.elt<type_sew_t<e64>::type>(rd_num, i, false)); \
+        } \
+      } \
       break; \
     } \
     default: \

--- a/riscv/v_ext_macros.h
+++ b/riscv/v_ext_macros.h
@@ -71,6 +71,16 @@ T vector_agnostic(T value) {
     VI_LOOP_ELEMENT_SKIP(); \
   }
 
+#define VI_ELEMENT_SKIP_NO_VMA_CHECK \
+  if (i >= vl) { \
+    continue; \
+  } else if (i < P.VU.vstart->read()) { \
+    continue; \
+  } else { \
+    VI_LOOP_ELEMENT_SKIP_NO_VMA_CHECK(); \
+    if(skip) continue;\
+  }
+
 //
 // vector: operation and register acccess check helper
 //
@@ -1875,7 +1885,7 @@ reg_t index[P.VU.vlmax]; \
   VI_CHECK_STORE(elt_width, is_mask_ldst); \
   for (reg_t i = 0; i < vl; ++i) { \
     VI_STRIP(i) \
-    VI_ELEMENT_SKIP; \
+    VI_ELEMENT_SKIP_NO_VMA_CHECK; \
     P.VU.vstart->write(i); \
     for (reg_t fn = 0; fn < nf; ++fn) { \
       elt_width##_t val = P.VU.elt<elt_width##_t>(vs3 + fn * emul, vreg_inx); \
@@ -1896,7 +1906,7 @@ reg_t index[P.VU.vlmax]; \
   VI_DUPLICATE_VREG(insn.rs2(), elt_width); \
   for (reg_t i = 0; i < vl; ++i) { \
     VI_STRIP(i) \
-    VI_ELEMENT_SKIP; \
+    VI_ELEMENT_SKIP_NO_VMA_CHECK; \
     P.VU.vstart->write(i); \
     for (reg_t fn = 0; fn < nf; ++fn) { \
       switch (P.VU.vsew) { \

--- a/riscv/v_ext_macros.h
+++ b/riscv/v_ext_macros.h
@@ -20,7 +20,7 @@ T setAllBitsToOne(T value) {
   const int midx = i / 64; \
   const int mpos = i % 64;
 
-#define V_EXT_VSTART_CHECK do { if(P.VU.vstart->read() >= P.VU.vl->read()) return npc;  } while (0)
+#define V_EXT_VSTART_CHECK do { if(P.VU.vstart->read() >= P.VU.vl->read()) { P.VU.vstart->write(0); return npc; } } while (0)
 
 //mata_action 0:origin, 1:calculate, 2:pad 1s
 #define VI_LOOP_ELEMENT_SKIP(BODY) \
@@ -703,6 +703,7 @@ static inline bool is_overlapped_widen(const int astart, int asize,
 #define VI_VF_MERGE_LOOP(BODY) \
   VI_CHECK_SSS(false); \
   VI_VFP_COMMON \
+  V_EXT_VSTART_CHECK; \
   for (reg_t i = P.VU.vstart->read(); i < std::max(P.VU.vlmax, P.VU.VLEN/P.VU.vsew); ++i) { \
   VI_MERGE_VARS \
   if (0 == P.VU.vta && i >= vl) { \
@@ -781,6 +782,7 @@ static inline bool is_overlapped_widen(const int astart, int asize,
   reg_t rs2_num = insn.rs2(); \
   auto &vd_0_des = P.VU.elt<type_usew_t<x>::type>(rd_num, 0, true); \
   auto vd_0_res = P.VU.elt<type_usew_t<x>::type>(rs1_num, 0); \
+  V_EXT_VSTART_CHECK; \
   for (reg_t i = P.VU.vstart->read(); i < std::max(P.VU.vlmax, P.VU.VLEN/P.VU.vsew); ++i) { \
     VI_LOOP_ELEMENT_SKIP_NO_VMA_CHECK(); \
     auto vs2 = P.VU.elt<type_usew_t<x>::type>(rs2_num, i);
@@ -2067,6 +2069,7 @@ reg_t index[P.VU.vlmax]; \
 
 #define VI_VFP_LOOP_BASE \
   VI_VFP_COMMON \
+  V_EXT_VSTART_CHECK; \
   for (reg_t i = P.VU.vstart->read(); i < std::max(P.VU.vlmax, P.VU.VLEN/P.VU.vsew); ++i) { \
     VI_LOOP_ELEMENT_SKIP();
 
@@ -2077,6 +2080,7 @@ reg_t index[P.VU.vlmax]; \
 
 #define VI_VFP_LOOP_CMP_BASE \
   VI_VFP_COMMON \
+  V_EXT_VSTART_CHECK; \
   for (reg_t i = P.VU.vstart->read(); i < P.VU.VLEN; ++i) { \
     VI_LOOP_ELEMENT_SKIP(); \
     uint64_t mmask = UINT64_C(1) << mpos; \
@@ -2088,6 +2092,7 @@ reg_t index[P.VU.vlmax]; \
   float##width##_t vs1_0 = P.VU.elt<float##width##_t>(rs1_num, 0); \
   vd_0 = vs1_0; \
   bool is_active = false; \
+  V_EXT_VSTART_CHECK; \
   for (reg_t i = P.VU.vstart->read(); i < std::max(P.VU.vlmax, P.VU.VLEN/P.VU.vsew); ++i) { \
     VI_LOOP_ELEMENT_SKIP_NO_VMA_CHECK(); \
     float##width##_t vs2 = P.VU.elt<float##width##_t>(rs2_num, i); \
@@ -2315,6 +2320,7 @@ reg_t index[P.VU.vlmax]; \
   switch (P.VU.vsew) { \
     case e16: { \
       float32_t vd_0 = P.VU.elt<float32_t>(rs1_num, 0); \
+      V_EXT_VSTART_CHECK; \
       for (reg_t i = P.VU.vstart->read(); i < std::max(P.VU.vlmax, P.VU.VLEN/P.VU.vsew); ++i) { \
         VI_LOOP_ELEMENT_SKIP_NO_VMA_CHECK(); \
         is_active = true; \
@@ -2330,6 +2336,7 @@ reg_t index[P.VU.vlmax]; \
     } \
     case e32: { \
       float64_t vd_0 = P.VU.elt<float64_t>(rs1_num, 0); \
+      V_EXT_VSTART_CHECK; \
       for (reg_t i = P.VU.vstart->read(); i < std::max(P.VU.vlmax, P.VU.VLEN/P.VU.vsew); ++i) { \
         VI_LOOP_ELEMENT_SKIP_NO_VMA_CHECK(); \
         is_active = true; \
@@ -2698,6 +2705,7 @@ reg_t index[P.VU.vlmax]; \
   reg_t UNUSED rs1_num = insn.rs1(); \
   reg_t rs2_num = insn.rs2(); \
   softfloat_roundingMode = STATE.frm->read(); \
+  V_EXT_VSTART_CHECK; \
   for (reg_t i = P.VU.vstart->read(); i < std::max(P.VU.vlmax, P.VU.VLEN/P.VU.vsew); ++i) { \
     VI_LOOP_ELEMENT_SKIP();
 

--- a/riscv/v_ext_macros.h
+++ b/riscv/v_ext_macros.h
@@ -223,7 +223,7 @@ static inline bool is_overlapped_widen(const int astart, int asize,
 //
 // vector: loop header and end helper
 //
-#define VI_GENERAL_LOOP_BASE \
+#define VI_GENERAL_LOOP_BASE(factor) \
   require(P.VU.vsew >= e8 && P.VU.vsew <= e64); \
   require_vector(true); \
   reg_t vl = P.VU.vl->read(); \
@@ -232,7 +232,7 @@ static inline bool is_overlapped_widen(const int astart, int asize,
   reg_t UNUSED rs1_num = insn.rs1(); \
   reg_t rs2_num = insn.rs2(); \
   V_EXT_VSTART_CHECK; \
-  for (reg_t i = P.VU.vstart->read(); i < std::max(P.VU.vlmax, P.VU.VLEN/P.VU.vsew); ++i) {
+  for (reg_t i = P.VU.vstart->read(); i < std::max(P.VU.vlmax, (reg_t)(P.VU.VLEN/P.VU.vsew*(factor))); ++i) {
 
 //
 // vector: loop carry header and end helper
@@ -247,8 +247,8 @@ static inline bool is_overlapped_widen(const int astart, int asize,
   reg_t rs2_num = insn.rs2(); \
   V_EXT_VSTART_CHECK; \
   for (reg_t i = P.VU.vstart->read(); i < P.VU.VLEN; ++i) {
-#define VI_LOOP_BASE \
-    VI_GENERAL_LOOP_BASE \
+#define VI_LOOP_BASE(factor) \
+    VI_GENERAL_LOOP_BASE(factor) \
     VI_LOOP_ELEMENT_SKIP();
 
 #define VI_LOOP_END \
@@ -278,7 +278,7 @@ static inline bool is_overlapped_widen(const int astart, int asize,
   } \
   P.VU.vstart->write(0);
 #define VI_LOOP_WITH_CARRY_BASE \
-  VI_GENERAL_LOOP_BASE \
+  VI_GENERAL_LOOP_BASE(1) \
   VI_MASK_VARS \
   int mata_action = 0; \
   auto &v0 = P.VU.elt<uint64_t>(0, midx); \
@@ -325,7 +325,7 @@ static inline bool is_overlapped_widen(const int astart, int asize,
   P.VU.vstart->write(0);
 
 #define VI_LOOP_NSHIFT_BASE \
-  VI_GENERAL_LOOP_BASE; \
+  VI_GENERAL_LOOP_BASE(1); \
   VI_LOOP_ELEMENT_SKIP({ \
     require(!(insn.rd() == 0 && P.VU.vflmul > 1)); \
   });
@@ -588,7 +588,7 @@ static inline bool is_overlapped_widen(const int astart, int asize,
   bool UNUSED use_first = (P.VU.elt<uint64_t>(0, midx) >> mpos) & 0x1;
 
 #define VI_MERGE_LOOP_BASE \
-  VI_GENERAL_LOOP_BASE \
+  VI_GENERAL_LOOP_BASE(1) \
   VI_MERGE_VARS \
   if (0 == P.VU.vta && i >= vl) { \
     continue; \
@@ -753,7 +753,7 @@ static inline bool is_overlapped_widen(const int astart, int asize,
 
 #define REDUCTION_LOOP(x, BODY) \
   VI_LOOP_REDUCTION_BASE(x) \
-  if(1 == P.VU.vta && i > P.VU.vstart->read()) \
+  if(1 == P.VU.vta && i < (P.VU.VLEN/P.VU.vsew)) \
     P.VU.elt<type_sew_t<x>::type>(rd_num, i, true) = ((type_sew_t<x>::type)~0); \
   if(false == skip && i < vl) { \
     BODY; \
@@ -789,7 +789,7 @@ static inline bool is_overlapped_widen(const int astart, int asize,
 
 #define REDUCTION_ULOOP(x, BODY) \
   VI_ULOOP_REDUCTION_BASE(x) \
-  if(1 == P.VU.vta && i > P.VU.vstart->read()) \
+  if(1 == P.VU.vta && i < (P.VU.VLEN/P.VU.vsew)) \
     P.VU.elt<type_sew_t<x>::type>(rd_num, i, true) = ((type_sew_t<x>::type)~0); \
   if(false == skip && i < vl) { \
     BODY; \
@@ -812,7 +812,7 @@ static inline bool is_overlapped_widen(const int astart, int asize,
 // genearl VXI signed/unsigned loop
 #define VI_VV_ULOOP(BODY) \
   VI_CHECK_SSS(true) \
-  VI_LOOP_BASE \
+  VI_LOOP_BASE(1) \
   if (0 == P.VU.vta && i >= vl) { \
     continue; \
   } \
@@ -853,7 +853,7 @@ static inline bool is_overlapped_widen(const int astart, int asize,
 
 #define VI_VV_LOOP(BODY) \
   VI_CHECK_SSS(true) \
-  VI_LOOP_BASE \
+  VI_LOOP_BASE(1) \
   if (0 == P.VU.vta && i >= vl) { \
     continue; \
   } \
@@ -894,7 +894,7 @@ static inline bool is_overlapped_widen(const int astart, int asize,
 
 #define VI_V_ULOOP(BODY) \
   VI_CHECK_SSS(false) \
-  VI_LOOP_BASE \
+  VI_LOOP_BASE(1) \
   if (sew == e8) { \
     V_U_PARAMS(e8); \
     BODY; \
@@ -912,7 +912,7 @@ static inline bool is_overlapped_widen(const int astart, int asize,
 
 #define VI_VX_ULOOP(BODY) \
   VI_CHECK_SSS(false) \
-  VI_LOOP_BASE \
+  VI_LOOP_BASE(1) \
   if (0 == P.VU.vta && i >= vl) { \
     continue; \
   } \
@@ -953,7 +953,7 @@ static inline bool is_overlapped_widen(const int astart, int asize,
 
 #define VI_VX_LOOP(BODY) \
   VI_CHECK_SSS(false) \
-  VI_LOOP_BASE \
+  VI_LOOP_BASE(1) \
   if (0 == P.VU.vta && i >= vl) { \
     continue; \
   } \
@@ -994,7 +994,7 @@ static inline bool is_overlapped_widen(const int astart, int asize,
 
 #define VI_VI_ULOOP(BODY) \
   VI_CHECK_SSS(false) \
-  VI_LOOP_BASE \
+  VI_LOOP_BASE(1) \
   if (0 == P.VU.vta && i >= vl) { \
     continue; \
   } \
@@ -1035,7 +1035,7 @@ static inline bool is_overlapped_widen(const int astart, int asize,
 
 #define VI_VI_LOOP(BODY) \
   VI_CHECK_SSS(false) \
-  VI_LOOP_BASE \
+  VI_LOOP_BASE(1) \
   if (0 == P.VU.vta && i >= vl) { \
     continue; \
   } \
@@ -1077,7 +1077,7 @@ static inline bool is_overlapped_widen(const int astart, int asize,
 // signed unsigned operation loop (e.g. mulhsu)
 #define VI_VV_SU_LOOP(BODY) \
   VI_CHECK_SSS(true) \
-  VI_LOOP_BASE \
+  VI_LOOP_BASE(1) \
   if (0 == P.VU.vta && i >= vl) { \
     continue; \
   } \
@@ -1118,7 +1118,7 @@ static inline bool is_overlapped_widen(const int astart, int asize,
 
 #define VI_VX_SU_LOOP(BODY) \
   VI_CHECK_SSS(false) \
-  VI_LOOP_BASE \
+  VI_LOOP_BASE(1) \
   if (0 == P.VU.vta && i >= vl) { \
     continue; \
   } \
@@ -1160,7 +1160,7 @@ static inline bool is_overlapped_widen(const int astart, int asize,
 // narrow operation loop
 #define VI_VV_LOOP_NARROW(BODY) \
   VI_CHECK_SDS(true); \
-  VI_LOOP_BASE \
+  VI_LOOP_BASE(1) \
   if (0 == P.VU.vta && i >= vl) { \
     continue; \
   } \
@@ -1191,7 +1191,7 @@ static inline bool is_overlapped_widen(const int astart, int asize,
 
 #define VI_VX_LOOP_NARROW(BODY) \
   VI_CHECK_SDS(false); \
-  VI_LOOP_BASE \
+  VI_LOOP_BASE(1) \
   if (0 == P.VU.vta && i >= vl) { \
     continue; \
   } \
@@ -1222,7 +1222,7 @@ static inline bool is_overlapped_widen(const int astart, int asize,
 
 #define VI_VI_LOOP_NARROW(BODY) \
   VI_CHECK_SDS(false); \
-  VI_LOOP_BASE \
+  VI_LOOP_BASE(1) \
   if (0 == P.VU.vta && i >= vl) { \
     continue; \
   } \
@@ -1355,7 +1355,7 @@ static inline bool is_overlapped_widen(const int astart, int asize,
 
 // widen operation loop
 #define VI_VV_LOOP_WIDEN(BODY) \
-  VI_LOOP_BASE \
+  VI_LOOP_BASE(0.5) \
   if (0 == P.VU.vta && i >= vl) { \
     continue; \
   } \
@@ -1376,7 +1376,7 @@ static inline bool is_overlapped_widen(const int astart, int asize,
   VI_LOOP_END
 
 #define VI_VX_LOOP_WIDEN(BODY) \
-  VI_LOOP_BASE \
+  VI_LOOP_BASE(0.5) \
   if (0 == P.VU.vta && i >= vl) { \
     continue; \
   } \
@@ -1498,13 +1498,13 @@ static inline bool is_overlapped_widen(const int astart, int asize,
   auto &vd_0_des = P.VU.elt<type_sew_t<sew2>::type>(rd_num, 0, true); \
   auto vd_0_res = P.VU.elt<type_sew_t<sew2>::type>(rs1_num, 0); \
   V_EXT_VSTART_CHECK; \
-  for (reg_t i = P.VU.vstart->read(); i < std::max(P.VU.vlmax, P.VU.VLEN/P.VU.vsew); ++i) { \
+  for (reg_t i = P.VU.vstart->read(); i < std::max(P.VU.vlmax, (reg_t)(P.VU.VLEN/P.VU.vsew*(0.5))); ++i) { \
     VI_LOOP_ELEMENT_SKIP_NO_VMA_CHECK(); \
     auto vs2 = P.VU.elt<type_sew_t<sew1>::type>(rs2_num, i);
 
 #define WIDE_REDUCTION_LOOP(sew1, sew2, BODY) \
   VI_LOOP_WIDE_REDUCTION_BASE(sew1, sew2) \
-  if(1 == P.VU.vta && i > P.VU.vstart->read()) \
+  if(1 == P.VU.vta && i < (reg_t)(P.VU.VLEN/P.VU.vsew*(0.5))) \
 		P.VU.elt<type_sew_t<sew2>::type>(rd_num, i, true) = ((type_sew_t<sew2>::type)~0); \
 	if(false == skip && i < vl) { \
     BODY; \
@@ -1531,13 +1531,13 @@ static inline bool is_overlapped_widen(const int astart, int asize,
   auto &vd_0_des = P.VU.elt<type_usew_t<sew2>::type>(rd_num, 0, true); \
   auto vd_0_res = P.VU.elt<type_usew_t<sew2>::type>(rs1_num, 0); \
   V_EXT_VSTART_CHECK; \
-  for (reg_t i = P.VU.vstart->read(); i < std::max(P.VU.vlmax, P.VU.VLEN/P.VU.vsew); ++i) { \
+  for (reg_t i = P.VU.vstart->read(); i < std::max(P.VU.vlmax, (reg_t)(P.VU.VLEN/P.VU.vsew*(0.5))); ++i) { \
     VI_LOOP_ELEMENT_SKIP_NO_VMA_CHECK(); \
     auto vs2 = P.VU.elt<type_usew_t<sew1>::type>(rs2_num, i);
 
 #define WIDE_REDUCTION_ULOOP(sew1, sew2, BODY) \
   VI_ULOOP_WIDE_REDUCTION_BASE(sew1, sew2) \
-  if(1 == P.VU.vta && i > P.VU.vstart->read()) \
+  if(1 == P.VU.vta && i < (reg_t)(P.VU.VLEN/P.VU.vsew*(0.5))) \
 		P.VU.elt<type_sew_t<sew2>::type>(rd_num, i, true) = ((type_sew_t<sew2>::type)~0); \
 	if(false == skip && i < vl) { \
     BODY; \
@@ -1989,7 +1989,7 @@ reg_t index[P.VU.vlmax]; \
     require_noover_widen(insn.rd(), P.VU.vflmul, insn.rs2(), P.VU.vflmul / div); \
   } \
   reg_t pat = (((P.VU.vsew >> 3) << 4) | from >> 3); \
-  VI_GENERAL_LOOP_BASE \
+  VI_GENERAL_LOOP_BASE(1) \
   VI_LOOP_ELEMENT_SKIP(); \
     if (0 == P.VU.vta && i >= vl) { \
       continue; \
@@ -2067,10 +2067,10 @@ reg_t index[P.VU.vlmax]; \
   reg_t UNUSED rs2_num = insn.rs2(); \
   softfloat_roundingMode = STATE.frm->read();
 
-#define VI_VFP_LOOP_BASE \
+#define VI_VFP_LOOP_BASE(factor) \
   VI_VFP_COMMON \
   V_EXT_VSTART_CHECK; \
-  for (reg_t i = P.VU.vstart->read(); i < std::max(P.VU.vlmax, P.VU.VLEN/P.VU.vsew); ++i) { \
+  for (reg_t i = P.VU.vstart->read(); i < std::max(P.VU.vlmax, (reg_t)(P.VU.VLEN/P.VU.vsew*(factor))); ++i) { \
     VI_LOOP_ELEMENT_SKIP();
 
 #define VI_VFP_BF16_LOOP_BASE \
@@ -2176,7 +2176,7 @@ reg_t index[P.VU.vlmax]; \
 
 #define VI_VFP_VV_LOOP(BODY16, BODY32, BODY64) \
   VI_CHECK_SSS(true); \
-  VI_VFP_LOOP_BASE \
+  VI_VFP_LOOP_BASE(1) \
   if (0 == P.VU.vta && i >= vl) { \
     continue; \
   } \
@@ -2224,7 +2224,7 @@ reg_t index[P.VU.vlmax]; \
 
 #define VI_VFP_V_LOOP(BODY16, BODY32, BODY64) \
   VI_CHECK_SSS(false); \
-  VI_VFP_LOOP_BASE \
+  VI_VFP_LOOP_BASE(1) \
   if (0 == P.VU.vta && i >= vl) { \
     continue; \
   } \
@@ -2275,7 +2275,7 @@ reg_t index[P.VU.vlmax]; \
   switch (P.VU.vsew) { \
     case e16: { \
       VI_VFP_LOOP_REDUCTION_BASE(16) \
-        if(1 == P.VU.vta && i > P.VU.vstart->read()) \
+        if(1 == P.VU.vta && i < (P.VU.VLEN/P.VU.vsew)) \
           P.VU.elt<type_sew_t<16>::type>(rd_num, i, true) = ((type_sew_t<16>::type)~0); \
         if(false == skip && i < vl) { \
           BODY16; \
@@ -2286,7 +2286,7 @@ reg_t index[P.VU.vlmax]; \
     } \
     case e32: { \
       VI_VFP_LOOP_REDUCTION_BASE(32) \
-        if(1 == P.VU.vta && i > P.VU.vstart->read()) \
+        if(1 == P.VU.vta && i < (P.VU.VLEN/P.VU.vsew)) \
           P.VU.elt<type_sew_t<32>::type>(rd_num, i, true) = ((type_sew_t<32>::type)~0); \
         if(false == skip && i < vl) { \
           BODY32; \
@@ -2297,7 +2297,7 @@ reg_t index[P.VU.vlmax]; \
     } \
     case e64: { \
       VI_VFP_LOOP_REDUCTION_BASE(64) \
-        if(1 == P.VU.vta && i > P.VU.vstart->read()) \
+        if(1 == P.VU.vta && i < (P.VU.VLEN/P.VU.vsew)) \
           P.VU.elt<type_sew_t<64>::type>(rd_num, i, true) = ((type_sew_t<64>::type)~0); \
         if(false == skip && i < vl) { \
           BODY64; \
@@ -2321,11 +2321,11 @@ reg_t index[P.VU.vlmax]; \
     case e16: { \
       float32_t vd_0 = P.VU.elt<float32_t>(rs1_num, 0); \
       V_EXT_VSTART_CHECK; \
-      for (reg_t i = P.VU.vstart->read(); i < std::max(P.VU.vlmax, P.VU.VLEN/P.VU.vsew); ++i) { \
+      for (reg_t i = P.VU.vstart->read(); i < std::max(P.VU.vlmax, (reg_t)(P.VU.VLEN/P.VU.vsew*(0.5))); ++i) { \
         VI_LOOP_ELEMENT_SKIP_NO_VMA_CHECK(); \
         is_active = true; \
         float32_t vs2 = f16_to_f32(P.VU.elt<float16_t>(rs2_num, i)); \
-        if(1 == P.VU.vta && i > P.VU.vstart->read()) \
+        if(1 == P.VU.vta && i < (reg_t)(P.VU.VLEN/P.VU.vsew*(0.5))) \
           P.VU.elt<type_sew_t<e32>::type>(rd_num, i, true) = ((type_sew_t<e32>::type)~0); \
         if(false == skip && i < vl) { \
           BODY16; \
@@ -2337,11 +2337,11 @@ reg_t index[P.VU.vlmax]; \
     case e32: { \
       float64_t vd_0 = P.VU.elt<float64_t>(rs1_num, 0); \
       V_EXT_VSTART_CHECK; \
-      for (reg_t i = P.VU.vstart->read(); i < std::max(P.VU.vlmax, P.VU.VLEN/P.VU.vsew); ++i) { \
+      for (reg_t i = P.VU.vstart->read(); i < std::max(P.VU.vlmax, (reg_t)(P.VU.VLEN/P.VU.vsew*(0.5))); ++i) { \
         VI_LOOP_ELEMENT_SKIP_NO_VMA_CHECK(); \
         is_active = true; \
         float64_t vs2 = f32_to_f64(P.VU.elt<float32_t>(rs2_num, i)); \
-        if(1 == P.VU.vta && i > P.VU.vstart->read()) \
+        if(1 == P.VU.vta && i < (reg_t)(P.VU.VLEN/P.VU.vsew*(0.5))) \
           P.VU.elt<type_sew_t<e64>::type>(rd_num, i, true) = ((type_sew_t<e64>::type)~0); \
         if(false == skip && i < vl) { \
           BODY32; \
@@ -2357,7 +2357,7 @@ reg_t index[P.VU.vlmax]; \
 
 #define VI_VFP_VF_LOOP(BODY16, BODY32, BODY64) \
   VI_CHECK_SSS(false); \
-  VI_VFP_LOOP_BASE \
+  VI_VFP_LOOP_BASE(1) \
   if (0 == P.VU.vta && i >= vl) { \
     continue; \
   } \
@@ -2498,7 +2498,7 @@ reg_t index[P.VU.vlmax]; \
 
 #define VI_VFP_VF_LOOP_WIDE(BODY16, BODY32) \
   VI_CHECK_DSS(false); \
-  VI_VFP_LOOP_BASE \
+  VI_VFP_LOOP_BASE(0.5) \
   if (0 == P.VU.vta && i >= vl) { \
     continue; \
   } \
@@ -2557,7 +2557,7 @@ reg_t index[P.VU.vlmax]; \
 
 #define VI_VFP_VV_LOOP_WIDE(BODY16, BODY32) \
   VI_CHECK_DSS(true); \
-  VI_VFP_LOOP_BASE \
+  VI_VFP_LOOP_BASE(0.5) \
   if (0 == P.VU.vta && i >= vl) { \
     continue; \
   } \
@@ -2616,7 +2616,7 @@ reg_t index[P.VU.vlmax]; \
 
 #define VI_VFP_WF_LOOP_WIDE(BODY16, BODY32) \
   VI_CHECK_DDS(false); \
-  VI_VFP_LOOP_BASE \
+  VI_VFP_LOOP_BASE(0.5) \
   if (0 == P.VU.vta && i >= vl) { \
     continue; \
   } \
@@ -2657,7 +2657,7 @@ reg_t index[P.VU.vlmax]; \
 
 #define VI_VFP_WV_LOOP_WIDE(BODY16, BODY32) \
   VI_CHECK_DDS(true); \
-  VI_VFP_LOOP_BASE \
+  VI_VFP_LOOP_BASE(0.5) \
   if (0 == P.VU.vta && i >= vl) { \
     continue; \
   } \
@@ -2696,7 +2696,7 @@ reg_t index[P.VU.vlmax]; \
   DEBUG_RVV_FP_VV; \
   VI_VFP_LOOP_END
 
-#define VI_VFP_LOOP_SCALE_BASE \
+#define VI_VFP_LOOP_SCALE_BASE(factor) \
   require_fp; \
   require_vector(true); \
   require(STATE.frm->read() < 0x5); \
@@ -2706,12 +2706,12 @@ reg_t index[P.VU.vlmax]; \
   reg_t rs2_num = insn.rs2(); \
   softfloat_roundingMode = STATE.frm->read(); \
   V_EXT_VSTART_CHECK; \
-  for (reg_t i = P.VU.vstart->read(); i < std::max(P.VU.vlmax, P.VU.VLEN/P.VU.vsew); ++i) { \
+  for (reg_t i = P.VU.vstart->read(); i < std::max(P.VU.vlmax, (reg_t)((P.VU.VLEN/P.VU.vsew)*(factor))); ++i) { \
     VI_LOOP_ELEMENT_SKIP();
 
-#define VI_VFP_CVT_LOOP(CVT_PARAMS, CHECK, BODY) \
+#define VI_VFP_CVT_LOOP(CVT_PARAMS, CHECK, BODY, factor) \
   CHECK \
-  VI_VFP_LOOP_SCALE_BASE \
+  VI_VFP_LOOP_SCALE_BASE(factor) \
   if (0 == P.VU.vta && i >= vl) { \
     continue; \
   } \
@@ -2735,17 +2735,17 @@ reg_t index[P.VU.vlmax]; \
     case e16: \
       { VI_VFP_CVT_LOOP(CVT_INT_TO_FP_PARAMS(16, 16, sign), \
         { p->extension_enabled(EXT_ZVFH); }, \
-        BODY16); } \
+        BODY16, 1); } \
       break; \
     case e32: \
       { VI_VFP_CVT_LOOP(CVT_INT_TO_FP_PARAMS(32, 32, sign), \
         { p->extension_enabled('F'); }, \
-        BODY32); } \
+        BODY32, 1); } \
       break; \
     case e64: \
       { VI_VFP_CVT_LOOP(CVT_INT_TO_FP_PARAMS(64, 64, sign), \
         { p->extension_enabled('D'); }, \
-        BODY64); } \
+        BODY64, 1); } \
       break; \
     default: \
       require(0); \
@@ -2759,17 +2759,17 @@ reg_t index[P.VU.vlmax]; \
     case e16: \
       { VI_VFP_CVT_LOOP(CVT_FP_TO_INT_PARAMS(16, 16, sign), \
         { p->extension_enabled(EXT_ZVFH); }, \
-        BODY16); } \
+        BODY16, 1); } \
       break; \
     case e32: \
       { VI_VFP_CVT_LOOP(CVT_FP_TO_INT_PARAMS(32, 32, sign), \
         { p->extension_enabled('F'); }, \
-        BODY32); } \
+        BODY32, 1); } \
       break; \
     case e64: \
       { VI_VFP_CVT_LOOP(CVT_FP_TO_INT_PARAMS(64, 64, sign), \
         { p->extension_enabled('D'); }, \
-        BODY64); } \
+        BODY64, 1); } \
       break; \
     default: \
       require(0); \
@@ -2781,10 +2781,10 @@ reg_t index[P.VU.vlmax]; \
   VI_CHECK_DSS(false); \
   switch (P.VU.vsew) { \
     case e16: \
-      { VI_VFP_CVT_LOOP(CVT_FP_TO_FP_PARAMS(16, 32), CHECK16, BODY16); } \
+      { VI_VFP_CVT_LOOP(CVT_FP_TO_FP_PARAMS(16, 32), CHECK16, BODY16, 0.5); } \
       break; \
     case e32: \
-      { VI_VFP_CVT_LOOP(CVT_FP_TO_FP_PARAMS(32, 64), CHECK32, BODY32); } \
+      { VI_VFP_CVT_LOOP(CVT_FP_TO_FP_PARAMS(32, 64), CHECK32, BODY32, 0.5); } \
       break; \
     default: \
       require(0); \
@@ -2795,7 +2795,7 @@ reg_t index[P.VU.vlmax]; \
   VI_CHECK_DSS(false); \
   switch (P.VU.vsew) { \
     case e16: \
-      { VI_VFP_CVT_LOOP(CVT_FP_TO_FP_PARAMS(16, 32), CHECK, BODY); } \
+      { VI_VFP_CVT_LOOP(CVT_FP_TO_FP_PARAMS(16, 32), CHECK, BODY, 0.5); } \
       break; \
     default: \
       require(0); \
@@ -2808,13 +2808,13 @@ reg_t index[P.VU.vlmax]; \
   VI_CHECK_DSS(false); \
   switch (P.VU.vsew) { \
     case e8: \
-      { VI_VFP_CVT_LOOP(CVT_INT_TO_FP_PARAMS(8, 16, sign), CHECK8, BODY8); } \
+      { VI_VFP_CVT_LOOP(CVT_INT_TO_FP_PARAMS(8, 16, sign), CHECK8, BODY8, 0.5); } \
       break; \
     case e16: \
-      { VI_VFP_CVT_LOOP(CVT_INT_TO_FP_PARAMS(16, 32, sign), CHECK16, BODY16); } \
+      { VI_VFP_CVT_LOOP(CVT_INT_TO_FP_PARAMS(16, 32, sign), CHECK16, BODY16, 0.5); } \
       break; \
     case e32: \
-      { VI_VFP_CVT_LOOP(CVT_INT_TO_FP_PARAMS(32, 64, sign), CHECK32, BODY32); } \
+      { VI_VFP_CVT_LOOP(CVT_INT_TO_FP_PARAMS(32, 64, sign), CHECK32, BODY32, 0.5); } \
       break; \
     default: \
       require(0); \
@@ -2827,10 +2827,10 @@ reg_t index[P.VU.vlmax]; \
   VI_CHECK_DSS(false); \
   switch (P.VU.vsew) { \
     case e16: \
-      { VI_VFP_CVT_LOOP(CVT_FP_TO_INT_PARAMS(16, 32, sign), CHECK16, BODY16); } \
+      { VI_VFP_CVT_LOOP(CVT_FP_TO_INT_PARAMS(16, 32, sign), CHECK16, BODY16, 0.5); } \
       break; \
     case e32: \
-      { VI_VFP_CVT_LOOP(CVT_FP_TO_INT_PARAMS(32, 64, sign), CHECK32, BODY32); } \
+      { VI_VFP_CVT_LOOP(CVT_FP_TO_INT_PARAMS(32, 64, sign), CHECK32, BODY32, 0.5); } \
       break; \
     default: \
       require(0); \
@@ -2842,10 +2842,10 @@ reg_t index[P.VU.vlmax]; \
   VI_CHECK_SDS(false); \
   switch (P.VU.vsew) { \
     case e16: \
-      { VI_VFP_CVT_LOOP(CVT_FP_TO_FP_PARAMS(32, 16), CHECK32, BODY32); } \
+      { VI_VFP_CVT_LOOP(CVT_FP_TO_FP_PARAMS(32, 16), CHECK32, BODY32, 1); } \
       break; \
     case e32: \
-      { VI_VFP_CVT_LOOP(CVT_FP_TO_FP_PARAMS(64, 32), CHECK64, BODY64); } \
+      { VI_VFP_CVT_LOOP(CVT_FP_TO_FP_PARAMS(64, 32), CHECK64, BODY64, 1); } \
       break; \
     default: \
       require(0); \
@@ -2856,7 +2856,7 @@ reg_t index[P.VU.vlmax]; \
   VI_CHECK_SDS(false); \
   switch (P.VU.vsew) { \
     case e16: \
-      { VI_VFP_CVT_LOOP(CVT_FP_TO_FP_PARAMS(32, 16), CHECK, BODY); } \
+      { VI_VFP_CVT_LOOP(CVT_FP_TO_FP_PARAMS(32, 16), CHECK, BODY, 2); } \
       break; \
     default: \
       require(0); \
@@ -2869,10 +2869,10 @@ reg_t index[P.VU.vlmax]; \
   VI_CHECK_SDS(false); \
   switch (P.VU.vsew) { \
     case e16: \
-      { VI_VFP_CVT_LOOP(CVT_INT_TO_FP_PARAMS(32, 16, sign), CHECK32, BODY32); } \
+      { VI_VFP_CVT_LOOP(CVT_INT_TO_FP_PARAMS(32, 16, sign), CHECK32, BODY32, 1); } \
       break; \
     case e32: \
-      { VI_VFP_CVT_LOOP(CVT_INT_TO_FP_PARAMS(64, 32, sign), CHECK64, BODY64); } \
+      { VI_VFP_CVT_LOOP(CVT_INT_TO_FP_PARAMS(64, 32, sign), CHECK64, BODY64, 1); } \
       break; \
     default: \
       require(0); \
@@ -2885,13 +2885,13 @@ reg_t index[P.VU.vlmax]; \
   VI_CHECK_SDS(false); \
   switch (P.VU.vsew) { \
     case e8: \
-      { VI_VFP_CVT_LOOP(CVT_FP_TO_INT_PARAMS(16, 8, sign), CHECK16, BODY16); } \
+      { VI_VFP_CVT_LOOP(CVT_FP_TO_INT_PARAMS(16, 8, sign), CHECK16, BODY16, 1); } \
       break; \
     case e16: \
-      { VI_VFP_CVT_LOOP(CVT_FP_TO_INT_PARAMS(32, 16, sign), CHECK32, BODY32); } \
+      { VI_VFP_CVT_LOOP(CVT_FP_TO_INT_PARAMS(32, 16, sign), CHECK32, BODY32, 1); } \
       break; \
     case e32: \
-      { VI_VFP_CVT_LOOP(CVT_FP_TO_INT_PARAMS(64, 32, sign), CHECK64, BODY64); } \
+      { VI_VFP_CVT_LOOP(CVT_FP_TO_INT_PARAMS(64, 32, sign), CHECK64, BODY64, 1); } \
       break; \
     default: \
       require(0); \

--- a/riscv/zvk_ext_macros.h
+++ b/riscv/zvk_ext_macros.h
@@ -713,7 +713,7 @@
 #define VI_ZVK_VV_WIDENING_ULOOP(BODY) \
   do { \
     VI_CHECK_DSS(true); \
-    VI_LOOP_BASE \
+    VI_LOOP_BASE(1) \
       switch (sew) { \
         case e8: { \
           VI_ZVK_VV_WIDENING_U_PARAMS(e8); \
@@ -751,7 +751,7 @@
 #define VI_ZVK_VX_WIDENING_ULOOP(BODY) \
   do { \
     VI_CHECK_DSS(false); \
-    VI_LOOP_BASE \
+    VI_LOOP_BASE(1) \
       switch (sew) { \
         case e8: { \
           VI_ZVK_VX_WIDENING_U_PARAMS(e8); \
@@ -789,7 +789,7 @@
 #define VI_ZVK_VI_WIDENING_ULOOP(BODY) \
   do { \
     VI_CHECK_DSS(false); \
-    VI_LOOP_BASE \
+    VI_LOOP_BASE(1) \
       switch (sew) { \
         case e8: { \
           VI_ZVK_VI_WIDENING_U_PARAMS(e8); \


### PR DESCRIPTION
Enable "write ones" agnostic policy:

```
autoheader && autoconf
mkdir build
cd build
../configure --enable-varith-agnostic-write-ones --prefix=$RISCV
make
```

**Vector load instructions are not included**