### PR TITLE
cosim: right shift can't be applied on negative number

### DIFF
--- a/riscv/insns/vnsra_wi.h
+++ b/riscv/insns/vnsra_wi.h
@@ -1,5 +1,5 @@
 // vnsra.vi vd, vs2, zimm5
 VI_VI_LOOP_NSHIFT
 ({
-  vd = vs2 >> (zimm5 & (sew * 2 - 1) & 0x1f);
+  vd = vs2 >> (zimm5 & (sew * 2 - 1));
 })

--- a/riscv/insns/vsll_vi.h
+++ b/riscv/insns/vsll_vi.h
@@ -1,5 +1,5 @@
 // vsll.vi  vd, vs2, zimm5
-VI_VI_LOOP
+VI_VI_ULOOP
 ({
-  vd = vs2 << (simm5 & (sew - 1) & 0x1f);
+  vd = vs2 << (zimm5 & (sew - 1));
 })

--- a/riscv/insns/vsll_vv.h
+++ b/riscv/insns/vsll_vv.h
@@ -1,5 +1,5 @@
 // vsll
-VI_VV_LOOP
+VI_VV_ULOOP
 ({
   vd = vs2 << (vs1 & (sew - 1));
 })

--- a/riscv/insns/vsll_vx.h
+++ b/riscv/insns/vsll_vx.h
@@ -1,5 +1,5 @@
 // vsll
-VI_VX_LOOP
+VI_VX_ULOOP
 ({
   vd = vs2 << (rs1 & (sew - 1));
 })

--- a/riscv/insns/vsrl_vi.h
+++ b/riscv/insns/vsrl_vi.h
@@ -1,5 +1,5 @@
 // vsrl.vi vd, vs2, zimm5
 VI_VI_ULOOP
 ({
-  vd = vs2 >> (zimm5 & (sew - 1) & 0x1f);
+  vd = vs2 >> (zimm5 & (sew - 1));
 })

--- a/riscv/insns/vssra_vi.h
+++ b/riscv/insns/vssra_vi.h
@@ -2,7 +2,7 @@
 VI_VI_LOOP
 ({
   VRM xrm = P.VU.get_vround_mode();
-  int sh = simm5 & (sew - 1) & 0x1f;
+  int sh = simm5 & (sew - 1);
   int128_t val = vs2;
 
   INT_ROUNDING(val, xrm, sh);

--- a/riscv/insns/vssrl_vi.h
+++ b/riscv/insns/vssrl_vi.h
@@ -2,7 +2,7 @@
 VI_VI_ULOOP
 ({
   VRM xrm = P.VU.get_vround_mode();
-  int sh = zimm5 & (sew - 1) & 0x1f;
+  int sh = zimm5 & (sew - 1);
   uint128_t val = vs2;
 
   INT_ROUNDING(val, xrm, sh);


### PR DESCRIPTION
referece from:  ISO C99 (6.5.7/4)
"The result of E1 << E2 is E1 left-shifted E2 bit positions; vacated
 bits are ﬁlled with zeros. If E1 has an unsigned type, the value of the
 result is E1 × 2E2, reduced modulo one more than the maximum value
 representable in the result type. If E1 has a signed type and
 nonnegative value, and E1 × 2E2 is representable in the result type,
 then that is the resulting value; otherwise, the behavior is undeﬁned."