### PR TITLE
workaround to support custom extensions that use standard prefixes

### DIFF
--- a/ci-tests/create-ci-binary-tarball
+++ b/ci-tests/create-ci-binary-tarball
@@ -12,9 +12,13 @@ mkdir -p build/hello && cd "$_"
 riscv64-unknown-elf-gcc -O2 -o hello `git rev-parse --show-toplevel`/ci-tests/hello.c
 cd -
 
+mkdir -p build/dummy-slliuw && cd "$_"
+riscv64-unknown-elf-gcc -O2 -o dummy-slliuw `git rev-parse --show-toplevel`/ci-tests/dummy-slliuw.c
+cd -
+
 mv build/pk/pk .
 mv build/hello/hello .
+mv build/dummy-slliuw/dummy-slliuw .
+tar -cf spike-ci.tar pk hello dummy-slliuw
 
-tar -cf spike-ci.tar pk hello
-
-rm pk hello
+rm pk hello dummy-slliuw

--- a/ci-tests/dummy-slliuw.c
+++ b/ci-tests/dummy-slliuw.c
@@ -1,0 +1,8 @@
+#include <stdio.h>
+
+int main() {
+  // as if slli.uw zero, t1, 3
+  asm(".4byte 0x0833101b");
+  printf("Executed successfully\n");
+  return 0;
+}

--- a/ci-tests/test-customext.cc
+++ b/ci-tests/test-customext.cc
@@ -1,0 +1,90 @@
+#include <riscv/extension.h>
+#include <riscv/sim.h>
+
+struct : public arg_t {
+  std::string to_string(insn_t insn) const { return xpr_name[insn.rd()]; }
+} xrd;
+
+struct : public arg_t {
+  std::string to_string(insn_t insn) const { return xpr_name[insn.rs1()]; }
+} xrs1;
+
+struct : public arg_t {
+  std::string to_string(insn_t insn) const { return xpr_name[insn.rs2()]; }
+} xrs2;
+
+struct : public arg_t {
+  std::string to_string(insn_t insn) const {
+    return std::to_string((int)insn.shamt());
+  }
+} shamt;
+
+static reg_t do_nop4([[maybe_unused]] processor_t *p,
+                     [[maybe_unused]] insn_t insn, reg_t pc) {
+  return pc + 4;
+}
+
+// dummy extension that uses the same prefix as standard zba extension
+struct xslliuw_dummy_t : public extension_t {
+  const char *name() { return "dummyslliuw"; }
+
+  xslliuw_dummy_t() {}
+
+  std::vector<insn_desc_t> get_instructions() {
+    std::vector<insn_desc_t> insns;
+    insns.push_back(insn_desc_t{MATCH_SLLI_UW, MASK_SLLI_UW, do_nop4, do_nop4,
+                                do_nop4, do_nop4, do_nop4, do_nop4, do_nop4,
+                                do_nop4});
+    return insns;
+  }
+
+  std::vector<disasm_insn_t *> get_disasms() {
+    std::vector<disasm_insn_t *> insns;
+    insns.push_back(new disasm_insn_t("dummy_slliuw", MATCH_SLLI_UW,
+                                      MASK_SLLI_UW, {&xrd, &xrs1, &shamt}));
+    return insns;
+  }
+};
+
+REGISTER_EXTENSION(dummyslliuw, []() { return new xslliuw_dummy_t; })
+
+// Copied from spike main.
+// TODO: This should really be provided in libriscv
+static std::vector<std::pair<reg_t, abstract_mem_t *>>
+make_mems(const std::vector<mem_cfg_t> &layout) {
+  std::vector<std::pair<reg_t, abstract_mem_t *>> mems;
+  mems.reserve(layout.size());
+  for (const auto &cfg : layout) {
+    mems.push_back(std::make_pair(cfg.get_base(), new mem_t(cfg.get_size())));
+  }
+  return mems;
+}
+
+int main(int argc, char **argv) {
+  cfg_t cfg;
+  cfg.isa = "RV64IMAFDCV_xdummyslliuw";
+  std::vector<device_factory_t *> plugin_devices;
+  if (argc != 3) {
+    std::cerr << "Error: invalid arguments\n";
+    exit(1);
+  }
+  std::vector<std::string> htif_args{argv[1] /* pk */, argv[2] /* executable */};
+  debug_module_config_t dm_config = {.progbufsize = 2,
+                                     .max_sba_data_width = 0,
+                                     .require_authentication = false,
+                                     .abstract_rti = 0,
+                                     .support_hasel = true,
+                                     .support_abstract_csr_access = true,
+                                     .support_abstract_fpr_access = true,
+                                     .support_haltgroups = true,
+                                     .support_impebreak = true};
+  std::vector<std::pair<reg_t, abstract_mem_t *>> mems =
+      make_mems(cfg.mem_layout);
+  sim_t sim(&cfg, false, mems, plugin_devices, htif_args, dm_config,
+            nullptr,  // log_path
+            true,     // dtb_enabled
+            nullptr,  // dtb_file
+            false,    // socket_enabled
+            nullptr); // cmd_file
+  sim.run();
+}

--- a/ci-tests/test-spike
+++ b/ci-tests/test-spike
@@ -14,4 +14,7 @@ time ../install/bin/spike --isa=rv64gc pk hello | grep "Hello, world!  Pi is app
 
 # check that including sim.h in an external project works
 g++ -std=c++17 -I../install/include -L../install/lib $DIR/testlib.c -lriscv -o test-libriscv
-LD_LIBRARY_PATH=../install/lib ./test-libriscv | grep "Hello, world!  Pi is approximately 3.141588."
+g++ -std=c++17 -I../install/include -L../install/lib $DIR/test-customext.cc -lriscv -o test-customext
+
+LD_LIBRARY_PATH=../install/lib ./test-libriscv pk hello| grep "Hello, world!  Pi is approximately 3.141588."
+LD_LIBRARY_PATH=../install/lib ./test-customext pk dummy-slliuw | grep "Executed successfully"

--- a/ci-tests/testlib.c
+++ b/ci-tests/testlib.c
@@ -12,11 +12,16 @@ static std::vector<std::pair<reg_t, abstract_mem_t*>> make_mems(const std::vecto
   return mems;
 }
 
-int main()
-{
+int main(int argc, char **argv) {
   cfg_t cfg;
   std::vector<device_factory_t*> plugin_devices;
-  std::vector<std::string> htif_args {"pk", "hello"};
+
+  if (argc != 3) {
+    std::cerr << "Error: invalid arguments\n";
+    exit(1);
+  }
+  std::vector<std::string> htif_args{argv[1] /* pk */,
+                                     argv[2] /* executable */};
   debug_module_config_t dm_config;
   std::vector<std::pair<reg_t, abstract_mem_t*>> mems =
       make_mems(cfg.mem_layout);

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -281,7 +281,12 @@ public:
 
   FILE *get_log_file() { return log_file; }
 
-  void register_insn(insn_desc_t);
+  void register_base_insn(insn_desc_t insn) {
+    register_insn(insn, false /* is_custom */);
+  }
+  void register_custom_insn(insn_desc_t insn) {
+    register_insn(insn, true /* is_custom */);
+  }
   void register_extension(extension_t*);
 
   // MMIO slave interface
@@ -336,6 +341,7 @@ private:
   mutable std::bitset<NUM_ISA_EXTENSIONS> extension_assumed_const;
 
   std::vector<insn_desc_t> instructions;
+  std::vector<insn_desc_t> custom_instructions;
   std::unordered_map<reg_t,uint64_t> pc_histogram;
 
   static const size_t OPCODE_CACHE_SIZE = 8191;
@@ -346,6 +352,7 @@ private:
   void take_trap(trap_t& t, reg_t epc); // take an exception
   void take_trigger_action(triggers::action_t action, reg_t breakpoint_tval, reg_t epc, bool virt);
   void disasm(insn_t insn); // disassemble and print an instruction
+  void register_insn(insn_desc_t, bool);
   int paddr_bits();
 
   void enter_debug_mode(uint8_t cause);


### PR DESCRIPTION
RISC-V ISA states (21.1):
> A standard-compatible global encoding can also use standard prefixes for non-standard extensions if the associated standard extensions are not included in the global encoding."

Currently all the instructions (either from standard or custom extensions) are all being inserted into a single std::vector which is then being sorted. An instruction matching process performs linear search on that vector. The problem is that when a custom extension uses the same opcode as standard one (i.e. match and mask are equal to the standard counterparts) it is undefined which instruction will be picked. That is because in std::sort "The order of equal elements is not guaranteed to be preserved". That being said it is impossible to define custom extension (via customext) that would use the prefix of a disabled standard extension.

In this change I separate custom and standard extensions in two separate std::vector's. By default we report an error if they have common elements (There're an additional processor_t constructor's argument that skips this check). If this error is disabled during instruction matching we first trying to find it among custom instructions. If it has been found the search is stopped and custom instruction is executed, otherwise we look for it among standard instructions. Overall this change does not completely fix the problem but at least makes it possible to use the feature of RISC-V ISA.