### PR TITLE
Fix double checking for EXT_SMCSRIND in isa_parser.cc

### DIFF
--- a/disasm/isa_parser.cc
+++ b/disasm/isa_parser.cc
@@ -324,8 +324,6 @@ isa_parser_t::isa_parser_t(const char* str, const char *priv)
         extension_table[EXT_SSTC] = true;
     } else if (ext_str == "smcsrind") {
       extension_table[EXT_SMCSRIND] = true;
-    } else if (ext_str == "sscsrind") {
-      extension_table[EXT_SSCSRIND] = true;
     } else if (ext_str == "smcntrpmf") {
       extension_table[EXT_SMCNTRPMF] = true;
     } else if (ext_str == "zimop") {


### PR DESCRIPTION
Signed-off-by: muhammad.moiz.hussain@semidynamics.com