### PR TITLE
Enable more configuration using the DTB

### DIFF
--- a/riscv/dts.cc
+++ b/riscv/dts.cc
@@ -99,86 +99,91 @@ std::string make_dts(size_t insns_per_rtc_tick, size_t cpu_hz,
   return s.str();
 }
 
-std::string dts_compile(const std::string& dts)
+std::string dtc_compile(const std::string& dtc_input, const std::string& input_type, const std::string& output_type)
 {
-  // Convert the DTS to DTB
-  int dts_pipe[2];
-  pid_t dts_pid;
+  if (input_type == output_type)
+    std::cerr << "Must have differing {in,out}put types for running " DTC << std::endl;
+
+  if (!((input_type == "dts" && output_type == "dtb") || (input_type == "dtb" && output_type == "dts")))
+    std::cerr << "Invalid {in,out}put types for running " DTC ": Must convert from 'dts' to 'dtb' (or vice versa)" << std::endl;
+
+  int dtc_input_pipe[2];
+  pid_t dtc_input_pid;
 
   fflush(NULL); // flush stdout/stderr before forking
-  if (pipe(dts_pipe) != 0 || (dts_pid = fork()) < 0) {
-    std::cerr << "Failed to fork dts child: " << strerror(errno) << std::endl;
+  if (pipe(dtc_input_pipe) != 0 || (dtc_input_pid = fork()) < 0) {
+    std::cerr << "Failed to fork dtc_input child: " << strerror(errno) << std::endl;
     exit(1);
   }
 
-  // Child process to output dts
-  if (dts_pid == 0) {
-    close(dts_pipe[0]);
-    int step, len = dts.length();
-    const char *buf = dts.c_str();
+  // Child process to output dtc_input
+  if (dtc_input_pid == 0) {
+    close(dtc_input_pipe[0]);
+    int step, len = dtc_input.length();
+    const char *buf = dtc_input.c_str();
     for (int done = 0; done < len; done += step) {
-      step = write(dts_pipe[1], buf+done, len-done);
+      step = write(dtc_input_pipe[1], buf+done, len-done);
       if (step == -1) {
-        std::cerr << "Failed to write dts: " << strerror(errno) << std::endl;
+        std::cerr << "Failed to write dtc_input: " << strerror(errno) << std::endl;
         exit(1);
       }
     }
-    close(dts_pipe[1]);
+    close(dtc_input_pipe[1]);
     exit(0);
   }
 
-  pid_t dtb_pid;
-  int dtb_pipe[2];
-  if (pipe(dtb_pipe) != 0 || (dtb_pid = fork()) < 0) {
-    std::cerr << "Failed to fork dtb child: " << strerror(errno) << std::endl;
+  pid_t dtc_output_pid;
+  int dtc_output_pipe[2];
+  if (pipe(dtc_output_pipe) != 0 || (dtc_output_pid = fork()) < 0) {
+    std::cerr << "Failed to fork dtc_output child: " << strerror(errno) << std::endl;
     exit(1);
   }
 
-  // Child process to output dtb
-  if (dtb_pid == 0) {
-    dup2(dts_pipe[0], 0);
-    dup2(dtb_pipe[1], 1);
-    close(dts_pipe[0]);
-    close(dts_pipe[1]);
-    close(dtb_pipe[0]);
-    close(dtb_pipe[1]);
-    execlp(DTC, DTC, "-O", "dtb", (char *)0);
+  // Child process to output dtc_output
+  if (dtc_output_pid == 0) {
+    dup2(dtc_input_pipe[0], 0);
+    dup2(dtc_output_pipe[1], 1);
+    close(dtc_input_pipe[0]);
+    close(dtc_input_pipe[1]);
+    close(dtc_output_pipe[0]);
+    close(dtc_output_pipe[1]);
+    execlp(DTC, DTC, "-O", output_type.c_str(), "-I", input_type.c_str(), (char *)0);
     std::cerr << "Failed to run " DTC ": " << strerror(errno) << std::endl;
     exit(1);
   }
 
-  close(dts_pipe[1]);
-  close(dts_pipe[0]);
-  close(dtb_pipe[1]);
+  close(dtc_input_pipe[1]);
+  close(dtc_input_pipe[0]);
+  close(dtc_output_pipe[1]);
 
-  // Read-out dtb
-  std::stringstream dtb;
+  // Read-out dtc_output
+  std::stringstream dtc_output;
 
   int got;
   char buf[4096];
-  while ((got = read(dtb_pipe[0], buf, sizeof(buf))) > 0) {
-    dtb.write(buf, got);
+  while ((got = read(dtc_output_pipe[0], buf, sizeof(buf))) > 0) {
+    dtc_output.write(buf, got);
   }
   if (got == -1) {
-    std::cerr << "Failed to read dtb: " << strerror(errno) << std::endl;
+    std::cerr << "Failed to read dtc_output: " << strerror(errno) << std::endl;
     exit(1);
   }
-  close(dtb_pipe[0]);
+  close(dtc_output_pipe[0]);
 
   // Reap children
   int status;
-  waitpid(dts_pid, &status, 0);
+  waitpid(dtc_input_pid, &status, 0);
   if (!WIFEXITED(status) || WEXITSTATUS(status) != 0) {
-    std::cerr << "Child dts process failed" << std::endl;
+    std::cerr << "Child dtc_input process failed" << std::endl;
     exit(1);
   }
-  waitpid(dtb_pid, &status, 0);
+  waitpid(dtc_output_pid, &status, 0);
   if (!WIFEXITED(status) || WEXITSTATUS(status) != 0) {
-    std::cerr << "Child dtb process failed" << std::endl;
+    std::cerr << "Child dtc_output process failed" << std::endl;
     exit(1);
   }
 
-  return dtb.str();
+  return dtc_output.str();
 }
 
 int fdt_get_node_addr_size(const void *fdt, int node, reg_t *addr,

--- a/riscv/dts.cc
+++ b/riscv/dts.cc
@@ -14,7 +14,6 @@
 
 std::string make_dts(size_t insns_per_rtc_tick, size_t cpu_hz,
                      const cfg_t* cfg,
-                     const isa_parser_t* isa,
                      std::vector<std::pair<reg_t, abstract_mem_t*>> mems,
                      std::string device_nodes)
 {
@@ -23,6 +22,7 @@ std::string make_dts(size_t insns_per_rtc_tick, size_t cpu_hz,
   const char* bootargs = cfg->bootargs;
   reg_t pmpregions = cfg->pmpregions;
   reg_t pmpgranularity = cfg->pmpgranularity;
+  isa_parser_t isa(cfg->isa, cfg->priv);
 
   std::stringstream s;
   s << std::dec <<
@@ -63,8 +63,8 @@ std::string make_dts(size_t insns_per_rtc_tick, size_t cpu_hz,
          "      reg = <" << cfg->hartids[i] << ">;\n"
          "      status = \"okay\";\n"
          "      compatible = \"riscv\";\n"
-         "      riscv,isa = \"" << isa->get_isa_string() << "\";\n"
-         "      mmu-type = \"riscv," << (isa->get_max_xlen() <= 32 ? "sv32" : "sv57") << "\";\n"
+         "      riscv,isa = \"" << isa.get_isa_string() << "\";\n"
+         "      mmu-type = \"riscv," << (isa.get_max_xlen() <= 32 ? "sv32" : "sv57") << "\";\n"
          "      riscv,pmpregions = <" << pmpregions << ">;\n"
          "      riscv,pmpgranularity = <" << pmpgranularity << ">;\n"
          "      clock-frequency = <" << cpu_hz << ">;\n"

--- a/riscv/dts.cc
+++ b/riscv/dts.cc
@@ -389,3 +389,44 @@ int fdt_parse_mmu_type(const void *fdt, int cpu_offset, const char **mmu_type)
 
   return 0;
 }
+
+int fdt_parse_isa(const void *fdt, int cpu_offset, const char **isa)
+{
+  assert(isa);
+
+  int len, rc;
+  const void *prop;
+
+  if ((rc = check_cpu_node(fdt, cpu_offset)) < 0)
+    return rc;
+
+  prop = fdt_getprop(fdt, cpu_offset, "riscv,isa", &len);
+  if (!prop || !len)
+    return -EINVAL;
+
+  *isa = (const char *)prop;
+
+  return 0;
+}
+
+int fdt_parse_hartid(const void *fdt, int cpu_offset, uint32_t *hartid)
+{
+  int len, rc;
+  const void *prop;
+  const fdt32_t *val;
+
+  if ((rc = check_cpu_node(fdt, cpu_offset)) < 0)
+    return rc;
+
+  val = (fdt32_t*) fdt_getprop(fdt, cpu_offset, "reg", &len);
+  if (!val || len < (int) sizeof(fdt32_t))
+    return -EINVAL;
+
+  if (len > (int) sizeof(fdt32_t))
+    val++;
+
+  if (hartid)
+    *hartid = fdt32_to_cpu(*val);
+
+  return 0;
+}

--- a/riscv/dts.h
+++ b/riscv/dts.h
@@ -7,11 +7,8 @@
 #include <string>
 
 std::string make_dts(size_t insns_per_rtc_tick, size_t cpu_hz,
-                     reg_t initrd_start, reg_t initrd_end,
-                     const char* bootargs,
-                     size_t pmpregions,
-                     size_t pmpgranularity,
-                     std::vector<processor_t*> procs,
+                     const cfg_t* cfg,
+                     const isa_parser_t* isa,
                      std::vector<std::pair<reg_t, abstract_mem_t*>> mems,
                      std::string device_nodes);
 

--- a/riscv/dts.h
+++ b/riscv/dts.h
@@ -8,7 +8,6 @@
 
 std::string make_dts(size_t insns_per_rtc_tick, size_t cpu_hz,
                      const cfg_t* cfg,
-                     const isa_parser_t* isa,
                      std::vector<std::pair<reg_t, abstract_mem_t*>> mems,
                      std::string device_nodes);
 

--- a/riscv/dts.h
+++ b/riscv/dts.h
@@ -11,7 +11,7 @@ std::string make_dts(size_t insns_per_rtc_tick, size_t cpu_hz,
                      std::vector<std::pair<reg_t, abstract_mem_t*>> mems,
                      std::string device_nodes);
 
-std::string dts_compile(const std::string& dts);
+std::string dtc_compile(const std::string& dtc_input, const std::string& input_type, const std::string& output_type);
 
 int fdt_get_node_addr_size(const void *fdt, int node, reg_t *addr,
                            unsigned long *size, const char *field);

--- a/riscv/dts.h
+++ b/riscv/dts.h
@@ -29,4 +29,6 @@ int fdt_parse_ns16550(const void *fdt, reg_t *ns16550_addr,
 int fdt_parse_pmp_num(const void *fdt, int cpu_offset, reg_t *pmp_num);
 int fdt_parse_pmp_alignment(const void *fdt, int cpu_offset, reg_t *pmp_align);
 int fdt_parse_mmu_type(const void *fdt, int cpu_offset, const char **mmu_type);
+int fdt_parse_isa(const void *fdt, int cpu_offset, const char **isa_str);
+int fdt_parse_hartid(const void *fdt, int cpu_offset, uint32_t *hartid);
 #endif

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -236,12 +236,13 @@ class opcode_cache_entry_t {
 class processor_t : public abstract_device_t
 {
 public:
-  processor_t(const isa_parser_t *isa, const cfg_t* cfg,
+  processor_t(const char* isa_str, const char* priv_str,
+              const cfg_t* cfg,
               simif_t* sim, uint32_t id, bool halt_on_reset,
               FILE *log_file, std::ostream& sout_); // because of command line option --log and -s we need both
   ~processor_t();
 
-  const isa_parser_t &get_isa() { return *isa; }
+  const isa_parser_t &get_isa() { return isa; }
   const cfg_t &get_cfg() { return *cfg; }
 
   void set_debug(bool value);
@@ -303,7 +304,7 @@ public:
   void set_extension_enable(unsigned char ext, bool enable) {
     assert(!extension_assumed_const[ext]);
     extension_dynamic[ext] = true;
-    extension_enable_table[ext] = enable && isa->extension_enabled(ext);
+    extension_enable_table[ext] = enable && isa.extension_enabled(ext);
   }
   void set_impl(uint8_t impl, bool val) { impl_table[impl] = val; }
   bool supports_impl(uint8_t impl) const {
@@ -362,7 +363,7 @@ public:
   void check_if_lpad_required();
 
 private:
-  const isa_parser_t * const isa;
+  const isa_parser_t isa;
   const cfg_t * const cfg;
 
   simif_t* sim;

--- a/riscv/sim.cc
+++ b/riscv/sim.cc
@@ -141,10 +141,7 @@ sim_t::sim_t(const cfg_t *cfg, bool halted,
       const std::vector<std::string>& sargs = factory_sargs.second;
       device_nodes.append(factory->generate_dts(this, sargs));
     }
-    dts = make_dts(INSNS_PER_RTC_TICK, CPU_HZ,
-                   initrd_bounds.first, initrd_bounds.second,
-                   cfg->bootargs, cfg->pmpregions, cfg->pmpgranularity,
-                   procs, mems, device_nodes);
+    dts = make_dts(INSNS_PER_RTC_TICK, CPU_HZ, cfg, &isa, mems, device_nodes);
     dtb = dts_compile(dts);
   }
 

--- a/riscv/sim.cc
+++ b/riscv/sim.cc
@@ -133,6 +133,7 @@ sim_t::sim_t(const cfg_t *cfg, bool halted,
     std::stringstream strstream;
     strstream << fin.rdbuf();
     dtb = strstream.str();
+    dts = dtc_compile(dtb, "dtb", "dts");
   } else {
     std::pair<reg_t, reg_t> initrd_bounds = cfg->initrd_bounds;
     std::string device_nodes;
@@ -142,7 +143,7 @@ sim_t::sim_t(const cfg_t *cfg, bool halted,
       device_nodes.append(factory->generate_dts(this, sargs));
     }
     dts = make_dts(INSNS_PER_RTC_TICK, CPU_HZ, cfg, mems, device_nodes);
-    dtb = dts_compile(dts);
+    dtb = dtc_compile(dts, "dts", "dtb");
   }
 
   int fdt_code = fdt_check_header(dtb.c_str());

--- a/riscv/sim.h
+++ b/riscv/sim.h
@@ -69,7 +69,6 @@ public:
   static const size_t CPU_HZ = 1000000000; // 1GHz CPU
 
 private:
-  isa_parser_t isa;
   const cfg_t * const cfg;
   std::vector<std::pair<reg_t, abstract_mem_t*>> mems;
   std::vector<processor_t*> procs;

--- a/spike_main/spike-log-parser.cc
+++ b/spike_main/spike-log-parser.cc
@@ -31,7 +31,7 @@ int main(int UNUSED argc, char** argv)
   cfg_t cfg;
 
   isa_parser_t isa(isa_string, DEFAULT_PRIV);
-  processor_t p(&isa, &cfg, 0, 0, false, nullptr, cerr);
+  processor_t p(isa_string, DEFAULT_PRIV, &cfg, 0, 0, false, nullptr, cerr);
   if (extension) {
     p.register_extension(extension());
   }


### PR DESCRIPTION
Addresses parts of #1716 

Thanks @jerryz123 for the main work on this.

- A DTB that is passed in is used to set the number of harts, ISA, PMPs, MMU, and more of Spike.
  - Note: Device extensions that generate a DTS string do not affect the output of `--dump-dts` if the DTB is given.
  - Note: DTB provided memory regions are not used.
- Correctly catches interactive traps v.s. other traps in interactive mode.