### PR TITLE
Add extension_t csrs in reset(), not register_extension()

### DIFF
--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -197,8 +197,11 @@ void processor_t::reset()
     put_csr(CSR_PMPCFG0, PMP_R | PMP_W | PMP_X | PMP_NAPOT);
   }
 
-  for (auto e : custom_extensions) // reset any extensions
+  for (auto e : custom_extensions) { // reset any extensions
+    for (auto &csr: e.second->get_csrs(*this))
+      state.add_csr(csr->address, csr);
     e.second->reset();
+  }
 
   if (sim)
     sim->proc_reset(id);
@@ -711,8 +714,6 @@ void processor_t::register_extension(extension_t *x) {
     fprintf(stderr, "extensions must have unique names (got two named \"%s\"!)\n", x->name());
     abort();
   }
-  for (auto &csr: x->get_csrs(*this))
-    state.add_csr(csr->address, csr);
   x->set_processor(this);
 }
 


### PR DESCRIPTION
This addresses one issue raised in #1863. register_extension() is only called once, while reset() is called whenever the processor_t is reset. This ensures that extension_t state, including CSRs, is always reset with reset()