### PR TITLE
Bump GitHub Actions runners to Ubuntu 22.04

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -18,7 +18,7 @@ on:
 jobs:
   test:
     name: Test Spike build (Ubuntu)
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/debug-smoke.yml
+++ b/.github/workflows/debug-smoke.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   test:
     name: Test debug (Ubuntu)
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
 

--- a/Makefile.in
+++ b/Makefile.in
@@ -69,7 +69,7 @@ install_exes_dir := $(INSTALLDIR)/bin
 sprojs         := @subprojects@
 sprojs_enabled := @subprojects_enabled@
 
-sprojs_include := -I. -I$(src_dir) $(addprefix -I$(src_dir)/, $(sprojs_enabled))
+sprojs_include := -iquote . -I$(src_dir) $(addprefix -iquote $(src_dir)/, $(sprojs_enabled))
 VPATH := $(addprefix $(src_dir)/, $(sprojs_enabled))
 
 #-------------------------------------------------------------------------

--- a/fdt/fdt.mk.in
+++ b/fdt/fdt.mk.in
@@ -15,3 +15,5 @@ fdt_c_srcs = \
 	fdt_empty_tree.c \
 	fdt_addresses.c \
 	fdt_overlay.c \
+
+fdt_CFLAGS = -I$(src_dir)/fdt

--- a/riscv/interactive.cc
+++ b/riscv/interactive.cc
@@ -413,7 +413,7 @@ void sim_t::interactive_run(const std::string& cmd, const std::vector<std::strin
     step(1);
 
   if (actual_steps < steps) {
-    next_interactive_action = [=](){ interactive_run(cmd, {std::to_string(steps - actual_steps)}, noisy); };
+    next_interactive_action = [=, this](){ interactive_run(cmd, {std::to_string(steps - actual_steps)}, noisy); };
     return;
   }
 
@@ -766,7 +766,7 @@ void sim_t::interactive_until(const std::string& cmd, const std::vector<std::str
     step(1);
   }
 
-  next_interactive_action = [=](){ interactive_until(cmd, args, noisy); };
+  next_interactive_action = [=, this](){ interactive_until(cmd, args, noisy); };
 }
 
 void sim_t::interactive_dumpmems(const std::string& cmd, const std::vector<std::string>& args)

--- a/riscv/riscv.mk.in
+++ b/riscv/riscv.mk.in
@@ -7,7 +7,7 @@ riscv_subproject_deps = \
 	fesvr \
 	softfloat \
 
-riscv_CFLAGS = -fPIC
+riscv_CFLAGS = -fPIC -I$(src_dir)/fdt
 
 riscv_install_shared_lib = yes
 


### PR DESCRIPTION
The problem was our use of `-I` to add subprojects' headers to the include path.  Our `syscall.h` was interfering with libstdc++'s dependence on the system's version of the same header (which is why we were getting `SYS_futex`-not-defined errors).

Resolves #1618 