### PR TITLE
Smstateen: Ignore writes to read-only hstateen*[n] bits when mstateen*[n]=0

### DIFF
--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -762,7 +762,7 @@ class vxsat_csr_t: public masked_csr_t {
   virtual bool unlogged_write(const reg_t val) noexcept override;
 };
 
-class hstateen_csr_t: public masked_csr_t {
+class hstateen_csr_t: public basic_csr_t {
  public:
   hstateen_csr_t(processor_t* const proc, const reg_t addr, const reg_t mask, const reg_t init, uint8_t index);
   virtual reg_t read() const noexcept override;
@@ -771,6 +771,8 @@ class hstateen_csr_t: public masked_csr_t {
   virtual bool unlogged_write(const reg_t val) noexcept override;
 protected:
   uint8_t index;
+ private:
+  const reg_t mask;
 };
 
 class sstateen_csr_t: public hstateen_csr_t {


### PR DESCRIPTION
The specification states that writes to read-only bits in a RW CSR are ignored.
![image](https://github.com/riscv-software-src/riscv-isa-sim/assets/39526191/9fd1d40a-205c-4d26-852a-b9af69687aec)

The hstateen*[n] bits are read-only when mstateen*[n]=0.
![image](https://github.com/riscv-software-src/riscv-isa-sim/assets/39526191/603d0a0c-3cc3-4651-a700-64c77d7d72a2)

This PR propose ignoring writes to read-only hstateen*[n] bits when mstateen*[n]=0 instead of writing the bits to 0.