### PR TITLE
fix: log store only if it actually happened

### DIFF
--- a/ci-tests/atomics.c
+++ b/ci-tests/atomics.c
@@ -1,0 +1,20 @@
+#include <stdio.h>
+#include <stdatomic.h>
+
+atomic_int acnt = 0;
+atomic_int bcnt = 0;
+
+int foo() {
+  for(int n = 0; n < 1000; ++n) {
+    ++acnt;
+    if(acnt % 10 == 0)
+      ++bcnt;
+  }
+  return acnt;
+}
+
+int main(void) {
+  int acnt = foo();
+  printf("First atomic counter is %u, second is %u\n", acnt, bcnt);
+  return 0;
+}

--- a/ci-tests/create-ci-binary-tarball
+++ b/ci-tests/create-ci-binary-tarball
@@ -20,10 +20,16 @@ mkdir -p build/dummycsr && cd "$_"
 riscv64-unknown-elf-gcc -O2 -o customcsr `git rev-parse --show-toplevel`/ci-tests/customcsr.c
 cd -
 
+mkdir -p build/atomics && cd "$_"
+riscv64-unknown-elf-gcc -O2 -o atomics `git rev-parse --show-toplevel`/ci-tests/atomics.c
+cd -
+
+
 mv build/pk/pk .
 mv build/hello/hello .
 mv build/dummy-slliuw/dummy-slliuw .
 mv build/dummycsr/customcsr .
-tar -cf spike-ci.tar pk hello dummy-slliuw customcsr
+mv build/atomics/atomics .
+tar -cf spike-ci.tar pk hello dummy-slliuw customcsr atomics
 
-rm pk hello dummy-slliuw customcsr
+rm pk hello dummy-slliuw customcsr atomics

--- a/ci-tests/test-spike
+++ b/ci-tests/test-spike
@@ -11,6 +11,7 @@ cd run
 wget https://github.com/riscv-software-src/riscv-isa-sim/releases/download/dummy-tag-for-ci-storage/spike-ci.tar
 tar xf spike-ci.tar
 time ../install/bin/spike --isa=rv64gc pk hello | grep "Hello, world!  Pi is approximately 3.141588."
+../install/bin/spike --log-commits --isa=rv64gc pk atomics | grep "First atomic counter is 1000, second is 100"
 
 # check that including sim.h in an external project works
 g++ -std=c++2a -I../install/include -L../install/lib $DIR/testlib.cc -lriscv -o test-libriscv

--- a/riscv/mmu.cc
+++ b/riscv/mmu.cc
@@ -369,7 +369,7 @@ void mmu_t::store_slow_path(reg_t original_addr, reg_t len, const uint8_t* bytes
     store_slow_path_intrapage(len, bytes, access_info, actually_store);
   }
 
-  if (proc && unlikely(proc->get_log_commits_enabled()))
+  if (actually_store && proc && unlikely(proc->get_log_commits_enabled()))
     proc->state.log_mem_write.push_back(std::make_tuple(original_addr, reg_from_bytes(len, bytes), len));
 }
 


### PR DESCRIPTION
Since 92e4f021121f2d175e7c74eac536342bb7b202fb moved logging logic into `store_slow_path` function it has been logging stores even if  `actually_store` parameter is false. Because of that logging is broken for all atomic instructions. Function `amo` calls `store_slow_path` with `nullptr` argument and `actually_store` equal to false while callee uses `reg_from_bytes` independently from `actually_store` value All of that causes dereferencing of `nullptr`. This commit logs memory access only if it actually happened.

This bug was found while trying to execute some code with atomics with `--log-commits` option (Made reproducer into a test in this commit). And getting segmentation fault. After rebuilding with address sanitizer got the following error:
```
AddressSanitizer:DEADLYSIGNAL
=================================================================
==14771==ERROR: AddressSanitizer: SEGV on unknown address 0x000000000000 (pc 0x55886fe5d610 bp 0x62f00000e400 sp 0x7ffcad1ad2b8 T0)
==14771==The signal is caused by a READ memory access.
==14771==Hint: address points to the zero page.
    #0 0x55886fe5d610 in reg_from_bytes(unsigned long, unsigned char const*) riscv-isa-sim/riscv/mmu.cc:126
    #1 0x55886fe5fd4c in mmu_t::store_slow_path(unsigned long, unsigned long, unsigned char const*, xlate_flags_t, bool, bool) riscv-isa-sim/riscv/mmu.cc:373
    #2 0x55886ff20fae in amo<unsigned int, logged_rv64i_amoadd_w(processor_t*, insn_t, reg_t)::<lambda(uint32_t)> > riscv-isa-sim/riscv/mmu.h:180
    #3 0x55886ff20fae in logged_rv64i_amoadd_w(processor_t*, insn_t, unsigned long) riscv-isa-sim/riscv/insns/amoadd_w.h:2
    #4 0x5588701e51ca in execute_insn_logged riscv-isa-sim/riscv/execute.cc:174
    #5 0x5588701e51ca in processor_t::step(unsigned long) riscv-isa-sim/riscv/execute.cc:286
    #6 0x55886fe481f3 in sim_t::step(unsigned long) riscv-isa-sim/riscv/sim.cc:288
    #7 0x55886fe4834b in sim_t::idle() riscv-isa-sim/riscv/sim.cc:445
    #8 0x55887021cd24 in htif_t::run() riscv-isa-sim/fesvr/htif.cc:290
    #9 0x55886fdfd61a in main riscv-isa-sim/spike_main/spike.cc:551
    #10 0x7f432496ed8f in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58
    #11 0x7f432496ee3f in __libc_start_main_impl ../csu/libc-start.c:392
    #12 0x55886fe095d4 in _start (riscv-isa-sim/build/install/bin/spike+0x2825d4)

AddressSanitizer can not provide additional info.
SUMMARY: AddressSanitizer: SEGV riscv-isa-sim/riscv/mmu.cc:126 in reg_from_bytes(unsigned long, unsigned char const*)
==14771==ABORTING
```