### PR TITLE
Require vector extension when attempting vxsat writes

### DIFF
--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -1452,6 +1452,8 @@ vxsat_csr_t::vxsat_csr_t(processor_t* const proc, const reg_t addr):
 
 void vxsat_csr_t::verify_permissions(insn_t insn, bool write) const {
   require_vector_vs;
+  if (!proc->extension_enabled('V'))
+    throw trap_illegal_instruction(insn.bits());
   masked_csr_t::verify_permissions(insn, write);
 }
 


### PR DESCRIPTION
This requirement was accidentally removed in c9468f6e02.

See pull request #1660 