### PR TITLE
feat: move cache block size initialization to constructor

### DIFF
--- a/riscv/cfg.cc
+++ b/riscv/cfg.cc
@@ -47,4 +47,5 @@ cfg_t::cfg_t()
   explicit_hartids = false;
   real_time_clint  = false;
   trigger_count    = 4;
+  cache_blocksz    = 64;
 }

--- a/riscv/cfg.h
+++ b/riscv/cfg.h
@@ -78,6 +78,7 @@ public:
   bool                    explicit_hartids;
   bool                    real_time_clint;
   reg_t                   trigger_count;
+  reg_t                   cache_blocksz;
   std::optional<abstract_sim_if_t*> external_simulator;
 
   size_t nprocs() const { return hartids.size(); }

--- a/riscv/mmu.cc
+++ b/riscv/mmu.cc
@@ -7,8 +7,8 @@
 #include "processor.h"
 #include "decode_macros.h"
 
-mmu_t::mmu_t(simif_t* sim, endianness_t endianness, processor_t* proc)
- : sim(sim), proc(proc),
+mmu_t::mmu_t(simif_t* sim, endianness_t endianness, processor_t* proc, reg_t cache_blocksz)
+ : sim(sim), proc(proc), blocksz(cache_blocksz),
 #ifdef RISCV_ENABLE_DUAL_ENDIAN
   target_big_endian(endianness == endianness_big),
 #endif

--- a/riscv/mmu.h
+++ b/riscv/mmu.h
@@ -89,7 +89,7 @@ private:
   mem_access_info_t generate_access_info(reg_t addr, access_type type, xlate_flags_t xlate_flags);
 
 public:
-  mmu_t(simif_t* sim, endianness_t endianness, processor_t* proc);
+  mmu_t(simif_t* sim, endianness_t endianness, processor_t* proc, reg_t cache_blocksz);
   ~mmu_t();
 
   template<typename T>
@@ -395,11 +395,6 @@ public:
   template<typename T> inline target_endian<T> to_target(T n) const
   {
     return target_big_endian? target_endian<T>::to_be(n) : target_endian<T>::to_le(n);
-  }
-
-  void set_cache_blocksz(reg_t size)
-  {
-    blocksz = size;
   }
 
 private:

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -62,7 +62,7 @@ processor_t::processor_t(const char* isa_str, const char* priv_str,
   VU.vstart_alu = 0;
 
   register_base_instructions();
-  mmu = new mmu_t(sim, cfg->endianness, this);
+  mmu = new mmu_t(sim, cfg->endianness, this, cfg->cache_blocksz);
 
   disassembler = new disassembler_t(&isa);
   for (auto e : isa.get_extensions())

--- a/riscv/sim.cc
+++ b/riscv/sim.cc
@@ -96,7 +96,7 @@ sim_t::sim_t(const cfg_t *cfg, bool halted,
   }
 #endif
 
-  debug_mmu = new mmu_t(this, cfg->endianness, NULL);
+  debug_mmu = new mmu_t(this, cfg->endianness, NULL, cfg->cache_blocksz);
 
   // When running without using a dtb, skip the fdt-based configuration steps
   if (!dtb_enabled) {

--- a/spike_main/spike.cc
+++ b/spike_main/spike.cc
@@ -451,6 +451,7 @@ int main(int argc, char** argv)
         min_blocksz, max_blocksz);
       exit(-1);
     }
+    cfg.cache_blocksz = blocksz;
   });
   parser.option(0, "instructions", 1, [&](const char* s){
     instructions = strtoull(s, 0, 0);
@@ -541,7 +542,6 @@ int main(int argc, char** argv)
     if (dc) s.get_core(i)->get_mmu()->register_memtracer(&*dc);
     for (auto e : extensions)
       s.get_core(i)->register_extension(e());
-    s.get_core(i)->get_mmu()->set_cache_blocksz(blocksz);
   }
 
   s.set_debug(debug);


### PR DESCRIPTION
Previously cache block size had to be initialized via special set_chache_blocksz setter function and was uninitialized if you didn't call it. This caused us some issues when we forgot to call a setter function and everything worked fine until first Zicbom instruction where spike went into an infinite loop (on uninitialized value). This commit was made as a measure to prevent similar issues in the future. In this commit I move initialization of the block size to the mmu_t's constructor. The value of this member goes through cfg_t struct. This way the value will always be initialized without loosing ability to be reset via mentioned setter function if one needs to do so.