### PR TITLE
Add instruction limit

### DIFF
--- a/ci-tests/custom-csr.cc
+++ b/ci-tests/custom-csr.cc
@@ -76,6 +76,7 @@ int main(int argc, char **argv) {
             true,     // dtb_enabled
             nullptr,  // dtb_file
             false,    // socket_enabled
-            nullptr); // cmd_file
+            nullptr,  // cmd_file
+            std::nullopt); // instruction_limit
   sim.run();
 }

--- a/ci-tests/test-customext.cc
+++ b/ci-tests/test-customext.cc
@@ -85,6 +85,7 @@ int main(int argc, char **argv) {
             true,     // dtb_enabled
             nullptr,  // dtb_file
             false,    // socket_enabled
-            nullptr); // cmd_file
+            nullptr,  // cmd_file
+            std::nullopt); // instruction_limit
   sim.run();
 }

--- a/ci-tests/testlib.cc
+++ b/ci-tests/testlib.cc
@@ -34,6 +34,7 @@ int main(int argc, char **argv) {
             true,
             nullptr,
             false,
-            nullptr);
+            nullptr,
+            std::nullopt);
   sim.run();
 }

--- a/fesvr/htif.h
+++ b/fesvr/htif.h
@@ -24,6 +24,9 @@ class htif_t : public chunked_memif_t
   virtual void start();
   virtual void stop();
 
+  // Cause the simulation to exit with the given exit code.
+  void htif_exit(int exit_code);
+
   int run();
   bool done();
   int exit_code();
@@ -76,6 +79,10 @@ class htif_t : public chunked_memif_t
   // Given an address, return symbol from addr2symbol map
   const char* get_symbol(uint64_t addr);
 
+  // Return true if the simulation should exit due to a signal,
+  // or end-of-test from HTIF, or an instruction limit.
+  bool should_exit() const;
+
  private:
   void parse_arguments(int argc, char ** argv);
   void register_devices();
@@ -93,7 +100,8 @@ class htif_t : public chunked_memif_t
   addr_t sig_len; // torture
   addr_t tohost_addr;
   addr_t fromhost_addr;
-  int exitcode;
+  // Set to a value by htif_exit() when the simulation should exit.
+  std::optional<int> exitcode;
   bool stopped;
 
   device_list_t device_list;

--- a/fesvr/syscall.cc
+++ b/fesvr/syscall.cc
@@ -137,7 +137,7 @@ struct riscv_statx
       __spare2(), __spare3()
 #else
       __spare2()
-#endif      
+#endif
       {}
 };
 #endif
@@ -221,7 +221,7 @@ void syscall_t::handle_syscall(command_t cmd)
 
 reg_t syscall_t::sys_exit(reg_t code, reg_t a1, reg_t a2, reg_t a3, reg_t a4, reg_t a5, reg_t a6)
 {
-  htif->exitcode = code << 1 | 1;
+  htif->htif_exit(code << 1 | 1);
   return 0;
 }
 

--- a/riscv/sim.cc
+++ b/riscv/sim.cc
@@ -44,13 +44,15 @@ sim_t::sim_t(const cfg_t *cfg, bool halted,
              const char *log_path,
              bool dtb_enabled, const char *dtb_file,
              bool socket_enabled,
-             FILE *cmd_file) // needed for command line option --cmd
+             FILE *cmd_file, // needed for command line option --cmd
+             std::optional<unsigned long long> instruction_limit)
   : htif_t(args),
     cfg(cfg),
     mems(mems),
     dtb_enabled(dtb_enabled),
     log_file(log_path),
     cmd_file(cmd_file),
+    instruction_limit(instruction_limit),
     sout_(nullptr),
     current_step(0),
     current_proc(0),
@@ -429,8 +431,19 @@ void sim_t::idle()
 
   if (debug || ctrlc_pressed)
     interactive();
-  else
+  else {
+    if (instruction_limit.has_value()) {
+      if (*instruction_limit < INTERLEAVE) {
+        // Final step.
+        step(*instruction_limit);
+        htif_exit(0);
+        *instruction_limit = 0;
+        return;
+      }
+      *instruction_limit -= INTERLEAVE;
+    }
     step(INTERLEAVE);
+  }
 
   if (remote_bitbang)
     remote_bitbang->tick();

--- a/riscv/sim.h
+++ b/riscv/sim.h
@@ -35,10 +35,10 @@ public:
         const debug_module_config_t &dm_config, const char *log_path,
         bool dtb_enabled, const char *dtb_file,
         bool socket_enabled,
-        FILE *cmd_file); // needed for command line option --cmd
+        FILE *cmd_file, // needed for command line option --cmd
+        std::optional<unsigned long long> instruction_limit);
   ~sim_t();
 
-  // run the simulation to completion
   int run();
   void set_debug(bool value);
   void set_histogram(bool value);
@@ -84,6 +84,8 @@ private:
   log_file_t log_file;
 
   FILE *cmd_file; // pointer to debug command input file
+
+  std::optional<unsigned long long> instruction_limit;
 
   socketif_t *socketif;
   std::ostream sout_; // used for socket and terminal interface

--- a/spike_main/spike.cc
+++ b/spike_main/spike.cc
@@ -84,6 +84,7 @@ static void help(int exit_code = 1)
   fprintf(stderr, "  --dm-no-halt-groups   Debug module won't support halt groups\n");
   fprintf(stderr, "  --dm-no-impebreak     Debug module won't support implicit ebreak in program buffer\n");
   fprintf(stderr, "  --blocksz=<size>      Cache block size (B) for CMO operations(powers of 2) [default 64]\n");
+  fprintf(stderr, "  --instructions=<n>    Stop after n instructions\n");
 
   exit(exit_code);
 }
@@ -338,6 +339,7 @@ int main(int argc, char** argv)
   bool use_rbb = false;
   unsigned dmi_rti = 0;
   reg_t blocksz = 64;
+  std::optional<unsigned long long> instructions;
   debug_module_config_t dm_config;
   cfg_arg_t<size_t> nprocs(1);
 
@@ -450,6 +452,9 @@ int main(int argc, char** argv)
       exit(-1);
     }
   });
+  parser.option(0, "instructions", 1, [&](const char* s){
+    instructions = strtoull(s, 0, 0);
+  });
 
   auto argv1 = parser.parse(argv);
   std::vector<std::string> htif_args(argv1, (const char*const*)argv + argc);
@@ -511,7 +516,8 @@ int main(int argc, char** argv)
   sim_t s(&cfg, halted,
       mems, plugin_device_factories, htif_args, dm_config, log_path, dtb_enabled, dtb_file,
       socket,
-      cmd_file);
+      cmd_file,
+      instructions);
   std::unique_ptr<remote_bitbang_t> remote_bitbang((remote_bitbang_t *) NULL);
   std::unique_ptr<jtag_dtm_t> jtag_dtm(
       new jtag_dtm_t(&s.debug_module, dmi_rti));


### PR DESCRIPTION
Adds an optional --instructions=N CLI argument which will stop the simulation after N instructions.

This is useful for benchmarking and profiling and sometimes debugging.