### PR TITLE
zicflip: fix [ms]ret behavior

### DIFF
--- a/riscv/insns/mret.h
+++ b/riscv/insns/mret.h
@@ -11,8 +11,8 @@ s = set_field(s, MSTATUS_MPP, p->extension_enabled('U') ? PRV_U : PRV_M);
 s = set_field(s, MSTATUS_MPV, 0);
 if (ZICFILP_xLPE(prev_virt, prev_prv)) {
   STATE.elp = static_cast<elp_t>(get_field(s, MSTATUS_MPELP));
-  s = set_field(s, MSTATUS_MPELP, elp_t::NO_LP_EXPECTED);
 }
+s = set_field(s, MSTATUS_MPELP, elp_t::NO_LP_EXPECTED);
 STATE.mstatus->write(s);
 if (STATE.mstatush) STATE.mstatush->write(s >> 32); // log mstatush change
 p->set_privilege(prev_prv, prev_virt);

--- a/riscv/insns/sret.h
+++ b/riscv/insns/sret.h
@@ -25,7 +25,7 @@ if (!STATE.v) {
 }
 if (ZICFILP_xLPE(prev_virt, prev_prv)) {
   STATE.elp = static_cast<elp_t>(get_field(s, SSTATUS_SPELP));
-  s = set_field(s, SSTATUS_SPELP, elp_t::NO_LP_EXPECTED);
 }
+s = set_field(s, SSTATUS_SPELP, elp_t::NO_LP_EXPECTED);
 STATE.sstatus->write(s);
 p->set_privilege(prev_prv, prev_virt);


### PR DESCRIPTION
Based on spec chapter 3.5
"An MRET or SRET instruction is used to return from a trap in M-mode or S-mode, respectively. When executing an xRET instruction, if xPP holds the value y, then ELP is set to the value of xPELP if yLPE is 1; otherwise, it is set to NO_LP_EXPECTED; xPELP is set to NO_LP_EXPECTED."

The change follows the last statement after semicolon "xPELP is set to NO_LP_EXPECTED"