### PR TITLE
pointer masking: Always apply sstatus.MXR regardless of effective V

### DIFF
--- a/riscv/mmu.cc
+++ b/riscv/mmu.cc
@@ -614,7 +614,7 @@ void mmu_t::register_memtracer(memtracer_t* t)
 }
 
 reg_t mmu_t::get_pmlen(bool effective_virt, reg_t effective_priv, xlate_flags_t flags) const {
-  if (!proc || proc->get_xlen() != 64 || (proc->state.sstatus->readvirt(effective_virt) & MSTATUS_MXR) || flags.hlvx)
+  if (!proc || proc->get_xlen() != 64 || ((proc->state.sstatus->readvirt(false) | proc->state.sstatus->readvirt(effective_virt)) & MSTATUS_MXR) || flags.hlvx)
     return 0;
 
   reg_t pmm = 0;


### PR DESCRIPTION
ISA spec says "Setting MXR at HS-level overrides both VS-stage and G-stage execute-only permissions."

Related issue: https://github.com/riscv-software-src/riscv-isa-sim/pull/1789#issuecomment-2316200325