### PR TITLE
Fix for CSRRWI writing to CSR when uimm = 0.

### DIFF
--- a/riscv/insns/csrrwi.h
+++ b/riscv/insns/csrrwi.h
@@ -1,5 +1,8 @@
+bool write = insn.rs1() != 0;
 int csr = validate_csr(insn.csr(), true);
 reg_t old = p->get_csr(csr, insn, true);
-p->put_csr(csr, insn.rs1());
+if (write) {
+  p->put_csr(csr, insn.rs1());
+}
 WRITE_RD(sext_xlen(old));
 serialize();


### PR DESCRIPTION
Proposed fix for #1813 