### PR TITLE
Assert misa.B bit through --isa=...B...

### DIFF
--- a/disasm/isa_parser.cc
+++ b/disasm/isa_parser.cc
@@ -29,7 +29,7 @@ static void bad_priv_string(const char* priv)
 isa_parser_t::isa_parser_t(const char* str, const char *priv)
 {
   isa_string = strtolower(str);
-  const char* all_subsets = "mafdqcpvh";
+  const char* all_subsets = "mafdqcpvhb";
 
   if (isa_string.compare(0, 4, "rv32") == 0)
     max_xlen = 32;


### PR DESCRIPTION
This PR provides misa.B=1 by --isa=...B...

Reference: https://github.com/riscv-software-src/riscv-isa-sim/pull/1559