### PR TITLE
Fix: Vector CSRs exist without any vector extension since a484f6e

### DIFF
--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -642,11 +642,6 @@ bool sstatus_csr_t::enabled(const reg_t which) {
     if (!state->v || (virt_sstatus->read() & which) != 0)
       return true;
   }
-
-  // If the field doesn't exist, it is always enabled. See #823.
-  if (!orig_sstatus->field_exists(which))
-    return true;
-
   return false;
 }
 

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -1446,7 +1446,7 @@ vector_csr_t::vector_csr_t(processor_t* const proc, const reg_t addr, const reg_
 }
 
 void vector_csr_t::verify_permissions(insn_t insn, bool write) const {
-  require_vector_vs;
+  require(proc->any_vector_extensions() && STATE.sstatus->enabled(SSTATUS_VS));
   basic_csr_t::verify_permissions(insn, write);
 }
 
@@ -1467,7 +1467,7 @@ vxsat_csr_t::vxsat_csr_t(processor_t* const proc, const reg_t addr):
 }
 
 void vxsat_csr_t::verify_permissions(insn_t insn, bool write) const {
-  require_vector_vs;
+  require(proc->any_vector_extensions() && STATE.sstatus->enabled(SSTATUS_VS));
   masked_csr_t::verify_permissions(insn, write);
 }
 

--- a/riscv/decode_macros.h
+++ b/riscv/decode_macros.h
@@ -167,7 +167,7 @@ static inline bool is_aligned(const unsigned val, const unsigned pos)
 #define require_fs          require(STATE.sstatus->enabled(SSTATUS_FS))
 #define require_fp          STATE.fflags->verify_permissions(insn, false)
 #define require_accelerator require(STATE.sstatus->enabled(SSTATUS_XS))
-#define require_vector_vs   require(STATE.sstatus->enabled(SSTATUS_VS))
+#define require_vector_vs   require(p->any_vector_extensions() && STATE.sstatus->enabled(SSTATUS_VS))
 #define require_vector(alu) \
   do { \
     require_vector_vs; \

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -577,7 +577,8 @@ void processor_t::reset()
   state.reset(this, isa->get_max_isa());
   state.dcsr->halt = halt_on_reset;
   halt_on_reset = false;
-  VU.reset();
+  if (any_vector_extensions())
+    VU.reset();
   in_wfi = false;
 
   if (n_pmp > 0) {

--- a/riscv/v_ext_macros.h
+++ b/riscv/v_ext_macros.h
@@ -1202,10 +1202,10 @@ reg_t index[P.VU.vlmax]; \
 
 #define VI_LD(stride, offset, elt_width, is_mask_ldst) \
   const reg_t nf = insn.v_nf() + 1; \
+  VI_CHECK_LOAD(elt_width, is_mask_ldst); \
   const reg_t vl = is_mask_ldst ? ((P.VU.vl->read() + 7) / 8) : P.VU.vl->read(); \
   const reg_t baseAddr = RS1; \
   const reg_t vd = insn.rd(); \
-  VI_CHECK_LOAD(elt_width, is_mask_ldst); \
   for (reg_t i = 0; i < vl; ++i) { \
     VI_ELEMENT_SKIP; \
     VI_STRIP(i); \
@@ -1220,12 +1220,12 @@ reg_t index[P.VU.vlmax]; \
 
 #define VI_LD_INDEX(elt_width, is_seg) \
   const reg_t nf = insn.v_nf() + 1; \
+  VI_CHECK_LD_INDEX(elt_width); \
   const reg_t vl = P.VU.vl->read(); \
   const reg_t baseAddr = RS1; \
   const reg_t vd = insn.rd(); \
   if (!is_seg) \
     require(nf == 1); \
-  VI_CHECK_LD_INDEX(elt_width); \
   VI_DUPLICATE_VREG(insn.rs2(), elt_width); \
   for (reg_t i = 0; i < vl; ++i) { \
     VI_ELEMENT_SKIP; \
@@ -1256,10 +1256,10 @@ reg_t index[P.VU.vlmax]; \
 
 #define VI_ST(stride, offset, elt_width, is_mask_ldst) \
   const reg_t nf = insn.v_nf() + 1; \
+  VI_CHECK_STORE(elt_width, is_mask_ldst); \
   const reg_t vl = is_mask_ldst ? ((P.VU.vl->read() + 7) / 8) : P.VU.vl->read(); \
   const reg_t baseAddr = RS1; \
   const reg_t vs3 = insn.rd(); \
-  VI_CHECK_STORE(elt_width, is_mask_ldst); \
   for (reg_t i = 0; i < vl; ++i) { \
     VI_STRIP(i) \
     VI_ELEMENT_SKIP; \
@@ -1274,12 +1274,12 @@ reg_t index[P.VU.vlmax]; \
 
 #define VI_ST_INDEX(elt_width, is_seg) \
   const reg_t nf = insn.v_nf() + 1; \
+  VI_CHECK_ST_INDEX(elt_width); \
   const reg_t vl = P.VU.vl->read(); \
   const reg_t baseAddr = RS1; \
   const reg_t vs3 = insn.rd(); \
   if (!is_seg) \
     require(nf == 1); \
-  VI_CHECK_ST_INDEX(elt_width); \
   VI_DUPLICATE_VREG(insn.rs2(), elt_width); \
   for (reg_t i = 0; i < vl; ++i) { \
     VI_STRIP(i) \
@@ -1310,10 +1310,10 @@ reg_t index[P.VU.vlmax]; \
 
 #define VI_LDST_FF(elt_width) \
   const reg_t nf = insn.v_nf() + 1; \
+  VI_CHECK_LOAD(elt_width, false); \
   const reg_t vl = p->VU.vl->read(); \
   const reg_t baseAddr = RS1; \
   const reg_t rd_num = insn.rd(); \
-  VI_CHECK_LOAD(elt_width, false); \
   bool early_stop = false; \
   for (reg_t i = p->VU.vstart->read(); i < vl; ++i) { \
     VI_STRIP(i); \


### PR DESCRIPTION
The require_vector_vs, i.e., sstatus_csr_t::enabled(SSTATUS_VS), was expected to provide has_any_vector() check [1]. Unfortunately, a previous commit [2] made the sstatus_csr_t::enabled(SSTATUS_VS) true without any vector extension.

The previous commit [2] was for P-extension, which has been removed from Spike [3].

This commit reverts the commit [2] and corrects require_vector_vs [1].

[1] https://github.com/riscv-software-src/riscv-isa-sim/pull/1701/commits/a484f6efc5f50836bb8d846180dfbb9786d09ae2
[2] https://github.com/riscv-software-src/riscv-isa-sim/commit/66c4853bdc5b22bf4c4b364218c713e3f1e487f3
[3] https://github.com/riscv-software-src/riscv-isa-sim/pull/1660