### PR TITLE
Add flag to disable ns16550 device

### DIFF
--- a/riscv/dts.cc
+++ b/riscv/dts.cc
@@ -13,6 +13,7 @@
 #include <sys/types.h>
 
 std::string make_dts(size_t insns_per_rtc_tick, size_t cpu_hz,
+                     bool disable_ns16550,
                      reg_t initrd_start, reg_t initrd_end,
                      const char* bootargs,
                      size_t pmpregions,
@@ -30,8 +31,11 @@ std::string make_dts(size_t insns_per_rtc_tick, size_t cpu_hz,
          "  #size-cells = <2>;\n"
          "  compatible = \"ucbbar,spike-bare-dev\";\n"
          "  model = \"ucbbar,spike-bare\";\n"
-         "  chosen {\n"
-         "    stdout-path = &SERIAL0;\n";
+         "  chosen {\n";
+  if (!disable_ns16550)
+    s << "    stdout-path = &SERIAL0;\n";
+  else
+    s << "    stdout-path = &HTIF;\n";
   if (initrd_start < initrd_end) {
     s << "    linux,initrd-start = <" << (size_t)initrd_start << ">;\n"
          "    linux,initrd-end = <" << (size_t)initrd_end << ">;\n";
@@ -89,7 +93,7 @@ std::string make_dts(size_t insns_per_rtc_tick, size_t cpu_hz,
          "    ranges;\n"
     << device_nodes
     <<   "  };\n"
-         "  htif {\n"
+         "  HTIF: htif {\n"
          "    compatible = \"ucb,htif0\";\n"
          "  };\n"
          "};\n";

--- a/riscv/dts.h
+++ b/riscv/dts.h
@@ -7,6 +7,7 @@
 #include <string>
 
 std::string make_dts(size_t insns_per_rtc_tick, size_t cpu_hz,
+                     bool disable_ns16550,
                      reg_t initrd_start, reg_t initrd_end,
                      const char* bootargs,
                      size_t pmpregions,

--- a/riscv/sim.cc
+++ b/riscv/sim.cc
@@ -43,6 +43,7 @@ sim_t::sim_t(const cfg_t *cfg, bool halted,
              const debug_module_config_t &dm_config,
              const char *log_path,
              bool dtb_enabled, const char *dtb_file,
+             bool disable_ns16550,
              bool socket_enabled,
              FILE *cmd_file) // needed for command line option --cmd
   : htif_t(args),
@@ -117,8 +118,8 @@ sim_t::sim_t(const cfg_t *cfg, bool halted,
   // setting the dtb_file argument has one.
   std::vector<device_factory_sargs_t> device_factories = {
     {clint_factory, {}}, // clint must be element 0
-    {plic_factory, {}}, // plic must be element 1
-    {ns16550_factory, {}}};
+    {plic_factory, {}}}; // plic must be element 1
+  if (!disable_ns16550) device_factories.push_back({ns16550_factory, {}});
   device_factories.insert(device_factories.end(),
                           plugin_device_factories.begin(),
                           plugin_device_factories.end());
@@ -142,6 +143,7 @@ sim_t::sim_t(const cfg_t *cfg, bool halted,
       device_nodes.append(factory->generate_dts(this, sargs));
     }
     dts = make_dts(INSNS_PER_RTC_TICK, CPU_HZ,
+                   disable_ns16550,
                    initrd_bounds.first, initrd_bounds.second,
                    cfg->bootargs, cfg->pmpregions, cfg->pmpgranularity,
                    procs, mems, device_nodes);

--- a/riscv/sim.h
+++ b/riscv/sim.h
@@ -34,6 +34,7 @@ public:
         const std::vector<std::string>& args,
         const debug_module_config_t &dm_config, const char *log_path,
         bool dtb_enabled, const char *dtb_file,
+        bool disable_ns16550,
         bool socket_enabled,
         FILE *cmd_file); // needed for command line option --cmd
   ~sim_t();

--- a/spike_main/spike.cc
+++ b/spike_main/spike.cc
@@ -64,6 +64,7 @@ static void help(int exit_code = 1)
   fprintf(stderr, "  --dump-dts            Print device tree string and exit\n");
   fprintf(stderr, "  --dtb=<path>          Use specified device tree blob [default: auto-generate]\n");
   fprintf(stderr, "  --disable-dtb         Don't write the device tree blob into memory\n");
+  fprintf(stderr, "  --disable-ns16550     Disable default ns16550 UART device\n");
   fprintf(stderr, "  --kernel=<path>       Load kernel flat image into memory\n");
   fprintf(stderr, "  --initrd=<path>       Load kernel initrd into memory\n");
   fprintf(stderr, "  --bootargs=<args>     Provide custom bootargs for kernel [default: %s]\n",
@@ -332,6 +333,7 @@ int main(int argc, char** argv)
   bool UNUSED socket = false;  // command line option -s
   bool dump_dts = false;
   bool dtb_enabled = true;
+  bool disable_ns16550 = false;
   const char* kernel = NULL;
   reg_t kernel_offset, kernel_size;
   std::vector<device_factory_sargs_t> plugin_device_factories;
@@ -408,6 +410,7 @@ int main(int argc, char** argv)
   parser.option(0, "dump-dts", 0, [&](const char UNUSED *s){dump_dts = true;});
   parser.option(0, "disable-dtb", 0, [&](const char UNUSED *s){dtb_enabled = false;});
   parser.option(0, "dtb", 1, [&](const char *s){dtb_file = s;});
+  parser.option(0, "disable-ns16550", 0, [&](const char UNUSED *s){disable_ns16550 = true;});
   parser.option(0, "kernel", 1, [&](const char* s){kernel = s;});
   parser.option(0, "initrd", 1, [&](const char* s){initrd = s;});
   parser.option(0, "bootargs", 1, [&](const char* s){cfg.bootargs = s;});
@@ -520,7 +523,7 @@ int main(int argc, char** argv)
   }
 
   sim_t s(&cfg, halted,
-      mems, plugin_device_factories, htif_args, dm_config, log_path, dtb_enabled, dtb_file,
+      mems, plugin_device_factories, htif_args, dm_config, log_path, dtb_enabled, dtb_file, disable_ns16550,
       socket,
       cmd_file);
   std::unique_ptr<remote_bitbang_t> remote_bitbang((remote_bitbang_t *) NULL);


### PR DESCRIPTION
Sometimes, it makes sense to use HTIF (and only HTIF) as a console device (for example when booting Linux). This allows users to disable the default console device (removing it from the DTS).