### PR TITLE
Sscofpmf: Support delegate LCOFI to VS-mode through hideleg

### DIFF
--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -1171,7 +1171,7 @@ void hypervisor_csr_t::verify_permissions(insn_t insn, bool write) const {
 }
 
 hideleg_csr_t::hideleg_csr_t(processor_t* const proc, const reg_t addr, csr_t_p mideleg):
-  masked_csr_t(proc, addr, MIP_VS_MASK, 0),
+  masked_csr_t(proc, addr, MIP_VS_MASK | (proc->extension_enabled(EXT_SSCOFPMF) ? MIP_LCOFIP : 0), 0),
   mideleg(mideleg) {
 }
 

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -893,7 +893,7 @@ void processor_t::take_trap(trap_t& t, reg_t epc)
   }
   if (state.prv <= PRV_S && bit < max_xlen && ((vsdeleg >> bit) & 1)) {
     // Handle the trap in VS-mode
-    const reg_t adjusted_cause = interrupt ? bit - 1 : bit;  // VSSIP -> SSIP, etc
+    const reg_t adjusted_cause = interrupt && bit != IRQ_LCOF ? bit - 1 : bit;  // VSSIP -> SSIP, etc
     reg_t vector = (state.vstvec->read() & 1) && interrupt ? 4 * adjusted_cause : 0;
     state.pc = (state.vstvec->read() & ~(reg_t)1) + vector;
     state.vscause->write(adjusted_cause | (interrupt ? interrupt_bit : 0));


### PR DESCRIPTION
This PR lets hideleg.LCOFI be writable. That is support LCOFI delegation to VS-mode through the hideleg CSR.