### PR TITLE
Allow software check exception to be delegated from M mode regardless of Zicfilp being enabled

### DIFF
--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -906,7 +906,7 @@ bool medeleg_csr_t::unlogged_write(const reg_t val) noexcept {
     | (1 << CAUSE_LOAD_PAGE_FAULT)
     | (1 << CAUSE_STORE_PAGE_FAULT)
     | (proc->extension_enabled('H') ? hypervisor_exceptions : 0)
-    | (proc->extension_enabled(EXT_ZICFILP) ? (1 << CAUSE_SOFTWARE_CHECK_FAULT) : 0)
+    | (1 << CAUSE_SOFTWARE_CHECK_FAULT)
     ;
   return basic_csr_t::unlogged_write((read() & ~mask) | (val & mask));
 }


### PR DESCRIPTION
Sorry it's a bit late, but I noticed this bug when casually viewing my just-merged Zicfilp #1582 :

Software check is a new exception which is not dependent on Zicfilp, so it should be delegable regardless of Zicfilp enabled or not.