### PR TITLE
Fix CSR initial affected by DTS

### DIFF
--- a/riscv/sim.cc
+++ b/riscv/sim.cc
@@ -238,6 +238,8 @@ sim_t::sim_t(const cfg_t *cfg, bool halted,
       procs[cpu_idx]->set_mmu_capability(IMPL_MMU_SBARE);
     }
 
+    procs[cpu_idx]->reset();
+
     cpu_idx++;
   }
 


### PR DESCRIPTION
Add processor_t::reset() method after MMU update by DTS to correct status mask value