### PR TITLE
feat: mark processor_t getters as const

### DIFF
--- a/riscv/execute.cc
+++ b/riscv/execute.cc
@@ -201,7 +201,7 @@ static inline reg_t execute_insn_logged(processor_t* p, reg_t pc, insn_fetch_t f
   return npc;
 }
 
-bool processor_t::slow_path()
+bool processor_t::slow_path() const
 {
   return debug || state.single_step != state.STEP_NONE || state.debug_mode ||
          log_commits_enabled || histogram_enabled || in_wfi || check_triggers_icount;

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -327,7 +327,7 @@ void processor_t::set_privilege(reg_t prv, bool virt)
   state.v_changed = state.v != state.prev_v;
 }
 
-const char* processor_t::get_privilege_string()
+const char* processor_t::get_privilege_string() const
 {
   if (state.debug_mode)
     return "D";

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -249,8 +249,8 @@ public:
               FILE *log_file, std::ostream& sout_); // because of command line option --log and -s we need both
   ~processor_t();
 
-  const isa_parser_t &get_isa() { return isa; }
-  const cfg_t &get_cfg() { return *cfg; }
+  const isa_parser_t &get_isa() const & { return isa; }
+  const cfg_t &get_cfg() const & { return *cfg; }
 
   void set_debug(bool value);
   void set_histogram(bool value);
@@ -327,7 +327,7 @@ public:
   }
   reg_t legalize_privilege(reg_t);
   void set_privilege(reg_t, bool);
-  const char* get_privilege_string();
+  const char* get_privilege_string() const;
   void update_histogram(reg_t pc);
   const disassembler_t* get_disassembler() { return disassembler; }
 
@@ -349,8 +349,8 @@ public:
   // When true, display disassembly of each instruction that's executed.
   bool debug;
   // When true, take the slow simulation path.
-  bool slow_path();
-  bool halted() { return state.debug_mode; }
+  bool slow_path() const;
+  bool halted() const { return state.debug_mode; }
   enum {
     HR_NONE,    /* Halt request is inactive. */
     HR_REGULAR, /* Regular halt request/debug interrupt. */


### PR DESCRIPTION
Now users can access getters through const reference to processor_t

This commit addresses part of https://github.com/riscv-software-src/riscv-isa-sim/issues/1978