### PR TITLE
Enabling using Spike as a library

### DIFF
--- a/riscv/cfg.h
+++ b/riscv/cfg.h
@@ -6,6 +6,7 @@
 #include <vector>
 #include "decode.h"
 #include <cassert>
+class abstract_sim_if_t;
 
 typedef enum {
   endianness_little,
@@ -77,6 +78,7 @@ public:
   bool                    explicit_hartids;
   bool                    real_time_clint;
   reg_t                   trigger_count;
+  std::optional<abstract_sim_if_t*> external_simulator;
 
   size_t nprocs() const { return hartids.size(); }
   size_t max_hartid() const { return hartids.back(); }

--- a/riscv/devices.cc
+++ b/riscv/devices.cc
@@ -155,3 +155,25 @@ void mem_t::dump(std::ostream& o) {
     }
   }
 }
+
+external_sim_device_t::external_sim_device_t(void* sim) 
+  : external_simulator(sim) {}
+
+void external_sim_device_t::set_simulator(void* sim) {
+  external_simulator = sim;
+}
+
+bool external_sim_device_t::load(reg_t addr, size_t len, uint8_t* bytes) {
+  if (unlikely(external_simulator == nullptr)) return false;
+  return static_cast<abstract_sim_if_t*>(external_simulator)->do_load(addr, len, bytes);
+}
+
+bool external_sim_device_t::store(reg_t addr, size_t len, const uint8_t* bytes) {
+  if (unlikely(external_simulator == nullptr)) return false;
+  return static_cast<abstract_sim_if_t*>(external_simulator)->do_store(addr, len, bytes);
+}
+
+reg_t external_sim_device_t::size() {
+  if (unlikely(external_simulator == nullptr)) return 0;
+  return PGSIZE; // TODO: proper size
+}

--- a/riscv/devices.cc
+++ b/riscv/devices.cc
@@ -165,12 +165,12 @@ void external_sim_device_t::set_simulator(void* sim) {
 
 bool external_sim_device_t::load(reg_t addr, size_t len, uint8_t* bytes) {
   if (unlikely(external_simulator == nullptr)) return false;
-  return static_cast<abstract_sim_if_t*>(external_simulator)->do_load(addr, len, bytes);
+  return static_cast<abstract_sim_if_t*>(external_simulator)->load(addr, len, bytes);
 }
 
 bool external_sim_device_t::store(reg_t addr, size_t len, const uint8_t* bytes) {
   if (unlikely(external_simulator == nullptr)) return false;
-  return static_cast<abstract_sim_if_t*>(external_simulator)->do_store(addr, len, bytes);
+  return static_cast<abstract_sim_if_t*>(external_simulator)->store(addr, len, bytes);
 }
 
 reg_t external_sim_device_t::size() {

--- a/riscv/devices.h
+++ b/riscv/devices.h
@@ -71,6 +71,13 @@ class mem_t : public abstract_mem_t {
   reg_t sz;
 };
 
+class abstract_sim_if_t {
+public:
+  virtual ~abstract_sim_if_t() = default;
+  virtual bool do_load(reg_t addr, size_t len, uint8_t* bytes) = 0;
+  virtual bool do_store(reg_t addr, size_t len, const uint8_t* bytes) = 0;
+};
+
 class clint_t : public abstract_device_t {
  public:
   clint_t(const simif_t*, uint64_t freq_hz, bool real_time);

--- a/riscv/devices.h
+++ b/riscv/devices.h
@@ -74,8 +74,8 @@ class mem_t : public abstract_mem_t {
 class abstract_sim_if_t {
 public:
   virtual ~abstract_sim_if_t() = default;
-  virtual bool do_load(reg_t addr, size_t len, uint8_t* bytes) = 0;
-  virtual bool do_store(reg_t addr, size_t len, const uint8_t* bytes) = 0;
+  virtual bool load(reg_t addr, size_t len, uint8_t* bytes) = 0;
+  virtual bool store(reg_t addr, size_t len, const uint8_t* bytes) = 0;
 };
 
 class external_sim_device_t : public abstract_device_t {

--- a/riscv/devices.h
+++ b/riscv/devices.h
@@ -78,6 +78,18 @@ public:
   virtual bool do_store(reg_t addr, size_t len, const uint8_t* bytes) = 0;
 };
 
+class external_sim_device_t : public abstract_device_t {
+public:
+  external_sim_device_t(void* sim);
+  void set_simulator(void* sim);
+  bool load(reg_t addr, size_t len, uint8_t* bytes) override;
+  bool store(reg_t addr, size_t len, const uint8_t* bytes) override;
+  reg_t size() override;
+
+private:
+  void* external_simulator;
+};
+
 class clint_t : public abstract_device_t {
  public:
   clint_t(const simif_t*, uint64_t freq_hz, bool real_time);


### PR DESCRIPTION
This PR should introduce API to enable some external simulator connect to Spike.

Steps:
1. External simulator (e.g. wrapper of a simulator, or a bridge) has be derived from `abstract_sim_if_t` class and has to implement abstract functions `do_load` and `do_store`.
2. `cfg_t` is now extended with `std::optional<abstract_sim_if_t*> external_simulator` field. This field should be filled with pointer to simulator object from Step 1. 
3. `external_sim_device_t` should be constructed with pointer from step 2, and create `bus_t` with `fallback` parameter of `external_sim_device_t`. 

For all addresses which are not in Spike address space, bus will issue `load/store` requests to `fallback` branch, i.e. `external simulator`
