### PR TITLE
remove unused EGS constant from vsm4r_vs handler

### DIFF
--- a/riscv/insns/vsm4r_vs.h
+++ b/riscv/insns/vsm4r_vs.h
@@ -2,8 +2,6 @@
 
 #include "zvksed_ext_macros.h"
 
-const uint32_t EGS = 4;
-
 require_vsm4_constraints;
 require_align(insn.rd(), P.VU.vflmul);
 require_vs2_align_eglmul(128);


### PR DESCRIPTION
The macro require_vsm4_constraints defines EGS once again (shadowing the definition of this constant, since it introduces a new scope). This renders the original definition as "unused", causing warning during compilation.