### PR TITLE
Bypass masked-off elements for viota

### DIFF
--- a/riscv/insns/viota_m.h
+++ b/riscv/insns/viota_m.h
@@ -21,23 +21,22 @@ for (reg_t i = 0; i < vl; ++i) {
     }
   }
 
-  bool use_ori = (insn.v_vm() == 0) && !do_mask;
+  // Bypass masked-off elements
+  if ((insn.v_vm() == 0) && !do_mask)
+    continue;
+
   switch (sew) {
   case e8:
-    P.VU.elt<uint8_t>(rd_num, i, true) = use_ori ?
-                                   P.VU.elt<uint8_t>(rd_num, i) : cnt;
+    P.VU.elt<uint8_t>(rd_num, i, true) = cnt;
     break;
   case e16:
-    P.VU.elt<uint16_t>(rd_num, i, true) = use_ori ?
-                                    P.VU.elt<uint16_t>(rd_num, i) : cnt;
+    P.VU.elt<uint16_t>(rd_num, i, true) = cnt;
     break;
   case e32:
-    P.VU.elt<uint32_t>(rd_num, i, true) = use_ori ?
-                                    P.VU.elt<uint32_t>(rd_num, i) : cnt;
+    P.VU.elt<uint32_t>(rd_num, i, true) = cnt;
     break;
   default:
-    P.VU.elt<uint64_t>(rd_num, i, true) = use_ori ?
-                                    P.VU.elt<uint64_t>(rd_num, i) : cnt;
+    P.VU.elt<uint64_t>(rd_num, i, true) = cnt;
     break;
   }
 


### PR DESCRIPTION
This patch bypasses masked-off elements for viota.  Thus these elements keep untouched.  It's helpful to detect inactive elements.
