### PR TITLE
vcompress.vm: Check vstart value even if vl = 0

### DIFF
--- a/riscv/insns/vcompress_vm.h
+++ b/riscv/insns/vcompress_vm.h
@@ -1,4 +1,5 @@
 // vcompress vd, vs2, vs1
+require(P.any_vector_extensions());
 require(P.VU.vstart->read() == 0);
 require_align(insn.rd(), P.VU.vflmul);
 require_align(insn.rs2(), P.VU.vflmul);

--- a/riscv/insns/vcompress_vm.h
+++ b/riscv/insns/vcompress_vm.h
@@ -1,14 +1,13 @@
 // vcompress vd, vs2, vs1
+require(P.VU.vstart->read() == 0);
+require_align(insn.rd(), P.VU.vflmul);
+require_align(insn.rs2(), P.VU.vflmul);
 require(insn.rd() != insn.rs2());
+require_noover(insn.rd(), P.VU.vflmul, insn.rs1(), 1);
 
 reg_t pos = 0;
 
 VI_GENERAL_LOOP_BASE
-  require(P.VU.vstart->read() == 0);
-  require_align(insn.rd(), P.VU.vflmul);
-  require_align(insn.rs2(), P.VU.vflmul);
-  require_noover(insn.rd(), P.VU.vflmul, insn.rs1(), 1);
-
   const int midx = i / 64;
   const int mpos = i % 64;
 


### PR DESCRIPTION
A previous commit inadvertently included an incorrect behavior: when vl=0, the instruction incorrectly failed to check if vstart!=0. (https://github.com/riscv-software-src/riscv-isa-sim/pull/1754#issuecomment-2609155665)

This PR aims to achieve the same goal as https://github.com/riscv-software-src/riscv-isa-sim/pull/1754 while correcting this incorrect behavior.