### PR TITLE
Fix implementation of instreth writes

### DIFF
--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -542,10 +542,10 @@ class wide_counter_csr_t: public csr_t {
   void bump(const reg_t howmuch) noexcept;
  protected:
   virtual bool unlogged_write(const reg_t val) noexcept override;
-  virtual reg_t written_value() const noexcept override;
  private:
   bool is_counting_enabled() const noexcept;
   reg_t val;
+  bool written;
   smcntrpmf_csr_t_p config_csr;
 };
 

--- a/riscv/execute.cc
+++ b/riscv/execute.cc
@@ -365,12 +365,10 @@ void processor_t::step(size_t n)
       in_wfi = true;
     }
 
-    if (!(state.mcountinhibit->read() & MCOUNTINHIBIT_IR))
-      state.minstret->bump(instret);
+    state.minstret->bump((state.mcountinhibit->read() & MCOUNTINHIBIT_IR) ? 0 : instret);
 
     // Model a hart whose CPI is 1.
-    if (!(state.mcountinhibit->read() & MCOUNTINHIBIT_CY))
-      state.mcycle->bump(instret);
+    state.mcycle->bump((state.mcountinhibit->read() & MCOUNTINHIBIT_CY) ? 0 : instret);
 
     n -= instret;
   }


### PR DESCRIPTION
Decrementing the counter in advance of incrementing it produces incorrect results when there's a carry-out.  Fix by getting rid of this scheme altogher: just skip the increment if there was an expicit write.

Looks like Spike tried to do the right thing here, but misimplemented it--i.e. it wasn't a misreading of the spec.

See test case https://github.com/riscv-software-src/riscv-tests/commit/162d3e7b61559dc47d001c6a42bb6c14982b7866 and ISA spec discussion https://github.com/riscv/riscv-isa-manual/issues/1255

cc @Timmmm
