### PR TITLE
refactor: Remove dcsr::halt variable

### DIFF
--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -1345,7 +1345,6 @@ dcsr_csr_t::dcsr_csr_t(processor_t* const proc, const reg_t addr):
   ebreaku(false),
   ebreakvs(false),
   ebreakvu(false),
-  halt(false),
   v(false),
   cause(0),
   ext_cause(0),

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -696,7 +696,6 @@ class dcsr_csr_t: public csr_t {
   bool ebreaku;
   bool ebreakvs;
   bool ebreakvu;
-  bool halt;
   bool v;
   uint8_t cause;
   uint8_t ext_cause;

--- a/riscv/execute.cc
+++ b/riscv/execute.cc
@@ -216,8 +216,8 @@ void processor_t::step(size_t n)
       enter_debug_mode(DCSR_CAUSE_DEBUGINT, 0);
     } else if (halt_request == HR_GROUP) {
       enter_debug_mode(DCSR_CAUSE_GROUP, 0);
-    } else if (state.dcsr->halt) {
-      state.dcsr->halt = false;
+    } else if (halt) {
+      halt = false;
       enter_debug_mode(DCSR_CAUSE_HALT, 0);
     }
   }

--- a/riscv/execute.cc
+++ b/riscv/execute.cc
@@ -216,8 +216,8 @@ void processor_t::step(size_t n)
       enter_debug_mode(DCSR_CAUSE_DEBUGINT, 0);
     } else if (halt_request == HR_GROUP) {
       enter_debug_mode(DCSR_CAUSE_GROUP, 0);
-    } else if (halt) {
-      halt = false;
+    } else if (halt_on_reset) {
+      halt_on_reset = false;
       enter_debug_mode(DCSR_CAUSE_HALT, 0);
     }
   }

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -186,7 +186,7 @@ void processor_t::reset()
 {
   xlen = isa.get_max_xlen();
   state.reset(this, isa.get_max_isa());
-  state.dcsr->halt = halt_on_reset;
+  halt = halt_on_reset;
   halt_on_reset = false;
   if (any_vector_extensions())
     VU.reset();

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -186,8 +186,6 @@ void processor_t::reset()
 {
   xlen = isa.get_max_xlen();
   state.reset(this, isa.get_max_isa());
-  halt = halt_on_reset;
-  halt_on_reset = false;
   if (any_vector_extensions())
     VU.reset();
   in_wfi = false;

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -384,7 +384,6 @@ private:
   FILE *log_file;
   std::ostream sout_; // needed for socket command interface -s, also used for -d and -l, but not for --log
   bool halt_on_reset;
-  bool halt;
   bool in_wfi;
   bool check_triggers_icount;
   std::vector<bool> impl_table;

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -384,6 +384,7 @@ private:
   FILE *log_file;
   std::ostream sout_; // needed for socket command interface -s, also used for -d and -l, but not for --log
   bool halt_on_reset;
+  bool halt;
   bool in_wfi;
   bool check_triggers_icount;
   std::vector<bool> impl_table;


### PR DESCRIPTION
This is a refactoring PR, which removes dcsr::halt.

The dcsr::halt was for dcsr.halt in debug spec v0.13. The debug spec v1.0.0 removes the dcsr.halt.

Reference: https://github.com/riscv-software-src/riscv-isa-sim/pull/1816#pullrequestreview-2331806142

@rtwfroody 