### PR TITLE
Zfa: fix: fmaxm.q requires Q instead of D extension

### DIFF
--- a/riscv/insns/fmaxm_q.h
+++ b/riscv/insns/fmaxm_q.h
@@ -1,4 +1,4 @@
-require_extension('D');
+require_extension('Q');
 require_extension(EXT_ZFA);
 require_fp;
 ui128_f128 ui1;


### PR DESCRIPTION
The fmaxm.q requires Q instead of D extension.

Reference: https://github.com/riscv/riscv-isa-manual/blob/main/src/zfa.adoc#minimum-and-maximum-instructions