### PR TITLE
Fix build of softfloat.h when threads.h is not available.

### DIFF
--- a/softfloat/softfloat.h
+++ b/softfloat/softfloat.h
@@ -54,7 +54,13 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 # include <threads.h>
 # define THREAD_LOCAL thread_local
 #else
-# define THREAD_LOCAL _Thread_local
+
+#ifdef __cplusplus
+#define THREAD_LOCAL thread_local
+#else
+#define THREAD_LOCAL _Thread_local
+#endif
+
 #endif
 
 #ifdef __cplusplus


### PR DESCRIPTION
softfloat.h happens to be included both in C and C++ modules and these languages have different keywords for thread local attribute.