### PR TITLE
don't read CSR in csrrw(i) with rd=0

### DIFF
--- a/riscv/insns/csrrw.h
+++ b/riscv/insns/csrrw.h
@@ -1,5 +1,8 @@
 int csr = validate_csr(insn.csr(), true);
-reg_t old = p->get_csr(csr, insn, true);
+reg_t old = (insn.rd() != 0) ? p->get_csr(csr, insn, true) : 0; // don't if rd = 0
+auto &carmap = p->get_state()->csrmap;
+// permission on write
+csrmap.count(csr) ? p->get_state()->csrmap[csr]->verify_permissions(insn, true) : throw trap_illegal_instruction(insn.bits());
 p->put_csr(csr, RS1);
 WRITE_RD(sext_xlen(old));
 serialize();

--- a/riscv/insns/csrrwi.h
+++ b/riscv/insns/csrrwi.h
@@ -1,5 +1,8 @@
 int csr = validate_csr(insn.csr(), true);
-reg_t old = p->get_csr(csr, insn, true);
+reg_t old = (insn.rd() != 0) ? p->get_csr(csr, insn, true) : 0; // don't if rd = 0
+auto &carmap = p->get_state()->csrmap;
+// permission on write
+csrmap.count(csr) ? p->get_state()->csrmap[csr]->verify_permissions(insn, true) : throw trap_illegal_instruction(insn.bits());
 p->put_csr(csr, insn.rs1());
 WRITE_RD(sext_xlen(old));
 serialize();


### PR DESCRIPTION
According to 
The RISC-V Instruction Set Manual Volume I: Unprivileged ISA Document Version 20191213 Table 9.1,
there are some conditional with rd = 0 that inhibit read on CSRs.
<img width="608" alt="螢幕擷取畫面 2024-03-19 110524" src="https://github.com/riscv-software-src/riscv-isa-sim/assets/162972686/ff8d179f-c286-4864-83e0-ca5ac31342f4">

Though original implementation is correct in most cases, this always-read implementation may cause some effects. For example, some CSRs that read-write to it may change the architectural state.