### PR TITLE
Avoid appending chars to result `strtolower`

### DIFF
--- a/disasm/isa_parser.cc
+++ b/disasm/isa_parser.cc
@@ -1,11 +1,12 @@
 #include "isa_parser.h"
+#include <cstring>
 #include <stdexcept>
 
 static std::string strtolower(const char* str)
 {
-  std::string res;
-  for (const char *r = str; *r; r++)
-    res += std::tolower(*r);
+  std::string res(str);
+  for (char &c : res)
+    c = std::tolower(c);
   return res;
 }
 

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -15,6 +15,7 @@
 #include <cinttypes>
 #include <cmath>
 #include <cstdlib>
+#include <cstring>
 #include <iostream>
 #include <iomanip>
 #include <assert.h>
@@ -120,9 +121,9 @@ static bool check_pow2(int val)
 
 static std::string strtolower(const char* str)
 {
-  std::string res;
-  for (const char *r = str; *r; r++)
-    res += std::tolower(*r);
+  std::string res(str);
+  for (char &c : res)
+    c = std::tolower(c);
   return res;
 }
 


### PR DESCRIPTION
Avoids reallocations.

BTW, the function is not used in the processor.cc file (along with other static util functions). Should we remove them as they are unused?