### PR TITLE
fcvtmod.w.d: Not update fflags if no exception flag, e.g., exp == frac == 0

### DIFF
--- a/riscv/decode_macros.h
+++ b/riscv/decode_macros.h
@@ -211,10 +211,12 @@ static inline bool is_aligned(const unsigned val, const unsigned pos)
     } \
   } while (0);
 
-#define set_fp_exceptions ({ if (softfloat_exceptionFlags) { \
-                               STATE.fflags->write(STATE.fflags->read() | softfloat_exceptionFlags); \
-                             } \
-                             softfloat_exceptionFlags = 0; })
+#define raise_fp_exceptions(flags) do { if (flags) STATE.fflags->write(STATE.fflags->read() | (flags)); } while (0);
+#define set_fp_exceptions \
+  do { \
+    raise_fp_exceptions(softfloat_exceptionFlags); \
+    softfloat_exceptionFlags = 0; \
+  } while (0);
 
 #define sext32(x) ((sreg_t)(int32_t)(x))
 #define zext32(x) ((reg_t)(uint32_t)(x))

--- a/riscv/insns/fcvtmod_w_d.h
+++ b/riscv/insns/fcvtmod_w_d.h
@@ -55,6 +55,5 @@ if (exp == 0) {
 }
 
 WRITE_RD(sext32(frac));
-STATE.fflags->write(STATE.fflags->read() |
-		    (inexact ? softfloat_flag_inexact : 0) |
+raise_fp_exceptions((inexact ? softfloat_flag_inexact : 0) |
 		    (invalid ? softfloat_flag_invalid : 0));


### PR DESCRIPTION
The commit proposes not updating the fflags if there is no exception flag at all. For instance, when exp == frac == 0, there is no exception flag. 

Other floating-point instructions do not update the fflags when there is no exception. This commit follows the habit.