### PR TITLE
Partially revert #1987 to fix regrssion in vsra.vi and vssra.vi 

### DIFF
--- a/riscv/insns/vsra_vi.h
+++ b/riscv/insns/vsra_vi.h
@@ -1,5 +1,5 @@
 // vsra.vi vd, vs2, zimm5
-VI_VI_ULOOP
+VI_VI_LOOP
 ({
-  vd = vs2 >> (zimm5 & (sew - 1));
+  vd = vs2 >> (insn.v_zimm5() & (sew - 1));
 })

--- a/riscv/insns/vssra_vi.h
+++ b/riscv/insns/vssra_vi.h
@@ -1,8 +1,8 @@
 // vssra.vi vd, vs2, zimm5
-VI_VI_ULOOP
+VI_VI_LOOP
 ({
   VRM xrm = P.VU.get_vround_mode();
-  int sh = zimm5 & (sew - 1);
+  int sh = insn.v_zimm5() & (sew - 1);
   int128_t val = vs2;
 
   INT_ROUNDING(val, xrm, sh);

--- a/riscv/v_ext_macros.h
+++ b/riscv/v_ext_macros.h
@@ -200,7 +200,7 @@ static inline bool is_overlapped_widen(const int astart, int asize,
   require_vector(true); \
   reg_t vl = P.VU.vl->read(); \
   reg_t UNUSED sew = P.VU.vsew; \
-  reg_t rd_num = insn.rd(); \
+  reg_t UNUSED rd_num = insn.rd(); \
   reg_t UNUSED rs1_num = insn.rs1(); \
   reg_t rs2_num = insn.rs2(); \
   for (reg_t i = P.VU.vstart->read(); i < vl; ++i) {
@@ -336,7 +336,7 @@ static inline bool is_overlapped_widen(const int astart, int asize,
 
 #define VI_PARAMS(x) \
   type_sew_t<x>::type &vd = P.VU.elt<type_sew_t<x>::type>(rd_num, i, true); \
-  type_sew_t<x>::type simm5 = (type_sew_t<x>::type)insn.v_simm5(); \
+  type_sew_t<x>::type UNUSED simm5 = (type_sew_t<x>::type)insn.v_simm5(); \
   type_sew_t<x>::type UNUSED vs2 = P.VU.elt<type_sew_t<x>::type>(rs2_num, i);
 
 #define XV_PARAMS(x) \


### PR DESCRIPTION
Resolves #1996.

Use arithmetic shifts, not logical shifts.

I broke these instructions while fixing #1915.