### PR TITLE
add support to load ET_DYN elf

### DIFF
--- a/fesvr/elf.h
+++ b/fesvr/elf.h
@@ -6,6 +6,7 @@
 #include <stdint.h>
 
 #define ET_EXEC 2
+#define ET_DYN 3
 #define EM_RISCV 243
 #define EM_NONE 0
 #define EV_CURRENT 1
@@ -21,6 +22,7 @@
 #define IS_ELFLE(hdr) (IS_ELF(hdr) && (hdr).e_ident[5] == 1)
 #define IS_ELFBE(hdr) (IS_ELF(hdr) && (hdr).e_ident[5] == 2)
 #define IS_ELF_EXEC(hdr) (IS_ELF(hdr) && ELF_SWAP((hdr), (hdr).e_type) == ET_EXEC)
+#define IS_ELF_DYN(hdr) (IS_ELF(hdr) && ELF_SWAP((hdr), (hdr).e_type) == ET_DYN)
 #define IS_ELF_RISCV(hdr) (IS_ELF(hdr) && ELF_SWAP((hdr), (hdr).e_machine) == EM_RISCV)
 #define IS_ELF_EM_NONE(hdr) (IS_ELF(hdr) && ELF_SWAP((hdr), (hdr).e_machine) == EM_NONE)
 #define IS_ELF_VCURRENT(hdr) (IS_ELF(hdr) && ELF_SWAP((hdr), (hdr).e_version) == EV_CURRENT)

--- a/fesvr/elf2hex.cc
+++ b/fesvr/elf2hex.cc
@@ -40,7 +40,7 @@ int main(int argc, char** argv)
   htif_hexwriter_t htif(base, width, depth);
   memif_t memif(&htif);
   reg_t entry;
-  load_elf(argv[3], &memif, &entry);
+  load_elf(argv[3], &memif, &entry, 0);
   std::cout << htif;
 
   return 0;

--- a/fesvr/elfloader.h
+++ b/fesvr/elfloader.h
@@ -8,6 +8,7 @@
 #include <string>
 
 class memif_t;
-std::map<std::string, uint64_t> load_elf(const char* fn, memif_t* memif, reg_t* entry, unsigned required_xlen = 0);
+std::map<std::string, uint64_t> load_elf(const char* fn, memif_t* memif, reg_t* entry,
+                                         reg_t load_offset, unsigned required_xlen = 0);
 
 #endif

--- a/fesvr/htif.h
+++ b/fesvr/htif.h
@@ -7,6 +7,7 @@
 #include "syscall.h"
 #include "device.h"
 #include "byteorder.h"
+#include "../riscv/platform.h"
 #include <string.h>
 #include <map>
 #include <vector>
@@ -58,7 +59,8 @@ class htif_t : public chunked_memif_t
   virtual size_t chunk_align() = 0;
   virtual size_t chunk_max_size() = 0;
 
-  virtual std::map<std::string, uint64_t> load_payload(const std::string& payload, reg_t* entry);
+  virtual std::map<std::string, uint64_t> load_payload(const std::string& payload, reg_t* entry,
+                                                       reg_t load_addr);
   virtual void load_program();
   virtual void idle() {}
 
@@ -79,6 +81,7 @@ class htif_t : public chunked_memif_t
   void register_devices();
   void usage(const char * program_name);
   unsigned int expected_xlen = 0;
+  const reg_t load_offset = DRAM_BASE;
   memif_t mem;
   reg_t entry;
   bool writezeros;


### PR DESCRIPTION
When compiled as PIE, executable can be loaded at any memory address. Lately, OpenSBI switched to such behavior and spike was not able to load it anymore. This patch add an additional load_offset parameter for load_elf(). This load_offset value is passed as DRAM_BASE and used only for ET_DYN elfs.