### PR TITLE
hvip: Correct logging value of mip on writing hvip

### DIFF
--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -1777,8 +1777,9 @@ reg_t hvip_csr_t::read() const noexcept {
 }
 
 bool hvip_csr_t::unlogged_write(const reg_t val) noexcept {
+  basic_csr_t::unlogged_write(val & (MIP_VSEIP | MIP_VSTIP));
   state->mip->write_with_mask(MIP_VSSIP, val); // hvip.VSSIP is an alias of mip.VSSIP
-  return basic_csr_t::unlogged_write(val & (MIP_VSEIP | MIP_VSTIP));
+  return true;
 }
 
 ssp_csr_t::ssp_csr_t(processor_t* const proc, const reg_t addr, const reg_t mask, const reg_t init):


### PR DESCRIPTION
I found an issue in commit https://github.com/riscv-software-src/riscv-isa-sim/commit/20a735414863ffaa5525bc5bac04f6bc256e6f07. Sorry for the mistake.

The logging value is the read value on updating. The read value of mip depends on the value of hvip. Updating mip before hvip leaves an incorrect logging mip value that does not consider the new hvip. Thus, updating mip should be after ```basic_csr_t::unlogged_write()``` of hvip to log the correct value.

The return value of basic_csr_t::unlogged_write() is a constant true. Thus, the return value does not change after this commit.