### PR TITLE
Add spike-dasm --strict option 

### DIFF
--- a/riscv/disasm.h
+++ b/riscv/disasm.h
@@ -82,7 +82,7 @@ class disasm_insn_t
 class disassembler_t
 {
  public:
-  disassembler_t(const isa_parser_t *isa);
+  disassembler_t(const isa_parser_t *isa, bool strict = false);
   ~disassembler_t();
 
   std::string disassemble(insn_t insn) const;
@@ -94,7 +94,7 @@ class disassembler_t
   static const int HASH_SIZE = 255;
   std::vector<const disasm_insn_t*> chain[HASH_SIZE+1];
 
-  void add_instructions(const isa_parser_t* isa);
+  void add_instructions(const isa_parser_t* isa, bool strict);
 
   const disasm_insn_t* probe_once(insn_t insn, size_t idx) const;
 

--- a/spike_dasm/spike-dasm.cc
+++ b/spike_dasm/spike-dasm.cc
@@ -19,6 +19,7 @@ int main(int UNUSED argc, char** argv)
 {
   string s;
   const char* isa = DEFAULT_ISA;
+  bool strict = false;
 
   std::function<extension_t*()> extension;
   option_parser_t parser;
@@ -26,10 +27,11 @@ int main(int UNUSED argc, char** argv)
   parser.option(0, "extension", 1, [&](const char* s){extension = find_extension(s);});
 #endif
   parser.option(0, "isa", 1, [&](const char* s){isa = s;});
+  parser.option(0, "strict", 0, [&](const char UNUSED *s){strict = true;});
   parser.parse(argv);
 
   isa_parser_t isa_parser(isa, DEFAULT_PRIV);
-  disassembler_t* disassembler = new disassembler_t(&isa_parser);
+  disassembler_t* disassembler = new disassembler_t(&isa_parser, strict);
   if (extension) {
     for (auto disasm_insn : extension()->get_disasms()) {
       disassembler->add_insn(disasm_insn);


### PR DESCRIPTION
Prevents disassembling instructions that are not enabled by the `--isa` setting.

Resolves #1879