### PR TITLE
Remove --with-isa/priv compile flags

### DIFF
--- a/config.h.in
+++ b/config.h.in
@@ -6,9 +6,6 @@
 /* Define if subproject MCPPBS_SPROJ_NORM is enabled */
 #undef CUSTOMEXT_ENABLED
 
-/* Default value for --priv switch */
-#undef DEFAULT_PRIV
-
 /* Define if subproject MCPPBS_SPROJ_NORM is enabled */
 #undef DISASM_ENABLED
 

--- a/config.h.in
+++ b/config.h.in
@@ -6,9 +6,6 @@
 /* Define if subproject MCPPBS_SPROJ_NORM is enabled */
 #undef CUSTOMEXT_ENABLED
 
-/* Default value for --isa switch */
-#undef DEFAULT_ISA
-
 /* Default value for --priv switch */
 #undef DEFAULT_PRIV
 

--- a/configure
+++ b/configure
@@ -737,7 +737,6 @@ with_boost
 with_boost_libdir
 with_boost_asio
 with_boost_regex
-with_isa
 with_priv
 with_target
 enable_dual_endian
@@ -1403,8 +1402,6 @@ Optional Packages:
                           use the Regex library from boost - it is possible to
                           specify a certain library for the linker e.g.
                           --with-boost-regex=boost_regex-gcc-mt-d-1_33_1
-  --with-isa=RV64IMAFDC_zicntr_zihpm
-                          Sets the default RISC-V ISA
   --with-priv=MSU         Sets the default RISC-V privilege modes supported
   --with-target=riscv64-unknown-elf
                           Sets the default target config
@@ -6557,20 +6554,6 @@ then :
   printf "%s\n" "#define HAVE_LIBBOOST_REGEX 1" >>confdefs.h
 
   LIBS="-lboost_regex $LIBS"
-
-fi
-
-
-
-# Check whether --with-isa was given.
-if test ${with_isa+y}
-then :
-  withval=$with_isa;
-printf "%s\n" "#define DEFAULT_ISA \"$withval\"" >>confdefs.h
-
-else $as_nop
-
-printf "%s\n" "#define DEFAULT_ISA \"RV64IMAFDC_zicntr_zihpm\"" >>confdefs.h
 
 fi
 

--- a/configure
+++ b/configure
@@ -737,7 +737,6 @@ with_boost
 with_boost_libdir
 with_boost_asio
 with_boost_regex
-with_priv
 with_target
 enable_dual_endian
 '
@@ -1402,7 +1401,6 @@ Optional Packages:
                           use the Regex library from boost - it is possible to
                           specify a certain library for the linker e.g.
                           --with-boost-regex=boost_regex-gcc-mt-d-1_33_1
-  --with-priv=MSU         Sets the default RISC-V privilege modes supported
   --with-target=riscv64-unknown-elf
                           Sets the default target config
 
@@ -6554,20 +6552,6 @@ then :
   printf "%s\n" "#define HAVE_LIBBOOST_REGEX 1" >>confdefs.h
 
   LIBS="-lboost_regex $LIBS"
-
-fi
-
-
-
-# Check whether --with-priv was given.
-if test ${with_priv+y}
-then :
-  withval=$with_priv;
-printf "%s\n" "#define DEFAULT_PRIV \"$withval\"" >>confdefs.h
-
-else $as_nop
-
-printf "%s\n" "#define DEFAULT_PRIV \"MSU\"" >>confdefs.h
 
 fi
 

--- a/disasm/disasm.cc
+++ b/disasm/disasm.cc
@@ -2,6 +2,7 @@
 
 #include "disasm.h"
 #include "decode_macros.h"
+#include "platform.h"
 #include <cassert>
 #include <string>
 #include <vector>

--- a/riscv/platform.h
+++ b/riscv/platform.h
@@ -5,6 +5,7 @@
 #define DEFAULT_KERNEL_BOOTARGS "console=ttyS0 earlycon"
 #define DEFAULT_RSTVEC     0x00001000
 #define DEFAULT_ISA        "rv64imafdc_zicntr_zihpm"
+#define DEFAULT_PRIV       "MSU"
 #define CLINT_BASE         0x02000000
 #define CLINT_SIZE         0x000c0000
 #define PLIC_BASE          0x0c000000

--- a/riscv/platform.h
+++ b/riscv/platform.h
@@ -4,6 +4,7 @@
 
 #define DEFAULT_KERNEL_BOOTARGS "console=ttyS0 earlycon"
 #define DEFAULT_RSTVEC     0x00001000
+#define DEFAULT_ISA        "rv64imafdc_zicntr_zihpm"
 #define CLINT_BASE         0x02000000
 #define CLINT_SIZE         0x000c0000
 #define PLIC_BASE          0x0c000000

--- a/riscv/riscv.ac
+++ b/riscv/riscv.ac
@@ -8,12 +8,6 @@ AC_CHECK_LIB([boost_system], [main], [], [])
 
 AC_CHECK_LIB([boost_regex], [main], [], [])
 
-AC_ARG_WITH(isa,
-	[AS_HELP_STRING([--with-isa=RV64IMAFDC_zicntr_zihpm],
-		[Sets the default RISC-V ISA])],
-  AC_DEFINE_UNQUOTED([DEFAULT_ISA], "$withval", [Default value for --isa switch]),
-  AC_DEFINE_UNQUOTED([DEFAULT_ISA], "RV64IMAFDC_zicntr_zihpm", [Default value for --isa switch]))
-
 AC_ARG_WITH(priv,
 	[AS_HELP_STRING([--with-priv=MSU],
 		[Sets the default RISC-V privilege modes supported])],

--- a/riscv/riscv.ac
+++ b/riscv/riscv.ac
@@ -8,12 +8,6 @@ AC_CHECK_LIB([boost_system], [main], [], [])
 
 AC_CHECK_LIB([boost_regex], [main], [], [])
 
-AC_ARG_WITH(priv,
-	[AS_HELP_STRING([--with-priv=MSU],
-		[Sets the default RISC-V privilege modes supported])],
-  AC_DEFINE_UNQUOTED([DEFAULT_PRIV], "$withval", [Default value for --priv switch]),
-  AC_DEFINE_UNQUOTED([DEFAULT_PRIV], "MSU", [Default value for --priv switch]))
-
 AC_ARG_WITH(target,
 	[AS_HELP_STRING([--with-target=riscv64-unknown-elf],
 		[Sets the default target config])],

--- a/spike_dasm/spike-dasm.cc
+++ b/spike_dasm/spike-dasm.cc
@@ -6,7 +6,6 @@
 // enclosed hexadecimal number, interpreted as a RISC-V
 // instruction.
 
-#include "config.h"
 #include "disasm.h"
 #include "extension.h"
 #include "platform.h"

--- a/spike_dasm/spike-dasm.cc
+++ b/spike_dasm/spike-dasm.cc
@@ -9,6 +9,7 @@
 #include "config.h"
 #include "disasm.h"
 #include "extension.h"
+#include "platform.h"
 #include <iostream>
 #include <string>
 #include <cstdint>

--- a/spike_main/spike-log-parser.cc
+++ b/spike_main/spike-log-parser.cc
@@ -5,7 +5,6 @@
 // in its inputs, then output the RISC-V instruction with the disassembly
 // enclosed hexadecimal number.
 
-#include "config.h"
 #include <iostream>
 #include <string>
 #include <cstdint>

--- a/spike_main/spike-log-parser.cc
+++ b/spike_main/spike-log-parser.cc
@@ -14,6 +14,7 @@
 
 #include "disasm.h"
 #include "extension.h"
+#include "platform.h"
 
 using namespace std;
 


### PR DESCRIPTION
Users should use the `--isa` and `--priv` runtime flags instead.

Addresses #1802 