### PR TITLE
Fix: Add missing <stdexcept> header for std::logic_error

### DIFF
--- a/disasm/isa_parser.cc
+++ b/disasm/isa_parser.cc
@@ -1,4 +1,5 @@
 #include "isa_parser.h"
+#include <stdexcept>
 
 static std::string strtolower(const char* str)
 {


### PR DESCRIPTION
- Added #include <stdexcept> to isa_parser.cc to fix the compilation error:
  /riscv-isa-sim/ci-tests/../disasm/isa_parser.cc:324:21: error: 'logic_error' in namespace 'std' does not name a type
  324 | } catch (std::logic_error& e) {
  | ^~~~~~~~~~~
  /riscv-isa-sim/ci-tests/../disasm/isa_parser.cc:2:1: note: 'std::logic_error' is defined in header '<stdexcept>'; did you forget to '#include <stdexcept>'?
  1 | #include "isa_parser.h"
  +++ |+#include <stdexcept>
  2 |

- This inclusion ensures that the 'std::logic_error' type is recognized during compilation.