### PR TITLE
changing type of external_simulator member of external_sim_device_t

### DIFF
--- a/riscv/devices.cc
+++ b/riscv/devices.cc
@@ -156,21 +156,21 @@ void mem_t::dump(std::ostream& o) {
   }
 }
 
-external_sim_device_t::external_sim_device_t(void* sim) 
+external_sim_device_t::external_sim_device_t(abstract_sim_if_t* sim) 
   : external_simulator(sim) {}
 
-void external_sim_device_t::set_simulator(void* sim) {
+void external_sim_device_t::set_simulator(abstract_sim_if_t* sim) {
   external_simulator = sim;
 }
 
 bool external_sim_device_t::load(reg_t addr, size_t len, uint8_t* bytes) {
   if (unlikely(external_simulator == nullptr)) return false;
-  return static_cast<abstract_sim_if_t*>(external_simulator)->load(addr, len, bytes);
+  return external_simulator->load(addr, len, bytes);
 }
 
 bool external_sim_device_t::store(reg_t addr, size_t len, const uint8_t* bytes) {
   if (unlikely(external_simulator == nullptr)) return false;
-  return static_cast<abstract_sim_if_t*>(external_simulator)->store(addr, len, bytes);
+  return external_simulator->store(addr, len, bytes);
 }
 
 reg_t external_sim_device_t::size() {

--- a/riscv/devices.h
+++ b/riscv/devices.h
@@ -80,14 +80,14 @@ public:
 
 class external_sim_device_t : public abstract_device_t {
 public:
-  external_sim_device_t(void* sim);
-  void set_simulator(void* sim);
+  external_sim_device_t(abstract_sim_if_t* sim);
+  void set_simulator(abstract_sim_if_t* sim);
   bool load(reg_t addr, size_t len, uint8_t* bytes) override;
   bool store(reg_t addr, size_t len, const uint8_t* bytes) override;
   reg_t size() override;
 
 private:
-  void* external_simulator;
+abstract_sim_if_t* external_simulator;
 };
 
 class clint_t : public abstract_device_t {

--- a/riscv/devices.h
+++ b/riscv/devices.h
@@ -87,7 +87,7 @@ public:
   reg_t size() override;
 
 private:
-abstract_sim_if_t* external_simulator;
+  abstract_sim_if_t* external_simulator;
 };
 
 class clint_t : public abstract_device_t {


### PR DESCRIPTION
Even though we allowed `void*` data member of `external_simulator`, in `load/store` we need do `static cast`. I.e. `static_cast<abstract_sim_if_t*>(external_simulator)`. I think it is better to have proper data member type which also prevents some bugs which can happen with `static_cast`
