### PR TITLE
Make Zaamo + Zalrsc (Zba + Zbb + Zbs) imply A (B) in misa

### DIFF
--- a/disasm/isa_parser.cc
+++ b/disasm/isa_parser.cc
@@ -339,6 +339,8 @@ isa_parser_t::isa_parser_t(const char* str, const char *priv)
   if (extension_table['A']) {
     extension_table[EXT_ZAAMO] = true;
     extension_table[EXT_ZALRSC] = true;
+  } else if (extension_table[EXT_ZAAMO] && extension_table[EXT_ZALRSC]) {
+    extension_table['A'] = true;
   }
 
   if (extension_table['B']) {

--- a/disasm/isa_parser.cc
+++ b/disasm/isa_parser.cc
@@ -347,6 +347,8 @@ isa_parser_t::isa_parser_t(const char* str, const char *priv)
     extension_table[EXT_ZBA] = true;
     extension_table[EXT_ZBB] = true;
     extension_table[EXT_ZBS] = true;
+  } else if (extension_table[EXT_ZBA] && extension_table[EXT_ZBB] && extension_table[EXT_ZBS]) {
+    extension_table['B'] = true;
   }
 
   if (extension_table['C']) {


### PR DESCRIPTION
The PR makes Zaamo + Zalrsc imply A in misa.
Additionally, it makes Zba + Zbb + Zbs imply B in misa.

Reference: https://github.com/riscv-software-src/riscv-isa-sim/pull/1649#pullrequestreview-2018427770