### PR TITLE
Fesvr non htif bootloader support

### DIFF
--- a/fesvr/htif.cc
+++ b/fesvr/htif.cc
@@ -84,12 +84,17 @@ htif_t::~htif_t()
 
 void htif_t::start()
 {
-  if (!targs.empty() && targs[0] != "none") {
-    try {
-      load_program();
-    } catch (const incompat_xlen & err) {
-      fprintf(stderr, "Error: cannot execute %d-bit program on RV%d hart\n", err.actual_xlen, err.expected_xlen);
-      exit(1);
+  if (!targs.empty()) {
+    if (targs[0] != "none") {
+      try {
+        load_program();
+      } catch (const incompat_xlen & err) {
+        fprintf(stderr, "Error: cannot execute %d-bit program on RV%d hart\n", err.actual_xlen, err.expected_xlen);
+        exit(1);
+      }
+    } else {
+      auto empty_symbols = std::map<std::string, uint64_t>();
+      load_symbols(empty_symbols);
     }
   }
 
@@ -150,21 +155,8 @@ std::map<std::string, uint64_t> htif_t::load_payload(const std::string& payload,
   }
 }
 
-void htif_t::load_program()
+void htif_t::load_symbols(std::map<std::string, uint64_t>& symbols)
 {
-  std::map<std::string, uint64_t> symbols = load_payload(targs[0], &entry, load_offset);
-
-  // detect torture tests so we can print the memory signature at the end
-  if (symbols.count("begin_signature") && symbols.count("end_signature")) {
-    sig_addr = symbols["begin_signature"];
-    sig_len = symbols["end_signature"] - sig_addr;
-  }
-
-  for (auto payload : payloads) {
-    reg_t dummy_entry;
-    load_payload(payload, &dummy_entry, 0);
-  }
-
   class nop_memif_t : public memif_t {
    public:
     nop_memif_t(htif_t* htif) : memif_t(htif), htif(htif) {}
@@ -181,6 +173,12 @@ void htif_t::load_program()
     symbols.merge(other_symbols);
   }
 
+  // detect torture tests so we can print the memory signature at the end
+  if (symbols.count("begin_signature") && symbols.count("end_signature")) {
+    sig_addr = symbols["begin_signature"];
+    sig_len = symbols["end_signature"] - sig_addr;
+  }
+
   if (symbols.count("tohost") && symbols.count("fromhost")) {
     tohost_addr = symbols["tohost"];
     fromhost_addr = symbols["fromhost"];
@@ -192,6 +190,18 @@ void htif_t::load_program()
     auto it = addr2symbol.find(i.second);
     if ( it == addr2symbol.end())
       addr2symbol[i.second] = i.first;
+  }
+}
+
+void htif_t::load_program()
+{
+  std::map<std::string, uint64_t> symbols = load_payload(targs[0], &entry, load_offset);
+
+  load_symbols(symbols);
+
+  for (auto payload : payloads) {
+    reg_t dummy_entry;
+    load_payload(payload, &dummy_entry, 0);
   }
 
   return;

--- a/fesvr/htif.cc
+++ b/fesvr/htif.cc
@@ -92,13 +92,12 @@ void htif_t::start()
         fprintf(stderr, "Error: cannot execute %d-bit program on RV%d hart\n", err.actual_xlen, err.expected_xlen);
         exit(1);
       }
+      reset();
     } else {
       auto empty_symbols = std::map<std::string, uint64_t>();
       load_symbols(empty_symbols);
     }
   }
-
-  reset();
 }
 
 static void bad_address(const std::string& situation, reg_t addr)

--- a/fesvr/htif.cc
+++ b/fesvr/htif.cc
@@ -154,13 +154,6 @@ void htif_t::load_program()
 {
   std::map<std::string, uint64_t> symbols = load_payload(targs[0], &entry, load_offset);
 
-  if (symbols.count("tohost") && symbols.count("fromhost")) {
-    tohost_addr = symbols["tohost"];
-    fromhost_addr = symbols["fromhost"];
-  } else {
-    fprintf(stderr, "warning: tohost and fromhost symbols not in ELF; can't communicate with target\n");
-  }
-
   // detect torture tests so we can print the memory signature at the end
   if (symbols.count("begin_signature") && symbols.count("end_signature")) {
     sig_addr = symbols["begin_signature"];
@@ -186,6 +179,13 @@ void htif_t::load_program()
     std::map<std::string, uint64_t> other_symbols = load_elf(s.c_str(), &nop_memif, &nop_entry,
                                                              expected_xlen);
     symbols.merge(other_symbols);
+  }
+
+  if (symbols.count("tohost") && symbols.count("fromhost")) {
+    tohost_addr = symbols["tohost"];
+    fromhost_addr = symbols["fromhost"];
+  } else {
+    fprintf(stderr, "warning: tohost and fromhost symbols not in ELF; can't communicate with target\n");
   }
 
   for (auto i : symbols) {

--- a/fesvr/htif.h
+++ b/fesvr/htif.h
@@ -65,6 +65,7 @@ class htif_t : public chunked_memif_t
   virtual std::map<std::string, uint64_t> load_payload(const std::string& payload, reg_t* entry,
                                                        reg_t load_addr);
   virtual void load_program();
+  virtual void load_symbols(std::map<std::string, uint64_t>&);
   virtual void idle() {}
 
   const std::vector<std::string>& host_args() { return hargs; }


### PR DESCRIPTION
These changes are helpful in scenarios where a bootup mechanism outside of HTIF is used, but HTIF is still wanted as a communication interface. (e.g. with libgloss-htif)

FESVR already allowed to specify `"none"` as the binary, which skipped the loading.
But it still tried to reset the system, which would interfere with the function of a bootloader on the simulated system, which was still loading a binary over a different channel.

As an example, a simulator (with libfesvr) using these changes might have a command line invocation like this:
`sim +custom_boot_mechanism_binary=foo +symbol-elf=foo none`

To my knowledge these changes do not break any behaviour likely to be relied upon by any program using libfesvr.