### PR TITLE
Substantially improve uncommon-case memory-system performance

### DIFF
--- a/riscv/execute.cc
+++ b/riscv/execute.cc
@@ -342,10 +342,6 @@ void processor_t::step(size_t n)
     }
     catch (triggers::matched_t& t)
     {
-      if (mmu->matched_trigger) {
-        delete mmu->matched_trigger;
-        mmu->matched_trigger = NULL;
-      }
       take_trigger_action(t.action, t.address, pc, t.gva);
     }
     catch(trap_debug_mode&)

--- a/riscv/mmu.cc
+++ b/riscv/mmu.cc
@@ -77,11 +77,11 @@ tlb_entry_t mmu_t::fetch_slow_path(reg_t vaddr)
   tlb_entry_t result;
   reg_t vpn = vaddr >> PGSHIFT;
   if (unlikely(tlb_insn_tag[vpn % TLB_ENTRIES] != (vpn | TLB_CHECK_TRIGGERS))) {
-    reg_t paddr = translate(access_info, sizeof(fetch_temp));
+    reg_t paddr = translate(access_info, sizeof(fetch_temp[0]));
     if (auto host_addr = sim->addr_to_mem(paddr)) {
       result = refill_tlb(vaddr, paddr, host_addr, FETCH);
     } else {
-      if (!mmio_fetch(paddr, sizeof fetch_temp, (uint8_t*)&fetch_temp))
+      if (!mmio_fetch(paddr, sizeof(fetch_temp[0]), (uint8_t*)&fetch_temp))
         throw trap_instruction_access_fault(proc->state.v, vaddr, 0, 0);
       result = {(char*)&fetch_temp - vaddr, paddr - vaddr};
     }

--- a/riscv/mmu.cc
+++ b/riscv/mmu.cc
@@ -36,9 +36,9 @@ void mmu_t::flush_icache()
 
 void mmu_t::flush_tlb()
 {
-  memset(tlb_insn_tag, -1, sizeof(tlb_insn_tag));
-  memset(tlb_load_tag, -1, sizeof(tlb_load_tag));
-  memset(tlb_store_tag, -1, sizeof(tlb_store_tag));
+  memset(tlb_insn, -1, sizeof(tlb_insn));
+  memset(tlb_load, -1, sizeof(tlb_load));
+  memset(tlb_store, -1, sizeof(tlb_store));
 
   flush_icache();
 }
@@ -76,7 +76,7 @@ tlb_entry_t mmu_t::fetch_slow_path(reg_t vaddr)
 
   tlb_entry_t result;
   reg_t vpn = vaddr >> PGSHIFT;
-  if (unlikely(tlb_insn_tag[vpn % TLB_ENTRIES] != (vpn | TLB_CHECK_TRIGGERS))) {
+  if (unlikely(tlb_insn[vpn % TLB_ENTRIES].tag != (vpn | TLB_CHECK_TRIGGERS))) {
     reg_t paddr = translate(access_info, sizeof(fetch_temp[0]));
     if (auto host_addr = sim->addr_to_mem(paddr)) {
       result = refill_tlb(vaddr, paddr, host_addr, FETCH);
@@ -86,7 +86,7 @@ tlb_entry_t mmu_t::fetch_slow_path(reg_t vaddr)
       result = {uintptr_t(&fetch_temp), paddr - (vaddr % PGSIZE)};
     }
   } else {
-    result = tlb_data[vpn % TLB_ENTRIES];
+    result = tlb_insn[vpn % TLB_ENTRIES].data;
   }
 
   check_triggers(triggers::OPERATION_EXECUTE, vaddr, access_info.effective_virt, from_le(*(const uint16_t*)(result.host_addr + (vaddr % PGSIZE))));
@@ -196,8 +196,8 @@ void mmu_t::load_slow_path_intrapage(reg_t len, uint8_t* bytes, mem_access_info_
   reg_t addr = access_info.vaddr;
   reg_t transformed_addr = access_info.transformed_vaddr;
   reg_t vpn = transformed_addr >> PGSHIFT;
-  if (!access_info.flags.is_special_access() && vpn == (tlb_load_tag[vpn % TLB_ENTRIES] & ~TLB_CHECK_TRIGGERS)) {
-    auto host_addr = (const void*)(tlb_data[vpn % TLB_ENTRIES].host_addr + (transformed_addr % PGSIZE));
+  if (!access_info.flags.is_special_access() && vpn == (tlb_load[vpn % TLB_ENTRIES].tag & ~TLB_CHECK_TRIGGERS)) {
+    auto host_addr = (const void*)(tlb_load[vpn % TLB_ENTRIES].data.host_addr + (transformed_addr % PGSIZE));
     memcpy(bytes, host_addr, len);
     return;
   }
@@ -263,9 +263,9 @@ void mmu_t::store_slow_path_intrapage(reg_t len, const uint8_t* bytes, mem_acces
   reg_t addr = access_info.vaddr;
   reg_t transformed_addr = access_info.transformed_vaddr;
   reg_t vpn = transformed_addr >> PGSHIFT;
-  if (!access_info.flags.is_special_access() && vpn == (tlb_store_tag[vpn % TLB_ENTRIES] & ~TLB_CHECK_TRIGGERS)) {
+  if (!access_info.flags.is_special_access() && vpn == (tlb_store[vpn % TLB_ENTRIES].tag & ~TLB_CHECK_TRIGGERS)) {
     if (actually_store) {
-      auto host_addr = (void*)(tlb_data[vpn % TLB_ENTRIES].host_addr + (transformed_addr % PGSIZE));
+      auto host_addr = (void*)(tlb_store[vpn % TLB_ENTRIES].data.host_addr + (transformed_addr % PGSIZE));
       memcpy(host_addr, bytes, len);
     }
     return;
@@ -327,28 +327,26 @@ tlb_entry_t mmu_t::refill_tlb(reg_t vaddr, reg_t paddr, char* host_addr, access_
 
   tlb_entry_t entry = {uintptr_t(host_addr) - (vaddr % PGSIZE), paddr - (vaddr % PGSIZE)};
 
-  if (in_mprv())
+  if (in_mprv() || !pmp_homogeneous(paddr & ~reg_t(PGSIZE - 1), PGSIZE))
     return entry;
 
-  if ((tlb_load_tag[idx] & ~TLB_CHECK_TRIGGERS) != expected_tag)
-    tlb_load_tag[idx] = -1;
-  if ((tlb_store_tag[idx] & ~TLB_CHECK_TRIGGERS) != expected_tag)
-    tlb_store_tag[idx] = -1;
-  if ((tlb_insn_tag[idx] & ~TLB_CHECK_TRIGGERS) != expected_tag)
-    tlb_insn_tag[idx] = -1;
-
-  if ((check_triggers_fetch && type == FETCH) ||
-      (check_triggers_load && type == LOAD) ||
-      (check_triggers_store && type == STORE))
-    expected_tag |= TLB_CHECK_TRIGGERS;
-
-  if (pmp_homogeneous(paddr & ~reg_t(PGSIZE - 1), PGSIZE)) {
-    if (type == FETCH) tlb_insn_tag[idx] = expected_tag;
-    else if (type == STORE) tlb_store_tag[idx] = expected_tag;
-    else tlb_load_tag[idx] = expected_tag;
+  switch (type) {
+    case FETCH:
+      tlb_insn[idx].data = entry;
+      tlb_insn[idx].tag = expected_tag | (check_triggers_fetch ? TLB_CHECK_TRIGGERS : 0);
+      break;
+    case LOAD:
+      tlb_load[idx].data = entry;
+      tlb_load[idx].tag = expected_tag | (check_triggers_load ? TLB_CHECK_TRIGGERS : 0);
+      break;
+    case STORE:
+      tlb_store[idx].data = entry;
+      tlb_store[idx].tag = expected_tag | (check_triggers_store ? TLB_CHECK_TRIGGERS : 0);
+      break;
+    default:
+      abort();
   }
 
-  tlb_data[idx] = entry;
   return entry;
 }
 

--- a/riscv/mmu.cc
+++ b/riscv/mmu.cc
@@ -14,8 +14,7 @@ mmu_t::mmu_t(simif_t* sim, endianness_t endianness, processor_t* proc)
 #endif
   check_triggers_fetch(false),
   check_triggers_load(false),
-  check_triggers_store(false),
-  matched_trigger(NULL)
+  check_triggers_store(false)
 {
 #ifndef RISCV_ENABLE_DUAL_ENDIAN
   assert(endianness == endianness_little);
@@ -188,7 +187,7 @@ void mmu_t::check_triggers(triggers::operation_t operation, reg_t address, bool 
         // We want to take this exception on the next instruction.  We check
         // whether to do so in the I$ refill path, so flush the I$.
         flush_icache();
-        matched_trigger = new triggers::matched_t(operation, tval, match->action, virt);
+        matched_trigger = triggers::matched_t(operation, tval, match->action, virt);
     }
 }
 

--- a/riscv/mmu.h
+++ b/riscv/mmu.h
@@ -344,7 +344,8 @@ public:
     auto vpn = vaddr / PGSIZE, pgoff = vaddr % PGSIZE;
     auto& entry = tlb[vpn % TLB_ENTRIES];
     auto hit = likely((entry.tag & ~allowed_flags) == vpn);
-    auto host_addr = entry.data.host_addr + pgoff;
+    bool mmio = allowed_flags & TLB_MMIO & entry.tag;
+    auto host_addr = mmio ? 0 : entry.data.host_addr + pgoff;
     auto paddr = entry.data.target_addr + pgoff;
     return std::make_tuple(hit, host_addr, paddr);
   }
@@ -395,7 +396,8 @@ private:
   // trigger match before completing an access.
   static const reg_t TLB_CHECK_TRIGGERS = reg_t(1) << 63;
   static const reg_t TLB_CHECK_TRACER = reg_t(1) << 62;
-  static const reg_t TLB_FLAGS = TLB_CHECK_TRIGGERS | TLB_CHECK_TRACER;
+  static const reg_t TLB_MMIO = reg_t(1) << 61;
+  static const reg_t TLB_FLAGS = TLB_CHECK_TRIGGERS | TLB_CHECK_TRACER | TLB_MMIO;
   dtlb_entry_t tlb_load[TLB_ENTRIES];
   dtlb_entry_t tlb_store[TLB_ENTRIES];
   dtlb_entry_t tlb_insn[TLB_ENTRIES];

--- a/riscv/mmu.h
+++ b/riscv/mmu.h
@@ -386,7 +386,6 @@ private:
   processor_t* proc;
   memtracer_list_t tracer;
   reg_t load_reservation_address;
-  uint16_t fetch_temp;
   reg_t blocksz;
 
   // implement an instruction cache for simulator performance
@@ -401,6 +400,9 @@ private:
   reg_t tlb_insn_tag[TLB_ENTRIES];
   reg_t tlb_load_tag[TLB_ENTRIES];
   reg_t tlb_store_tag[TLB_ENTRIES];
+
+  // temporary location to store instructions fetched from an MMIO region
+  uint16_t fetch_temp[PGSIZE / sizeof(uint16_t)];
 
   // finish translation on a TLB miss and update the TLB
   tlb_entry_t refill_tlb(reg_t vaddr, reg_t paddr, char* host_addr, access_type type);

--- a/riscv/mmu.h
+++ b/riscv/mmu.h
@@ -293,8 +293,11 @@ public:
 
   inline icache_entry_t* refill_icache(reg_t addr, icache_entry_t* entry)
   {
-    if (matched_trigger)
-      throw *matched_trigger;
+    if (matched_trigger) {
+      auto trig = matched_trigger.value();
+      matched_trigger.reset();
+      throw trig;
+    }
 
     auto [first_parcel, paddr] = fetch_insn_parcel_and_paddr(addr);
     insn_bits_t insn = first_parcel;
@@ -507,8 +510,7 @@ private:
   bool check_triggers_fetch;
   bool check_triggers_load;
   bool check_triggers_store;
-  // The exception describing a matched trigger, or NULL.
-  triggers::matched_t *matched_trigger;
+  std::optional<triggers::matched_t> matched_trigger;
 
   friend class processor_t;
 };

--- a/riscv/mmu.h
+++ b/riscv/mmu.h
@@ -394,7 +394,8 @@ private:
   // If a TLB tag has TLB_CHECK_TRIGGERS set, then the MMU must check for a
   // trigger match before completing an access.
   static const reg_t TLB_CHECK_TRIGGERS = reg_t(1) << 63;
-  static const reg_t TLB_FLAGS = TLB_CHECK_TRIGGERS;
+  static const reg_t TLB_CHECK_TRACER = reg_t(1) << 62;
+  static const reg_t TLB_FLAGS = TLB_CHECK_TRIGGERS | TLB_CHECK_TRACER;
   dtlb_entry_t tlb_load[TLB_ENTRIES];
   dtlb_entry_t tlb_store[TLB_ENTRIES];
   dtlb_entry_t tlb_insn[TLB_ENTRIES];

--- a/riscv/mmu.h
+++ b/riscv/mmu.h
@@ -394,6 +394,7 @@ private:
   // If a TLB tag has TLB_CHECK_TRIGGERS set, then the MMU must check for a
   // trigger match before completing an access.
   static const reg_t TLB_CHECK_TRIGGERS = reg_t(1) << 63;
+  static const reg_t TLB_FLAGS = TLB_CHECK_TRIGGERS;
   dtlb_entry_t tlb_load[TLB_ENTRIES];
   dtlb_entry_t tlb_store[TLB_ENTRIES];
   dtlb_entry_t tlb_insn[TLB_ENTRIES];
@@ -413,8 +414,10 @@ private:
   std::pair<insn_parcel_t, reg_t> fetch_slow_path(reg_t addr);
   void load_slow_path(reg_t original_addr, reg_t len, uint8_t* bytes, xlate_flags_t xlate_flags);
   void load_slow_path_intrapage(reg_t len, uint8_t* bytes, mem_access_info_t access_info);
+  void perform_intrapage_load(reg_t vaddr, uintptr_t host_addr, reg_t paddr, reg_t len, uint8_t* bytes, xlate_flags_t xlate_flags);
   void store_slow_path(reg_t original_addr, reg_t len, const uint8_t* bytes, xlate_flags_t xlate_flags, bool actually_store, bool require_alignment);
   void store_slow_path_intrapage(reg_t len, const uint8_t* bytes, mem_access_info_t access_info, bool actually_store);
+  void perform_intrapage_store(reg_t vaddr, uintptr_t host_addr, reg_t paddr, reg_t len, const uint8_t* bytes, xlate_flags_t xlate_flags);
   bool mmio_fetch(reg_t paddr, size_t len, uint8_t* bytes);
   bool mmio_load(reg_t paddr, size_t len, uint8_t* bytes);
   bool mmio_store(reg_t paddr, size_t len, const uint8_t* bytes);

--- a/riscv/mmu.h
+++ b/riscv/mmu.h
@@ -37,6 +37,11 @@ struct tlb_entry_t {
   reg_t target_addr;
 };
 
+struct dtlb_entry_t {
+  tlb_entry_t data;
+  reg_t tag;
+};
+
 struct xlate_flags_t {
   const bool forced_virt : 1 {false};
   const bool hlvx : 1 {false};
@@ -77,10 +82,10 @@ public:
     target_endian<T> res;
     reg_t vpn = addr >> PGSHIFT;
     bool aligned = (addr & (sizeof(T) - 1)) == 0;
-    bool tlb_hit = tlb_load_tag[vpn % TLB_ENTRIES] == vpn;
+    bool tlb_hit = tlb_load[vpn % TLB_ENTRIES].tag == vpn;
 
     if (likely(!xlate_flags.is_special_access() && aligned && tlb_hit)) {
-      res = *(target_endian<T>*)(tlb_data[vpn % TLB_ENTRIES].host_addr + (addr % PGSIZE));
+      res = *(target_endian<T>*)(tlb_load[vpn % TLB_ENTRIES].data.host_addr + (addr % PGSIZE));
     } else {
       load_slow_path(addr, sizeof(T), (uint8_t*)&res, xlate_flags);
     }
@@ -118,10 +123,10 @@ public:
   void ALWAYS_INLINE store(reg_t addr, T val, xlate_flags_t xlate_flags = {}) {
     reg_t vpn = addr >> PGSHIFT;
     bool aligned = (addr & (sizeof(T) - 1)) == 0;
-    bool tlb_hit = tlb_store_tag[vpn % TLB_ENTRIES] == vpn;
+    bool tlb_hit = tlb_store[vpn % TLB_ENTRIES].tag == vpn;
 
     if (!xlate_flags.is_special_access() && likely(aligned && tlb_hit)) {
-      *(target_endian<T>*)(tlb_data[vpn % TLB_ENTRIES].host_addr + (addr % PGSIZE)) = to_target(val);
+      *(target_endian<T>*)(tlb_store[vpn % TLB_ENTRIES].data.host_addr + (addr % PGSIZE)) = to_target(val);
     } else {
       target_endian<T> target_val = to_target(val);
       store_slow_path(addr, sizeof(T), (const uint8_t*)&target_val, xlate_flags, true, false);
@@ -392,10 +397,9 @@ private:
   // If a TLB tag has TLB_CHECK_TRIGGERS set, then the MMU must check for a
   // trigger match before completing an access.
   static const reg_t TLB_CHECK_TRIGGERS = reg_t(1) << 63;
-  tlb_entry_t tlb_data[TLB_ENTRIES];
-  reg_t tlb_insn_tag[TLB_ENTRIES];
-  reg_t tlb_load_tag[TLB_ENTRIES];
-  reg_t tlb_store_tag[TLB_ENTRIES];
+  dtlb_entry_t tlb_load[TLB_ENTRIES];
+  dtlb_entry_t tlb_store[TLB_ENTRIES];
+  dtlb_entry_t tlb_insn[TLB_ENTRIES];
 
   // temporary location to store instructions fetched from an MMIO region
   uint16_t fetch_temp[PGSIZE / sizeof(uint16_t)];
@@ -477,8 +481,8 @@ private:
   // ITLB lookup
   inline tlb_entry_t translate_insn_addr(reg_t addr) {
     reg_t vpn = addr >> PGSHIFT;
-    if (likely(tlb_insn_tag[vpn % TLB_ENTRIES] == vpn))
-      return tlb_data[vpn % TLB_ENTRIES];
+    if (likely(tlb_insn[vpn % TLB_ENTRIES].tag == vpn))
+      return tlb_insn[vpn % TLB_ENTRIES].data;
     return fetch_slow_path(addr);
   }
 

--- a/riscv/mmu.h
+++ b/riscv/mmu.h
@@ -90,9 +90,6 @@ public:
       load_slow_path(addr, sizeof(T), (uint8_t*)&res, xlate_flags);
     }
 
-    if (unlikely(proc && proc->get_log_commits_enabled()))
-      proc->state.log_mem_read.push_back(std::make_tuple(addr, 0, sizeof(T)));
-
     return from_target(res);
   }
 
@@ -131,9 +128,6 @@ public:
       target_endian<T> target_val = to_target(val);
       store_slow_path(addr, sizeof(T), (const uint8_t*)&target_val, xlate_flags, true, false);
     }
-
-    if (unlikely(proc && proc->get_log_commits_enabled()))
-      proc->state.log_mem_write.push_back(std::make_tuple(addr, val, sizeof(T)));
   }
 
   template<typename T>

--- a/riscv/mmu.h
+++ b/riscv/mmu.h
@@ -293,12 +293,6 @@ public:
 
   inline icache_entry_t* refill_icache(reg_t addr, icache_entry_t* entry)
   {
-    if (matched_trigger) {
-      auto trig = matched_trigger.value();
-      matched_trigger.reset();
-      throw trig;
-    }
-
     auto [first_parcel, paddr] = fetch_insn_parcel_and_paddr(addr);
     insn_bits_t insn = first_parcel;
 

--- a/riscv/mmu.h
+++ b/riscv/mmu.h
@@ -18,7 +18,6 @@
 // virtual memory configuration
 #define PGSHIFT 12
 const reg_t PGSIZE = 1 << PGSHIFT;
-const reg_t PGMASK = ~(PGSIZE-1);
 #define MAX_PADDR_BITS 64
 
 struct insn_fetch_t
@@ -66,9 +65,6 @@ void throw_access_exception(bool virt, reg_t addr, access_type type);
 class mmu_t
 {
 private:
-  std::map<reg_t, reg_t> alloc_cache;
-  std::vector<std::pair<reg_t, reg_t >> addr_tbl;
-
   reg_t get_pmlen(bool effective_virt, reg_t effective_priv, xlate_flags_t flags) const;
   mem_access_info_t generate_access_info(reg_t addr, access_type type, xlate_flags_t xlate_flags);
 

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -144,6 +144,7 @@ void processor_t::set_histogram(bool value)
 void processor_t::enable_log_commits()
 {
   log_commits_enabled = true;
+  mmu->flush_tlb(); // the TLB caches this setting
 }
 
 void processor_t::reset()


### PR DESCRIPTION
Several commingled improvements, but no API changes:

- Allow TLB to be used for MMIO accesses.  This speeds up simple MMIO accesses (e.g. reading the boot ROM) by >2x when VM is disabled or 5x when VM is enabled.
- Skip checking the debug triggers for MMIO accesses and misaligned-but-intrapage memory accesses unless necessary, speeding up these cases by another >2x.
- Allow TLB to be used even when a memtracer is registered on an address.  This speeds up D$ simulation by 6x.
- Give the load/store/fetch TLBs their own tags, since they already had their own data anyway.  This eliminates a common source of conflict misses and simplifies the implementation.
- Also fix an ubsan error associated with outside-of-object memory accesses when computing host addresses.
- Also improve common-case performance by moving uncommon-case checks (commit log, matched debug trigger) off the critical code path.