### PR TITLE
medeleg: the third bit(CAUSE_BREAKPOINT) of medeleg is unwritable when Sdtrig exist.

### DIFF
--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -934,7 +934,7 @@ bool medeleg_csr_t::unlogged_write(const reg_t val) noexcept {
     | (1 << CAUSE_MISALIGNED_FETCH)
     | (1 << CAUSE_FETCH_ACCESS)
     | (1 << CAUSE_ILLEGAL_INSTRUCTION)
-    | (1 << CAUSE_BREAKPOINT)
+    | (proc->extension_enabled(EXT_SDTRIG) ? 0 : (1 << CAUSE_BREAKPOINT))
     | (1 << CAUSE_MISALIGNED_LOAD)
     | (1 << CAUSE_LOAD_ACCESS)
     | (1 << CAUSE_MISALIGNED_STORE) 


### PR DESCRIPTION
According to the riscv instruction set manual, when the Sdtrig extension exists, the CAUSE_BREAKPOINT bit (the third bit) of the medeleg CSR is unwritable. Otherwise, this bit is writable.