### PR TITLE
pointer masking: Fix: Let transformed_addr of fetching be unchanged

### DIFF
--- a/riscv/mmu.cc
+++ b/riscv/mmu.cc
@@ -654,10 +654,11 @@ mem_access_info_t mmu_t::generate_access_info(reg_t addr, access_type type, xlat
       virt = true;
       mode = get_field(proc->state.hstatus->read(), HSTATUS_SPVP);
     }
+    auto xlen = proc->get_const_xlen();
     reg_t pmlen = get_pmlen(virt, mode, xlate_flags);
     reg_t satp = proc->state.satp->readvirt(virt);
     bool is_physical_addr = mode == PRV_M || get_field(satp, SATP64_MODE) == SATP_MODE_OFF;
-    transformed_addr = is_physical_addr ? zext(addr, 64 - pmlen) : sext(addr, 64 - pmlen);
+    transformed_addr = is_physical_addr ? zext(addr, xlen - pmlen) : sext(addr, xlen - pmlen);
   }
   return {addr, transformed_addr, mode, virt, xlate_flags, type};
 }


### PR DESCRIPTION
The transformation does not apply to implicit accesses such as instruction fetches.