### PR TITLE
Set dcsr.xdebugver to 4, as it ought to be

### DIFF
--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -1359,7 +1359,7 @@ void dcsr_csr_t::verify_permissions(insn_t insn, bool write) const {
 
 reg_t dcsr_csr_t::read() const noexcept {
   reg_t result = 0;
-  result = set_field(result, DCSR_XDEBUGVER, 1);
+  result = set_field(result, DCSR_XDEBUGVER, 4);
   result = set_field(result, DCSR_EBREAKM, ebreakm);
   result = set_field(result, DCSR_EBREAKS, ebreaks);
   result = set_field(result, DCSR_EBREAKU, ebreaku);


### PR DESCRIPTION
See discusson on #1878.  This restores the behavior prior to ec292be4fdac9685c9d6f2f209b73743c2e573f7, which inadvertently changed the value to 1.

Resolves #1878