### PR TITLE
Fix a typo in f11bd7b (Support parsing procs fully from DTS)

### DIFF
--- a/riscv/sim.cc
+++ b/riscv/sim.cc
@@ -103,8 +103,8 @@ sim_t::sim_t(const cfg_t *cfg, bool halted,
                                       cfg, this, cfg->hartids[i], halted,
                                       log_file.get(), sout_));
       harts[cfg->hartids[i]] = procs[i];
-      return;
     }
+    return;
   } // otherwise, generate the procs by parsing the DTS
 
   // Only make a CLINT (Core-Local INTerrupt controller) and PLIC (Platform-


### PR DESCRIPTION
Fix a typo in https://github.com/riscv-software-src/riscv-isa-sim/pull/1721/commits/f11bd7b511d7909f0291589e3aaab720ededdc8a