### PR TITLE
Update vcompress.vm to not write vstart with 0 upon completion

### DIFF
--- a/riscv/insns/vcompress_vm.h
+++ b/riscv/insns/vcompress_vm.h
@@ -30,4 +30,4 @@ VI_GENERAL_LOOP_BASE
 
     ++pos;
   }
-VI_LOOP_END;
+VI_LOOP_END_BASE;

--- a/riscv/v_ext_macros.h
+++ b/riscv/v_ext_macros.h
@@ -215,8 +215,11 @@ static inline bool is_overlapped_widen(const int astart, int asize,
     VI_GENERAL_LOOP_BASE \
     VI_LOOP_ELEMENT_SKIP();
 
+#define VI_LOOP_END_BASE \
+ }
+
 #define VI_LOOP_END \
-  } \
+  VI_LOOP_END_BASE \
   P.VU.vstart->write(0);
 
 #define VI_LOOP_REDUCTION_END(x) \


### PR DESCRIPTION
Vmcompress.vm requires vstart==0, so writing vstart with 0 is redundant.

Based on discussion on #1623, splits off VI_LOOP_END_BASE from VI_LOOP_END.
