### PR TITLE
ssqosid: modify permission check condition for srmcfg

### DIFF
--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -1752,8 +1752,6 @@ srmcfg_csr_t::srmcfg_csr_t(processor_t* const proc, const reg_t addr, const reg_
 }
 
 void srmcfg_csr_t::verify_permissions(insn_t insn, bool write) const {
-  csr_t::verify_permissions(insn, write);
-
   if (!proc->extension_enabled(EXT_SSQOSID))
     throw trap_illegal_instruction(insn.bits());
 
@@ -1764,6 +1762,10 @@ void srmcfg_csr_t::verify_permissions(insn_t insn, bool write) const {
 
   if (state->v)
       throw trap_virtual_instruction(insn.bits());
+
+  if (state->prv < PRV_S) {
+    throw trap_illegal_instruction(insn.bits());
+  }
 }
 
 hvip_csr_t::hvip_csr_t(processor_t* const proc, const reg_t addr, const reg_t init):


### PR DESCRIPTION
The srmcfg csr number is 0x181 which is a S-mode csr. The patch uses independent permission check to make the csr available even there is no S-mode