### PR TITLE
vector: crypto: fix constraint checks for vector-crypto instructions

### DIFF
--- a/riscv/insns/vghsh_vv.h
+++ b/riscv/insns/vghsh_vv.h
@@ -2,9 +2,13 @@
 
 #include "zvk_ext_macros.h"
 
+const uint32_t EGS = 4;
+
 require_zvkg;
 require(P.VU.vsew == 32);
 require_egw_fits(128);
+require(P.VU.vl->read() % EGS == 0);
+VI_CHECK_SSS(true)
 
 VI_ZVK_VD_VS1_VS2_EGU32x4_NOVM_LOOP(
   {},

--- a/riscv/insns/vgmul_vv.h
+++ b/riscv/insns/vgmul_vv.h
@@ -2,9 +2,13 @@
 
 #include "zvk_ext_macros.h"
 
+const uint32_t EGS = 4;
+
 require_zvkg;
 require(P.VU.vsew == 32);
 require_egw_fits(128);
+require(P.VU.vl->read() % EGS == 0);
+VI_CHECK_SSS(false)
 
 VI_ZVK_VD_VS2_EGU32x4_NOVM_LOOP(
   {},

--- a/riscv/insns/vsm3c_vi.h
+++ b/riscv/insns/vsm3c_vi.h
@@ -3,6 +3,7 @@
 #include "zvksh_ext_macros.h"
 
 require_vsm3_constraints;
+VI_CHECK_SSS(false)
 
 VI_ZVK_VD_VS2_ZIMM5_EGU32x8_NOVM_LOOP(
   {},

--- a/riscv/insns/vsm3me_vv.h
+++ b/riscv/insns/vsm3me_vv.h
@@ -13,6 +13,7 @@
   (ZVKSH_P1((M16) ^  (M9) ^ ZVK_ROL32((M3), 15)) ^ ZVK_ROL32((M13), 7) ^ (M6))
 
 require_vsm3_constraints;
+VI_CHECK_SSS(true)
 
 VI_ZVK_VD_VS1_VS2_EGU32x8_NOVM_LOOP(
   {},

--- a/riscv/insns/vsm4k_vi.h
+++ b/riscv/insns/vsm4k_vi.h
@@ -15,6 +15,7 @@ static constexpr uint32_t zvksed_ck[32] = {
 };
 
 require_vsm4_constraints;
+VI_CHECK_SSS(false)
 
 VI_ZVK_VD_VS2_ZIMM5_EGU32x4_NOVM_LOOP(
   {},

--- a/riscv/insns/vsm4r_vs.h
+++ b/riscv/insns/vsm4r_vs.h
@@ -7,7 +7,7 @@ const uint32_t EGS = 4;
 require_vsm4_constraints;
 require_align(insn.rd(), P.VU.vflmul);
 // No overlap of vd and vs2.
-require_noover(insn.rs2(), 1, insn.rd(), P.VU.vflmul);
+require_noover_eglmul(insn.rd(), insn.rs2());
 
 VI_ZVK_VD_VS2_NOOPERANDS_PRELOOP_EGU32x4_NOVM_LOOP(
   {},

--- a/riscv/insns/vsm4r_vs.h
+++ b/riscv/insns/vsm4r_vs.h
@@ -2,9 +2,12 @@
 
 #include "zvksed_ext_macros.h"
 
+const uint32_t EGS = 4;
+
 require_vsm4_constraints;
+require_align(insn.rd(), P.VU.vflmul);
 // No overlap of vd and vs2.
-require(insn.rd() != insn.rs2());
+require_noover(insn.rs2(), 1, insn.rd(), P.VU.vflmul);
 
 VI_ZVK_VD_VS2_NOOPERANDS_PRELOOP_EGU32x4_NOVM_LOOP(
   {},

--- a/riscv/insns/vsm4r_vs.h
+++ b/riscv/insns/vsm4r_vs.h
@@ -6,6 +6,7 @@ const uint32_t EGS = 4;
 
 require_vsm4_constraints;
 require_align(insn.rd(), P.VU.vflmul);
+require_vs2_align_eglmul(128);
 // No overlap of vd and vs2.
 require_noover_eglmul(insn.rd(), insn.rs2());
 

--- a/riscv/insns/vsm4r_vv.h
+++ b/riscv/insns/vsm4r_vv.h
@@ -2,7 +2,9 @@
 
 #include "zvksed_ext_macros.h"
 
+
 require_vsm4_constraints;
+VI_CHECK_SSS(false)
 
 VI_ZVK_VD_VS2_EGU32x4_NOVM_LOOP(
   {},

--- a/riscv/insns/vwsll_vi.h
+++ b/riscv/insns/vwsll_vi.h
@@ -3,6 +3,7 @@
 #include "zvk_ext_macros.h"
 
 require_zvbb;
+VI_CHECK_DSS(false);
 
 VI_ZVK_VI_WIDENING_ULOOP({
   const reg_t shift = zimm5 & ((2 * sew) - 1);

--- a/riscv/insns/vwsll_vv.h
+++ b/riscv/insns/vwsll_vv.h
@@ -3,6 +3,7 @@
 #include "zvk_ext_macros.h"
 
 require_zvbb;
+VI_CHECK_DSS(true);
 
 VI_ZVK_VV_WIDENING_ULOOP({
   const reg_t shift = (vs1 & ((2 * sew) - 1));

--- a/riscv/insns/vwsll_vx.h
+++ b/riscv/insns/vwsll_vx.h
@@ -3,6 +3,7 @@
 #include "zvk_ext_macros.h"
 
 require_zvbb;
+VI_CHECK_DSS(false);
 
 VI_ZVK_VX_WIDENING_ULOOP({
   const reg_t shift = (rs1 & ((2 * sew) - 1));

--- a/riscv/zvk_ext_macros.h
+++ b/riscv/zvk_ext_macros.h
@@ -86,6 +86,18 @@
 //    (LMUL * VLEN) <= EGW
 #define require_egw_fits(EGW)  require((EGW) <= (P.VU.VLEN * P.VU.vflmul))
 
+// ensure that rs2 and rd do not overlap, assuming rd encodes an LMUL wide
+// vector register group and rs2 encodes an vs2_EMUL=ceil(EGW / VLEN) vector register
+// group.
+// Assumption: LMUL >= vs2_EMUL which is enforced independently through require_egw_fits.
+#define require_noover_eglmul(vd, vs2) \
+  do { \
+    int vd_emul = P.VU.vflmul < 1.f ? 1 : (int) P.VU.vflmul; \
+    int aligned_vd = vd / vd_emul; \
+    int aligned_vs2 = vs2 / vd_emul; \
+    require(aligned_vd != aligned_vs2); \
+  } while (0)
+
 // Checks that the vector unit state (vtype and vl) can be interpreted
 // as element groups with EEW=32, EGS=4 (four 32-bits elements per group),
 // for an effective element group width of EGW=128 bits.

--- a/riscv/zvk_ext_macros.h
+++ b/riscv/zvk_ext_macros.h
@@ -86,6 +86,20 @@
 //    (LMUL * VLEN) <= EGW
 #define require_egw_fits(EGW)  require((EGW) <= (P.VU.VLEN * P.VU.vflmul))
 
+// Ensures that a register index is aligned to EMUL
+// evaluated as EGW / VLEN.
+// The check is only enabled if this value is greater
+// than one (no index alignment check required for fractional EMUL)
+#define require_vreg_align_eglmul(EGW, VREG_NUM) \
+  do { \
+    float vfeglmul = EGW / P.VU.VLEN; \
+    if (vfeglmul > 1) { \
+      require_align(VREG_NUM, vfeglmul); \
+    }\
+  } while (0)
+
+#define require_vs2_align_eglmul(EGW) require_vreg_align_eglmul(EGW, insn.rs2())
+
 // ensure that rs2 and rd do not overlap, assuming rd encodes an LMUL wide
 // vector register group and rs2 encodes an vs2_EMUL=ceil(EGW / VLEN) vector register
 // group.

--- a/riscv/zvkned_ext_macros.h
+++ b/riscv/zvkned_ext_macros.h
@@ -2,6 +2,7 @@
 // the RISC-V Zvkned extension (vector AES single round).
 
 #include "insns/aes_common.h"
+#include "zvk_ext_macros.h"
 
 #ifndef RISCV_ZVKNED_EXT_MACROS_H_
 #define RISCV_ZVKNED_EXT_MACROS_H_
@@ -21,7 +22,7 @@
     require(P.VU.vsew == 32); \
     require_egw_fits(128); \
     require_align(insn.rd(), P.VU.vflmul); \
-    require_noover(insn.rs2(), 1, insn.rd(), P.VU.vflmul); \
+    require_noover_eglmul(insn.rd(), insn.rs2()); \
   } while (false)
 
 // vaes*.vv instruction constraints. Those are the same as the .vs ones,

--- a/riscv/zvkned_ext_macros.h
+++ b/riscv/zvkned_ext_macros.h
@@ -10,6 +10,8 @@
 // vaes*.vs instruction constraints:
 //  - Zvkned is enabled
 //  - EGW (128) <= LMUL * VLEN
+//  - vd is LMUL aligned
+//  - vs2 is ceil(EGW / VLEN) aligned
 //  - vd and vs2 cannot overlap
 //
 // The constraint that vstart and vl are both EGS (4) aligned
@@ -22,6 +24,7 @@
     require(P.VU.vsew == 32); \
     require_egw_fits(128); \
     require_align(insn.rd(), P.VU.vflmul); \
+    require_vs2_align_eglmul(128); \
     require_noover_eglmul(insn.rd(), insn.rs2()); \
   } while (false)
 

--- a/riscv/zvkned_ext_macros.h
+++ b/riscv/zvkned_ext_macros.h
@@ -15,10 +15,13 @@
 // is checked in the VI_ZVK_..._EGU32x4_..._LOOP macros.
 #define require_vaes_vs_constraints \
   do { \
+    const uint32_t EGS = 4; \
     require_zvkned; \
+    require(P.VU.vl->read() % EGS == 0); \
     require(P.VU.vsew == 32); \
     require_egw_fits(128); \
-    require(insn.rd() != insn.rs2()); \
+    require_align(insn.rd(), P.VU.vflmul); \
+    require_noover(insn.rs2(), 1, insn.rd(), P.VU.vflmul); \
   } while (false)
 
 // vaes*.vv instruction constraints. Those are the same as the .vs ones,
@@ -30,17 +33,24 @@
 // is checked in the VI_ZVK_..._EGU32x4_..._LOOP macros.
 #define require_vaes_vv_constraints \
   do { \
+    const uint32_t EGS = 4; \
     require_zvkned; \
+    require(P.VU.vl->read() % EGS == 0); \
     require(P.VU.vsew == 32); \
     require_egw_fits(128); \
+    VI_CHECK_SSS(false) \
   } while (false)
 
 // vaeskf*.vi instruction constraints. Those are the same as the .vv ones.
 #define require_vaeskf_vi_constraints \
   do { \
+    const uint32_t EGS = 4; \
     require_zvkned; \
+    require(P.VU.vstart->read() % EGS == 0); \
+    require(P.VU.vl->read() % EGS == 0); \
     require(P.VU.vsew == 32); \
     require_egw_fits(128); \
+    VI_CHECK_SSS(false) \
   } while (false)
 
 #define VAES_XTIME(A) (((A) << 1) ^ (((A) & 0x80) ? 0x1b : 0))

--- a/riscv/zvknh_ext_macros.h
+++ b/riscv/zvknh_ext_macros.h
@@ -15,6 +15,7 @@
 // macros.
 #define require_vsha2_common_constraints \
   do { \
+    VI_CHECK_SSS(true) \
     require(P.VU.vsew == 32 || P.VU.vsew == 64); \
     require(insn.rd() != insn.rs1()); \
     require(insn.rd() != insn.rs2()); \

--- a/riscv/zvksed_ext_macros.h
+++ b/riscv/zvksed_ext_macros.h
@@ -16,9 +16,12 @@
 // is checked in the VI_ZVK_..._EGU32x4_..._LOOP macros.
 #define require_vsm4_constraints \
   do { \
+    const uint32_t EGS = 4; \
     require_zvksed; \
     require(P.VU.vsew == 32); \
     require_egw_fits(128); \
+    require(P.VU.vstart->read() % EGS == 0); \
+    require(P.VU.vl->read() % EGS == 0); \
   } while (false)
 
 // Returns a uint32_t value constructed from the 4 bytes (uint8_t)

--- a/riscv/zvksh_ext_macros.h
+++ b/riscv/zvksh_ext_macros.h
@@ -16,9 +16,12 @@
 // is checked in the VI_ZVK_..._EGU32x8_..._LOOP macros.
 #define require_vsm3_constraints \
   do { \
+    const uint32_t EGS = 8; \
     require_zvksh; \
     require(P.VU.vsew == 32); \
     require_egw_fits(256); \
+    require(P.VU.vstart->read() % EGS == 0); \
+    require(P.VU.vl->read() % EGS == 0); \
     require(insn.rd() != insn.rs2()); \
   } while (false)
 


### PR DESCRIPTION
These are the changes:
- Zvkg (vghsh.vv, vgmul.vv)
    - vl must be a multiple of EGS=4. (spec p.13)
    - Check alignment of vd, vs1, vs2 with lmul
- Zvksh (vsm3c.vi, vsm3me.vv)
    - vstart, vl must be multiple of EGS=8 (spec p.17)
    - Check alignment of vd, vs1, vs2 with lmul
- Zvksed (vsm4k.[vi,vs,vv])
    - vstart, vl must be multiple of EGS=4 (spec p.16)
    - Check alignment of vd, vs1, vs2 with lmul
    - For vsm4r.vs, check overlap between vs2 and vd (spec p.7)
- Zvbb (vwsll.[vv,vx,vi])
    - Check alignment of vd, vs1, vs2 with lmul	(for widening instructions)
    - Check overlap between vs2 and vd
- Zvkned
    - vstart, vl must be multiple of EGS=4 (spec p.14)
    - Check alignment of vd, vs1, vs2 with lmul
    - For vaes*.vs, check overlap between vs2 and vd (spec p.7)
- Zvknh
    - Check alignment of vd, vs1, vs2 with lmul