### PR TITLE
Interaction: Support until-mem operation on physical memory space

### DIFF
--- a/riscv/interactive.cc
+++ b/riscv/interactive.cc
@@ -721,7 +721,7 @@ void sim_t::interactive_until(const std::string& cmd, const std::vector<std::str
   if (args.size() < 3)
     throw trap_interactive();
 
-  if (args.size() == 3)
+  if (args.size() == 4 || (args[0] == "pc" && args.size() == 3)) //dont check mem with arg len = 3
     get_core(args[1]); // make sure that argument is a valid core number
 
   char *end;
@@ -732,7 +732,9 @@ void sim_t::interactive_until(const std::string& cmd, const std::vector<std::str
     throw trap_interactive();
 
   // mask bits above max_xlen
-  int max_xlen = procs[strtol(args[1].c_str(),NULL,10)]->get_isa().get_max_xlen();
+  bool until_mem_paddr = args[0] == "mem" && args.size() == 3;
+  size_t procnum = until_mem_paddr ? 0 : strtol(args[1].c_str(), NULL, 10);
+  int max_xlen = procs[procnum]->get_isa().get_max_xlen();
   if (max_xlen == 32) val &= 0xFFFFFFFF;
 
   std::vector<std::string> args2;


### PR DESCRIPTION
This operation is supposed to be available but not actually.
This PR now permitted followings when running debug interactive interface:
```
until mem 80000000 5a7f
```
Spike will keep running until physical memory at 0x80000000 changed to 0x5a7f