### PR TITLE
Implement Ziccid extension

### DIFF
--- a/disasm/isa_parser.cc
+++ b/disasm/isa_parser.cc
@@ -140,6 +140,8 @@ isa_parser_t::isa_parser_t(const char* str, const char *priv)
       // HINTs encoded in base-ISA instructions are always present.
     } else if (ext_str == "zihintntl") {
       // HINTs encoded in base-ISA instructions are always present.
+    } else if (ext_str == "ziccid") {
+      extension_table[EXT_ZICCID] = true;
     } else if (ext_str == "ziccif") {
       // aligned instruction fetch is always atomic in Spike
     } else if (ext_str == "zaamo") {

--- a/disasm/isa_parser.cc
+++ b/disasm/isa_parser.cc
@@ -140,6 +140,8 @@ isa_parser_t::isa_parser_t(const char* str, const char *priv)
       // HINTs encoded in base-ISA instructions are always present.
     } else if (ext_str == "zihintntl") {
       // HINTs encoded in base-ISA instructions are always present.
+    } else if (ext_str == "ziccif") {
+      // aligned instruction fetch is always atomic in Spike
     } else if (ext_str == "zaamo") {
       extension_table[EXT_ZAAMO] = true;
     } else if (ext_str == "zalrsc") {

--- a/riscv/execute.cc
+++ b/riscv/execute.cc
@@ -210,6 +210,8 @@ bool processor_t::slow_path() const
 // fetch/decode/execute loop
 void processor_t::step(size_t n)
 {
+  mmu_t* _mmu = mmu;
+
   if (!state.debug_mode) {
     if (halt_request == HR_REGULAR) {
       enter_debug_mode(DCSR_CAUSE_DEBUGINT, 0);
@@ -221,10 +223,15 @@ void processor_t::step(size_t n)
     }
   }
 
+  if (extension_enabled(EXT_ZICCID)) {
+    // Ziccid requires stores eventually become visible to instruction fetch,
+    // so periodically flush the I$
+    _mmu->flush_icache();
+  }
+
   while (n > 0) {
     size_t instret = 0;
     reg_t pc = state.pc;
-    mmu_t* _mmu = mmu;
     state.prv_changed = false;
     state.v_changed = false;
 

--- a/riscv/execute.cc
+++ b/riscv/execute.cc
@@ -226,7 +226,10 @@ void processor_t::step(size_t n)
   if (extension_enabled(EXT_ZICCID)) {
     // Ziccid requires stores eventually become visible to instruction fetch,
     // so periodically flush the I$
-    _mmu->flush_icache();
+    if (ziccid_flush_count-- == 0) {
+      ziccid_flush_count += ZICCID_FLUSH_PERIOD;
+      _mmu->flush_icache();
+    }
   }
 
   while (n > 0) {

--- a/riscv/isa_parser.h
+++ b/riscv/isa_parser.h
@@ -50,6 +50,7 @@ typedef enum {
   EXT_ZFINX,
   EXT_ZHINX,
   EXT_ZHINXMIN,
+  EXT_ZICCID,
   EXT_ZICBOM,
   EXT_ZICBOZ,
   EXT_ZICNTR,

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -412,6 +412,9 @@ private:
   static const size_t OPCODE_CACHE_SIZE = 4095;
   opcode_cache_entry_t opcode_cache[OPCODE_CACHE_SIZE];
 
+  unsigned ziccid_flush_count = 0;
+  static const unsigned ZICCID_FLUSH_PERIOD = 10;
+
   bool is_handled_in_vs();
   void take_pending_interrupt() { take_interrupt(state.mip->read() & state.mie->read()); }
   void take_interrupt(reg_t mask); // take first enabled interrupt in mask


### PR DESCRIPTION
The mechanism to make stores eventually visible to fetches is to flush the I$ every so often.  Not how a real implementation would do it, but it works fine in this context.

Also accept and trivially implement the Ziccif extension.