### PR TITLE
pointer masking: Consider effective v bit instead of current v bit

### DIFF
--- a/riscv/mmu.cc
+++ b/riscv/mmu.cc
@@ -614,7 +614,7 @@ void mmu_t::register_memtracer(memtracer_t* t)
 }
 
 reg_t mmu_t::get_pmlen(bool effective_virt, reg_t effective_priv, xlate_flags_t flags) const {
-  if (!proc || proc->get_xlen() != 64 || (proc->state.sstatus->read() & MSTATUS_MXR) || flags.hlvx)
+  if (!proc || proc->get_xlen() != 64 || (proc->state.sstatus->readvirt(effective_virt) & MSTATUS_MXR) || flags.hlvx)
     return 0;
 
   reg_t pmm = 0;


### PR DESCRIPTION
I am sorry that I overlooked an implication of the modification in RC2.

A previous commit removes the effectiveness of MPRV to MXR. (https://github.com/riscv-software-src/riscv-isa-sim/pull/1784)
However, the removal implies the MPRV affects point masking individually, and the MXR should consider the effective v bit.

