### PR TITLE
Fix c.mop.N decoding

### DIFF
--- a/riscv/insns/c_lui.h
+++ b/riscv/insns/c_lui.h
@@ -4,7 +4,7 @@ if (insn.rvc_rd() == 2) { // c.addi16sp
   WRITE_REG(X_SP, sext_xlen(RVC_SP + insn.rvc_addi16sp_imm()));
 } else if (insn.rvc_imm() != 0) { // c.lui
   WRITE_RD(insn.rvc_imm() << 12);
-} else if ((insn.rvc_rd() & 1) != 0) { // c.mop.N
+} else if ((insn.rvc_rd() & 0x11) == 1) { // c.mop.N
   #include "c_mop_N.h"
 } else {
   require(false);


### PR DESCRIPTION
The c.mop.N only accepts rd={x1, x3, x5, x7, x9, x11, x13, x15}. The previous implemention incorrectly accepts additional rd={x17, x19, x21, x23, x25, x27, x29, x31}.