### PR TITLE
Fix ePMP checking on hlvx instructions

### DIFF
--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -197,13 +197,13 @@ bool pmpaddr_csr_t::access_ok(access_type type, reg_t mode, bool hlvx) const noe
   if (mseccfg_mml) {
     if (cfgx && cfgw && cfgr && cfgl) {
       // Locked Shared data region: Read only on both M and S/U mode.
-      return typer;
+      return typer && !hlvx;
     } else {
       const bool mml_shared_region = !cfgr && cfgw;
       const bool mml_chk_normal = (prvm == cfgl) && normal_rwx;
       const bool mml_chk_shared =
-              (!cfgl && cfgx && (typer || typew)) ||
-              (!cfgl && !cfgx && (typer || (typew && prvm))) ||
+              (!cfgl && cfgx && ((typer && !hlvx) || typew)) ||
+              (!cfgl && !cfgx && ((typer && !hlvx) || (typew && prvm))) ||
               (cfgl && typex) ||
               (cfgl && typer && cfgx && prvm);
       return mml_shared_region ? mml_chk_shared : mml_chk_normal;


### PR DESCRIPTION
The hlvx instruction must grant PMP permissions of both execution and reading (Figure 1). Thus, with ePMP (mseccfg.MML==1), the hlvx instructions are only permitted with pmpcfg.RWXL=0111 from M-mode (Figure 2).

Figure 1. 
![image](https://github.com/user-attachments/assets/05041460-7301-4ad8-b8a0-891fb34f617a)

Figure 2.
![image](https://github.com/user-attachments/assets/32c7100c-3347-44d2-b902-64f97e962d98)
