### PR TITLE
Fix dtc_output read when interrupted by EINTR

### DIFF
--- a/riscv/dts.cc
+++ b/riscv/dts.cc
@@ -158,9 +158,11 @@ static std::string dtc_compile(const std::string& dtc_input, bool compile)
 
   int got;
   char buf[4096];
-  while ((got = read(dtc_output_pipe[0], buf, sizeof(buf))) > 0) {
-    dtc_output.write(buf, got);
-  }
+  do {
+    while ((got = read(dtc_output_pipe[0], buf, sizeof(buf))) > 0) {
+      dtc_output.write(buf, got);
+    }
+  } while (got == -1 && errno == EINTR); // Retry the read() if it was interrupted by a signal
   if (got == -1) {
     std::cerr << "Failed to read dtc_output: " << strerror(errno) << std::endl;
     exit(1);


### PR DESCRIPTION
The read() call may be interrupted by a signal, resulting in an EINTR error. In this case, read() will return -1 and set errno to EINTR. This is a common issue when dealing with I/O in a multi-process environment.

Check the error code returned by errno.
If it is EINTR, we can safely retry the read().