### PR TITLE
mmu: fix pointer masking with mstatus.MXR in M-mode

### DIFF
--- a/riscv/mmu.cc
+++ b/riscv/mmu.cc
@@ -618,12 +618,14 @@ void mmu_t::register_memtracer(memtracer_t* t)
 }
 
 reg_t mmu_t::get_pmlen(bool effective_virt, reg_t effective_priv, xlate_flags_t flags) const {
-  if (!proc || proc->get_xlen() != 64 || ((proc->state.sstatus->readvirt(false) | proc->state.sstatus->readvirt(effective_virt)) & MSTATUS_MXR) || flags.hlvx)
+  if (!proc || proc->get_xlen() != 64 || flags.hlvx)
     return 0;
 
   reg_t pmm = 0;
   if (effective_priv == PRV_M)
     pmm = get_field(proc->state.mseccfg->read(), MSECCFG_PMM);
+  else if ((proc->state.sstatus->readvirt(false) | proc->state.sstatus->readvirt(effective_virt)) & MSTATUS_MXR)
+    pmm = 0;
   else if (!effective_virt && (effective_priv == PRV_S || (!proc->extension_enabled('S') && effective_priv == PRV_U)))
     pmm = get_field(proc->state.menvcfg->read(), MENVCFG_PMM);
   else if (effective_virt && effective_priv == PRV_S)


### PR DESCRIPTION
Pointer masking is disabled if sstatus.MXR is in effect, but M-mode doesn't use paging and hence sstatus.MXR should not be in effect for effective M-mode loads.

Do not consider mstatus.MXR when deciding the pointer mask length for effective M-mode loads.

vsstatus.MXR wasn't an issue as no effective M-mode load could happen with V=1, but move it below M-mode as well to simplify the conditions.

Fixes: 71bdc3bbd13a ("pointer masking: Pointer masking does not apply when MXR=1 regardless of MPRV in v1.0.0-rc2")