### PR TITLE
Only implement tcontrol to handle reentrant triggers.

### DIFF
--- a/riscv/triggers.h
+++ b/riscv/triggers.h
@@ -99,7 +99,6 @@ public:
 protected:
   static action_t legalize_action(reg_t val, reg_t action_mask, reg_t dmode_mask) noexcept;
   bool common_match(processor_t * const proc, bool use_prev_prv = false) const noexcept;
-  bool allow_action(const state_t * const state) const;
   reg_t tdata2;
 
   bool vs = false;


### PR DESCRIPTION
The spec says to only implement a single option. Option 2 gives software more flexibility, and we already have an implementation. Let's use that one. See also #1777.