### PR TITLE
Ignore writes to henvcfg fields (PBMTE, STCE, and ADUE) when read-only 0

### DIFF
--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -1549,6 +1549,11 @@ void henvcfg_csr_t::verify_permissions(insn_t insn, bool write) const {
   masked_csr_t::verify_permissions(insn, write);
 }
 
+bool henvcfg_csr_t::unlogged_write(const reg_t val) noexcept {
+  const reg_t mask = menvcfg->read() | ~(MENVCFG_PBMTE | MENVCFG_STCE | MENVCFG_ADUE);
+  return envcfg_csr_t::unlogged_write((masked_csr_t::read() & ~mask) | (val & mask));
+}
+
 stimecmp_csr_t::stimecmp_csr_t(processor_t* const proc, const reg_t addr, const reg_t imask):
   basic_csr_t(proc, addr, 0), intr_mask(imask) {
 }

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -490,6 +490,9 @@ class henvcfg_csr_t final: public envcfg_csr_t {
 
   virtual void verify_permissions(insn_t insn, bool write) const override;
 
+ protected:
+  virtual bool unlogged_write(const reg_t val) noexcept override;
+
  private:
   csr_t_p menvcfg;
 };


### PR DESCRIPTION
The henvcfg fields, i.e., PBMTE, STCE, and ADUE, are read-only 0 when the corresponding bits in menvcfg are 0. Besides the reading behavior, the spec also specified the writing behavior, i.e., ignoring writes. This commit ignores writes to the henvcfg fields when read-only 0.

Reference: https://github.com/riscv/riscv-isa-manual/issues/1312