### PR TITLE
Raise illegal instruction instead of virtual instruction on WFI when TW=1 and VTW=0 in VU-mode

### DIFF
--- a/riscv/insns/wfi.h
+++ b/riscv/insns/wfi.h
@@ -1,9 +1,7 @@
-if (STATE.v && STATE.prv == PRV_U) {
-  require_novirt();
-} else if (get_field(STATE.mstatus->read(), MSTATUS_TW)) {
+if (get_field(STATE.mstatus->read(), MSTATUS_TW)) {
   require_privilege(PRV_M);
-} else if (STATE.v) { // VS-mode
-  if (get_field(STATE.hstatus->read(), HSTATUS_VTW))
+} else if (STATE.v) {
+  if (STATE.prv == PRV_U || get_field(STATE.hstatus->read(), HSTATUS_VTW))
     require_novirt();
 } else if (p->extension_enabled('S')) {
   // When S-mode is implemented, then executing WFI in


### PR DESCRIPTION
The previous implementation raises virtual instruction on WFI when TW=1 and VTW=0 in VU-mode. According to the recent discussion, we expect illegal instruction in this case.

Reference: https://github.com/riscv/riscv-isa-manual/issues/1234