### PR TITLE
vnclip.wx: Check if there is any vector extension before using vector CSRs

### DIFF
--- a/riscv/insns/vnclip_wx.h
+++ b/riscv/insns/vnclip_wx.h
@@ -1,9 +1,9 @@
 // vnclip: vd[i] = clip(round(vs2[i] + rnd) >> rs1[i])
-VRM xrm = P.VU.get_vround_mode();
-int64_t int_max = INT64_MAX >> (64 - P.VU.vsew);
-int64_t int_min = INT64_MIN >> (64 - P.VU.vsew);
 VI_VX_LOOP_NARROW
 ({
+  VRM xrm = P.VU.get_vround_mode();
+  int64_t int_max = INT64_MAX >> (64 - P.VU.vsew);
+  int64_t int_min = INT64_MIN >> (64 - P.VU.vsew);
   int128_t result = vs2;
   unsigned shift = rs1 & ((sew * 2) - 1);
 


### PR DESCRIPTION
Since https://github.com/riscv-software-src/riscv-isa-sim/pull/1729/commits/707b1f24841fbe80453f5978ac298df14c54546d, we must check if there is any vector extension before using vector CSRs.

This is a miss of https://github.com/riscv-software-src/riscv-isa-sim/pull/1729/commits/af90d427af03fe11ba84d962fb539e8d33976d69. Sorry for the mistake.