### PR TITLE
Add insn cmd to interactive debug mode

### DIFF
--- a/riscv/sim.h
+++ b/riscv/sim.h
@@ -123,6 +123,7 @@ private:
   void interactive_fregs(const std::string& cmd, const std::vector<std::string>& args);
   void interactive_fregd(const std::string& cmd, const std::vector<std::string>& args);
   void interactive_pc(const std::string& cmd, const std::vector<std::string>& args);
+  void interactive_insn(const std::string& cmd, const std::vector<std::string>& args);
   void interactive_priv(const std::string& cmd, const std::vector<std::string>& args);
   void interactive_mem(const std::string& cmd, const std::vector<std::string>& args);
   void interactive_str(const std::string& cmd, const std::vector<std::string>& args);
@@ -136,6 +137,7 @@ private:
   freg_t get_freg(const std::vector<std::string>& args, int size);
   reg_t get_mem(const std::vector<std::string>& args);
   reg_t get_pc(const std::vector<std::string>& args);
+  reg_t get_insn(const std::vector<std::string>& args);
 
   friend class processor_t;
   friend class mmu_t;


### PR DESCRIPTION
This PR adds a new interactive debug mode cmd of `insn` with the same API as the `pc` command to print out the instruction associated with the PC of a specific hart. This command can be used with the `until*` commands to run a binary "until" the "insn" value is a specific value.