### PR TITLE
exposing riscv and softfloat as libraries

### DIFF
--- a/riscv/riscv.mk.in
+++ b/riscv/riscv.mk.in
@@ -13,6 +13,8 @@ riscv_install_shared_lib = yes
 
 riscv_install_pcs = yes
 
+riscv_install_lib = yes
+
 riscv_install_prog_srcs = \
 
 riscv_install_hdrs = \

--- a/softfloat/softfloat.mk.in
+++ b/softfloat/softfloat.mk.in
@@ -247,6 +247,8 @@ softfloat_c_srcs = \
 
 softfloat_install_shared_lib = yes
 
+softfloat_install_lib = yes
+
 softfloat_test_srcs =
 
 softfloat_install_hdrs = \


### PR DESCRIPTION
this PR will make `riscv` and `softfloat` exposed and easily linked in case we want to link `riscv-isa-sim` with some other simulation environment.