### PR TITLE
Fix C/C++ thread-local linkage differently

### DIFF
--- a/softfloat/softfloat.h
+++ b/softfloat/softfloat.h
@@ -50,8 +50,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <stdint.h>
 #include "softfloat_types.h"
 
-#if __has_include(<threads.h>)
-# include <threads.h>
+#if defined(__cplusplus) && !defined(__APPLE__)
 # define THREAD_LOCAL thread_local
 #else
 # define THREAD_LOCAL _Thread_local


### PR DESCRIPTION
Just admit Mac OS is broken, so explicitly special-case it.

See #1689 and #1703