### PR TITLE
Deprecate dcsr.halt

### DIFF
--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -1354,7 +1354,6 @@ bool dcsr_csr_t::unlogged_write(const reg_t val) noexcept {
   ebreaku = proc->extension_enabled('U') ? get_field(val, DCSR_EBREAKU) : false;
   ebreakvs = proc->extension_enabled('H') ? get_field(val, CSR_DCSR_EBREAKVS) : false;
   ebreakvu = proc->extension_enabled('H') ? get_field(val, CSR_DCSR_EBREAKVU) : false;
-  halt = get_field(val, DCSR_NMIP);
   v = proc->extension_enabled('H') ? get_field(val, CSR_DCSR_V) : false;
   pelp = proc->extension_enabled(EXT_ZICFILP) ?
          static_cast<elp_t>(get_field(val, DCSR_PELP)) : elp_t::NO_LP_EXPECTED;

--- a/riscv/execute.cc
+++ b/riscv/execute.cc
@@ -216,7 +216,7 @@ void processor_t::step(size_t n)
       enter_debug_mode(DCSR_CAUSE_DEBUGINT);
     } else if (halt_request == HR_GROUP) {
       enter_debug_mode(DCSR_CAUSE_GROUP);
-    } // !!!The halt bit in DCSR is deprecated.
+    }
     else if (state.dcsr->halt) {
       enter_debug_mode(DCSR_CAUSE_HALT);
     }


### PR DESCRIPTION
The debug spec 1.0.0-rc3 deprecates the dcsr.halt and lets the bit become read-only dcsr.nmip.

To my knowledge, the dcsr_csr_t::halt variable is for halt_on_reset, i.e., the -H flag for the debugger, meanwhile the dcsr.nmip is to indicate a hardware error condition. The halt_on_reset debugging feature does not necessarily mean a hardware error condition. Thus, Spike should decouple the halt variable and the dcsr.nmip. 
@rtwfroody Would you share some words about this?

This commit separates the halt variable from the dcsr.nmip and designates it as an internal variable for halt_on_reset (-H flag). Additionally, this commit removes the notifying comment about the deprecated dcsr.halt in the main loop.

Update 2024.07.17:
@rtwfroody clarified that the debugger should not depend the writability of dcsr.halt (dcsr.nmip) in https://github.com/riscv-software-src/riscv-isa-sim/issues/1727#issuecomment-2231328997.