### PR TITLE
Add `size` method to `abstract_device_t`; make `bus_t` more robust

### DIFF
--- a/riscv/abstract_device.h
+++ b/riscv/abstract_device.h
@@ -16,6 +16,7 @@ class abstract_device_t {
  public:
   virtual bool load(reg_t addr, size_t len, uint8_t* bytes) = 0;
   virtual bool store(reg_t addr, size_t len, const uint8_t* bytes) = 0;
+  virtual reg_t size() = 0;
   virtual ~abstract_device_t() {}
   virtual void tick(reg_t UNUSED rtc_ticks) {}
 };

--- a/riscv/debug_module.cc
+++ b/riscv/debug_module.cc
@@ -249,6 +249,11 @@ bool debug_module_t::store(reg_t addr, size_t len, const uint8_t* bytes)
   return false;
 }
 
+reg_t debug_module_t::size()
+{
+  return PGSIZE;
+}
+
 void debug_module_t::write32(uint8_t *memory, unsigned int index, uint32_t value)
 {
   uint8_t* base = memory + index * 4;

--- a/riscv/debug_module.h
+++ b/riscv/debug_module.h
@@ -114,8 +114,9 @@ class debug_module_t : public abstract_device_t
     debug_module_t(simif_t *sim, const debug_module_config_t &config);
     ~debug_module_t();
 
-    bool load(reg_t addr, size_t len, uint8_t* bytes);
-    bool store(reg_t addr, size_t len, const uint8_t* bytes);
+    bool load(reg_t addr, size_t len, uint8_t* bytes) override;
+    bool store(reg_t addr, size_t len, const uint8_t* bytes) override;
+    reg_t size() override;
 
     // Debug Module Interface that the debugger (in our case through JTAG DTM)
     // uses to access the DM.

--- a/riscv/devices.cc
+++ b/riscv/devices.cc
@@ -69,25 +69,25 @@ reg_t bus_t::size()
 
 std::pair<reg_t, abstract_device_t*> bus_t::find_device(reg_t addr, size_t len)
 {
-  if (!len || addr + len - 1 < addr)
+  if (unlikely(!len || addr + len - 1 < addr))
     return std::make_pair(0, nullptr);
 
   // Obtain iterator to device immediately after the one that might match
   auto it_after = devices.upper_bound(addr);
   reg_t base, size;
-  if (it_after != devices.begin()) {
+  if (likely(it_after != devices.begin())) {
     // Obtain iterator to device that might match
     auto it = std::prev(it_after);
     base = it->first;
     size = it->second->size();
-    if (addr - base + len - 1 < size) {
+    if (likely(addr - base + len - 1 < size)) {
       // it fully contains [addr, addr + len)
       return std::make_pair(it->first, it->second);
     }
   }
 
-  if ((it_after != devices.end() && addr + len - 1 >= it_after->first)
-      || (it_after != devices.begin() && addr - base < size)) {
+  if (unlikely((it_after != devices.end() && addr + len - 1 >= it_after->first)
+      || (it_after != devices.begin() && addr - base < size))) {
     // it_after or it contains part of, but not all of, [addr, add + len)
     return std::make_pair(0, nullptr);
   }

--- a/riscv/devices.cc
+++ b/riscv/devices.cc
@@ -51,7 +51,10 @@ std::pair<reg_t, abstract_device_t*> bus_t::find_device(reg_t addr)
 
 std::pair<reg_t, abstract_device_t*> bus_t::find_device(reg_t addr, size_t len)
 {
-  return find_device(addr);
+  if (auto [base, dev] = find_device(addr); addr - base + len - 1 < dev->size())
+    return std::make_pair(base, dev);
+
+  return std::make_pair(0, nullptr);
 }
 
 mem_t::mem_t(reg_t size)

--- a/riscv/devices.cc
+++ b/riscv/devices.cc
@@ -27,6 +27,13 @@ bool bus_t::store(reg_t addr, size_t len, const uint8_t* bytes)
   return false;
 }
 
+reg_t bus_t::size()
+{
+  if (auto last = devices.rbegin(); last != devices.rend())
+    return last->first + last->second->size();
+  return 0;
+}
+
 std::pair<reg_t, abstract_device_t*> bus_t::find_device(reg_t addr)
 {
   // Obtain iterator to device immediately after the one that might match

--- a/riscv/devices.cc
+++ b/riscv/devices.cc
@@ -10,51 +10,41 @@ mmio_device_map_t& mmio_device_map()
 
 void bus_t::add_device(reg_t addr, abstract_device_t* dev)
 {
-  // Searching devices via lower_bound/upper_bound
-  // implicitly relies on the underlying std::map 
-  // container to sort the keys and provide ordered
-  // iteration over this sort, which it does. (python's
-  // SortedDict is a good analogy)
   devices[addr] = dev;
 }
 
 bool bus_t::load(reg_t addr, size_t len, uint8_t* bytes)
 {
-  // Find the device with the base address closest to but
-  // less than addr (price-is-right search)
-  auto it = devices.upper_bound(addr);
-  if (devices.empty() || it == devices.begin()) {
-    // Either the bus is empty, or there weren't 
-    // any items with a base address <= addr
-    return false;
-  }
-  // Found at least one item with base address <= addr
-  // The iterator points to the device after this, so
-  // go back by one item.
-  it--;
-  return it->second->load(addr - it->first, len, bytes);
+  if (auto [base, dev] = find_device(addr, len); dev)
+    return dev->load(addr - base, len, bytes);
+  return false;
 }
 
 bool bus_t::store(reg_t addr, size_t len, const uint8_t* bytes)
 {
-  // See comments in bus_t::load
-  auto it = devices.upper_bound(addr);
-  if (devices.empty() || it == devices.begin()) {
-    return false;
-  }
-  it--;
-  return it->second->store(addr - it->first, len, bytes);
+  if (auto [base, dev] = find_device(addr, len); dev)
+    return dev->store(addr - base, len, bytes);
+  return false;
 }
 
 std::pair<reg_t, abstract_device_t*> bus_t::find_device(reg_t addr)
 {
-  // See comments in bus_t::load
+  // Obtain iterator to device immediately after the one that might match
   auto it = devices.upper_bound(addr);
   if (devices.empty() || it == devices.begin()) {
+    // No devices with base address <= addr
     return std::make_pair((reg_t)0, (abstract_device_t*)NULL);
   }
+
+  // Rewind to device that will match if its size suffices
   it--;
+
   return std::make_pair(it->first, it->second);
+}
+
+std::pair<reg_t, abstract_device_t*> bus_t::find_device(reg_t addr, size_t len)
+{
+  return find_device(addr);
 }
 
 mem_t::mem_t(reg_t size)

--- a/riscv/devices.h
+++ b/riscv/devices.h
@@ -21,6 +21,7 @@ class bus_t : public abstract_device_t {
   void add_device(reg_t addr, abstract_device_t* dev);
 
   std::pair<reg_t, abstract_device_t*> find_device(reg_t addr);
+  std::pair<reg_t, abstract_device_t*> find_device(reg_t addr, size_t len);
 
  private:
   std::map<reg_t, abstract_device_t*> devices;

--- a/riscv/devices.h
+++ b/riscv/devices.h
@@ -24,8 +24,6 @@ class bus_t : public abstract_device_t {
   std::pair<reg_t, abstract_device_t*> find_device(reg_t addr, size_t len);
 
  private:
-  std::pair<reg_t, abstract_device_t*> find_device(reg_t addr);
-
   std::map<reg_t, abstract_device_t*> devices;
 };
 

--- a/riscv/devices.h
+++ b/riscv/devices.h
@@ -45,7 +45,6 @@ class abstract_mem_t : public abstract_device_t {
   virtual ~abstract_mem_t() = default;
 
   virtual char* contents(reg_t addr) = 0;
-  virtual reg_t size() = 0;
   virtual void dump(std::ostream& o) = 0;
 };
 

--- a/riscv/devices.h
+++ b/riscv/devices.h
@@ -16,6 +16,11 @@ class simif_t;
 
 class bus_t : public abstract_device_t {
  public:
+  bus_t();
+
+  // the fallback device owns all addresses not owned by other devices
+  bus_t(abstract_device_t* fallback);
+
   bool load(reg_t addr, size_t len, uint8_t* bytes) override;
   bool store(reg_t addr, size_t len, const uint8_t* bytes) override;
   reg_t size() override;
@@ -25,6 +30,7 @@ class bus_t : public abstract_device_t {
 
  private:
   std::map<reg_t, abstract_device_t*> devices;
+  abstract_device_t* fallback;
 };
 
 class rom_device_t : public abstract_device_t {

--- a/riscv/devices.h
+++ b/riscv/devices.h
@@ -18,6 +18,7 @@ class bus_t : public abstract_device_t {
  public:
   bool load(reg_t addr, size_t len, uint8_t* bytes) override;
   bool store(reg_t addr, size_t len, const uint8_t* bytes) override;
+  reg_t size() override;
   void add_device(reg_t addr, abstract_device_t* dev);
 
   std::pair<reg_t, abstract_device_t*> find_device(reg_t addr);
@@ -32,6 +33,7 @@ class rom_device_t : public abstract_device_t {
   rom_device_t(std::vector<char> data);
   bool load(reg_t addr, size_t len, uint8_t* bytes) override;
   bool store(reg_t addr, size_t len, const uint8_t* bytes) override;
+  reg_t size() override { return data.size(); }
   const std::vector<char>& contents() { return data; }
  private:
   std::vector<char> data;
@@ -70,7 +72,7 @@ class clint_t : public abstract_device_t {
   clint_t(const simif_t*, uint64_t freq_hz, bool real_time);
   bool load(reg_t addr, size_t len, uint8_t* bytes) override;
   bool store(reg_t addr, size_t len, const uint8_t* bytes) override;
-  size_t size() { return CLINT_SIZE; }
+  reg_t size() override { return CLINT_SIZE; }
   void tick(reg_t rtc_ticks) override;
   uint64_t get_mtimecmp(reg_t hartid) { return mtimecmp[hartid]; }
   uint64_t get_mtime() { return mtime; }
@@ -110,7 +112,7 @@ class plic_t : public abstract_device_t, public abstract_interrupt_controller_t 
   bool load(reg_t addr, size_t len, uint8_t* bytes) override;
   bool store(reg_t addr, size_t len, const uint8_t* bytes) override;
   void set_interrupt_level(uint32_t id, int lvl) override;
-  size_t size() { return PLIC_SIZE; }
+  reg_t size() override { return PLIC_SIZE; }
  private:
   std::vector<plic_context_t> contexts;
   uint32_t num_ids;
@@ -141,7 +143,7 @@ class ns16550_t : public abstract_device_t {
   bool load(reg_t addr, size_t len, uint8_t* bytes) override;
   bool store(reg_t addr, size_t len, const uint8_t* bytes) override;
   void tick(reg_t rtc_ticks) override;
-  size_t size() { return NS16550_SIZE; }
+  reg_t size() override { return NS16550_SIZE; }
  private:
   abstract_interrupt_controller_t *intctrl;
   uint32_t interrupt_id;

--- a/riscv/devices.h
+++ b/riscv/devices.h
@@ -21,10 +21,11 @@ class bus_t : public abstract_device_t {
   reg_t size() override;
   void add_device(reg_t addr, abstract_device_t* dev);
 
-  std::pair<reg_t, abstract_device_t*> find_device(reg_t addr);
   std::pair<reg_t, abstract_device_t*> find_device(reg_t addr, size_t len);
 
  private:
+  std::pair<reg_t, abstract_device_t*> find_device(reg_t addr);
+
   std::map<reg_t, abstract_device_t*> devices;
 };
 

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -813,6 +813,11 @@ bool processor_t::store(reg_t addr, size_t len, const uint8_t* bytes)
   return false;
 }
 
+reg_t processor_t::size()
+{
+  return PGSIZE;
+}
+
 void processor_t::trigger_updated(const std::vector<triggers::trigger_t *> &triggers)
 {
   mmu->flush_tlb();

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -341,8 +341,9 @@ public:
   void register_extension(extension_t*);
 
   // MMIO slave interface
-  bool load(reg_t addr, size_t len, uint8_t* bytes);
-  bool store(reg_t addr, size_t len, const uint8_t* bytes);
+  bool load(reg_t addr, size_t len, uint8_t* bytes) override;
+  bool store(reg_t addr, size_t len, const uint8_t* bytes) override;
+  reg_t size() override;
 
   // When true, display disassembly of each instruction that's executed.
   bool debug;

--- a/riscv/sim.cc
+++ b/riscv/sim.cc
@@ -406,10 +406,9 @@ void sim_t::set_rom()
 char* sim_t::addr_to_mem(reg_t paddr) {
   if (!paddr_ok(paddr))
     return NULL;
-  auto desc = bus.find_device(paddr);
+  auto desc = bus.find_device(paddr >> PGSHIFT << PGSHIFT, PGSIZE);
   if (auto mem = dynamic_cast<abstract_mem_t*>(desc.second))
-    if (paddr - desc.first < mem->size())
-      return mem->contents(paddr - desc.first);
+    return mem->contents(paddr - desc.first);
   return NULL;
 }
 

--- a/riscv/sim.h
+++ b/riscv/sim.h
@@ -100,8 +100,13 @@ private:
   remote_bitbang_t* remote_bitbang;
   std::optional<std::function<void()>> next_interactive_action;
 
-  // memory-mapped I/O routines
+  // If padd corresponds to memory (as opposed to an I/O device), return a
+  // host pointer corresponding to paddr.
+  // For these purposes, only memories that include the entire base page
+  // surrounding paddr are considered; smaller memories are treated as I/O.
   virtual char* addr_to_mem(reg_t paddr) override;
+
+  // memory-mapped I/O routines
   virtual bool mmio_load(reg_t paddr, size_t len, uint8_t* bytes) override;
   virtual bool mmio_store(reg_t paddr, size_t len, const uint8_t* bytes) override;
   void set_rom();


### PR DESCRIPTION
Check for address validity wrt. device sizes; check for device address overlap.