### PR TITLE
Narrow scontext.data length to 32

### DIFF
--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -417,7 +417,7 @@ void state_t::reset(processor_t* const proc, reg_t max_isa)
     csrmap[CSR_TDATA3] = std::make_shared<const_csr_t>(proc, CSR_TDATA3, 0);
     csrmap[CSR_TINFO] = std::make_shared<const_csr_t>(proc, CSR_TINFO, 0);
   }
-  unsigned scontext_length = (xlen == 32 ? 16 : 34); // debug spec suggests 16-bit for RV32 and 34-bit for RV64
+  unsigned scontext_length = (xlen == 32 ? 16 : 32); // debug spec suggests 16-bit for RV32 and 32-bit for RV64
   csrmap[CSR_SCONTEXT] = scontext = std::make_shared<masked_csr_t>(proc, CSR_SCONTEXT, (reg_t(1) << scontext_length) - 1, 0);
   unsigned hcontext_length = (xlen == 32 ? 6 : 13) + (proc->extension_enabled('H') ? 1 : 0); // debug spec suggest 7-bit (6-bit) for RV32 and 14-bit (13-bit) for RV64 with (without) H extension
   csrmap[CSR_HCONTEXT] = std::make_shared<masked_csr_t>(proc, CSR_HCONTEXT, (reg_t(1) << hcontext_length) - 1, 0);


### PR DESCRIPTION
The commit provdes the change between debug spec 1.0.0-rc1 and 1.0.0-rc2.

Reference: https://github.com/riscv/riscv-debug-spec/pull/981

![image](https://github.com/riscv-software-src/riscv-isa-sim/assets/39526191/f129ecba-63c5-4f2a-9608-5988136f41e1)
