### PR TITLE
triggers: implement tcontrol

### DIFF
--- a/riscv/insn_template.h
+++ b/riscv/insn_template.h
@@ -8,4 +8,5 @@
 #include "specialize.h"
 #include "tracer.h"
 #include "v_ext_macros.h"
+#include "debug_defines.h"
 #include <assert.h>

--- a/riscv/insns/mret.h
+++ b/riscv/insns/mret.h
@@ -15,4 +15,5 @@ if (ZICFILP_xLPE(prev_virt, prev_prv)) {
 s = set_field(s, MSTATUS_MPELP, elp_t::NO_LP_EXPECTED);
 STATE.mstatus->write(s);
 if (STATE.mstatush) STATE.mstatush->write(s >> 32); // log mstatush change
+STATE.tcontrol->write((STATE.tcontrol->read() & CSR_TCONTROL_MPTE) ? (CSR_TCONTROL_MPTE | CSR_TCONTROL_MTE) : 0);
 p->set_privilege(prev_prv, prev_virt);

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -141,6 +141,7 @@ struct state_t
   dcsr_csr_t_p dcsr;
   csr_t_p tselect;
   csr_t_p tdata2;
+  csr_t_p tcontrol;
   csr_t_p scontext;
   csr_t_p mcontext;
 

--- a/riscv/triggers.cc
+++ b/riscv/triggers.cc
@@ -59,7 +59,8 @@ bool trigger_t::common_match(processor_t * const proc, bool use_prev_prv) const 
   auto state = proc->get_state();
   auto prv = use_prev_prv ? state->prev_prv : state->prv;
   auto v = use_prev_prv ? state->prev_v : state->v;
-  return mode_match(prv, v) && textra_match(proc);
+  auto m_enabled = get_action() != 0 || (state->tcontrol->read() & CSR_TCONTROL_MTE);
+  return (prv < PRV_M || m_enabled) && mode_match(prv, v) && textra_match(proc);
 }
 
 bool trigger_t::mode_match(reg_t prv, bool v) const noexcept


### PR DESCRIPTION
Implement Debug spec Section 5.7.6. Trigger Control (tcontrol). This commit lets tcontrol be read-only 0 if the number of triggers is 0.

The spec says the optional tcontrol is useful only if medeleg[3] (breakpoint) is read-only 0. Please note that Spike lets the medeleg[3] be read-write.
![image](https://github.com/riscv-software-src/riscv-isa-sim/assets/39526191/880b5ae8-277c-4724-9226-f92e4e96bc3d)
