### PR TITLE
Fix read value of CSR mip.

### DIFF
--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -781,7 +781,7 @@ mip_csr_t::mip_csr_t(processor_t* const proc, const reg_t addr):
 }
 
 reg_t mip_csr_t::read() const noexcept {
-  return val | state->hvip->basic_csr_t::read();
+  return val | (state->hvip->basic_csr_t::read() & (MIP_VSEIP | MIP_VSTIP));
 }
 
 void mip_csr_t::backdoor_write_with_mask(const reg_t mask, const reg_t val) noexcept {


### PR DESCRIPTION
The read value of mip should not depend on the value of hvip.

hvip.VSSIP is an alias of mip.VSSIP, so when reading hvip, the VSSIP bit of mip needs to be OR-ed. Similarly, when writing to hvip, the VSSIP bit of mip also needs to be updated.

However, there is no reason for the value of mip to depend on the value of hvip when being read.