### PR TITLE
Updated load/store pair for RV32 to v0.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,8 @@ Spike supports the following RISC-V ISA features:
   - Zvkn, Zvknc, Zvkng extension, v1.0
   - Zvks, Zvksc, Zvksg extension, v1.0 
   - Zicond extension, v1.0
-  - Zilsd extension, v0.9.0
-  - Zcmlsd extension, v0.9.0
+  - Zilsd extension, v0.10
+  - Zclsd extension, v0.10
 
 Versioning and APIs
 -------------------

--- a/disasm/disasm.cc
+++ b/disasm/disasm.cc
@@ -1513,7 +1513,7 @@ void disassembler_t::add_instructions(const isa_parser_t* isa)
       DISASM_INSN("c.addiw", c_addiw, 0, {&xrd, &rvc_imm});
     }
 
-    if (isa->get_max_xlen() == 64 || isa->extension_enabled(EXT_ZCMLSD)) {
+    if (isa->get_max_xlen() == 64 || isa->extension_enabled(EXT_ZCLSD)) {
       DISASM_INSN("c.ld", c_ld, 0, {&rvc_rs2s, &rvc_ld_address});
       DISASM_INSN("c.ldsp", c_ldsp, 0, {&xrd, &rvc_ldsp_address});
       DISASM_INSN("c.sd", c_sd, 0, {&rvc_rs2s, &rvc_ld_address});

--- a/disasm/isa_parser.cc
+++ b/disasm/isa_parser.cc
@@ -267,8 +267,8 @@ isa_parser_t::isa_parser_t(const char* str, const char *priv)
       if (max_xlen != 32)
         bad_isa_string(str, "'Zilsd' requires RV32");
       extension_table[EXT_ZILSD] = true;
-    } else if (ext_str == "zcmlsd") {
-      extension_table[EXT_ZCMLSD] = true;
+    } else if (ext_str == "zclsd") {
+      extension_table[EXT_ZCLSD] = true;
     } else if (ext_str == "zvbb") {
       extension_table[EXT_ZVBB] = true;
     } else if (ext_str == "zvbc") {
@@ -416,12 +416,12 @@ isa_parser_t::isa_parser_t(const char* str, const char *priv)
       extension_table[EXT_ZCD] = true;
   }
 
-  if (extension_table[EXT_ZCMLSD] && extension_table[EXT_ZCF]) {
-    bad_isa_string(str, "'Zcmlsd' extension conflicts with 'Zcf' extensions");
+  if (extension_table[EXT_ZCLSD] && extension_table[EXT_ZCF]) {
+    bad_isa_string(str, "'Zclsd' extension conflicts with 'Zcf' extensions");
   }
 
-  if (extension_table[EXT_ZCMLSD] && (!extension_table[EXT_ZCA] || !extension_table[EXT_ZILSD])) {
-    bad_isa_string(str, "'Zcmlsd' extension requires 'Zca' and 'Zilsd' extensions");
+  if (extension_table[EXT_ZCLSD] && (!extension_table[EXT_ZCA] || !extension_table[EXT_ZILSD])) {
+    bad_isa_string(str, "'Zclsd' extension requires 'Zca' and 'Zilsd' extensions");
   }
 
   if (extension_table[EXT_ZFBFMIN] && !extension_table['F']) {

--- a/riscv/decode_macros.h
+++ b/riscv/decode_macros.h
@@ -84,7 +84,7 @@
 // Zilsd macros
 #define WRITE_RD_D(value) (xlen == 32 ? WRITE_RD_PAIR(value) : WRITE_RD(value))
 
-// Zcmlsd macros
+// Zclsd macros
 #define WRITE_RVC_RS2S_PAIR(value) WRITE_REG_PAIR(insn.rvc_rs2s(), value)
 #define RVC_RS2S_PAIR READ_REG_PAIR(insn.rvc_rs2s())
 #define RVC_RS2_PAIR READ_REG_PAIR(insn.rvc_rs2())

--- a/riscv/insns/c_ld.h
+++ b/riscv/insns/c_ld.h
@@ -1,5 +1,5 @@
 require_extension(EXT_ZCA);
-require((xlen == 64) || p->extension_enabled(EXT_ZCMLSD));
+require((xlen == 64) || p->extension_enabled(EXT_ZCLSD));
 
 if (xlen == 32) {
   WRITE_RVC_RS2S_PAIR(MMU.load<int64_t>(RVC_RS1S + insn.rvc_ld_imm()));

--- a/riscv/insns/c_ldsp.h
+++ b/riscv/insns/c_ldsp.h
@@ -1,5 +1,5 @@
 require_extension(EXT_ZCA);
-require((xlen == 64) || p->extension_enabled(EXT_ZCMLSD));
+require((xlen == 64) || p->extension_enabled(EXT_ZCLSD));
 require(insn.rvc_rd() != 0);
 
 if (xlen == 32) {

--- a/riscv/insns/c_sd.h
+++ b/riscv/insns/c_sd.h
@@ -1,5 +1,5 @@
 require_extension(EXT_ZCA);
-require((xlen == 64) || p->extension_enabled(EXT_ZCMLSD));
+require((xlen == 64) || p->extension_enabled(EXT_ZCLSD));
 
 if (xlen == 32) {
   MMU.store<uint64_t>(RVC_RS1S + insn.rvc_ld_imm(), RVC_RS2S_PAIR);

--- a/riscv/insns/c_sdsp.h
+++ b/riscv/insns/c_sdsp.h
@@ -1,5 +1,5 @@
 require_extension(EXT_ZCA);
-require((xlen == 64) || p->extension_enabled(EXT_ZCMLSD));
+require((xlen == 64) || p->extension_enabled(EXT_ZCLSD));
 
 if (xlen == 32) {
   MMU.store<uint64_t>(RVC_SP + insn.rvc_sdsp_imm(), RVC_RS2_PAIR);

--- a/riscv/isa_parser.h
+++ b/riscv/isa_parser.h
@@ -23,7 +23,7 @@ typedef enum {
   EXT_ZCB,
   EXT_ZCD,
   EXT_ZCF,
-  EXT_ZCMLSD,
+  EXT_ZCLSD,
   EXT_ZCMP,
   EXT_ZCMT,
   EXT_ZKND,


### PR DESCRIPTION
- renamed Zcmlsd to Zclsd
- bumped version number