### PR TITLE
vcompress.vm: Check if there is any vector extension before using vector CSRs

### DIFF
--- a/riscv/insns/vcompress_vm.h
+++ b/riscv/insns/vcompress_vm.h
@@ -1,13 +1,14 @@
 // vcompress vd, vs2, vs1
-require(P.VU.vstart->read() == 0);
-require_align(insn.rd(), P.VU.vflmul);
-require_align(insn.rs2(), P.VU.vflmul);
 require(insn.rd() != insn.rs2());
-require_noover(insn.rd(), P.VU.vflmul, insn.rs1(), 1);
 
 reg_t pos = 0;
 
 VI_GENERAL_LOOP_BASE
+  require(P.VU.vstart->read() == 0);
+  require_align(insn.rd(), P.VU.vflmul);
+  require_align(insn.rs2(), P.VU.vflmul);
+  require_noover(insn.rd(), P.VU.vflmul, insn.rs1(), 1);
+
   const int midx = i / 64;
   const int mpos = i % 64;
 


### PR DESCRIPTION
The commit resolves the same issue of https://github.com/riscv-software-src/riscv-isa-sim/pull/1750 and https://github.com/riscv-software-src/riscv-isa-sim/pull/1749. We executed all vector instructions; this is the last one that missed out.