### PR TITLE
Make compilation with -Wextra -Wall -Werror work

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -93,7 +93,7 @@ VPATH := $(addprefix $(src_dir)/, $(sprojs_enabled))
 # These all appear on the command line, from lowest precedence to
 # highest.
 
-default-CFLAGS   := -DPREFIX=\"$(prefix)\" -Wall -Wno-unused -Wno-nonportable-include-path -g -O2 -fPIC
+default-CFLAGS   := -DPREFIX=\"$(prefix)\" -Wall -Wno-nonportable-include-path -g -O2 -fPIC
 default-CXXFLAGS := $(default-CFLAGS) -std=c++2a
 
 mcppbs-CPPFLAGS := @CPPFLAGS@

--- a/ci-tests/build-spike
+++ b/ci-tests/build-spike
@@ -8,7 +8,7 @@ rm -rf build
 mkdir build
 cd build
 mkdir install
-CXXFLAGS="-Wnon-virtual-dtor" CFLAGS="-Werror -Wignored-qualifiers -Wunused-function -Wunused-parameter -Wunused-variable" $DIR/../configure --prefix=`pwd`/install
+CXXFLAGS="-Wnon-virtual-dtor" CFLAGS="-Werror -Wall -Wextra -Wvla" $DIR/../configure --prefix=`pwd`/install
 make -j"$(nproc 2> /dev/null || sysctl -n hw.ncpu)"
 make check
 make install install-hdrs-list.h

--- a/customext/cflush.cc
+++ b/customext/cflush.cc
@@ -24,18 +24,18 @@ class cflush_t : public extension_t
   cflush_t() {}
 
   std::vector<insn_desc_t> get_instructions(const processor_t &) override {
-    std::vector<insn_desc_t> insns;
-    insns.push_back((insn_desc_t){0xFC000073, 0xFFF07FFF, custom_cflush, custom_cflush, custom_cflush, custom_cflush, custom_cflush, custom_cflush, custom_cflush, custom_cflush});
-    insns.push_back((insn_desc_t){0xFC200073, 0xFFF07FFF, custom_cflush, custom_cflush, custom_cflush, custom_cflush, custom_cflush, custom_cflush, custom_cflush, custom_cflush});
-    insns.push_back((insn_desc_t){0xFC100073, 0xFFF07FFF, custom_cflush, custom_cflush, custom_cflush, custom_cflush, custom_cflush, custom_cflush, custom_cflush, custom_cflush});
+    std::vector<insn_desc_t> insns = {
+      {0xFC000073, 0xFFF07FFF, custom_cflush, custom_cflush, custom_cflush, custom_cflush, custom_cflush, custom_cflush, custom_cflush, custom_cflush},
+      {0xFC200073, 0xFFF07FFF, custom_cflush, custom_cflush, custom_cflush, custom_cflush, custom_cflush, custom_cflush, custom_cflush, custom_cflush},
+      {0xFC100073, 0xFFF07FFF, custom_cflush, custom_cflush, custom_cflush, custom_cflush, custom_cflush, custom_cflush, custom_cflush, custom_cflush}};
     return insns;
   }
 
   std::vector<disasm_insn_t *> get_disasms(const processor_t *) override {
-    std::vector<disasm_insn_t*> insns;
-    insns.push_back(new disasm_insn_t("cflush.d.l1", 0xFC000073, 0xFFF07FFF, {&xrs1}));
-    insns.push_back(new disasm_insn_t("cdiscard.d.l1", 0xFC200073, 0xFFF07FFF, {&xrs1}));
-    insns.push_back(new disasm_insn_t("cflush.i.l1", 0xFC100073, 0xFFF07FFF, {&xrs1}));
+    std::vector<disasm_insn_t*> insns = {
+      new disasm_insn_t("cflush.d.l1", 0xFC000073, 0xFFF07FFF, {&xrs1}),
+      new disasm_insn_t("cdiscard.d.l1", 0xFC200073, 0xFFF07FFF, {&xrs1}),
+      new disasm_insn_t("cflush.i.l1", 0xFC100073, 0xFFF07FFF, {&xrs1})};
     return insns;
   }
 };

--- a/customext/cflush.cc
+++ b/customext/cflush.cc
@@ -19,7 +19,7 @@ static reg_t custom_cflush(processor_t* p, insn_t insn, reg_t pc)
 class cflush_t : public extension_t
 {
  public:
-  const char* name() const { return "cflush"; }
+  const char* name() const override { return "cflush"; }
 
   cflush_t() {}
 

--- a/disasm/disasm.cc
+++ b/disasm/disasm.cc
@@ -706,26 +706,6 @@ static void NOINLINE add_sfence_insn(disassembler_t* d, const char* name, uint32
   d->add_insn(new disasm_insn_t(name, match, mask, {&xrs1, &xrs2}));
 }
 
-static void NOINLINE add_pitype3_insn(disassembler_t* d, const char* name, uint32_t match, uint32_t mask)
-{
-  d->add_insn(new disasm_insn_t(name, match, mask, {&xrd, &xrs1, &p_imm3}));
-}
-
-static void NOINLINE add_pitype4_insn(disassembler_t* d, const char* name, uint32_t match, uint32_t mask)
-{
-  d->add_insn(new disasm_insn_t(name, match, mask, {&xrd, &xrs1, &p_imm4}));
-}
-
-static void NOINLINE add_pitype5_insn(disassembler_t* d, const char* name, uint32_t match, uint32_t mask)
-{
-  d->add_insn(new disasm_insn_t(name, match, mask, {&xrd, &xrs1, &p_imm5}));
-}
-
-static void NOINLINE add_pitype6_insn(disassembler_t* d, const char* name, uint32_t match, uint32_t mask)
-{
-  d->add_insn(new disasm_insn_t(name, match, mask, {&xrd, &xrs1, &p_imm6}));
-}
-
 static void NOINLINE add_vector_v_insn(disassembler_t* d, const char* name, uint32_t match, uint32_t mask)
 {
   d->add_insn(new disasm_insn_t(name, match, mask, {&vd, &vs2, opt, &vm}));

--- a/disasm/isa_parser.cc
+++ b/disasm/isa_parser.cc
@@ -70,7 +70,7 @@ isa_parser_t::isa_parser_t(const char* str, const char *priv)
       // G = IMAFD_Zicsr_Zifencei, but Spike includes the latter two
       // unconditionally, so they need not be explicitly added here.
       isa_string = isa_string.substr(0, 4) + "imafd" + isa_string.substr(5);
-      // Fall through
+      [[fallthrough]];
     case 'i':
       extension_table['I'] = true;
       break;
@@ -98,9 +98,9 @@ isa_parser_t::isa_parser_t(const char* str, const char *priv)
 
     switch (*p) {
       case 'v': vlen = 128; elen = 64; zvf = true; zvd = true;
-                // even rv32iv implies double float
+                [[fallthrough]];
       case 'q': extension_table['D'] = true;
-                // Fall through
+                [[fallthrough]];
       case 'd': extension_table['F'] = true;
     }
     extension_table[toupper(*p)] = true;

--- a/fdt/fdt.mk.in
+++ b/fdt/fdt.mk.in
@@ -16,4 +16,4 @@ fdt_c_srcs = \
 	fdt_addresses.c \
 	fdt_overlay.c \
 
-fdt_CFLAGS = -I$(src_dir)/fdt
+fdt_CFLAGS = -I$(src_dir)/fdt -Wno-sign-compare

--- a/fesvr/byteorder.h
+++ b/fesvr/byteorder.h
@@ -16,8 +16,8 @@ static inline int32_t swap(int32_t n) { return int32_t(swap(uint32_t(n))); }
 static inline int64_t swap(int64_t n) { return int64_t(swap(uint64_t(n))); }
 
 #ifdef HAVE_INT128
-typedef __int128 int128_t;
-typedef unsigned __int128 uint128_t;
+__extension__ typedef __int128 int128_t;
+__extension__ typedef unsigned __int128 uint128_t;
 static inline uint128_t swap(uint128_t n) { return (uint128_t(swap(uint64_t(n))) << 64) | swap(uint64_t(n >> 64)); }
 static inline int128_t swap(int128_t n) { return int128_t(swap(uint128_t(n))); }
 #endif

--- a/fesvr/dtm.cc
+++ b/fesvr/dtm.cc
@@ -477,8 +477,8 @@ uint32_t dtm_t::get_xlen()
   uint32_t command = AC_ACCESS_REGISTER_TRANSFER | AC_AR_REGNO(S0);
   uint32_t cmderr;
   
-  const uint32_t prog[] = {};
-  uint32_t data[] = {};
+  const uint32_t prog[1] = {};
+  uint32_t data[1] = {};
 
   cmderr = run_abstract_command(command | AC_AR_SIZE(128), prog, 0, data, 0);
   if (cmderr == 0){

--- a/fesvr/dtm.cc
+++ b/fesvr/dtm.cc
@@ -107,7 +107,7 @@ void dtm_t::halt(int hartsel)
     read(DM_DMSTATUS);
   }
 
-  int dmcontrol = DM_DMCONTROL_HALTREQ | DM_DMCONTROL_DMACTIVE;
+  reg_t dmcontrol = DM_DMCONTROL_HALTREQ | DM_DMCONTROL_DMACTIVE;
   dmcontrol = set_field(dmcontrol, DM_DMCONTROL_HASEL, hartsel);
   write(DM_DMCONTROL, dmcontrol);
   int dmstatus;

--- a/fesvr/dtm.cc
+++ b/fesvr/dtm.cc
@@ -51,6 +51,9 @@
     }                                                           \
   }
 
+#define MAX_DATA_WORDS (1 << DM_ABSTRACTCS_DATACOUNT_LENGTH)
+#define MAX_PROG_WORDS (1 << DM_ABSTRACTCS_PROGBUFSIZE_LENGTH)
+
 uint32_t dtm_t::do_command(dtm_t::req r)
 {
   req_buf = r;
@@ -145,7 +148,7 @@ void dtm_t::resume(int hartsel)
 
 uint64_t dtm_t::save_reg(unsigned regno)
 {
-  uint32_t data[xlen/(8*4)];
+  uint32_t data[MAX_DATA_WORDS];
   uint32_t command = AC_ACCESS_REGISTER_TRANSFER | AC_AR_SIZE(xlen) | AC_AR_REGNO(regno);
   RUN_AC_OR_DIE(command, 0, 0, data, xlen / (8*4));
 
@@ -158,7 +161,7 @@ uint64_t dtm_t::save_reg(unsigned regno)
 
 void dtm_t::restore_reg(unsigned regno, uint64_t val)
 {
-  uint32_t data[xlen/(8*4)];
+  uint32_t data[MAX_DATA_WORDS];
   data[0] = (uint32_t) val;
   if (xlen > 32) {
     data[1] = (uint32_t) (val >> 32);
@@ -177,8 +180,8 @@ uint32_t dtm_t::run_abstract_command(uint32_t command,
                                      const uint32_t program[], size_t program_n,
                                      uint32_t data[], size_t data_n)
 { 
-  assert(program_n <= ram_words);
-  assert(data_n    <= data_words);
+  assert(program_n <= MAX_PROG_WORDS);
+  assert(data_n    <= MAX_DATA_WORDS);
   
   for (size_t i = 0; i < program_n; i++) {
     write(DM_PROGBUF0 + i, program[i]);
@@ -217,8 +220,8 @@ size_t dtm_t::chunk_align()
 
 void dtm_t::read_chunk(uint64_t taddr, size_t len, void* dst)
 {
-  uint32_t prog[ram_words];
-  uint32_t data[data_words];
+  uint32_t prog[MAX_PROG_WORDS];
+  uint32_t data[MAX_DATA_WORDS];
 
   uint8_t * curr = (uint8_t*) dst;
 
@@ -270,8 +273,8 @@ void dtm_t::read_chunk(uint64_t taddr, size_t len, void* dst)
 
 void dtm_t::write_chunk(uint64_t taddr, size_t len, const void* src)
 {  
-  uint32_t prog[ram_words];
-  uint32_t data[data_words];
+  uint32_t prog[MAX_PROG_WORDS];
+  uint32_t data[MAX_DATA_WORDS];
 
   const uint8_t * curr = (const uint8_t*) src;
 
@@ -365,8 +368,8 @@ void dtm_t::die(uint32_t cmderr)
 
 void dtm_t::clear_chunk(uint64_t taddr, size_t len)
 {
-  uint32_t prog[ram_words];
-  uint32_t data[data_words];
+  uint32_t prog[MAX_PROG_WORDS];
+  uint32_t data[MAX_DATA_WORDS];
   
   halt(current_hart);
   uint64_t s0 = save_reg(S0);
@@ -563,11 +566,6 @@ void dtm_t::producer_thread()
   // Poll until the debugger agrees it's enabled.
   while ((read(DM_DMCONTROL) & DM_DMCONTROL_DMACTIVE) == 0) ;
     
-  // These are checked every time we run an abstract command.
-  uint32_t abstractcs = read(DM_ABSTRACTCS);
-  ram_words = get_field(abstractcs, DM_ABSTRACTCS_PROGBUFSIZE);
-  data_words = get_field(abstractcs, DM_ABSTRACTCS_DATACOUNT);
-
   // These things are only needed for the 'modify_csr' function.
   // That could be re-written to not use these at some performance
   // overhead.

--- a/fesvr/dtm.cc
+++ b/fesvr/dtm.cc
@@ -61,17 +61,20 @@ uint32_t dtm_t::do_command(dtm_t::req r)
 
 uint32_t dtm_t::read(uint32_t addr)
 {
-  return do_command((req){addr, 1, 0});
+  req r = {addr, 1, 0};
+  return do_command(r);
 }
 
 uint32_t dtm_t::write(uint32_t addr, uint32_t data)
 {
-  return do_command((req){addr, 2, data});
+  req r = {addr, 2, data};
+  return do_command(r);
 }
 
 void dtm_t::nop()
 {
-  do_command((req){0, 0, 0});
+  req r = {0, 0, 0};
+  do_command(r);
 }
 
 void dtm_t::select_hart(int hartsel) {

--- a/fesvr/dtm.h
+++ b/fesvr/dtm.h
@@ -109,8 +109,6 @@ class dtm_t : public htif_t
 
   static const int max_idle_cycles = 10000;
 
-  size_t ram_words;
-  size_t data_words;
   int num_harts;
   int current_hart;
   

--- a/fesvr/htif.cc
+++ b/fesvr/htif.cc
@@ -158,11 +158,9 @@ void htif_t::load_symbols(std::map<std::string, uint64_t>& symbols)
 {
   class nop_memif_t : public memif_t {
    public:
-    nop_memif_t(htif_t* htif) : memif_t(htif), htif(htif) {}
+    nop_memif_t(htif_t* htif) : memif_t(htif) {}
     void read(addr_t UNUSED addr, size_t UNUSED len, void UNUSED *bytes) override {}
     void write(addr_t UNUSED taddr, size_t UNUSED len, const void UNUSED *src) override {}
-   private:
-    htif_t* htif;
   } nop_memif(this);
 
   reg_t nop_entry;

--- a/fesvr/htif.cc
+++ b/fesvr/htif.cc
@@ -65,14 +65,14 @@ htif_t::htif_t(int argc, char** argv) : htif_t()
 htif_t::htif_t(const std::vector<std::string>& args) : htif_t()
 {
   int argc = args.size() + 1;
-  char * argv[argc];
+  std::vector<char*>argv(argc);
   argv[0] = (char *) "htif";
   for (unsigned int i = 0; i < args.size(); i++) {
     argv[i+1] = (char *) args[i].c_str();
   }
   //Set line size as 16 by default.
   line_size = 16;
-  parse_arguments(argc, argv);
+  parse_arguments(argc, &argv[0]);
   register_devices();
 }
 
@@ -253,11 +253,10 @@ void htif_t::stop()
 
 void htif_t::clear_chunk(addr_t taddr, size_t len)
 {
-  char zeros[chunk_max_size()];
-  memset(zeros, 0, chunk_max_size());
+  std::vector<uint8_t> zeros(chunk_max_size(), 0);
 
   for (size_t pos = 0; pos < len; pos += chunk_max_size())
-    write_chunk(taddr + pos, std::min(len - pos, chunk_max_size()), zeros);
+    write_chunk(taddr + pos, std::min(len - pos, chunk_max_size()), &zeros[0]);
 }
 
 int htif_t::run()

--- a/fesvr/memif.cc
+++ b/fesvr/memif.cc
@@ -12,10 +12,10 @@ void memif_t::read(addr_t addr, size_t len, void* bytes)
   if (len && (addr & (align-1)))
   {
     size_t this_len = std::min(len, align - size_t(addr & (align-1)));
-    uint8_t chunk[align];
+    std::vector<uint8_t> chunk(align);
 
-    cmemif->read_chunk(addr & ~(align-1), align, chunk);
-    memcpy(bytes, chunk + (addr & (align-1)), this_len);
+    cmemif->read_chunk(addr & ~(align-1), align, &chunk[0]);
+    memcpy(bytes, &chunk[addr & (align-1)], this_len);
 
     bytes = (char*)bytes + this_len;
     addr += this_len;
@@ -26,10 +26,10 @@ void memif_t::read(addr_t addr, size_t len, void* bytes)
   {
     size_t this_len = len & (align-1);
     size_t start = len - this_len;
-    uint8_t chunk[align];
+    std::vector<uint8_t> chunk(align);
 
-    cmemif->read_chunk(addr + start, align, chunk);
-    memcpy((char*)bytes + start, chunk, this_len);
+    cmemif->read_chunk(addr + start, align, &chunk[0]);
+    memcpy((char*)bytes + start, &chunk[0], this_len);
 
     len -= this_len;
   }
@@ -45,11 +45,11 @@ void memif_t::write(addr_t addr, size_t len, const void* bytes)
   if (len && (addr & (align-1)))
   {
     size_t this_len = std::min(len, align - size_t(addr & (align-1)));
-    uint8_t chunk[align];
+    std::vector<uint8_t> chunk(align);
 
-    cmemif->read_chunk(addr & ~(align-1), align, chunk);
-    memcpy(chunk + (addr & (align-1)), bytes, this_len);
-    cmemif->write_chunk(addr & ~(align-1), align, chunk);
+    cmemif->read_chunk(addr & ~(align-1), align, &chunk[0]);
+    memcpy(&chunk[addr & (align-1)], bytes, this_len);
+    cmemif->write_chunk(addr & ~(align-1), align, &chunk[0]);
 
     bytes = (char*)bytes + this_len;
     addr += this_len;
@@ -60,11 +60,11 @@ void memif_t::write(addr_t addr, size_t len, const void* bytes)
   {
     size_t this_len = len & (align-1);
     size_t start = len - this_len;
-    uint8_t chunk[align];
+    std::vector<uint8_t> chunk(align);
 
-    cmemif->read_chunk(addr + start, align, chunk);
-    memcpy(chunk, (char*)bytes + start, this_len);
-    cmemif->write_chunk(addr + start, align, chunk);
+    cmemif->read_chunk(addr + start, align, &chunk[0]);
+    memcpy(&chunk[0], (char*)bytes + start, this_len);
+    cmemif->write_chunk(addr + start, align, &chunk[0]);
 
     len -= this_len;
   }

--- a/fesvr/syscall.cc
+++ b/fesvr/syscall.cc
@@ -114,19 +114,23 @@ struct riscv_statx
       attributes_mask(htif->to_target<uint64_t>(s.stx_attributes_mask)),
       atime {
         htif->to_target<int64_t>(s.stx_atime.tv_sec),
-        htif->to_target<uint32_t>(s.stx_atime.tv_nsec)
+        htif->to_target<uint32_t>(s.stx_atime.tv_nsec),
+        htif->to_target<int32_t>(0)
       },
       btime {
         htif->to_target<int64_t>(s.stx_btime.tv_sec),
-        htif->to_target<uint32_t>(s.stx_btime.tv_nsec)
+        htif->to_target<uint32_t>(s.stx_btime.tv_nsec),
+        htif->to_target<int32_t>(0)
       },
       ctime {
         htif->to_target<int64_t>(s.stx_ctime.tv_sec),
-        htif->to_target<uint32_t>(s.stx_ctime.tv_nsec)
+        htif->to_target<uint32_t>(s.stx_ctime.tv_nsec),
+        htif->to_target<int32_t>(0)
       },
       mtime {
         htif->to_target<int64_t>(s.stx_mtime.tv_sec),
-        htif->to_target<uint32_t>(s.stx_mtime.tv_nsec)
+        htif->to_target<uint32_t>(s.stx_mtime.tv_nsec),
+        htif->to_target<int32_t>(0)
       },
       rdev_major(htif->to_target<uint32_t>(s.stx_rdev_major)),
       rdev_minor(htif->to_target<uint32_t>(s.stx_rdev_minor)),

--- a/riscv/clint.cc
+++ b/riscv/clint.cc
@@ -119,7 +119,7 @@ void clint_t::tick(reg_t rtc_ticks)
 }
 
 clint_t* clint_parse_from_fdt(const void* fdt, const sim_t* sim, reg_t* base,
-    const std::vector<std::string>& UNUSED sargs) {
+    const std::vector<std::string>& sargs UNUSED) {
   if (fdt_parse_clint(fdt, base, "riscv,clint0") == 0 || fdt_parse_clint(fdt, base, "sifive,clint0") == 0)
     return new clint_t(sim,
                        sim->CPU_HZ / sim->INSNS_PER_RTC_TICK,
@@ -128,7 +128,7 @@ clint_t* clint_parse_from_fdt(const void* fdt, const sim_t* sim, reg_t* base,
     return nullptr;
 }
 
-std::string clint_generate_dts(const sim_t* sim, const std::vector<std::string>& UNUSED sargs) {
+std::string clint_generate_dts(const sim_t* sim, const std::vector<std::string>& sargs UNUSED) {
   std::stringstream s;
   s << std::hex
     << "    clint@" << CLINT_BASE << " {\n"

--- a/riscv/clint.cc
+++ b/riscv/clint.cc
@@ -39,7 +39,8 @@ bool clint_t::load(reg_t addr, size_t len, uint8_t* bytes)
 
   tick(0);
 
-  if (addr >= MSIP_BASE && addr < MTIMECMP_BASE) {
+  static_assert(MSIP_BASE == 0);
+  if (/* addr >= MSIP_BASE && */ addr < MTIMECMP_BASE) {
     if (len == 8) {
       // Implement double-word loads as a pair of word loads
       return load(addr, 4, bytes) && load(addr + 4, 4, bytes + 4);
@@ -68,7 +69,8 @@ bool clint_t::store(reg_t addr, size_t len, const uint8_t* bytes)
   if (len > 8)
     return false;
 
-  if (addr >= MSIP_BASE && addr < MTIMECMP_BASE) {
+  static_assert(MSIP_BASE == 0);
+  if (/* addr >= MSIP_BASE && */ addr < MTIMECMP_BASE) {
     if (len == 8) {
       // Implement double-word stores as a pair of word stores
       return store(addr, 4, bytes) && store(addr + 4, 4, bytes + 4);

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -1811,7 +1811,7 @@ srmcfg_csr_t::srmcfg_csr_t(processor_t* const proc, const reg_t addr, const reg_
   masked_csr_t(proc, addr, mask, init) {
 }
 
-void srmcfg_csr_t::verify_permissions(insn_t insn, bool write) const {
+void srmcfg_csr_t::verify_permissions(insn_t insn, bool write UNUSED) const {
   if (!proc->extension_enabled(EXT_SSQOSID))
     throw trap_illegal_instruction(insn.bits());
 

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -1231,7 +1231,7 @@ hideleg_csr_t::hideleg_csr_t(processor_t* const proc, const reg_t addr, csr_t_p 
 
 reg_t hideleg_csr_t::read() const noexcept {
   return masked_csr_t::read() & mideleg->read();
-};
+}
 
 hgatp_csr_t::hgatp_csr_t(processor_t* const proc, const reg_t addr):
   basic_csr_t(proc, addr, 0) {

--- a/riscv/debug_module.cc
+++ b/riscv/debug_module.cc
@@ -450,7 +450,6 @@ bool debug_module_t::dmi_read(unsigned address, uint32_t *value)
               } else {
                 dmstatus.allresumeack = false;
               }
-              auto hart = sim->get_harts().at(hart_id);
               if (!hart_available(hart_id)) {
                 dmstatus.allrunning = false;
                 dmstatus.allhalted = false;

--- a/riscv/debug_module.cc
+++ b/riscv/debug_module.cc
@@ -13,7 +13,7 @@
 #if 0
 #  define D(x) x
 #else
-#  define D(x)
+#  define D(x) (void) 0
 #endif
 
 // Return the number of bits wide that a field has to be to encode up to n

--- a/riscv/decode.h
+++ b/riscv/decode.h
@@ -170,23 +170,29 @@ public:
     switch (rvc_rlist()) {
     case 15:
       stack_adj_base += 16;
+      [[fallthrough]];
     case 14:
       if (xlen == 64)
         stack_adj_base += 16;
+      [[fallthrough]];
     case 13:
     case 12:
       stack_adj_base += 16;
+      [[fallthrough]];
     case 11:
     case 10:
       if (xlen == 64)
         stack_adj_base += 16;
+      [[fallthrough]];
     case 9:
     case 8:
       stack_adj_base += 16;
+      [[fallthrough]];
     case 7:
     case 6:
       if (xlen == 64)
         stack_adj_base += 16;
+      [[fallthrough]];
     case 5:
     case 4:
       stack_adj_base += 16;

--- a/riscv/decode_macros.h
+++ b/riscv/decode_macros.h
@@ -337,10 +337,10 @@ inline long double to_f(float128_t f) { long double r; memcpy(&r, &f, sizeof(r))
 #define DEBUG_RVV_FMA_VF \
   printf("vfma(%lu) vd=%f vs1=%f vs2=%f vd_old=%f\n", i, to_f(vd), to_f(rs1), to_f(vs2), to_f(vd_old));
 #else
-#define DEBUG_RVV_FP_VV 0
-#define DEBUG_RVV_FP_VF 0
-#define DEBUG_RVV_FMA_VV 0
-#define DEBUG_RVV_FMA_VF 0
+#define DEBUG_RVV_FP_VV (void) 0
+#define DEBUG_RVV_FP_VF (void) 0
+#define DEBUG_RVV_FMA_VV (void) 0
+#define DEBUG_RVV_FMA_VF (void) 0
 #endif
 
 #define DECLARE_XENVCFG_VARS(field) \

--- a/riscv/dts.cc
+++ b/riscv/dts.cc
@@ -424,7 +424,6 @@ int fdt_parse_isa(const void *fdt, int cpu_offset, const char **isa)
 int fdt_parse_hartid(const void *fdt, int cpu_offset, uint32_t *hartid)
 {
   int len, rc;
-  const void *prop;
   const fdt32_t *val;
 
   if ((rc = check_cpu_node(fdt, cpu_offset)) < 0)

--- a/riscv/execute.cc
+++ b/riscv/execute.cc
@@ -45,7 +45,7 @@ static void commit_log_print_value(FILE *log_file, int width, const void *data)
 
         fprintf(log_file, "0x");
         for (int idx = width / 8 - 1; idx >= 0; --idx) {
-          fprintf(log_file, "%002" PRIx8, arr[idx]);
+          fprintf(log_file, "%02" PRIx8, arr[idx]);
         }
       } else {
         abort();

--- a/riscv/interactive.cc
+++ b/riscv/interactive.cc
@@ -229,7 +229,6 @@ static std::string readline(int fd)
         }
         return s.substr(initial_s_len);
       default:
-      DEFAULT_KEY:
         // unknown buffered key, do nothing
         if (key_buffer != 0) {
           key_buffer = 0;

--- a/riscv/interactive.cc
+++ b/riscv/interactive.cc
@@ -83,8 +83,7 @@ static void clear_str(bool noncanonical, int fd, std::string target_str)
       clear_motion += ' ';
     }
     clear_motion += '\r';
-    if (write(fd, clear_motion.c_str(), clear_motion.size() + 1))
-      ; // shut up gcc
+    (void) write(fd, clear_motion.c_str(), clear_motion.size() + 1);
   }
 }
 
@@ -97,8 +96,7 @@ static void send_key(bool noncanonical, int fd, keybuffer_t key_code, const int 
     {
       key_motion += (char) ((key_code >> (i * BITS_PER_CHAR)) & 0xff);
     }
-    if (write(fd, key_motion.c_str(), len) != len)
-      ; // shut up gcc
+    (void) write(fd, key_motion.c_str(), len);
   }
 }
 
@@ -145,8 +143,8 @@ static std::string readline(int fd)
         clear_str(noncanonical, fd, s);
         cursor_pos--;
         s.erase(cursor_pos, 1);
-        if (noncanonical && write(fd, s.c_str(), s.size() + 1) != 1)
-          ; // shut up gcc
+        if (noncanonical)
+          (void) write(fd, s.c_str(), s.size() + 1);
         // move cursor by left arrow key
         for (unsigned i = 0; i < s.size() - cursor_pos; i++) {
           send_key(noncanonical, fd, KEYCODE_LEFT, 3);
@@ -177,8 +175,8 @@ static std::string readline(int fd)
           clear_str(noncanonical, fd, s);
           history_index = std::min(history_commands.size(), history_index + 1);
           s = history_commands[history_commands.size() - history_index];
-          if (noncanonical && write(fd, s.c_str(), s.size() + 1))
-            ; // shut up gcc
+          if (noncanonical)
+            (void) write(fd, s.c_str(), s.size() + 1);
           cursor_pos = s.size();
         }
         key_buffer = 0;
@@ -193,8 +191,8 @@ static std::string readline(int fd)
           } else {
             s = history_commands[history_commands.size() - history_index];
           }
-          if (noncanonical && write(fd, s.c_str(), s.size() + 1))
-            ; // shut up gcc
+          if (noncanonical)
+            (void) write(fd, s.c_str(), s.size() + 1);
           cursor_pos = s.size();
         }
         key_buffer = 0;
@@ -222,8 +220,8 @@ static std::string readline(int fd)
         key_buffer = 0;
         break;
       case KEYCODE_ENTER:
-        if (noncanonical && write(fd, &ch, 1) != 1)
-          ; // shut up gcc
+        if (noncanonical)
+          (void) write(fd, &ch, 1);
         if (s.size() > initial_s_len && (history_commands.size() == 0 || s != history_commands[history_commands.size() - 1])) {
           history_commands.push_back(s);
         }
@@ -237,8 +235,8 @@ static std::string readline(int fd)
         clear_str(noncanonical, fd, s);
         s.insert(cursor_pos, 1, ch);
         cursor_pos++;
-        if (noncanonical && write(fd, s.c_str(), s.size() + 1) != 1)
-          ; // shut up gcc
+        if (noncanonical)
+          (void) write(fd, s.c_str(), s.size() + 1);
         // send left arrow key to move cursor
         for (unsigned i = 0; i < s.size() - cursor_pos; i++) {
           send_key(noncanonical, fd, KEYCODE_LEFT, 3);

--- a/riscv/mmu.cc
+++ b/riscv/mmu.cc
@@ -123,7 +123,8 @@ reg_t reg_from_bytes(size_t len, const uint8_t* bytes)
 bool mmu_t::mmio_ok(reg_t paddr, access_type UNUSED type)
 {
   // Disallow access to debug region when not in debug mode
-  if (paddr >= DEBUG_START && paddr <= DEBUG_END && proc && !proc->state.debug_mode)
+  static_assert(DEBUG_START == 0);
+  if (/* paddr >= DEBUG_START && */ paddr <= DEBUG_END && proc && !proc->state.debug_mode)
     return false;
 
   return true;

--- a/riscv/mmu.h
+++ b/riscv/mmu.h
@@ -214,7 +214,10 @@ public:
       throw trap_load_address_misaligned((proc) ? proc->state.v : false, addr, 0, 0);
     }
 
-    return (float128_t){load<uint64_t>(addr), load<uint64_t>(addr + 8)};
+    float128_t res;
+    res.v[0] = load<uint64_t>(addr);
+    res.v[1] = load<uint64_t>(addr + 8);
+    return res;
   }
 
   void cbo_zero(reg_t addr) {

--- a/riscv/ns16550.cc
+++ b/riscv/ns16550.cc
@@ -328,7 +328,7 @@ void ns16550_t::tick(reg_t UNUSED rtc_ticks)
   update_interrupt();
 }
 
-std::string ns16550_generate_dts(const sim_t* sim, const std::vector<std::string>& UNUSED sargs)
+std::string ns16550_generate_dts(const sim_t* sim, const std::vector<std::string>& sargs UNUSED)
 {
   std::stringstream s;
   s << std::hex
@@ -348,7 +348,7 @@ std::string ns16550_generate_dts(const sim_t* sim, const std::vector<std::string
   return s.str();
 }
 
-ns16550_t* ns16550_parse_from_fdt(const void* fdt, const sim_t* sim, reg_t* base, const std::vector<std::string>& UNUSED sargs)
+ns16550_t* ns16550_parse_from_fdt(const void* fdt, const sim_t* sim, reg_t* base, const std::vector<std::string>& sargs UNUSED)
 {
   uint32_t ns16550_shift, ns16550_io_width, ns16550_int_id;
   if (fdt_parse_ns16550(fdt, base,

--- a/riscv/plic.cc
+++ b/riscv/plic.cc
@@ -343,7 +343,8 @@ bool plic_t::load(reg_t addr, size_t len, uint8_t* bytes)
       return false;
   }
 
-  if (PRIORITY_BASE <= addr && addr < PENDING_BASE) {
+  static_assert(PRIORITY_BASE == 0);
+  if (/* PRIORITY_BASE <= addr && */ addr < PENDING_BASE) {
     ret = priority_read(addr, &val);
   } else if (PENDING_BASE <= addr && addr < ENABLE_BASE) {
     ret = pending_read(addr - PENDING_BASE, &val);
@@ -384,7 +385,8 @@ bool plic_t::store(reg_t addr, size_t len, const uint8_t* bytes)
 
   write_little_endian_reg(&val, addr, len, bytes);
 
-  if (PRIORITY_BASE <= addr && addr < ENABLE_BASE) {
+  static_assert(PRIORITY_BASE == 0);
+  if (/* PRIORITY_BASE <= addr && */ addr < ENABLE_BASE) {
     ret = priority_write(addr, val);
   } else if (ENABLE_BASE <= addr && addr < CONTEXT_BASE) {
     uint32_t cntx = (addr - ENABLE_BASE) / ENABLE_PER_HART;

--- a/riscv/plic.cc
+++ b/riscv/plic.cc
@@ -403,7 +403,7 @@ bool plic_t::store(reg_t addr, size_t len, const uint8_t* bytes)
   return ret;
 }
 
-std::string plic_generate_dts(const sim_t* sim, const std::vector<std::string>& UNUSED sargs)
+std::string plic_generate_dts(const sim_t* sim, const std::vector<std::string>& sargs UNUSED)
 {
   std::stringstream s;
   s << std::hex
@@ -426,7 +426,7 @@ std::string plic_generate_dts(const sim_t* sim, const std::vector<std::string>& 
   return s.str();
 }
 
-plic_t* plic_parse_from_fdt(const void* fdt, const sim_t* sim, reg_t* base, const std::vector<std::string>& UNUSED sargs)
+plic_t* plic_parse_from_fdt(const void* fdt, const sim_t* sim, reg_t* base, const std::vector<std::string>& sargs UNUSED)
 {
   uint32_t plic_ndev;
   if (fdt_parse_plic(fdt, base, &plic_ndev, "riscv,plic0") == 0 ||

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -705,21 +705,27 @@ void processor_t::register_base_instructions()
   #include "insn_list.h"
   #undef DEFINE_INSN
 
+  #define DEFINE_INSN_UNCOND(name) { \
+    insn_desc_t insn = { \
+      name##_match, \
+      name##_mask, \
+      fast_rv32i_##name, \
+      fast_rv64i_##name, \
+      fast_rv32e_##name, \
+      fast_rv64e_##name, \
+      logged_rv32i_##name, \
+      logged_rv64i_##name, \
+      logged_rv32e_##name, \
+      logged_rv64e_##name \
+    }; \
+    register_base_insn(insn); \
+  }
+
   // add overlapping instructions first, in order
   #define DECLARE_OVERLAP_INSN(name, ext) \
     name##_overlapping = true; \
     if (isa.extension_enabled(ext)) \
-      register_base_insn((insn_desc_t) { \
-        name##_match, \
-        name##_mask, \
-        fast_rv32i_##name, \
-        fast_rv64i_##name, \
-        fast_rv32e_##name, \
-        fast_rv64e_##name, \
-        logged_rv32i_##name, \
-        logged_rv64i_##name, \
-        logged_rv32e_##name, \
-        logged_rv64e_##name});
+      DEFINE_INSN_UNCOND(name);
   #include "overlap_list.h"
   #undef DECLARE_OVERLAP_INSN
 
@@ -728,19 +734,10 @@ void processor_t::register_base_instructions()
   // appear earlier to improve search time on opcode_cache misses.
   #define DEFINE_INSN(name) \
     if (!name##_overlapping) \
-      register_base_insn((insn_desc_t) { \
-        name##_match, \
-        name##_mask, \
-        fast_rv32i_##name, \
-        fast_rv64i_##name, \
-        fast_rv32e_##name, \
-        fast_rv64e_##name, \
-        logged_rv32i_##name, \
-        logged_rv64i_##name, \
-        logged_rv32e_##name, \
-        logged_rv64e_##name});
+      DEFINE_INSN_UNCOND(name);
   #include "insn_list.h"
   #undef DEFINE_INSN
+  #undef DEFINE_INSN_UNCOND
 
   // terminate instruction list with a catch-all
   register_base_insn(insn_desc_t::illegal_instruction);

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -15,7 +15,6 @@
 #include <cinttypes>
 #include <cmath>
 #include <cstdlib>
-#include <cstring>
 #include <iostream>
 #include <iomanip>
 #include <assert.h>
@@ -98,42 +97,6 @@ processor_t::~processor_t()
 
   delete mmu;
   delete disassembler;
-}
-
-static void bad_option_string(const char *option, const char *value,
-                              const char *msg)
-{
-  fprintf(stderr, "error: bad %s option '%s'. %s\n", option, value, msg);
-  abort();
-}
-
-static std::string get_string_token(std::string str, const char delimiter, size_t& pos)
-{
-  size_t _pos = pos;
-  while (pos < str.length() && str[pos] != delimiter) ++pos;
-  return str.substr(_pos, pos - _pos);
-}
-
-static bool check_pow2(int val)
-{
-  return ((val & (val - 1))) == 0;
-}
-
-static std::string strtolower(const char* str)
-{
-  std::string res(str);
-  for (char &c : res)
-    c = std::tolower(c);
-  return res;
-}
-
-static int xlen_to_uxl(int xlen)
-{
-  if (xlen == 32)
-    return 1;
-  if (xlen == 64)
-    return 2;
-  abort();
 }
 
 void state_t::reset(processor_t* const proc, reg_t max_isa)

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -222,10 +222,10 @@ void processor_t::set_mmu_capability(int cap)
       break;
     case IMPL_MMU_SV57:
       set_impl(IMPL_MMU_SV57, true);
-      // Fall through
+      [[fallthrough]];
     case IMPL_MMU_SV48:
       set_impl(IMPL_MMU_SV48, true);
-      // Fall through
+      [[fallthrough]];
     case IMPL_MMU_SV39:
       set_impl(IMPL_MMU_SV39, true);
       set_impl(IMPL_MMU, true);

--- a/riscv/rocc.cc
+++ b/riscv/rocc.cc
@@ -33,19 +33,11 @@ customX(3)
 
 std::vector<insn_desc_t> rocc_t::get_instructions(const processor_t &)
 {
-  std::vector<insn_desc_t> insns;
-  insns.push_back((insn_desc_t){0x0b, 0x7f,
-                                &::illegal_instruction, c0, &::illegal_instruction, c0,
-                                &::illegal_instruction, c0, &::illegal_instruction, c0});
-  insns.push_back((insn_desc_t){0x2b, 0x7f,
-                                &::illegal_instruction, c1, &::illegal_instruction, c1,
-                                &::illegal_instruction, c1, &::illegal_instruction, c1});
-  insns.push_back((insn_desc_t){0x5b, 0x7f,
-                                &::illegal_instruction, c2, &::illegal_instruction, c2,
-                                &::illegal_instruction, c2, &::illegal_instruction, c2});
-  insns.push_back((insn_desc_t){0x7b, 0x7f,
-                                &::illegal_instruction, c3, &::illegal_instruction, c3,
-                                &::illegal_instruction, c0, &::illegal_instruction, c3});
+  std::vector<insn_desc_t> insns = {
+    {0x0b, 0x7f, &::illegal_instruction, c0, &::illegal_instruction, c0, &::illegal_instruction, c0, &::illegal_instruction, c0},
+    {0x2b, 0x7f, &::illegal_instruction, c1, &::illegal_instruction, c1, &::illegal_instruction, c1, &::illegal_instruction, c1},
+    {0x5b, 0x7f, &::illegal_instruction, c2, &::illegal_instruction, c2, &::illegal_instruction, c2, &::illegal_instruction, c2},
+    {0x7b, 0x7f, &::illegal_instruction, c3, &::illegal_instruction, c3, &::illegal_instruction, c0, &::illegal_instruction, c3}};
   return insns;
 }
 

--- a/riscv/sim.cc
+++ b/riscv/sim.cc
@@ -137,7 +137,6 @@ sim_t::sim_t(const cfg_t *cfg, bool halted,
     dtb = strstream.str();
     dts = dtb_to_dts(dtb);
   } else {
-    std::pair<reg_t, reg_t> initrd_bounds = cfg->initrd_bounds;
     std::string device_nodes;
     for (const device_factory_sargs_t& factory_sargs: device_factories) {
       const device_factory_t* factory = factory_sargs.first;

--- a/riscv/triggers.cc
+++ b/riscv/triggers.cc
@@ -675,4 +675,4 @@ reg_t module_t::tinfo_read(unsigned UNUSED index) const noexcept
          (CSR_TINFO_VERSION_1 << CSR_TINFO_VERSION_OFFSET);
 }
 
-};
+}

--- a/riscv/triggers.cc
+++ b/riscv/triggers.cc
@@ -274,7 +274,10 @@ std::optional<match_result_t> mcontrol_common_t::detect_memory_access_match(proc
 mcontrol_common_t::match_t mcontrol_common_t::legalize_match(reg_t val, reg_t maskmax) noexcept
 {
   switch (val) {
-    case MATCH_NAPOT: if (maskmax == 0) return MATCH_EQUAL;
+    case MATCH_NAPOT:
+      if (maskmax == 0)
+        return MATCH_EQUAL;
+      [[fallthrough]];
     case MATCH_EQUAL:
     case MATCH_GE:
     case MATCH_LT:

--- a/riscv/triggers.cc
+++ b/riscv/triggers.cc
@@ -52,7 +52,7 @@ void trigger_t::tdata3_write(processor_t * const proc, const reg_t val) noexcept
   mhselect = get_field(val, CSR_TEXTRA_MHSELECT(xlen));
   sbytemask = get_field(val, CSR_TEXTRA_SBYTEMASK(xlen));
   svalue = proc->extension_enabled_const('S') ? get_field(val, CSR_TEXTRA_SVALUE(xlen)) : 0;
-  sselect = (sselect_t)((proc->extension_enabled_const('S') && get_field(val, CSR_TEXTRA_SSELECT(xlen)) <= SSELECT_MAXVAL) ? get_field(val, CSR_TEXTRA_SSELECT(xlen)) : SSELECT_IGNORE);
+  sselect = (sselect_t)((proc->extension_enabled_const('S') && get_field(val, CSR_TEXTRA_SSELECT(xlen)) <= SSELECT_MAXVAL) ? get_field(val, CSR_TEXTRA_SSELECT(xlen)) : (reg_t)SSELECT_IGNORE);
 }
 
 static reg_t tcontrol_value(const state_t * state) {

--- a/riscv/triggers.h
+++ b/riscv/triggers.h
@@ -301,6 +301,6 @@ private:
   std::vector<trigger_t *> triggers;
 };
 
-};
+}
 
 #endif

--- a/riscv/v_ext_macros.h
+++ b/riscv/v_ext_macros.h
@@ -454,7 +454,7 @@ static inline bool is_overlapped_widen(const int astart, int asize,
 
 #define VFP_VF_CMP_PARAMS(width) \
   float##width##_t rs1 = f##width(READ_FREG(rs1_num)); \
-  float##width##_t vs2 = P.VU.elt<float##width##_t>(rs2_num, i);
+  float##width##_t UNUSED vs2 = P.VU.elt<float##width##_t>(rs2_num, i);
 
 #define VFP_VF_PARAMS(width) \
   float##width##_t &vd = P.VU.elt<float##width##_t>(rd_num, i, true); \

--- a/riscv/v_ext_macros.h
+++ b/riscv/v_ext_macros.h
@@ -1181,25 +1181,6 @@ VI_VX_ULOOP({ \
 #define VI_STRIP(inx) \
   reg_t vreg_inx = inx;
 
-#define VI_DUPLICATE_VREG(reg_num, idx_sew) \
-reg_t index[P.VU.vlmax]; \
- for (reg_t i = 0; i < P.VU.vlmax && P.VU.vl->read() != 0; ++i) { \
-  switch (idx_sew) { \
-    case e8: \
-      index[i] = P.VU.elt<uint8_t>(reg_num, i); \
-      break; \
-    case e16: \
-      index[i] = P.VU.elt<uint16_t>(reg_num, i); \
-      break; \
-    case e32: \
-      index[i] = P.VU.elt<uint32_t>(reg_num, i); \
-      break; \
-    case e64: \
-      index[i] = P.VU.elt<uint64_t>(reg_num, i); \
-      break; \
-  } \
-}
-
 #define VI_LD(stride, offset, elt_width, is_mask_ldst) \
   const reg_t nf = insn.v_nf() + 1; \
   VI_CHECK_LOAD(elt_width, is_mask_ldst); \
@@ -1218,6 +1199,23 @@ reg_t index[P.VU.vlmax]; \
   } \
   P.VU.vstart->write(0);
 
+#define VI_LDST_GET_INDEX(elt_width) \
+  reg_t index; \
+  switch (elt_width) { \
+    case e8: \
+      index = P.VU.elt<uint8_t>(insn.rs2(), i); \
+      break; \
+    case e16: \
+      index = P.VU.elt<uint16_t>(insn.rs2(), i); \
+      break; \
+    case e32: \
+      index = P.VU.elt<uint32_t>(insn.rs2(), i); \
+      break; \
+    case e64: \
+      index = P.VU.elt<uint64_t>(insn.rs2(), i); \
+      break; \
+  } \
+
 #define VI_LD_INDEX(elt_width, is_seg) \
   const reg_t nf = insn.v_nf() + 1; \
   VI_CHECK_LD_INDEX(elt_width); \
@@ -1226,8 +1224,8 @@ reg_t index[P.VU.vlmax]; \
   const reg_t vd = insn.rd(); \
   if (!is_seg) \
     require(nf == 1); \
-  VI_DUPLICATE_VREG(insn.rs2(), elt_width); \
   for (reg_t i = 0; i < vl; ++i) { \
+    VI_LDST_GET_INDEX(elt_width); \
     VI_ELEMENT_SKIP; \
     VI_STRIP(i); \
     P.VU.vstart->write(i); \
@@ -1235,19 +1233,19 @@ reg_t index[P.VU.vlmax]; \
       switch (P.VU.vsew) { \
         case e8: \
           P.VU.elt<uint8_t>(vd + fn * flmul, vreg_inx, true) = \
-            MMU.load<uint8_t>(baseAddr + index[i] + fn * 1); \
+            MMU.load<uint8_t>(baseAddr + index + fn * 1); \
           break; \
         case e16: \
           P.VU.elt<uint16_t>(vd + fn * flmul, vreg_inx, true) = \
-            MMU.load<uint16_t>(baseAddr + index[i] + fn * 2); \
+            MMU.load<uint16_t>(baseAddr + index + fn * 2); \
           break; \
         case e32: \
           P.VU.elt<uint32_t>(vd + fn * flmul, vreg_inx, true) = \
-            MMU.load<uint32_t>(baseAddr + index[i] + fn * 4); \
+            MMU.load<uint32_t>(baseAddr + index + fn * 4); \
           break; \
         default: \
           P.VU.elt<uint64_t>(vd + fn * flmul, vreg_inx, true) = \
-            MMU.load<uint64_t>(baseAddr + index[i] + fn * 8); \
+            MMU.load<uint64_t>(baseAddr + index + fn * 8); \
           break; \
       } \
     } \
@@ -1280,27 +1278,27 @@ reg_t index[P.VU.vlmax]; \
   const reg_t vs3 = insn.rd(); \
   if (!is_seg) \
     require(nf == 1); \
-  VI_DUPLICATE_VREG(insn.rs2(), elt_width); \
   for (reg_t i = 0; i < vl; ++i) { \
+    VI_LDST_GET_INDEX(elt_width); \
     VI_STRIP(i) \
     VI_ELEMENT_SKIP; \
     P.VU.vstart->write(i); \
     for (reg_t fn = 0; fn < nf; ++fn) { \
       switch (P.VU.vsew) { \
       case e8: \
-        MMU.store<uint8_t>(baseAddr + index[i] + fn * 1, \
+        MMU.store<uint8_t>(baseAddr + index + fn * 1, \
           P.VU.elt<uint8_t>(vs3 + fn * flmul, vreg_inx)); \
         break; \
       case e16: \
-        MMU.store<uint16_t>(baseAddr + index[i] + fn * 2, \
+        MMU.store<uint16_t>(baseAddr + index + fn * 2, \
           P.VU.elt<uint16_t>(vs3 + fn * flmul, vreg_inx)); \
         break; \
       case e32: \
-        MMU.store<uint32_t>(baseAddr + index[i] + fn * 4, \
+        MMU.store<uint32_t>(baseAddr + index + fn * 4, \
           P.VU.elt<uint32_t>(vs3 + fn * flmul, vreg_inx)); \
         break; \
       default: \
-        MMU.store<uint64_t>(baseAddr + index[i] + fn * 8, \
+        MMU.store<uint64_t>(baseAddr + index + fn * 8, \
           P.VU.elt<uint64_t>(vs3 + fn * flmul, vreg_inx)); \
         break; \
       } \

--- a/softfloat/fall_maxmin.c
+++ b/softfloat/fall_maxmin.c
@@ -72,13 +72,13 @@ float ## bits ## _t f ## bits ## _min( float ## bits ## _t a, float ## bits ## _
     }                                                                                          \
 }
 
-COMPARE_MAX(a, b, 16);
-COMPARE_MAX(a, b, 32);
-COMPARE_MAX(a, b, 64);
+COMPARE_MAX(a, b, 16)
+COMPARE_MAX(a, b, 32)
+COMPARE_MAX(a, b, 64)
 
-COMPARE_MIN(a, b, 16);
-COMPARE_MIN(a, b, 32);
-COMPARE_MIN(a, b, 64);
+COMPARE_MIN(a, b, 16)
+COMPARE_MIN(a, b, 32)
+COMPARE_MIN(a, b, 64)
 
 bfloat16_t bf16_max( bfloat16_t a, bfloat16_t b )
 {

--- a/softfloat/softfloat.mk.in
+++ b/softfloat/softfloat.mk.in
@@ -252,3 +252,5 @@ softfloat_test_srcs =
 softfloat_install_hdrs = \
 	softfloat.h \
 	softfloat_types.h \
+
+softfloat_CFLAGS = -Wno-implicit-fallthrough

--- a/softfloat/softfloat.mk.in
+++ b/softfloat/softfloat.mk.in
@@ -253,4 +253,4 @@ softfloat_install_hdrs = \
 	softfloat.h \
 	softfloat_types.h \
 
-softfloat_CFLAGS = -Wno-implicit-fallthrough
+softfloat_CFLAGS = -Wno-sign-compare -Wno-implicit-fallthrough

--- a/spike_main/spike-log-parser.cc
+++ b/spike_main/spike-log-parser.cc
@@ -38,7 +38,6 @@ int main(int UNUSED argc, char** argv)
 
   std::regex reg("^core\\s+\\d+:\\s+0x[0-9a-f]+\\s+\\(0x([0-9a-f]+)\\)", std::regex_constants::icase);
   std::smatch m;
-  std::ssub_match sm ;
 
   while (getline(cin,s)){
     if (regex_search(s, m, reg)){


### PR DESCRIPTION
...at least for current GCC.

Turning on these errors for regular builds is generally ill-advised, since compiler upgrades (or downgrades) can result in spurious compilation failures.  So, only enable them in CI.

I gave up on `-Wpedantic`, as we use the GNUism `({ ... })` ubiquitously.