### PR TITLE
AIA: Implement Smaia/Ssaia extension

### DIFF
--- a/disasm/isa_parser.cc
+++ b/disasm/isa_parser.cc
@@ -377,6 +377,11 @@ isa_parser_t::isa_parser_t(const char* str, const char *priv)
       extension_table[EXT_SSDBLTRP] = true;
     } else if (ext_str == "smdbltrp") {
       extension_table[EXT_SMDBLTRP] = true;
+    } else if (ext_str == "smaia") {
+      extension_table[EXT_SMAIA] = true;
+      extension_table[EXT_SSAIA] = true;
+    } else if (ext_str == "ssaia") {
+      extension_table[EXT_SSAIA] = true;
     } else if (ext_str[0] == 'x') {
       extension_table['X'] = true;
       if (ext_str.size() == 1) {

--- a/disasm/isa_parser.cc
+++ b/disasm/isa_parser.cc
@@ -380,8 +380,11 @@ isa_parser_t::isa_parser_t(const char* str, const char *priv)
     } else if (ext_str == "smaia") {
       extension_table[EXT_SMAIA] = true;
       extension_table[EXT_SSAIA] = true;
+      extension_table[EXT_SMCSRIND] = true;
+      extension_table[EXT_SSCSRIND] = true;
     } else if (ext_str == "ssaia") {
       extension_table[EXT_SSAIA] = true;
+      extension_table[EXT_SSCSRIND] = true;
     } else if (ext_str[0] == 'x') {
       extension_table['X'] = true;
       if (ext_str.size() == 1) {

--- a/riscv/csr_init.cc
+++ b/riscv/csr_init.cc
@@ -467,7 +467,7 @@ void state_t::csr_init(processor_t* const proc, reg_t max_isa)
     }
   }
 
-  hvictl = std::make_shared<const_csr_t>(proc, CSR_HVICTL, set_field((reg_t)0, HVICTL_IID, IRQ_S_EXT)); // no interrupt in hvictl
+  hvictl = std::make_shared<masked_csr_t>(proc, CSR_HVICTL, HVICTL_VTI, set_field((reg_t)0, HVICTL_IID, IRQ_S_EXT)); // no interrupt in hvictl
   if (proc->extension_enabled_const(EXT_SSAIA)) { // Included by EXT_SMAIA
     add_supervisor_csr(CSR_STOPI, std::make_shared<nonvirtual_stopi_csr_t>(proc, CSR_STOPI));
     add_supervisor_csr(CSR_STOPEI, std::make_shared<inaccessible_csr_t>(proc, CSR_STOPEI));

--- a/riscv/csr_init.cc
+++ b/riscv/csr_init.cc
@@ -417,7 +417,7 @@ void state_t::csr_init(processor_t* const proc, reg_t max_isa)
   const reg_t srmcfg_mask = SRMCFG_MCID | SRMCFG_RCID;
   add_const_ext_csr(EXT_SSQOSID, CSR_SRMCFG, std::make_shared<srmcfg_csr_t>(proc, CSR_SRMCFG, srmcfg_mask, 0));
 
-  mvien = std::make_shared<masked_csr_t>(proc, CSR_MVIEN, MIP_SSIP, 0);
+  mvien = std::make_shared<masked_csr_t>(proc, CSR_MVIEN, MIP_SEIP | MIP_SSIP, 0);
   mvip = std::make_shared<mvip_csr_t>(proc, CSR_MVIP, 0);
   if (proc->extension_enabled_const(EXT_SMAIA)) {
     add_csr(CSR_MTOPI, std::make_shared<mtopi_csr_t>(proc, CSR_MTOPI));

--- a/riscv/csr_init.cc
+++ b/riscv/csr_init.cc
@@ -148,9 +148,9 @@ void state_t::csr_init(processor_t* const proc, reg_t max_isa)
   auto sip = std::make_shared<virtualized_with_special_permission_csr_t>(proc, nonvirtual_sip, vsip);
   if (xlen == 32 && proc->extension_enabled_const(EXT_SSAIA)) {
     add_hypervisor_csr(CSR_VSIP, std::make_shared<rv32_low_csr_t>(proc, CSR_VSIP, vsip));
-    add_hypervisor_csr(CSR_VSIPH, std::make_shared<rv32_high_csr_t>(proc, CSR_VSIPH, vsip));
+    add_hypervisor_csr(CSR_VSIPH, std::make_shared<aia_rv32_high_csr_t>(proc, CSR_VSIPH, vsip));
     add_supervisor_csr(CSR_SIP, std::make_shared<rv32_low_csr_t>(proc, CSR_SIP, sip));
-    add_supervisor_csr(CSR_SIPH, std::make_shared<rv32_high_csr_t>(proc, CSR_SIPH, sip));
+    add_supervisor_csr(CSR_SIPH, std::make_shared<aia_rv32_high_csr_t>(proc, CSR_SIPH, sip));
   } else {
     add_hypervisor_csr(CSR_VSIP, vsip);
     add_supervisor_csr(CSR_SIP, sip);
@@ -159,7 +159,7 @@ void state_t::csr_init(processor_t* const proc, reg_t max_isa)
   hvip = std::make_shared<hvip_csr_t>(proc, CSR_HVIP, 0);
   if (xlen == 32 && proc->extension_enabled_const(EXT_SSAIA)) {
     add_hypervisor_csr(CSR_HVIP, std::make_shared<rv32_low_csr_t>(proc, CSR_HVIP, hvip));
-    add_hypervisor_csr(CSR_HVIPH, std::make_shared<rv32_high_csr_t>(proc, CSR_HVIPH, hvip));
+    add_hypervisor_csr(CSR_HVIPH, std::make_shared<aia_rv32_high_csr_t>(proc, CSR_HVIPH, hvip));
   } else {
     add_hypervisor_csr(CSR_HVIP, hvip);
   }
@@ -169,9 +169,9 @@ void state_t::csr_init(processor_t* const proc, reg_t max_isa)
   auto sie = std::make_shared<virtualized_with_special_permission_csr_t>(proc, nonvirtual_sie, vsie);
   if (xlen == 32 && proc->extension_enabled_const(EXT_SSAIA)) {
     add_hypervisor_csr(CSR_VSIE, std::make_shared<rv32_low_csr_t>(proc, CSR_VSIE, vsie));
-    add_hypervisor_csr(CSR_VSIEH, std::make_shared<rv32_high_csr_t>(proc, CSR_VSIEH, vsie));
+    add_hypervisor_csr(CSR_VSIEH, std::make_shared<aia_rv32_high_csr_t>(proc, CSR_VSIEH, vsie));
     add_supervisor_csr(CSR_SIE, std::make_shared<rv32_low_csr_t>(proc, CSR_SIE, sie));
-    add_supervisor_csr(CSR_SIEH, std::make_shared<rv32_high_csr_t>(proc, CSR_SIEH, sie));
+    add_supervisor_csr(CSR_SIEH, std::make_shared<aia_rv32_high_csr_t>(proc, CSR_SIEH, sie));
   } else {
     add_hypervisor_csr(CSR_VSIE, vsie);
     add_supervisor_csr(CSR_SIE, sie);
@@ -182,7 +182,7 @@ void state_t::csr_init(processor_t* const proc, reg_t max_isa)
   mideleg = std::make_shared<mideleg_csr_t>(proc, CSR_MIDELEG);
   if (xlen == 32 && proc->extension_enabled_const(EXT_SMAIA)) {
     add_supervisor_csr(CSR_MIDELEG, std::make_shared<rv32_low_csr_t>(proc, CSR_MIDELEG, mideleg));
-    add_supervisor_csr(CSR_MIDELEGH, std::make_shared<rv32_high_csr_t>(proc, CSR_MIDELEGH, mideleg));
+    add_supervisor_csr(CSR_MIDELEGH, std::make_shared<aia_rv32_high_csr_t>(proc, CSR_MIDELEGH, mideleg));
   } else {
     add_supervisor_csr(CSR_MIDELEG, mideleg);
   }

--- a/riscv/csr_init.cc
+++ b/riscv/csr_init.cc
@@ -417,7 +417,14 @@ void state_t::csr_init(processor_t* const proc, reg_t max_isa)
   const reg_t srmcfg_mask = SRMCFG_MCID | SRMCFG_RCID;
   add_const_ext_csr(EXT_SSQOSID, CSR_SRMCFG, std::make_shared<srmcfg_csr_t>(proc, CSR_SRMCFG, srmcfg_mask, 0));
 
+  mvien = std::make_shared<const_csr_t>(proc, CSR_MVIEN, 0);
   if (proc->extension_enabled_const(EXT_SMAIA)) {
     add_csr(CSR_MTOPI, std::make_shared<mtopi_csr_t>(proc, CSR_MTOPI));
+    if (xlen == 32) {
+      add_supervisor_csr(CSR_MVIEN, std::make_shared<rv32_low_csr_t>(proc, CSR_MVIEN, mvien));
+      add_supervisor_csr(CSR_MVIENH, std::make_shared<rv32_high_csr_t>(proc, CSR_MVIENH, mvien));
+    } else {
+      add_supervisor_csr(CSR_MVIEN, mvien);
+    }
   }
 }

--- a/riscv/csr_init.cc
+++ b/riscv/csr_init.cc
@@ -469,6 +469,7 @@ void state_t::csr_init(processor_t* const proc, reg_t max_isa)
 
   if (proc->extension_enabled_const(EXT_SSAIA)) { // Included by EXT_SMAIA
     add_supervisor_csr(CSR_STOPI, std::make_shared<nonvirtual_stopi_csr_t>(proc, CSR_STOPI));
+    add_supervisor_csr(CSR_STOPEI, std::make_shared<inaccessible_csr_t>(proc, CSR_STOPEI));
     auto hvien = std::make_shared<const_csr_t>(proc, CSR_HVIEN, 0);
     auto hviprio1 = std::make_shared<const_csr_t>(proc, CSR_HVIPRIO1, 0);
     auto hviprio2 = std::make_shared<const_csr_t>(proc, CSR_HVIPRIO2, 0);

--- a/riscv/csr_init.cc
+++ b/riscv/csr_init.cc
@@ -470,11 +470,19 @@ void state_t::csr_init(processor_t* const proc, reg_t max_isa)
   if (proc->extension_enabled_const(EXT_SSAIA)) { // Included by EXT_SMAIA
     add_supervisor_csr(CSR_STOPI, std::make_shared<nonvirtual_stopi_csr_t>(proc, CSR_STOPI));
     auto hvien = std::make_shared<const_csr_t>(proc, CSR_HVIEN, 0);
+    auto hviprio1 = std::make_shared<const_csr_t>(proc, CSR_HVIPRIO1, 0);
+    auto hviprio2 = std::make_shared<const_csr_t>(proc, CSR_HVIPRIO2, 0);
     if (xlen == 32) {
       add_hypervisor_csr(CSR_HVIEN, std::make_shared<rv32_low_csr_t>(proc, CSR_HVIEN, hvien));
       add_hypervisor_csr(CSR_HVIENH, std::make_shared<rv32_high_csr_t>(proc, CSR_HVIENH, hvien));
+      add_hypervisor_csr(CSR_HVIPRIO1, std::make_shared<rv32_low_csr_t>(proc, CSR_HVIPRIO1, hviprio1));
+      add_hypervisor_csr(CSR_HVIPRIO1H, std::make_shared<rv32_high_csr_t>(proc, CSR_HVIPRIO1H, hviprio1));
+      add_hypervisor_csr(CSR_HVIPRIO2, std::make_shared<rv32_low_csr_t>(proc, CSR_HVIPRIO2, hviprio2));
+      add_hypervisor_csr(CSR_HVIPRIO2H, std::make_shared<rv32_high_csr_t>(proc, CSR_HVIPRIO2H, hviprio2));
     } else {
       add_hypervisor_csr(CSR_HVIEN, hvien);
+      add_hypervisor_csr(CSR_HVIPRIO1, hviprio1);
+      add_hypervisor_csr(CSR_HVIPRIO2, hviprio2);
     }
   }
 }

--- a/riscv/csr_init.cc
+++ b/riscv/csr_init.cc
@@ -416,4 +416,8 @@ void state_t::csr_init(processor_t* const proc, reg_t max_isa)
 
   const reg_t srmcfg_mask = SRMCFG_MCID | SRMCFG_RCID;
   add_const_ext_csr(EXT_SSQOSID, CSR_SRMCFG, std::make_shared<srmcfg_csr_t>(proc, CSR_SRMCFG, srmcfg_mask, 0));
+
+  if (proc->extension_enabled_const(EXT_SMAIA)) {
+    add_csr(CSR_MTOPI, std::make_shared<mtopi_csr_t>(proc, CSR_MTOPI));
+  }
 }

--- a/riscv/csr_init.cc
+++ b/riscv/csr_init.cc
@@ -418,13 +418,17 @@ void state_t::csr_init(processor_t* const proc, reg_t max_isa)
   add_const_ext_csr(EXT_SSQOSID, CSR_SRMCFG, std::make_shared<srmcfg_csr_t>(proc, CSR_SRMCFG, srmcfg_mask, 0));
 
   mvien = std::make_shared<const_csr_t>(proc, CSR_MVIEN, 0);
+  mvip = std::make_shared<mvip_csr_t>(proc, CSR_MVIP, 0);
   if (proc->extension_enabled_const(EXT_SMAIA)) {
     add_csr(CSR_MTOPI, std::make_shared<mtopi_csr_t>(proc, CSR_MTOPI));
     if (xlen == 32) {
       add_supervisor_csr(CSR_MVIEN, std::make_shared<rv32_low_csr_t>(proc, CSR_MVIEN, mvien));
       add_supervisor_csr(CSR_MVIENH, std::make_shared<rv32_high_csr_t>(proc, CSR_MVIENH, mvien));
+      add_supervisor_csr(CSR_MVIP, std::make_shared<rv32_low_csr_t>(proc, CSR_MVIP, mvip));
+      add_supervisor_csr(CSR_MVIPH, std::make_shared<rv32_high_csr_t>(proc, CSR_MVIPH, mvip));
     } else {
       add_supervisor_csr(CSR_MVIEN, mvien);
+      add_supervisor_csr(CSR_MVIEN, mvip);
     }
   }
 }

--- a/riscv/csr_init.cc
+++ b/riscv/csr_init.cc
@@ -145,25 +145,35 @@ void state_t::csr_init(processor_t* const proc, reg_t max_isa)
 
   nonvirtual_sip = std::make_shared<sip_csr_t>(proc, CSR_SIP, sip_sie_accr);
   auto vsip = std::make_shared<mip_proxy_csr_t>(proc, CSR_VSIP, vsip_vsie_accr);
-  add_hypervisor_csr(CSR_VSIP, vsip);
   auto sip = std::make_shared<virtualized_csr_t>(proc, nonvirtual_sip, vsip);
   if (xlen == 32 && proc->extension_enabled_const(EXT_SSAIA)) {
+    add_hypervisor_csr(CSR_VSIP, std::make_shared<rv32_low_csr_t>(proc, CSR_VSIP, vsip));
+    add_hypervisor_csr(CSR_VSIPH, std::make_shared<rv32_high_csr_t>(proc, CSR_VSIPH, vsip));
     add_supervisor_csr(CSR_SIP, std::make_shared<rv32_low_csr_t>(proc, CSR_SIP, sip));
     add_supervisor_csr(CSR_SIPH, std::make_shared<rv32_high_csr_t>(proc, CSR_SIPH, sip));
   } else {
+    add_hypervisor_csr(CSR_VSIP, vsip);
     add_supervisor_csr(CSR_SIP, sip);
   }
   add_hypervisor_csr(CSR_HIP, std::make_shared<mip_proxy_csr_t>(proc, CSR_HIP, hip_hie_accr));
-  add_hypervisor_csr(CSR_HVIP, hvip = std::make_shared<hvip_csr_t>(proc, CSR_HVIP, 0));
+  hvip = std::make_shared<hvip_csr_t>(proc, CSR_HVIP, 0);
+  if (xlen == 32 && proc->extension_enabled_const(EXT_SSAIA)) {
+    add_hypervisor_csr(CSR_HVIP, std::make_shared<rv32_low_csr_t>(proc, CSR_HVIP, hvip));
+    add_hypervisor_csr(CSR_HVIPH, std::make_shared<rv32_high_csr_t>(proc, CSR_HVIPH, hvip));
+  } else {
+    add_hypervisor_csr(CSR_HVIP, hvip);
+  }
 
   nonvirtual_sie = std::make_shared<sie_csr_t>(proc, CSR_SIE, sip_sie_accr);
   auto vsie = std::make_shared<mie_proxy_csr_t>(proc, CSR_VSIE, vsip_vsie_accr);
-  add_hypervisor_csr(CSR_VSIE, vsie);
   auto sie = std::make_shared<virtualized_csr_t>(proc, nonvirtual_sie, vsie);
   if (xlen == 32 && proc->extension_enabled_const(EXT_SSAIA)) {
+    add_hypervisor_csr(CSR_VSIE, std::make_shared<rv32_low_csr_t>(proc, CSR_VSIE, vsie));
+    add_hypervisor_csr(CSR_VSIEH, std::make_shared<rv32_high_csr_t>(proc, CSR_VSIEH, vsie));
     add_supervisor_csr(CSR_SIE, std::make_shared<rv32_low_csr_t>(proc, CSR_SIE, sie));
     add_supervisor_csr(CSR_SIEH, std::make_shared<rv32_high_csr_t>(proc, CSR_SIEH, sie));
   } else {
+    add_hypervisor_csr(CSR_VSIE, vsie);
     add_supervisor_csr(CSR_SIE, sie);
   }
   add_hypervisor_csr(CSR_HIE, std::make_shared<mie_proxy_csr_t>(proc, CSR_HIE, hip_hie_accr));
@@ -207,7 +217,13 @@ void state_t::csr_init(processor_t* const proc, reg_t max_isa)
   add_hypervisor_csr(CSR_HSTATUS, hstatus = std::make_shared<hstatus_csr_t>(proc, CSR_HSTATUS));
   add_hypervisor_csr(CSR_HGEIE, std::make_shared<const_csr_t>(proc, CSR_HGEIE, 0));
   add_hypervisor_csr(CSR_HGEIP, std::make_shared<const_csr_t>(proc, CSR_HGEIP, 0));
-  add_hypervisor_csr(CSR_HIDELEG, hideleg = std::make_shared<hideleg_csr_t>(proc, CSR_HIDELEG, mideleg));
+  hideleg = std::make_shared<hideleg_csr_t>(proc, CSR_HIDELEG, mideleg);
+  if (xlen == 32 && proc->extension_enabled_const(EXT_SSAIA)) {
+    add_hypervisor_csr(CSR_HIDELEG, std::make_shared<rv32_low_csr_t>(proc, CSR_HIDELEG, hideleg));
+    add_hypervisor_csr(CSR_HIDELEGH, std::make_shared<rv32_high_csr_t>(proc, CSR_HIDELEGH, hideleg));
+  } else {
+    add_hypervisor_csr(CSR_HIDELEG, hideleg);
+  }
   const reg_t hedeleg_mask =
     (1 << CAUSE_MISALIGNED_FETCH) |
     (1 << CAUSE_FETCH_ACCESS) |

--- a/riscv/csr_init.cc
+++ b/riscv/csr_init.cc
@@ -467,7 +467,7 @@ void state_t::csr_init(processor_t* const proc, reg_t max_isa)
     }
   }
 
-  hvictl = std::make_shared<masked_csr_t>(proc, CSR_HVICTL, HVICTL_VTI, set_field((reg_t)0, HVICTL_IID, IRQ_S_EXT)); // no interrupt in hvictl
+  hvictl = std::make_shared<masked_csr_t>(proc, CSR_HVICTL, HVICTL_VTI | HVICTL_IID | HVICTL_DPR, 0);
   vstopi = std::make_shared<vstopi_csr_t>(proc, CSR_VSTOPI);
   if (proc->extension_enabled_const(EXT_SSAIA)) { // Included by EXT_SMAIA
     csr_t_p nonvirtual_stopi = std::make_shared<nonvirtual_stopi_csr_t>(proc, CSR_STOPI);

--- a/riscv/csr_init.cc
+++ b/riscv/csr_init.cc
@@ -468,8 +468,10 @@ void state_t::csr_init(processor_t* const proc, reg_t max_isa)
   }
 
   hvictl = std::make_shared<masked_csr_t>(proc, CSR_HVICTL, HVICTL_VTI, set_field((reg_t)0, HVICTL_IID, IRQ_S_EXT)); // no interrupt in hvictl
+  vstopi = std::make_shared<vstopi_csr_t>(proc, CSR_VSTOPI);
   if (proc->extension_enabled_const(EXT_SSAIA)) { // Included by EXT_SMAIA
-    add_supervisor_csr(CSR_STOPI, std::make_shared<nonvirtual_stopi_csr_t>(proc, CSR_STOPI));
+    csr_t_p nonvirtual_stopi = std::make_shared<nonvirtual_stopi_csr_t>(proc, CSR_STOPI);
+    add_supervisor_csr(CSR_STOPI, std::make_shared<virtualized_csr_t>(proc, nonvirtual_stopi, vstopi));
     add_supervisor_csr(CSR_STOPEI, std::make_shared<inaccessible_csr_t>(proc, CSR_STOPEI));
     auto hvien = std::make_shared<const_csr_t>(proc, CSR_HVIEN, 0);
     auto hviprio1 = std::make_shared<const_csr_t>(proc, CSR_HVIPRIO1, 0);
@@ -487,5 +489,6 @@ void state_t::csr_init(processor_t* const proc, reg_t max_isa)
       add_hypervisor_csr(CSR_HVIPRIO2, hviprio2);
     }
     add_hypervisor_csr(CSR_HVICTL, hvictl);
+    add_hypervisor_csr(CSR_VSTOPI, vstopi);
   }
 }

--- a/riscv/csr_init.cc
+++ b/riscv/csr_init.cc
@@ -469,5 +469,12 @@ void state_t::csr_init(processor_t* const proc, reg_t max_isa)
 
   if (proc->extension_enabled_const(EXT_SSAIA)) { // Included by EXT_SMAIA
     add_supervisor_csr(CSR_STOPI, std::make_shared<nonvirtual_stopi_csr_t>(proc, CSR_STOPI));
+    auto hvien = std::make_shared<const_csr_t>(proc, CSR_HVIEN, 0);
+    if (xlen == 32) {
+      add_hypervisor_csr(CSR_HVIEN, std::make_shared<rv32_low_csr_t>(proc, CSR_HVIEN, hvien));
+      add_hypervisor_csr(CSR_HVIENH, std::make_shared<rv32_high_csr_t>(proc, CSR_HVIENH, hvien));
+    } else {
+      add_hypervisor_csr(CSR_HVIEN, hvien);
+    }
   }
 }

--- a/riscv/csr_init.cc
+++ b/riscv/csr_init.cc
@@ -143,7 +143,7 @@ void state_t::csr_init(processor_t* const proc, reg_t max_isa)
     1              // shiftamt
   );
 
-  auto nonvirtual_sip = std::make_shared<mip_proxy_csr_t>(proc, CSR_SIP, sip_sie_accr);
+  auto nonvirtual_sip = std::make_shared<sip_csr_t>(proc, CSR_SIP, sip_sie_accr);
   auto vsip = std::make_shared<mip_proxy_csr_t>(proc, CSR_VSIP, vsip_vsie_accr);
   add_hypervisor_csr(CSR_VSIP, vsip);
   add_supervisor_csr(CSR_SIP, std::make_shared<virtualized_csr_t>(proc, nonvirtual_sip, vsip));

--- a/riscv/csr_init.cc
+++ b/riscv/csr_init.cc
@@ -150,7 +150,7 @@ void state_t::csr_init(processor_t* const proc, reg_t max_isa)
   add_hypervisor_csr(CSR_HIP, std::make_shared<mip_proxy_csr_t>(proc, CSR_HIP, hip_hie_accr));
   add_hypervisor_csr(CSR_HVIP, hvip = std::make_shared<hvip_csr_t>(proc, CSR_HVIP, 0));
 
-  auto nonvirtual_sie = std::make_shared<mie_proxy_csr_t>(proc, CSR_SIE, sip_sie_accr);
+  auto nonvirtual_sie = std::make_shared<sie_csr_t>(proc, CSR_SIE, sip_sie_accr);
   auto vsie = std::make_shared<mie_proxy_csr_t>(proc, CSR_VSIE, vsip_vsie_accr);
   add_hypervisor_csr(CSR_VSIE, vsie);
   add_supervisor_csr(CSR_SIE, std::make_shared<virtualized_csr_t>(proc, nonvirtual_sie, vsie));

--- a/riscv/csr_init.cc
+++ b/riscv/csr_init.cc
@@ -403,8 +403,15 @@ void state_t::csr_init(processor_t* const proc, reg_t max_isa)
     csr_t_p siselect = std::make_shared<basic_csr_t>(proc, CSR_SISELECT, 0);
     add_supervisor_csr(CSR_SISELECT, std::make_shared<virtualized_csr_t>(proc, siselect, vsiselect));
 
-    const reg_t vsireg_csrs[] = { CSR_VSIREG, CSR_VSIREG2, CSR_VSIREG3, CSR_VSIREG4, CSR_VSIREG5, CSR_VSIREG6 };
-    const reg_t sireg_csrs[] = { CSR_SIREG, CSR_SIREG2, CSR_SIREG3, CSR_SIREG4, CSR_SIREG5, CSR_SIREG6 };
+    auto vsireg = std::make_shared<sscsrind_reg_csr_t>(proc, CSR_VSIREG, vsiselect);
+    add_hypervisor_csr(CSR_VSIREG, vsireg);
+
+    auto sireg = std::make_shared<sscsrind_reg_csr_t>(proc, CSR_SIREG, siselect);
+    add_ireg_proxy(proc, sireg);
+    add_supervisor_csr(CSR_SIREG, std::make_shared<virtualized_indirect_csr_t>(proc, sireg, vsireg));
+
+    const reg_t vsireg_csrs[] = { CSR_VSIREG2, CSR_VSIREG3, CSR_VSIREG4, CSR_VSIREG5, CSR_VSIREG6 };
+    const reg_t sireg_csrs[] = { CSR_SIREG2, CSR_SIREG3, CSR_SIREG4, CSR_SIREG5, CSR_SIREG6 };
     for (size_t i = 0; i < std::size(vsireg_csrs); i++) {
       auto vsireg = std::make_shared<sscsrind_reg_csr_t>(proc, vsireg_csrs[i], vsiselect);
       add_hypervisor_csr(vsireg_csrs[i], vsireg);

--- a/riscv/csr_init.cc
+++ b/riscv/csr_init.cc
@@ -450,4 +450,8 @@ void state_t::csr_init(processor_t* const proc, reg_t max_isa)
       add_supervisor_csr(CSR_MVIEN, mvip);
     }
   }
+
+  if (proc->extension_enabled_const(EXT_SSAIA)) { // Included by EXT_SMAIA
+    add_supervisor_csr(CSR_STOPI, std::make_shared<nonvirtual_stopi_csr_t>(proc, CSR_STOPI));
+  }
 }

--- a/riscv/csr_init.cc
+++ b/riscv/csr_init.cc
@@ -381,7 +381,7 @@ void state_t::csr_init(processor_t* const proc, reg_t max_isa)
   if (proc->extension_enabled_const(EXT_SSTC)) {
     stimecmp = std::make_shared<stimecmp_csr_t>(proc, CSR_STIMECMP, MIP_STIP);
     vstimecmp = std::make_shared<stimecmp_csr_t>(proc, CSR_VSTIMECMP, MIP_VSTIP);
-    auto virtualized_stimecmp = std::make_shared<virtualized_stimecmp_csr_t>(proc, stimecmp, vstimecmp);
+    auto virtualized_stimecmp = std::make_shared<virtualized_with_special_permission_csr_t>(proc, stimecmp, vstimecmp);
     if (xlen == 32) {
       add_supervisor_csr(CSR_STIMECMP, std::make_shared<rv32_low_csr_t>(proc, CSR_STIMECMP, virtualized_stimecmp));
       add_supervisor_csr(CSR_STIMECMPH, std::make_shared<rv32_high_csr_t>(proc, CSR_STIMECMPH, virtualized_stimecmp));

--- a/riscv/csr_init.cc
+++ b/riscv/csr_init.cc
@@ -471,7 +471,7 @@ void state_t::csr_init(processor_t* const proc, reg_t max_isa)
   vstopi = std::make_shared<vstopi_csr_t>(proc, CSR_VSTOPI);
   if (proc->extension_enabled_const(EXT_SSAIA)) { // Included by EXT_SMAIA
     csr_t_p nonvirtual_stopi = std::make_shared<nonvirtual_stopi_csr_t>(proc, CSR_STOPI);
-    add_supervisor_csr(CSR_STOPI, std::make_shared<virtualized_csr_t>(proc, nonvirtual_stopi, vstopi));
+    add_supervisor_csr(CSR_STOPI, std::make_shared<virtualized_with_special_permission_csr_t>(proc, nonvirtual_stopi, vstopi));
     add_supervisor_csr(CSR_STOPEI, std::make_shared<inaccessible_csr_t>(proc, CSR_STOPEI));
     auto hvien = std::make_shared<aia_csr_t>(proc, CSR_HVIEN, 0, 0);
     auto hviprio1 = std::make_shared<aia_csr_t>(proc, CSR_HVIPRIO1, 0, 0);

--- a/riscv/csr_init.cc
+++ b/riscv/csr_init.cc
@@ -146,14 +146,26 @@ void state_t::csr_init(processor_t* const proc, reg_t max_isa)
   auto nonvirtual_sip = std::make_shared<sip_csr_t>(proc, CSR_SIP, sip_sie_accr);
   auto vsip = std::make_shared<mip_proxy_csr_t>(proc, CSR_VSIP, vsip_vsie_accr);
   add_hypervisor_csr(CSR_VSIP, vsip);
-  add_supervisor_csr(CSR_SIP, std::make_shared<virtualized_csr_t>(proc, nonvirtual_sip, vsip));
+  auto sip = std::make_shared<virtualized_csr_t>(proc, nonvirtual_sip, vsip);
+  if (xlen == 32 && proc->extension_enabled_const(EXT_SSAIA)) {
+    add_supervisor_csr(CSR_SIP, std::make_shared<rv32_low_csr_t>(proc, CSR_SIP, sip));
+    add_supervisor_csr(CSR_SIPH, std::make_shared<rv32_high_csr_t>(proc, CSR_SIPH, sip));
+  } else {
+    add_supervisor_csr(CSR_SIP, sip);
+  }
   add_hypervisor_csr(CSR_HIP, std::make_shared<mip_proxy_csr_t>(proc, CSR_HIP, hip_hie_accr));
   add_hypervisor_csr(CSR_HVIP, hvip = std::make_shared<hvip_csr_t>(proc, CSR_HVIP, 0));
 
   auto nonvirtual_sie = std::make_shared<sie_csr_t>(proc, CSR_SIE, sip_sie_accr);
   auto vsie = std::make_shared<mie_proxy_csr_t>(proc, CSR_VSIE, vsip_vsie_accr);
   add_hypervisor_csr(CSR_VSIE, vsie);
-  add_supervisor_csr(CSR_SIE, std::make_shared<virtualized_csr_t>(proc, nonvirtual_sie, vsie));
+  auto sie = std::make_shared<virtualized_csr_t>(proc, nonvirtual_sie, vsie);
+  if (xlen == 32 && proc->extension_enabled_const(EXT_SSAIA)) {
+    add_supervisor_csr(CSR_SIE, std::make_shared<rv32_low_csr_t>(proc, CSR_SIE, sie));
+    add_supervisor_csr(CSR_SIEH, std::make_shared<rv32_high_csr_t>(proc, CSR_SIEH, sie));
+  } else {
+    add_supervisor_csr(CSR_SIE, sie);
+  }
   add_hypervisor_csr(CSR_HIE, std::make_shared<mie_proxy_csr_t>(proc, CSR_HIE, hip_hie_accr));
 
   add_supervisor_csr(CSR_MEDELEG, medeleg = std::make_shared<medeleg_csr_t>(proc, CSR_MEDELEG));

--- a/riscv/csr_init.cc
+++ b/riscv/csr_init.cc
@@ -20,7 +20,7 @@ void state_t::add_ireg_proxy(processor_t* const proc, sscsrind_reg_csr_t::sscsri
 
   const reg_t iprio0_addr = 0x30;
   for (int i=0; i<16; i+=2) {
-    csr_t_p iprio = std::make_shared<const_csr_t>(proc, iprio0_addr + i, 0);
+    csr_t_p iprio = std::make_shared<aia_csr_t>(proc, iprio0_addr + i, 0, 0);
     if (xlen == 32) {
       ireg->add_ireg_proxy(iprio0_addr + i, std::make_shared<rv32_low_csr_t>(proc, iprio0_addr + i, iprio));
       ireg->add_ireg_proxy(iprio0_addr + i + 1, std::make_shared<rv32_high_csr_t>(proc, iprio0_addr + i + 1, iprio));
@@ -467,15 +467,15 @@ void state_t::csr_init(processor_t* const proc, reg_t max_isa)
     }
   }
 
-  hvictl = std::make_shared<masked_csr_t>(proc, CSR_HVICTL, HVICTL_VTI | HVICTL_IID | HVICTL_DPR | HVICTL_IPRIOM | HVICTL_IPRIO, 0);
+  hvictl = std::make_shared<aia_csr_t>(proc, CSR_HVICTL, HVICTL_VTI | HVICTL_IID | HVICTL_DPR | HVICTL_IPRIOM | HVICTL_IPRIO, 0);
   vstopi = std::make_shared<vstopi_csr_t>(proc, CSR_VSTOPI);
   if (proc->extension_enabled_const(EXT_SSAIA)) { // Included by EXT_SMAIA
     csr_t_p nonvirtual_stopi = std::make_shared<nonvirtual_stopi_csr_t>(proc, CSR_STOPI);
     add_supervisor_csr(CSR_STOPI, std::make_shared<virtualized_csr_t>(proc, nonvirtual_stopi, vstopi));
     add_supervisor_csr(CSR_STOPEI, std::make_shared<inaccessible_csr_t>(proc, CSR_STOPEI));
-    auto hvien = std::make_shared<const_csr_t>(proc, CSR_HVIEN, 0);
-    auto hviprio1 = std::make_shared<const_csr_t>(proc, CSR_HVIPRIO1, 0);
-    auto hviprio2 = std::make_shared<const_csr_t>(proc, CSR_HVIPRIO2, 0);
+    auto hvien = std::make_shared<aia_csr_t>(proc, CSR_HVIEN, 0, 0);
+    auto hviprio1 = std::make_shared<aia_csr_t>(proc, CSR_HVIPRIO1, 0, 0);
+    auto hviprio2 = std::make_shared<aia_csr_t>(proc, CSR_HVIPRIO2, 0, 0);
     if (xlen == 32) {
       add_hypervisor_csr(CSR_HVIEN, std::make_shared<rv32_low_csr_t>(proc, CSR_HVIEN, hvien));
       add_hypervisor_csr(CSR_HVIENH, std::make_shared<rv32_high_csr_t>(proc, CSR_HVIENH, hvien));

--- a/riscv/csr_init.cc
+++ b/riscv/csr_init.cc
@@ -417,7 +417,7 @@ void state_t::csr_init(processor_t* const proc, reg_t max_isa)
   const reg_t srmcfg_mask = SRMCFG_MCID | SRMCFG_RCID;
   add_const_ext_csr(EXT_SSQOSID, CSR_SRMCFG, std::make_shared<srmcfg_csr_t>(proc, CSR_SRMCFG, srmcfg_mask, 0));
 
-  mvien = std::make_shared<const_csr_t>(proc, CSR_MVIEN, 0);
+  mvien = std::make_shared<masked_csr_t>(proc, CSR_MVIEN, MIP_SSIP, 0);
   mvip = std::make_shared<mvip_csr_t>(proc, CSR_MVIP, 0);
   if (proc->extension_enabled_const(EXT_SMAIA)) {
     add_csr(CSR_MTOPI, std::make_shared<mtopi_csr_t>(proc, CSR_MTOPI));

--- a/riscv/csr_init.cc
+++ b/riscv/csr_init.cc
@@ -467,7 +467,7 @@ void state_t::csr_init(processor_t* const proc, reg_t max_isa)
     }
   }
 
-  hvictl = std::make_shared<masked_csr_t>(proc, CSR_HVICTL, HVICTL_VTI | HVICTL_IID | HVICTL_DPR, 0);
+  hvictl = std::make_shared<masked_csr_t>(proc, CSR_HVICTL, HVICTL_VTI | HVICTL_IID | HVICTL_DPR | HVICTL_IPRIOM | HVICTL_IPRIO, 0);
   vstopi = std::make_shared<vstopi_csr_t>(proc, CSR_VSTOPI);
   if (proc->extension_enabled_const(EXT_SSAIA)) { // Included by EXT_SMAIA
     csr_t_p nonvirtual_stopi = std::make_shared<nonvirtual_stopi_csr_t>(proc, CSR_STOPI);

--- a/riscv/csr_init.cc
+++ b/riscv/csr_init.cc
@@ -143,7 +143,7 @@ void state_t::csr_init(processor_t* const proc, reg_t max_isa)
     1              // shiftamt
   );
 
-  auto nonvirtual_sip = std::make_shared<sip_csr_t>(proc, CSR_SIP, sip_sie_accr);
+  nonvirtual_sip = std::make_shared<sip_csr_t>(proc, CSR_SIP, sip_sie_accr);
   auto vsip = std::make_shared<mip_proxy_csr_t>(proc, CSR_VSIP, vsip_vsie_accr);
   add_hypervisor_csr(CSR_VSIP, vsip);
   auto sip = std::make_shared<virtualized_csr_t>(proc, nonvirtual_sip, vsip);
@@ -156,7 +156,7 @@ void state_t::csr_init(processor_t* const proc, reg_t max_isa)
   add_hypervisor_csr(CSR_HIP, std::make_shared<mip_proxy_csr_t>(proc, CSR_HIP, hip_hie_accr));
   add_hypervisor_csr(CSR_HVIP, hvip = std::make_shared<hvip_csr_t>(proc, CSR_HVIP, 0));
 
-  auto nonvirtual_sie = std::make_shared<sie_csr_t>(proc, CSR_SIE, sip_sie_accr);
+  nonvirtual_sie = std::make_shared<sie_csr_t>(proc, CSR_SIE, sip_sie_accr);
   auto vsie = std::make_shared<mie_proxy_csr_t>(proc, CSR_VSIE, vsip_vsie_accr);
   add_hypervisor_csr(CSR_VSIE, vsie);
   auto sie = std::make_shared<virtualized_csr_t>(proc, nonvirtual_sie, vsie);

--- a/riscv/csr_init.cc
+++ b/riscv/csr_init.cc
@@ -345,7 +345,7 @@ void state_t::csr_init(processor_t* const proc, reg_t max_isa)
     const reg_t sstateen0_mask = (proc->extension_enabled(EXT_ZFINX) ? SSTATEEN0_FCSR : 0) |
                                  (proc->extension_enabled(EXT_ZCMT) ? SSTATEEN0_JVT : 0) |
                                  SSTATEEN0_CS;
-    const reg_t hstateen0_mask = sstateen0_mask | HSTATEEN0_SENVCFG | HSTATEEN_SSTATEEN;
+    const reg_t hstateen0_mask = sstateen0_mask | HSTATEEN0_CSRIND | HSTATEEN0_SENVCFG | HSTATEEN_SSTATEEN;
     const reg_t mstateen0_mask = hstateen0_mask | (proc->extension_enabled(EXT_SSQOSID) ?  MSTATEEN0_PRIV114 : 0);
     for (int i = 0; i < 4; i++) {
       const reg_t mstateen_mask = i == 0 ? mstateen0_mask : MSTATEEN_HSTATEEN;
@@ -413,11 +413,11 @@ void state_t::csr_init(processor_t* const proc, reg_t max_isa)
   }
 
   if (proc->extension_enabled_const(EXT_SSCSRIND)) {
-    csr_t_p vsiselect = std::make_shared<basic_csr_t>(proc, CSR_VSISELECT, 0);
+    csr_t_p vsiselect = std::make_shared<siselect_csr_t>(proc, CSR_VSISELECT, 0);
     add_hypervisor_csr(CSR_VSISELECT, vsiselect);
 
-    csr_t_p siselect = std::make_shared<basic_csr_t>(proc, CSR_SISELECT, 0);
-    add_supervisor_csr(CSR_SISELECT, std::make_shared<virtualized_csr_t>(proc, siselect, vsiselect));
+    csr_t_p siselect = std::make_shared<siselect_csr_t>(proc, CSR_SISELECT, 0);
+    add_supervisor_csr(CSR_SISELECT, std::make_shared<virtualized_with_special_permission_csr_t>(proc, siselect, vsiselect));
 
     auto vsireg = std::make_shared<sscsrind_reg_csr_t>(proc, CSR_VSIREG, vsiselect);
     add_hypervisor_csr(CSR_VSIREG, vsireg);

--- a/riscv/csr_init.cc
+++ b/riscv/csr_init.cc
@@ -12,6 +12,24 @@ void state_t::add_csr(reg_t addr, const csr_t_p& csr)
 #define add_supervisor_csr(addr, csr) add_const_ext_csr('S', addr, csr)
 #define add_hypervisor_csr(addr, csr) add_ext_csr('H', addr, csr)
 
+void state_t::add_ireg_proxy(processor_t* const proc, sscsrind_reg_csr_t::sscsrind_reg_csr_t_p ireg)
+{
+  // This assumes xlen is always max_xlen, which is true today (see
+  // mstatus_csr_t::unlogged_write()):
+  auto xlen = proc->get_isa().get_max_xlen();
+
+  const reg_t iprio0_addr = 0x30;
+  for (int i=0; i<16; i+=2) {
+    csr_t_p iprio = std::make_shared<const_csr_t>(proc, iprio0_addr + i, 0);
+    if (xlen == 32) {
+      ireg->add_ireg_proxy(iprio0_addr + i, std::make_shared<rv32_low_csr_t>(proc, iprio0_addr + i, iprio));
+      ireg->add_ireg_proxy(iprio0_addr + i + 1, std::make_shared<rv32_high_csr_t>(proc, iprio0_addr + i + 1, iprio));
+    } else {
+      ireg->add_ireg_proxy(iprio0_addr + i, iprio);
+    }
+  }
+}
+
 void state_t::csr_init(processor_t* const proc, reg_t max_isa)
 {
   // This assumes xlen is always max_xlen, which is true today (see
@@ -358,7 +376,10 @@ void state_t::csr_init(processor_t* const proc, reg_t max_isa)
     csr_t_p miselect = std::make_shared<basic_csr_t>(proc, CSR_MISELECT, 0);
     add_csr(CSR_MISELECT, miselect);
 
-    const reg_t mireg_csrs[] = { CSR_MIREG, CSR_MIREG2, CSR_MIREG3, CSR_MIREG4, CSR_MIREG5, CSR_MIREG6 };
+    sscsrind_reg_csr_t::sscsrind_reg_csr_t_p mireg;
+    add_csr(CSR_MIREG, mireg = std::make_shared<sscsrind_reg_csr_t>(proc, CSR_MIREG, miselect));
+    add_ireg_proxy(proc, mireg);
+    const reg_t mireg_csrs[] = { CSR_MIREG2, CSR_MIREG3, CSR_MIREG4, CSR_MIREG5, CSR_MIREG6 };
     for (auto csr : mireg_csrs)
       add_csr(csr, std::make_shared<sscsrind_reg_csr_t>(proc, csr, miselect));
   }

--- a/riscv/csr_init.cc
+++ b/riscv/csr_init.cc
@@ -467,6 +467,7 @@ void state_t::csr_init(processor_t* const proc, reg_t max_isa)
     }
   }
 
+  hvictl = std::make_shared<const_csr_t>(proc, CSR_HVICTL, set_field((reg_t)0, HVICTL_IID, IRQ_S_EXT)); // no interrupt in hvictl
   if (proc->extension_enabled_const(EXT_SSAIA)) { // Included by EXT_SMAIA
     add_supervisor_csr(CSR_STOPI, std::make_shared<nonvirtual_stopi_csr_t>(proc, CSR_STOPI));
     add_supervisor_csr(CSR_STOPEI, std::make_shared<inaccessible_csr_t>(proc, CSR_STOPEI));
@@ -485,5 +486,6 @@ void state_t::csr_init(processor_t* const proc, reg_t max_isa)
       add_hypervisor_csr(CSR_HVIPRIO1, hviprio1);
       add_hypervisor_csr(CSR_HVIPRIO2, hviprio2);
     }
+    add_hypervisor_csr(CSR_HVICTL, hvictl);
   }
 }

--- a/riscv/csr_init.cc
+++ b/riscv/csr_init.cc
@@ -145,7 +145,7 @@ void state_t::csr_init(processor_t* const proc, reg_t max_isa)
 
   nonvirtual_sip = std::make_shared<sip_csr_t>(proc, CSR_SIP, sip_sie_accr);
   auto vsip = std::make_shared<mip_proxy_csr_t>(proc, CSR_VSIP, vsip_vsie_accr);
-  auto sip = std::make_shared<virtualized_csr_t>(proc, nonvirtual_sip, vsip);
+  auto sip = std::make_shared<virtualized_with_special_permission_csr_t>(proc, nonvirtual_sip, vsip);
   if (xlen == 32 && proc->extension_enabled_const(EXT_SSAIA)) {
     add_hypervisor_csr(CSR_VSIP, std::make_shared<rv32_low_csr_t>(proc, CSR_VSIP, vsip));
     add_hypervisor_csr(CSR_VSIPH, std::make_shared<rv32_high_csr_t>(proc, CSR_VSIPH, vsip));
@@ -166,7 +166,7 @@ void state_t::csr_init(processor_t* const proc, reg_t max_isa)
 
   nonvirtual_sie = std::make_shared<sie_csr_t>(proc, CSR_SIE, sip_sie_accr);
   auto vsie = std::make_shared<mie_proxy_csr_t>(proc, CSR_VSIE, vsip_vsie_accr);
-  auto sie = std::make_shared<virtualized_csr_t>(proc, nonvirtual_sie, vsie);
+  auto sie = std::make_shared<virtualized_with_special_permission_csr_t>(proc, nonvirtual_sie, vsie);
   if (xlen == 32 && proc->extension_enabled_const(EXT_SSAIA)) {
     add_hypervisor_csr(CSR_VSIE, std::make_shared<rv32_low_csr_t>(proc, CSR_VSIE, vsie));
     add_hypervisor_csr(CSR_VSIEH, std::make_shared<rv32_high_csr_t>(proc, CSR_VSIEH, vsie));

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -641,6 +641,22 @@ reg_t rv32_high_csr_t::written_value() const noexcept {
   return (orig->written_value() >> 32) & 0xffffffffU;
 }
 
+aia_rv32_high_csr_t::aia_rv32_high_csr_t(processor_t* const proc, const reg_t addr, csr_t_p orig):
+  rv32_high_csr_t(proc, addr, orig) {
+}
+
+void aia_rv32_high_csr_t::verify_permissions(insn_t insn, bool write) const {
+  if (proc->extension_enabled(EXT_SMSTATEEN)) {
+    if ((state->prv < PRV_M) && !(state->mstateen[0]->read() & MSTATEEN0_AIA))
+      throw trap_illegal_instruction(insn.bits());
+
+    if (state->v && !(state->hstateen[0]->read() & HSTATEEN0_AIA))
+      throw trap_virtual_instruction(insn.bits());
+  }
+
+  aia_rv32_high_csr_t::verify_permissions(insn, write);
+}
+
 // implement class sstatus_csr_t
 sstatus_csr_t::sstatus_csr_t(processor_t* const proc, sstatus_proxy_csr_t_p orig, vsstatus_csr_t_p virt):
   virtualized_csr_t(proc, orig, virt),

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -1984,3 +1984,14 @@ reg_t nonvirtual_stopi_csr_t::read() const noexcept {
 bool nonvirtual_stopi_csr_t::unlogged_write(const reg_t UNUSED val) noexcept {
   return false;
 }
+
+inaccessible_csr_t::inaccessible_csr_t(processor_t* const proc, const reg_t addr):
+  csr_t(proc, addr) {
+}
+
+void inaccessible_csr_t::verify_permissions(insn_t insn, bool write) const {
+  if (state->v)
+    throw trap_virtual_instruction(insn.bits());
+  else
+    throw trap_illegal_instruction(insn.bits());
+}

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -2020,24 +2020,30 @@ reg_t vstopi_csr_t::read() const noexcept {
   bool vti = hvictl & HVICTL_VTI;
   reg_t iid = get_field(hvictl, HVICTL_IID);
   bool dpr = hvictl & HVICTL_DPR;
+  bool ipriom = hvictl & HVICTL_IPRIOM;
+  reg_t iprio = get_field(hvictl, HVICTL_IPRIO);
 
   reg_t enabled_interrupts = state->mip->read() & state->mie->read() & state->hideleg->read();
   enabled_interrupts >>= 1; // VSSIP -> SSIP, etc
+  reg_t vgein = get_field(state->hstatus->read(), HSTATUS_VGEIN);
+  reg_t virtual_sei_priority = (vgein == 0 && iid == IRQ_S_EXT && iprio != 0) ? iprio : 255; // vstopi.IPRIO is 255 for priority number 256
 
-  reg_t identity;
+  reg_t identity, priority;
   if (vti) {
     if (!(enabled_interrupts & MIP_SEIP) && iid == IRQ_S_EXT)
       return 0;
 
     identity = ((enabled_interrupts & MIP_SEIP) && (iid == IRQ_S_EXT || dpr)) ? IRQ_S_EXT : iid;
+    priority = (identity == IRQ_S_EXT) ? virtual_sei_priority : ((iprio != 0 || !dpr) ? iprio : 255);
   } else {
     if (!enabled_interrupts)
       return 0; // no enabled pending interrupt to VS-mode
 
     reg_t selected_interrupt = proc->select_an_interrupt_with_default_priority(enabled_interrupts);
     identity = ctz(selected_interrupt);
+    priority = (identity == IRQ_S_EXT) ? virtual_sei_priority : 255; // vstopi.IPRIO is 255 for interrupt with default priority lower than VSEI
   }
-  return set_field((reg_t)1, MTOPI_IID, identity); // vstopi.IPRIO is 1 if hvictl.IPRIOM is 0
+  return set_field((reg_t)(ipriom ? priority : 1), MTOPI_IID, identity);
 }
 
 bool vstopi_csr_t::unlogged_write(const reg_t UNUSED val) noexcept {

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -1966,3 +1966,21 @@ void mvip_csr_t::write_with_mask(const reg_t mask, const reg_t val) noexcept {
   basic_csr_t::unlogged_write((basic_csr_t::read() & ~mask) | (val & mask));
   log_write();
 }
+
+nonvirtual_stopi_csr_t::nonvirtual_stopi_csr_t(processor_t* const proc, const reg_t addr):
+  csr_t(proc, addr) {
+}
+
+reg_t nonvirtual_stopi_csr_t::read() const noexcept {
+  reg_t enabled_interrupts = state->nonvirtual_sip->read() & state->nonvirtual_sie->read() & ~state->hideleg->read();
+  if (!enabled_interrupts)
+    return 0; // no enabled pending interrupt to S-mode
+
+  reg_t selected_interrupt = proc->select_an_interrupt_with_default_priority(enabled_interrupts);
+  reg_t identity = ctz(selected_interrupt);
+  return set_field((reg_t)1, MTOPI_IID, identity); // IPRIO always 1 if iprio array is RO0
+}
+
+bool nonvirtual_stopi_csr_t::unlogged_write(const reg_t UNUSED val) noexcept {
+  return false;
+}

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -2075,3 +2075,19 @@ void siselect_csr_t::verify_permissions(insn_t insn, bool write) const {
 
   basic_csr_t::verify_permissions(insn, write);
 }
+
+aia_csr_t::aia_csr_t(processor_t* const proc, const reg_t addr, const reg_t mask, const reg_t init):
+  masked_csr_t(proc, addr, mask, init) {
+}
+
+void aia_csr_t::verify_permissions(insn_t insn, bool write) const {
+  if (proc->extension_enabled(EXT_SMSTATEEN)) {
+    if ((state->prv < PRV_M) && !(state->mstateen[0]->read() & MSTATEEN0_AIA))
+      throw trap_illegal_instruction(insn.bits());
+
+    if (state->v && !(state->hstateen[0]->read() & HSTATEEN0_AIA))
+      throw trap_virtual_instruction(insn.bits());
+  }
+
+  basic_csr_t::verify_permissions(insn, write);
+}

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -784,13 +784,13 @@ mip_csr_t::mip_csr_t(processor_t* const proc, const reg_t addr):
 }
 
 void mip_csr_t::write_with_mask(const reg_t mask, const reg_t val) noexcept {
-  if (mask & MIP_SEIP)
+  if (!(state->mvien->read() & MIP_SEIP) && (mask & MIP_SEIP))
     state->mvip->write_with_mask(MIP_SEIP, val); // mvip.SEIP is an alias of mip.SEIP when mvien.SEIP=0
   mip_or_mie_csr_t::write_with_mask(mask & ~MIP_SEIP, val);
 }
 
 reg_t mip_csr_t::read() const noexcept {
-  return val | state->hvip->basic_csr_t::read() | (state->mvip->basic_csr_t::read() & MIP_SEIP);
+  return val | state->hvip->basic_csr_t::read() | ((state->mvien->read() & MIP_SEIP) ? 0 : (state->mvip->basic_csr_t::read() & MIP_SEIP));
 }
 
 void mip_csr_t::backdoor_write_with_mask(const reg_t mask, const reg_t val) noexcept {

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -872,6 +872,12 @@ mip_proxy_csr_t::mip_proxy_csr_t(processor_t* const proc, const reg_t addr, gene
   accr(accr) {
 }
 
+void mip_proxy_csr_t::verify_permissions(insn_t insn, bool write) const {
+  csr_t::verify_permissions(insn, write);
+  if ((state->csrmap[CSR_HVICTL]->read() & HVICTL_VTI) && state->v)
+    throw trap_virtual_instruction(insn.bits()); // VS-mode attempts to access sip when hvictl.VTI=1
+}
+
 reg_t mip_proxy_csr_t::read() const noexcept {
   return accr->ip_read();
 }
@@ -885,6 +891,12 @@ bool mip_proxy_csr_t::unlogged_write(const reg_t val) noexcept {
 mie_proxy_csr_t::mie_proxy_csr_t(processor_t* const proc, const reg_t addr, generic_int_accessor_t_p accr):
   csr_t(proc, addr),
   accr(accr) {
+}
+
+void mie_proxy_csr_t::verify_permissions(insn_t insn, bool write) const {
+  csr_t::verify_permissions(insn, write);
+  if ((state->csrmap[CSR_HVICTL]->read() & HVICTL_VTI) && state->v)
+    throw trap_virtual_instruction(insn.bits()); // VS-mode attempts to access sie when hvictl.VTI=1
 }
 
 reg_t mie_proxy_csr_t::read() const noexcept {

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -2010,3 +2010,22 @@ void inaccessible_csr_t::verify_permissions(insn_t insn, bool write) const {
   else
     throw trap_illegal_instruction(insn.bits());
 }
+
+vstopi_csr_t::vstopi_csr_t(processor_t* const proc, const reg_t addr):
+  csr_t(proc, addr) {
+}
+
+reg_t vstopi_csr_t::read() const noexcept {
+  reg_t enabled_interrupts = state->mip->read() & state->mie->read() & state->hideleg->read();
+  enabled_interrupts >>= 1; // VSSIP -> SSIP, etc
+  if (!enabled_interrupts)
+    return 0; // no enabled pending interrupt to VS-mode
+
+  reg_t selected_interrupt = proc->select_an_interrupt_with_default_priority(enabled_interrupts);
+  reg_t identity = ctz(selected_interrupt);
+  return set_field((reg_t)1, MTOPI_IID, identity); // vstopi.IPRIO is 1 if hvictl.IPRIOM is 0
+}
+
+bool vstopi_csr_t::unlogged_write(const reg_t UNUSED val) noexcept {
+  return false;
+}

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -1798,9 +1798,19 @@ sscsrind_reg_csr_t::sscsrind_reg_csr_t(processor_t* const proc, const reg_t addr
 }
 
 void sscsrind_reg_csr_t::verify_permissions(insn_t insn, bool write) const {
+  if (proc->extension_enabled(EXT_SMSTATEEN)) {
+    if ((state->prv < PRV_M) && !(state->mstateen[0]->read() & MSTATEEN0_CSRIND))
+      throw trap_illegal_instruction(insn.bits());
+  }
+
   // Don't call base verify_permission for VS registers remapped to S-mode
   if (insn.csr() == address)
     csr_t::verify_permissions(insn, write);
+
+  if (proc->extension_enabled(EXT_SMSTATEEN)) {
+    if (state->v && !(state->hstateen[0]->read() & HSTATEEN0_CSRIND))
+      throw trap_virtual_instruction(insn.bits());
+  }
 
   csr_t_p proxy_csr = get_reg();
   if (proxy_csr == nullptr) {
@@ -2048,4 +2058,20 @@ reg_t vstopi_csr_t::read() const noexcept {
 
 bool vstopi_csr_t::unlogged_write(const reg_t UNUSED val) noexcept {
   return false;
+}
+
+siselect_csr_t::siselect_csr_t(processor_t* const proc, const reg_t addr, const reg_t init):
+  basic_csr_t(proc, addr, init) {
+}
+
+void siselect_csr_t::verify_permissions(insn_t insn, bool write) const {
+  if (proc->extension_enabled(EXT_SMSTATEEN)) {
+    if ((state->prv < PRV_M) && !(state->mstateen[0]->read() & MSTATEEN0_CSRIND))
+      throw trap_illegal_instruction(insn.bits());
+
+    if (state->v && !(state->hstateen[0]->read() & HSTATEEN0_CSRIND))
+      throw trap_virtual_instruction(insn.bits());
+  }
+
+  basic_csr_t::verify_permissions(insn, write);
 }

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -979,6 +979,23 @@ bool sip_csr_t::unlogged_write(const reg_t val) noexcept {
   return mip_proxy_csr_t::unlogged_write(val & ~mask);
 }
 
+sie_csr_t::sie_csr_t(processor_t* const proc, const reg_t addr, generic_int_accessor_t_p accr):
+  mie_proxy_csr_t(proc, addr, accr),
+  val(0) {
+}
+
+reg_t sie_csr_t::read() const noexcept {
+  const reg_t mask = ~state->mideleg->read() & state->mvien->read();
+  return (mie_proxy_csr_t::read() & ~mask) | (val & mask);
+}
+
+bool sie_csr_t::unlogged_write(const reg_t val) noexcept {
+  const reg_t mask = ~state->mideleg->read() & state->mvien->read();
+  this->val = (this->val & ~mask) | (val & mask);
+  mie_proxy_csr_t::unlogged_write(val & ~mask);
+  return true;
+}
+
 // implement class masked_csr_t
 masked_csr_t::masked_csr_t(processor_t* const proc, const reg_t addr, const reg_t mask, const reg_t init):
   basic_csr_t(proc, addr, init),

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -1682,7 +1682,7 @@ bool stimecmp_csr_t::unlogged_write(const reg_t val) noexcept {
   return basic_csr_t::unlogged_write(val);
 }
 
-virtualized_stimecmp_csr_t::virtualized_stimecmp_csr_t(processor_t* const proc, csr_t_p orig, csr_t_p virt):
+virtualized_with_special_permission_csr_t::virtualized_with_special_permission_csr_t(processor_t* const proc, csr_t_p orig, csr_t_p virt):
   virtualized_csr_t(proc, orig, virt) {
 }
 
@@ -1703,7 +1703,7 @@ void stimecmp_csr_t::verify_permissions(insn_t insn, bool write) const {
   basic_csr_t::verify_permissions(insn, write);
 }
 
-void virtualized_stimecmp_csr_t::verify_permissions(insn_t insn, bool write) const {
+void virtualized_with_special_permission_csr_t::verify_permissions(insn_t insn, bool write) const {
   orig_csr->verify_permissions(insn, write);
 }
 

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -1903,12 +1903,14 @@ mvip_csr_t::mvip_csr_t(processor_t* const proc, const reg_t addr, const reg_t in
 }
 
 reg_t mvip_csr_t::read() const noexcept {
+  const reg_t val = basic_csr_t::read();
+  const reg_t mvien = state->mvien->read();
   const reg_t mip = state->mip->read();
   const reg_t menvcfg = state->menvcfg->read();
   return 0
     | (mip & MIP_SEIP)
     | ((menvcfg & MENVCFG_STCE) ? 0 : (mip & MIP_STIP))
-    | (mip & MIP_SSIP)
+    | (((mvien & MIP_SSIP) ? val : mip) & MIP_SSIP)
     ;
 }
 
@@ -1916,7 +1918,9 @@ bool mvip_csr_t::unlogged_write(const reg_t val) noexcept {
   state->mip->write_with_mask(MIP_SEIP, val);
   if (!(state->menvcfg->read() & MENVCFG_STCE))
     state->mip->write_with_mask(MIP_STIP, val); // mvip.STIP is an alias of mip.STIP when mip.STIP is writable
-  state->mip->write_with_mask(MIP_SSIP, val);
+  if (!(state->mvien->read() & MIP_SSIP))
+    state->mip->write_with_mask(MIP_SSIP, val); // mvip.SSIP is an alias of mip.SSIP when mvien.SSIP=0
 
-  return false;
+  const reg_t new_val = ((state->mvien->read() & MIP_SSIP) ? val : basic_csr_t::read()) & MIP_SSIP;
+  return basic_csr_t::unlogged_write(new_val);
 }

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -964,6 +964,21 @@ bool medeleg_csr_t::unlogged_write(const reg_t val) noexcept {
   return basic_csr_t::unlogged_write((read() & ~mask) | (val & mask));
 }
 
+sip_csr_t::sip_csr_t(processor_t* const proc, const reg_t addr, generic_int_accessor_t_p accr):
+  mip_proxy_csr_t(proc, addr, accr) {
+}
+
+reg_t sip_csr_t::read() const noexcept {
+  const reg_t mask = ~state->mideleg->read() & state->mvien->read();
+  return (mip_proxy_csr_t::read() & ~mask) | (state->mvip->read() & mask);
+}
+
+bool sip_csr_t::unlogged_write(const reg_t val) noexcept {
+  const reg_t mask = ~state->mideleg->read() & state->mvien->read();
+  state->mvip->write_with_mask(mask & accr->get_ip_write_mask(), val);
+  return mip_proxy_csr_t::unlogged_write(val & ~mask);
+}
+
 // implement class masked_csr_t
 masked_csr_t::masked_csr_t(processor_t* const proc, const reg_t addr, const reg_t mask, const reg_t init):
   basic_csr_t(proc, addr, init),

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -1713,6 +1713,9 @@ void stimecmp_csr_t::verify_permissions(insn_t insn, bool write) const {
   }
 
   basic_csr_t::verify_permissions(insn, write);
+
+  if ((state->csrmap[CSR_HVICTL]->read() & HVICTL_VTI) && state->v && write)
+    throw trap_virtual_instruction(insn.bits());
 }
 
 void virtualized_with_special_permission_csr_t::verify_permissions(insn_t insn, bool write) const {

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -2025,6 +2025,18 @@ vstopi_csr_t::vstopi_csr_t(processor_t* const proc, const reg_t addr):
   csr_t(proc, addr) {
 }
 
+void vstopi_csr_t::verify_permissions(insn_t insn, bool write) const {
+  if (proc->extension_enabled(EXT_SMSTATEEN)) {
+    if ((state->prv < PRV_M) && !(state->mstateen[0]->read() & MSTATEEN0_AIA))
+      throw trap_illegal_instruction(insn.bits());
+
+    if (state->v && !(state->hstateen[0]->read() & HSTATEEN0_AIA))
+      throw trap_virtual_instruction(insn.bits());
+  }
+
+  csr_t::verify_permissions(insn, write);
+}
+
 reg_t vstopi_csr_t::read() const noexcept {
   reg_t hvictl = state->hvictl->read();
   bool vti = hvictl & HVICTL_VTI;

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -1897,3 +1897,26 @@ reg_t mtopi_csr_t::read() const noexcept {
 bool mtopi_csr_t::unlogged_write(const reg_t UNUSED val) noexcept {
   return false;
 }
+
+mvip_csr_t::mvip_csr_t(processor_t* const proc, const reg_t addr, const reg_t init):
+  basic_csr_t(proc, addr, init) {
+}
+
+reg_t mvip_csr_t::read() const noexcept {
+  const reg_t mip = state->mip->read();
+  const reg_t menvcfg = state->menvcfg->read();
+  return 0
+    | (mip & MIP_SEIP)
+    | ((menvcfg & MENVCFG_STCE) ? 0 : (mip & MIP_STIP))
+    | (mip & MIP_SSIP)
+    ;
+}
+
+bool mvip_csr_t::unlogged_write(const reg_t val) noexcept {
+  state->mip->write_with_mask(MIP_SEIP, val);
+  if (!(state->menvcfg->read() & MENVCFG_STCE))
+    state->mip->write_with_mask(MIP_STIP, val); // mvip.STIP is an alias of mip.STIP when mip.STIP is writable
+  state->mip->write_with_mask(MIP_SSIP, val);
+
+  return false;
+}

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -967,4 +967,10 @@ class vstopi_csr_t: public csr_t {
  protected:
   bool unlogged_write(const reg_t val) noexcept override;
 };
+
+class siselect_csr_t: public basic_csr_t {
+ public:
+  siselect_csr_t(processor_t* const proc, const reg_t addr, const reg_t init);
+  virtual void verify_permissions(insn_t insn, bool write) const override;
+};
 #endif

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -940,4 +940,12 @@ class mvip_csr_t : public basic_csr_t {
 };
 
 typedef std::shared_ptr<mvip_csr_t> mvip_csr_t_p;
+
+class nonvirtual_stopi_csr_t: public csr_t {
+ public:
+  nonvirtual_stopi_csr_t(processor_t* const proc, const reg_t addr);
+  virtual reg_t read() const noexcept override;
+ protected:
+  bool unlogged_write(const reg_t val) noexcept override;
+};
 #endif

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -907,4 +907,14 @@ class mtopi_csr_t: public csr_t {
  protected:
   bool unlogged_write(const reg_t val) noexcept override;
 };
+
+class mvip_csr_t : public basic_csr_t {
+ public:
+  mvip_csr_t(processor_t* const proc, const reg_t addr, const reg_t init);
+  reg_t read() const noexcept override;
+ protected:
+  virtual bool unlogged_write(const reg_t val) noexcept override;
+};
+
+typedef std::shared_ptr<mvip_csr_t> mvip_csr_t_p;
 #endif

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -959,4 +959,12 @@ class inaccessible_csr_t: public csr_t {
  protected:
   bool unlogged_write(const reg_t val) noexcept override { return false; }
 };
+
+class vstopi_csr_t: public csr_t {
+ public:
+  vstopi_csr_t(processor_t* const proc, const reg_t addr);
+  virtual reg_t read() const noexcept override;
+ protected:
+  bool unlogged_write(const reg_t val) noexcept override;
+};
 #endif

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -356,7 +356,7 @@ class mip_or_mie_csr_t: public csr_t {
   mip_or_mie_csr_t(processor_t* const proc, const reg_t addr);
   virtual reg_t read() const noexcept override;
 
-  void write_with_mask(const reg_t mask, const reg_t val) noexcept;
+  virtual void write_with_mask(const reg_t mask, const reg_t val) noexcept;
 
  protected:
   virtual bool unlogged_write(const reg_t val) noexcept override final;
@@ -370,6 +370,8 @@ class mip_csr_t: public mip_or_mie_csr_t {
  public:
   mip_csr_t(processor_t* const proc, const reg_t addr);
   virtual reg_t read() const noexcept override final;
+
+  void write_with_mask(const reg_t mask, const reg_t val) noexcept override;
 
   // Does not log. Used by external things (clint) that wiggle bits in mip.
   void backdoor_write_with_mask(const reg_t mask, const reg_t val) noexcept;
@@ -912,6 +914,9 @@ class mvip_csr_t : public basic_csr_t {
  public:
   mvip_csr_t(processor_t* const proc, const reg_t addr, const reg_t init);
   reg_t read() const noexcept override;
+
+  void write_with_mask(const reg_t mask, const reg_t val) noexcept;
+
  protected:
   virtual bool unlogged_write(const reg_t val) noexcept override;
 };

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -408,6 +408,7 @@ class generic_int_accessor_t {
   void ip_write(const reg_t val) noexcept;
   reg_t ie_read() const noexcept;
   void ie_write(const reg_t val) noexcept;
+  reg_t get_ip_write_mask() { return ip_write_mask; }
  private:
   state_t* const state;
   const reg_t read_mask;
@@ -428,7 +429,6 @@ class mip_proxy_csr_t: public csr_t {
   virtual reg_t read() const noexcept override;
  protected:
   virtual bool unlogged_write(const reg_t val) noexcept override;
- private:
   generic_int_accessor_t_p accr;
 };
 
@@ -460,6 +460,14 @@ class medeleg_csr_t: public basic_csr_t {
   virtual bool unlogged_write(const reg_t val) noexcept override;
  private:
   const reg_t hypervisor_exceptions;
+};
+
+class sip_csr_t: public mip_proxy_csr_t {
+ public:
+  sip_csr_t(processor_t* const proc, const reg_t addr, generic_int_accessor_t_p accr);
+  virtual reg_t read() const noexcept override;
+ protected:
+  virtual bool unlogged_write(const reg_t val) noexcept override;
 };
 
 // For CSRs with certain bits hardwired

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -973,4 +973,10 @@ class siselect_csr_t: public basic_csr_t {
   siselect_csr_t(processor_t* const proc, const reg_t addr, const reg_t init);
   virtual void verify_permissions(insn_t insn, bool write) const override;
 };
+
+class aia_csr_t: public masked_csr_t {
+ public:
+  aia_csr_t(processor_t* const proc, const reg_t addr, const reg_t mask, const reg_t init);
+  virtual void verify_permissions(insn_t insn, bool write) const override;
+};
 #endif

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -899,4 +899,12 @@ class hstatus_csr_t final: public basic_csr_t {
  protected:
   virtual bool unlogged_write(const reg_t val) noexcept override;
 };
+
+class mtopi_csr_t: public csr_t {
+ public:
+  mtopi_csr_t(processor_t* const proc, const reg_t addr);
+  virtual reg_t read() const noexcept override;
+ protected:
+  bool unlogged_write(const reg_t val) noexcept override;
+};
 #endif

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -470,6 +470,16 @@ class sip_csr_t: public mip_proxy_csr_t {
   virtual bool unlogged_write(const reg_t val) noexcept override;
 };
 
+class sie_csr_t: public mie_proxy_csr_t {
+ public:
+  sie_csr_t(processor_t* const proc, const reg_t addr, generic_int_accessor_t_p accr);
+  virtual reg_t read() const noexcept override;
+ protected:
+  virtual bool unlogged_write(const reg_t val) noexcept override;
+ private:
+  reg_t val;
+};
+
 // For CSRs with certain bits hardwired
 class masked_csr_t: public basic_csr_t {
  public:

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -948,4 +948,13 @@ class nonvirtual_stopi_csr_t: public csr_t {
  protected:
   bool unlogged_write(const reg_t val) noexcept override;
 };
+
+class inaccessible_csr_t: public csr_t {
+ public:
+  inaccessible_csr_t(processor_t* const proc, const reg_t addr);
+  virtual void verify_permissions(insn_t insn, bool write) const override;
+  reg_t read() const noexcept override { return 0; }
+ protected:
+  bool unlogged_write(const reg_t val) noexcept override { return false; }
+};
 #endif

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -963,6 +963,7 @@ class inaccessible_csr_t: public csr_t {
 class vstopi_csr_t: public csr_t {
  public:
   vstopi_csr_t(processor_t* const proc, const reg_t addr);
+  virtual void verify_permissions(insn_t insn, bool write) const override;
   virtual reg_t read() const noexcept override;
  protected:
   bool unlogged_write(const reg_t val) noexcept override;

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -825,9 +825,9 @@ class stimecmp_csr_t: public basic_csr_t {
   reg_t intr_mask;
 };
 
-class virtualized_stimecmp_csr_t: public virtualized_csr_t {
+class virtualized_with_special_permission_csr_t: public virtualized_csr_t {
  public:
-  virtualized_stimecmp_csr_t(processor_t* const proc, csr_t_p orig, csr_t_p virt);
+  virtualized_with_special_permission_csr_t(processor_t* const proc, csr_t_p orig, csr_t_p virt);
   virtual void verify_permissions(insn_t insn, bool write) const override;
 };
 

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -946,6 +946,7 @@ typedef std::shared_ptr<mvip_csr_t> mvip_csr_t_p;
 class nonvirtual_stopi_csr_t: public csr_t {
  public:
   nonvirtual_stopi_csr_t(processor_t* const proc, const reg_t addr);
+  virtual void verify_permissions(insn_t insn, bool write) const override;
   virtual reg_t read() const noexcept override;
  protected:
   bool unlogged_write(const reg_t val) noexcept override;

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -426,6 +426,7 @@ typedef std::shared_ptr<generic_int_accessor_t> generic_int_accessor_t_p;
 class mip_proxy_csr_t: public csr_t {
  public:
   mip_proxy_csr_t(processor_t* const proc, const reg_t addr, generic_int_accessor_t_p accr);
+  virtual void verify_permissions(insn_t insn, bool write) const override;
   virtual reg_t read() const noexcept override;
  protected:
   virtual bool unlogged_write(const reg_t val) noexcept override;
@@ -436,6 +437,7 @@ class mip_proxy_csr_t: public csr_t {
 class mie_proxy_csr_t: public csr_t {
  public:
   mie_proxy_csr_t(processor_t* const proc, const reg_t addr, generic_int_accessor_t_p accr);
+  virtual void verify_permissions(insn_t insn, bool write) const override;
   virtual reg_t read() const noexcept override;
  protected:
   virtual bool unlogged_write(const reg_t val) noexcept override;

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -301,6 +301,12 @@ class rv32_high_csr_t: public csr_t {
   csr_t_p orig;
 };
 
+class aia_rv32_high_csr_t: public rv32_high_csr_t {
+ public:
+  aia_rv32_high_csr_t(processor_t* const proc, const reg_t addr, csr_t_p orig);
+  virtual void verify_permissions(insn_t insn, bool write) const override;
+};
+
 // sstatus.sdt is read_only 0 when menvcfg.dte = 0
 class sstatus_proxy_csr_t final: public base_status_csr_t {
  public:

--- a/riscv/isa_parser.h
+++ b/riscv/isa_parser.h
@@ -86,6 +86,8 @@ typedef enum {
   EXT_SMMPM,
   EXT_SMNPM,
   EXT_SSNPM,
+  EXT_SMAIA,
+  EXT_SSAIA,
   NUM_ISA_EXTENSIONS
 } isa_extension_t;
 

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -308,9 +308,11 @@ reg_t processor_t::select_an_interrupt_with_default_priority(reg_t enabled_inter
 void processor_t::take_interrupt(reg_t pending_interrupts)
 {
   const reg_t s_pending_interrupts = state.nonvirtual_sip->read() & state.nonvirtual_sie->read();
+  const reg_t vstopi = state.vstopi->read();
+  const reg_t vs_pending_interrupt = vstopi ? (reg_t(1) << get_field(vstopi, MTOPI_IID)) : 0;
 
   // Do nothing if no pending interrupts
-  if (!pending_interrupts && !s_pending_interrupts) {
+  if (!pending_interrupts && !s_pending_interrupts && !vs_pending_interrupt) {
     return;
   }
 
@@ -329,9 +331,8 @@ void processor_t::take_interrupt(reg_t pending_interrupts)
     enabled_interrupts = ((pending_interrupts & deleg_to_hs) | (s_pending_interrupts & ~state.hideleg->read())) & -hs_enabled;
     if (state.v && enabled_interrupts == 0) {
       // VS-ints have least priority and can only be taken with virt enabled
-      const reg_t deleg_to_vs = state.hideleg->read();
       const reg_t vs_enabled = state.prv < PRV_S || (state.prv == PRV_S && sie);
-      enabled_interrupts = pending_interrupts & deleg_to_vs & -vs_enabled;
+      enabled_interrupts = vs_pending_interrupt & -vs_enabled;
     }
   }
 
@@ -460,7 +461,7 @@ void processor_t::take_trap(trap_t& t, reg_t epc)
   }
   if (state.prv <= PRV_S && bit < max_xlen && ((vsdeleg >> bit) & 1)) {
     // Handle the trap in VS-mode
-    const reg_t adjusted_cause = interrupt ? bit - 1 : bit;  // VSSIP -> SSIP, etc
+    const reg_t adjusted_cause = bit;
     reg_t vector = (state.vstvec->read() & 1) && interrupt ? 4 * adjusted_cause : 0;
     state.pc = (state.vstvec->read() & ~(reg_t)1) + vector;
     state.vscause->write(adjusted_cause | (interrupt ? interrupt_bit : 0));

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -444,7 +444,7 @@ void processor_t::take_trap(trap_t& t, reg_t epc)
   bool supv_double_trap = false;
   if (interrupt) {
     vsdeleg = (curr_virt && state.prv <= PRV_S) ? state.hideleg->read() : 0;
-    hsdeleg = (state.prv <= PRV_S) ? state.mideleg->read() : 0;
+    hsdeleg = (state.prv <= PRV_S) ? (state.mideleg->read() | state.nonvirtual_sip->read()) : 0;
     bit &= ~((reg_t)1 << (max_xlen - 1));
   } else {
     vsdeleg = (curr_virt && state.prv <= PRV_S) ? (state.medeleg->read() & state.hedeleg->read()) : 0;

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -335,10 +335,10 @@ void processor_t::take_interrupt(reg_t pending_interrupts)
 
   const bool nmie = !(state.mnstatus && !get_field(state.mnstatus->read(), MNSTATUS_NMIE));
   if (!state.debug_mode && nmie && enabled_interrupts) {
-    enabled_interrupts = select_an_interrupt_with_default_priority(enabled_interrupts);
+    reg_t selected_interrupt = select_an_interrupt_with_default_priority(enabled_interrupts);
 
     if (check_triggers_icount) TM.detect_icount_match();
-    throw trap_t(((reg_t)1 << (isa.get_max_xlen() - 1)) | ctz(enabled_interrupts));
+    throw trap_t(((reg_t)1 << (isa.get_max_xlen() - 1)) | ctz(selected_interrupt));
   }
 }
 

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -307,8 +307,10 @@ reg_t processor_t::select_an_interrupt_with_default_priority(reg_t enabled_inter
 
 void processor_t::take_interrupt(reg_t pending_interrupts)
 {
+  const reg_t s_pending_interrupts = state.nonvirtual_sip->read() & state.nonvirtual_sie->read();
+
   // Do nothing if no pending interrupts
-  if (!pending_interrupts) {
+  if (!pending_interrupts && !s_pending_interrupts) {
     return;
   }
 
@@ -324,7 +326,7 @@ void processor_t::take_interrupt(reg_t pending_interrupts)
     const reg_t deleg_to_hs = state.mideleg->read() & ~state.hideleg->read();
     const reg_t sie = get_field(state.sstatus->read(), MSTATUS_SIE);
     const reg_t hs_enabled = state.v || state.prv < PRV_S || (state.prv == PRV_S && sie);
-    enabled_interrupts = pending_interrupts & deleg_to_hs & -hs_enabled;
+    enabled_interrupts = ((pending_interrupts & deleg_to_hs) | (s_pending_interrupts & ~state.hideleg->read())) & -hs_enabled;
     if (state.v && enabled_interrupts == 0) {
       // VS-ints have least priority and can only be taken with virt enabled
       const reg_t deleg_to_vs = state.hideleg->read();

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -299,8 +299,6 @@ reg_t processor_t::select_an_interrupt_with_default_priority(reg_t enabled_inter
     enabled_interrupts = MIP_VSSIP;
   else if (enabled_interrupts & MIP_VSTIP)
     enabled_interrupts = MIP_VSTIP;
-  else
-    abort();
 
   return enabled_interrupts;
 }

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -273,6 +273,38 @@ void processor_t::set_mmu_capability(int cap)
   }
 }
 
+reg_t processor_t::select_an_interrupt_with_default_priority(reg_t enabled_interrupts) const
+{
+  // nonstandard interrupts have highest priority
+  if (enabled_interrupts >> (IRQ_M_EXT + 1))
+    enabled_interrupts = enabled_interrupts >> (IRQ_M_EXT + 1) << (IRQ_M_EXT + 1);
+  // standard interrupt priority is MEI, MSI, MTI, SEI, SSI, STI
+  else if (enabled_interrupts & MIP_MEIP)
+    enabled_interrupts = MIP_MEIP;
+  else if (enabled_interrupts & MIP_MSIP)
+    enabled_interrupts = MIP_MSIP;
+  else if (enabled_interrupts & MIP_MTIP)
+    enabled_interrupts = MIP_MTIP;
+  else if (enabled_interrupts & MIP_SEIP)
+    enabled_interrupts = MIP_SEIP;
+  else if (enabled_interrupts & MIP_SSIP)
+    enabled_interrupts = MIP_SSIP;
+  else if (enabled_interrupts & MIP_STIP)
+    enabled_interrupts = MIP_STIP;
+  else if (enabled_interrupts & MIP_LCOFIP)
+    enabled_interrupts = MIP_LCOFIP;
+  else if (enabled_interrupts & MIP_VSEIP)
+    enabled_interrupts = MIP_VSEIP;
+  else if (enabled_interrupts & MIP_VSSIP)
+    enabled_interrupts = MIP_VSSIP;
+  else if (enabled_interrupts & MIP_VSTIP)
+    enabled_interrupts = MIP_VSTIP;
+  else
+    abort();
+
+  return enabled_interrupts;
+}
+
 void processor_t::take_interrupt(reg_t pending_interrupts)
 {
   // Do nothing if no pending interrupts
@@ -303,32 +335,7 @@ void processor_t::take_interrupt(reg_t pending_interrupts)
 
   const bool nmie = !(state.mnstatus && !get_field(state.mnstatus->read(), MNSTATUS_NMIE));
   if (!state.debug_mode && nmie && enabled_interrupts) {
-    // nonstandard interrupts have highest priority
-    if (enabled_interrupts >> (IRQ_M_EXT + 1))
-      enabled_interrupts = enabled_interrupts >> (IRQ_M_EXT + 1) << (IRQ_M_EXT + 1);
-    // standard interrupt priority is MEI, MSI, MTI, SEI, SSI, STI
-    else if (enabled_interrupts & MIP_MEIP)
-      enabled_interrupts = MIP_MEIP;
-    else if (enabled_interrupts & MIP_MSIP)
-      enabled_interrupts = MIP_MSIP;
-    else if (enabled_interrupts & MIP_MTIP)
-      enabled_interrupts = MIP_MTIP;
-    else if (enabled_interrupts & MIP_SEIP)
-      enabled_interrupts = MIP_SEIP;
-    else if (enabled_interrupts & MIP_SSIP)
-      enabled_interrupts = MIP_SSIP;
-    else if (enabled_interrupts & MIP_STIP)
-      enabled_interrupts = MIP_STIP;
-    else if (enabled_interrupts & MIP_LCOFIP)
-      enabled_interrupts = MIP_LCOFIP;
-    else if (enabled_interrupts & MIP_VSEIP)
-      enabled_interrupts = MIP_VSEIP;
-    else if (enabled_interrupts & MIP_VSSIP)
-      enabled_interrupts = MIP_VSSIP;
-    else if (enabled_interrupts & MIP_VSTIP)
-      enabled_interrupts = MIP_VSTIP;
-    else
-      abort();
+    enabled_interrupts = select_an_interrupt_with_default_priority(enabled_interrupts);
 
     if (check_triggers_icount) TM.detect_icount_match();
     throw trap_t(((reg_t)1 << (isa.get_max_xlen() - 1)) | ctz(enabled_interrupts));

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -97,6 +97,8 @@ struct state_t
   wide_counter_csr_t_p mcycle;
   mie_csr_t_p mie;
   mip_csr_t_p mip;
+  csr_t_p nonvirtual_sip;
+  csr_t_p nonvirtual_sie;
   csr_t_p medeleg;
   csr_t_p mideleg;
   csr_t_p mcounteren;

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -177,6 +177,7 @@ struct state_t
 
   csr_t_p mvien;
   mvip_csr_t_p mvip;
+  csr_t_p hvictl;
 
   bool serialized; // whether timer CSRs are in a well-defined state
 

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -70,6 +70,7 @@ typedef std::vector<std::tuple<reg_t, uint64_t, uint8_t>> commit_log_mem_t;
 // architectural state of a RISC-V hart
 struct state_t
 {
+  void add_ireg_proxy(processor_t* const proc, sscsrind_reg_csr_t::sscsrind_reg_csr_t_p ireg);
   void reset(processor_t* const proc, reg_t max_isa);
   void add_csr(reg_t addr, const csr_t_p& csr);
 

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -178,6 +178,7 @@ struct state_t
   csr_t_p mvien;
   mvip_csr_t_p mvip;
   csr_t_p hvictl;
+  csr_t_p vstopi;
 
   bool serialized; // whether timer CSRs are in a well-defined state
 

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -410,6 +410,7 @@ private:
   static const size_t OPCODE_CACHE_SIZE = 4095;
   opcode_cache_entry_t opcode_cache[OPCODE_CACHE_SIZE];
 
+  bool is_handled_in_vs();
   void take_pending_interrupt() { take_interrupt(state.mip->read() & state.mie->read()); }
   void take_interrupt(reg_t mask); // take first enabled interrupt in mask
   void take_trap(trap_t& t, reg_t epc); // take an exception

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -173,6 +173,8 @@ struct state_t
 
   csr_t_p ssp;
 
+  csr_t_p mvien;
+
   bool serialized; // whether timer CSRs are in a well-defined state
 
   // When true, execute a single instruction and then enter debug mode.  This

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -368,6 +368,8 @@ public:
 
   void check_if_lpad_required();
 
+  reg_t select_an_interrupt_with_default_priority(reg_t enabled_interrupts) const;
+
 private:
   const isa_parser_t isa;
   const cfg_t * const cfg;

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -174,6 +174,7 @@ struct state_t
   csr_t_p ssp;
 
   csr_t_p mvien;
+  mvip_csr_t_p mvip;
 
   bool serialized; // whether timer CSRs are in a well-defined state
 


### PR DESCRIPTION
This PR aims to provide a minimal required (recommended) implementation for the AIA extension. There is no APLIC/IMSIC device in this PR. The hstatus.VGEIN is read-only 0. The ipiro arrays and hviprio1/hviprio2 are also read-only 0. The AIA specification allows these behaviors. Nevertheless, I am willing to provide enhancements for these features if desired.