### PR TITLE
pointer masking: Pointer masking does not apply when MXR=1 regardless of MPRV in v1.0.0-rc2

### DIFF
--- a/riscv/mmu.cc
+++ b/riscv/mmu.cc
@@ -614,7 +614,7 @@ void mmu_t::register_memtracer(memtracer_t* t)
 }
 
 reg_t mmu_t::get_pmlen(bool effective_virt, reg_t effective_priv, xlate_flags_t flags) const {
-  if (!proc || proc->get_xlen() != 64 || (in_mprv() && (proc->state.sstatus->read() & MSTATUS_MXR)) || flags.hlvx)
+  if (!proc || proc->get_xlen() != 64 || (proc->state.sstatus->read() & MSTATUS_MXR) || flags.hlvx)
     return 0;
 
   reg_t pmm = 0;


### PR DESCRIPTION
RC2 revises the following wordings and removes the effectiveness of MPRV to MXR.

![image](https://github.com/user-attachments/assets/f44c59f0-d7da-4334-9e99-e937b2b19c15)

Reference: https://github.com/riscv/riscv-j-extension/issues/70