### PR TITLE
Use ordered map for commit log

### DIFF
--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -62,7 +62,7 @@ struct insn_desc_t
 };
 
 // regnum, data
-typedef std::unordered_map<reg_t, freg_t> commit_log_reg_t;
+typedef std::map<reg_t, freg_t> commit_log_reg_t;
 
 // addr, value, size
 typedef std::vector<std::tuple<reg_t, uint64_t, uint8_t>> commit_log_mem_t;


### PR DESCRIPTION
In general, unordered maps should not be used for iteration, only for lookups.

In this case, using an ordered map guarantees that the order in which writes are logged is consistent for a given instruction.

Resolves #1499