### PR TITLE
Don't allow Smode to access MINH bit in counter config csrs.

### DIFF
--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -1716,6 +1716,9 @@ smcntrpmf_csr_t::smcntrpmf_csr_t(processor_t* const proc, const reg_t addr, cons
 
 reg_t smcntrpmf_csr_t::read_prev() const noexcept {
   reg_t val = prev_val.value_or(read());
+  if (state->prv < PRV_M)
+    return val & ~MHPMEVENT_MINH;
+
   return val;
 }
 
@@ -1725,6 +1728,9 @@ void smcntrpmf_csr_t::reset_prev() noexcept {
 
 bool smcntrpmf_csr_t::unlogged_write(const reg_t val) noexcept {
   prev_val = read();
+  if (state->prv < PRV_M)
+    return masked_csr_t::unlogged_write(val & ~MHPMEVENT_MINH);
+
   return masked_csr_t::unlogged_write(val);
 }
 


### PR DESCRIPTION
As per the Smcdeleg Spec [0], Chapter 3:

If Sscofpmf is implemented, sireg2 and sireg5 provide access only
to a subset of the event selector registers. Specifically, event
selector bit 62 (MINH) is read-only 0 when accessed through sireg*.
Similarly, if Smcntrpmf is implemented, sireg2 and sireg5 provide
access only to a subset of the counter configuration registers.
Counter configuration register bit 62 (MINH) is read-only 0 when
accessed through sireg*.

[0]: https://github.com/riscv/riscv-smcdeleg-ssccfg/releases/tag/v1.0.0

Sorry for the vague `chapter 3` reference. The spec doesn't have sub-headings. The mentioned part is the last paragraph of chapter 3.