### PR TITLE
Fix riscv-tests commit for CI

### DIFF
--- a/.github/workflows/debug-smoke.yml
+++ b/.github/workflows/debug-smoke.yml
@@ -47,7 +47,7 @@ jobs:
         run: |
           git clone --recurse-submodules https://github.com/riscv-software-src/riscv-tests.git
           cd riscv-tests
-          git checkout 00ab5f0dd4cf56b5a0551bc5adedf60c765d0c66
+          git checkout e06a435c1e545def71e833031356372f0828f165
 
       - name: Run Tests
         run: |


### PR DESCRIPTION
https://github.com/riscv-software-src/riscv-tests/pull/567 was merged by squash accidentally, so the referenced commit was lost