### PR TITLE
Only enter debug mode once with -H flag (halt_on_reset)

### DIFF
--- a/riscv/execute.cc
+++ b/riscv/execute.cc
@@ -217,6 +217,7 @@ void processor_t::step(size_t n)
     } else if (halt_request == HR_GROUP) {
       enter_debug_mode(DCSR_CAUSE_GROUP, 0);
     } else if (state.dcsr->halt) {
+      state.dcsr->halt = false;
       enter_debug_mode(DCSR_CAUSE_HALT, 0);
     }
   }


### PR DESCRIPTION
The dcsr->halt indicates whether to enter debug mode due to halt_on_reset. The variable only depends on whether the -H flag exists or not.

This commit proposes entering the debug mode only once and resetting the dcsr->halt. (Without the commit, the step() will always enter the debug mode with the -H flag.)

I need help confirming that the debugging software expects this behavior. @rtwfroody 