### PR TITLE
Bugfix cm.jalt

### DIFF
--- a/riscv/mmu.h
+++ b/riscv/mmu.h
@@ -303,7 +303,7 @@ public:
   T ALWAYS_INLINE fetch_jump_table(reg_t addr) {
     T res = 0;
     for (size_t i = 0; i < sizeof(T) / sizeof(insn_parcel_t); i++)
-      res |= (T)fetch_insn_parcel(addr + i * sizeof(insn_parcel_t)) << (i * sizeof(insn_parcel_t));
+      res |= (T)fetch_insn_parcel(addr + i * sizeof(insn_parcel_t)) << (i * sizeof(insn_parcel_t) * 8);
 
     // table accesses use data endianness, not instruction (little) endianness
     return target_big_endian ? to_be(res) : res;


### PR DESCRIPTION
Hello @aswaterman & al.

Completed my SystemC/TLM stuff, but when sync'ing upstream, I noticed lots of changes in mmu_t,
including a rewrite of `mmu_t::fetch_jump_table()`

Unfortunately, this breaks cm.jalt on my side -even on my 'non TLM' model.

I suspect a typo in `mmu_t::fetch_jump_table()` (note the `* 8`)

Could you please confirm my understanding ?

Thanks again
Jean-François