### PR TITLE
Fix ignored-attributes warning for unique_ptr declaration

### DIFF
--- a/riscv/log_file.h
+++ b/riscv/log_file.h
@@ -31,7 +31,7 @@ public:
   FILE *get() { return wrapped_file ? wrapped_file.get() : stderr; }
 
 private:
-  std::unique_ptr<FILE, decltype(&fclose)> wrapped_file;
+  std::unique_ptr<FILE, int(*)(FILE*)> wrapped_file;
 };
 
 #endif


### PR DESCRIPTION
The attribute `__nonnull` was added to `fclose` in glibc 2.38, which causes a warning when using its `decltype` on a template argument.