### PR TITLE
Avoid magic constants in hpmcounter implementation

### DIFF
--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -738,9 +738,9 @@ bool misa_csr_t::unlogged_write(const reg_t val) noexcept {
     state->mie->write_with_mask(MIP_HS_MASK, 0);  // also takes care of hie, sie
     state->mip->write_with_mask(MIP_HS_MASK, 0);  // also takes care of hip, sip, hvip
     state->hstatus->write(0);
-    for (reg_t i = 3; i < N_HPMCOUNTERS + 3; ++i) {
-      const reg_t new_mevent = state->mevent[i - 3]->read() & ~(MHPMEVENT_VUINH | MHPMEVENT_VSINH);
-      state->mevent[i - 3]->write(new_mevent);
+    for (reg_t i = 0; i < N_HPMCOUNTERS; ++i) {
+      const reg_t new_mevent = state->mevent[i]->read() & ~(MHPMEVENT_VUINH | MHPMEVENT_VSINH);
+      state->mevent[i]->write(new_mevent);
     }
   }
 
@@ -1668,9 +1668,9 @@ void scountovf_csr_t::verify_permissions(insn_t insn, bool write) const {
 
 reg_t scountovf_csr_t::read() const noexcept {
   reg_t val = 0;
-  for (reg_t i = 3; i < N_HPMCOUNTERS + 3; ++i) {
-    bool of = state->mevent[i - 3]->read() & MHPMEVENT_OF;
-    val |= of << i;
+  for (reg_t i = 0; i < N_HPMCOUNTERS; ++i) {
+    bool of = state->mevent[i]->read() & MHPMEVENT_OF;
+    val |= of << (i + FIRST_HPMCOUNTER);
   }
 
   /* In M and S modes, scountovf bit X is readable when mcounteren bit X is set, */

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -193,14 +193,14 @@ void state_t::reset(processor_t* const proc, reg_t max_isa)
     csrmap[CSR_MINSTRET] = minstret;
     csrmap[CSR_MCYCLE] = mcycle;
   }
-  for (reg_t i = 3; i < N_HPMCOUNTERS + 3; ++i) {
-    const reg_t which_mevent = CSR_MHPMEVENT3 + i - 3;
-    const reg_t which_meventh = CSR_MHPMEVENT3H + i - 3;
-    const reg_t which_mcounter = CSR_MHPMCOUNTER3 + i - 3;
-    const reg_t which_mcounterh = CSR_MHPMCOUNTER3H + i - 3;
-    const reg_t which_counter = CSR_HPMCOUNTER3 + i - 3;
-    const reg_t which_counterh = CSR_HPMCOUNTER3H + i - 3;
-    mevent[i - 3] = std::make_shared<mevent_csr_t>(proc, which_mevent);
+  for (reg_t i = 0; i < N_HPMCOUNTERS; ++i) {
+    const reg_t which_mevent = CSR_MHPMEVENT3 + i;
+    const reg_t which_meventh = CSR_MHPMEVENT3H + i;
+    const reg_t which_mcounter = CSR_MHPMCOUNTER3 + i;
+    const reg_t which_mcounterh = CSR_MHPMCOUNTER3H + i;
+    const reg_t which_counter = CSR_HPMCOUNTER3 + i;
+    const reg_t which_counterh = CSR_HPMCOUNTER3H + i;
+    mevent[i] = std::make_shared<mevent_csr_t>(proc, which_mevent);
     auto mcounter = std::make_shared<const_csr_t>(proc, which_mcounter, 0);
     csrmap[which_mcounter] = mcounter;
 
@@ -209,7 +209,7 @@ void state_t::reset(processor_t* const proc, reg_t max_isa)
       csrmap[which_counter] = counter;
     }
     if (xlen == 32) {
-      csrmap[which_mevent] = std::make_shared<rv32_low_csr_t>(proc, which_mevent, mevent[i - 3]);;
+      csrmap[which_mevent] = std::make_shared<rv32_low_csr_t>(proc, which_mevent, mevent[i]);;
       auto mcounterh = std::make_shared<const_csr_t>(proc, which_mcounterh, 0);
       csrmap[which_mcounterh] = mcounterh;
       if (proc->extension_enabled_const(EXT_ZIHPM)) {
@@ -217,11 +217,11 @@ void state_t::reset(processor_t* const proc, reg_t max_isa)
         csrmap[which_counterh] = counterh;
       }
       if (proc->extension_enabled_const(EXT_SSCOFPMF)) {
-        auto meventh = std::make_shared<rv32_high_csr_t>(proc, which_meventh, mevent[i - 3]);
+        auto meventh = std::make_shared<rv32_high_csr_t>(proc, which_meventh, mevent[i]);
         csrmap[which_meventh] = meventh;
       }
     } else {
-      csrmap[which_mevent] = mevent[i - 3];
+      csrmap[which_mevent] = mevent[i];
     }
   }
   csrmap[CSR_MCOUNTINHIBIT] = std::make_shared<const_csr_t>(proc, CSR_MCOUNTINHIBIT, 0);

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -18,6 +18,7 @@
 #include "../fesvr/memif.h"
 #include "vector_unit.h"
 
+#define FIRST_HPMCOUNTER 3
 #define N_HPMCOUNTERS 29
 
 class processor_t;


### PR DESCRIPTION
Spotted this while working on removing CSRs that shouldn't exist.