### PR TITLE
Support label-based sideband commands for printing register contents

### DIFF
--- a/fesvr/htif.h
+++ b/fesvr/htif.h
@@ -79,6 +79,9 @@ class htif_t : public chunked_memif_t
 
   // Given an address, return symbol from addr2symbol map
   const char* get_symbol(uint64_t addr);
+  std::vector<std::string> get_all_symbols(uint64_t addr);
+
+  std::ostream &log_label_intrinsic_output(void);
 
   // Return true if the simulation should exit due to a signal,
   // or end-of-test from HTIF, or an instruction limit.
@@ -112,7 +115,10 @@ class htif_t : public chunked_memif_t
   std::vector<std::string> payloads;
 
   std::vector<std::string> symbol_elfs;
-  std::map<uint64_t, std::string> addr2symbol;
+  std::map<uint64_t, std::vector<std::string>> addr2symbol;
+
+  std::string intrinsic_label_log_file;
+  std::ofstream *intrinsic_label_log_stream = nullptr;
 
   friend class memif_t;
   friend class syscall_t;
@@ -142,6 +148,8 @@ class htif_t : public chunked_memif_t
        +payload=PATH\n\
       --symbol-elf=PATH    Populate the symbol table with the ELF file at PATH\n\
        +symbol-elf=PATH\n\
+      --intrinsic-label-log=PATH    File for output caused by intrinsic labels\n\
+       +intrinsic-label-log=PATH\n\
 \n\
 HOST OPTIONS (currently unsupported)\n\
       --disk=DISK          Add DISK device. Use a ramdisk since this isn't\n\
@@ -162,6 +170,7 @@ TARGET (RISC-V BINARY) OPTIONS\n\
 {"signature-granularity",    required_argument, 0, HTIF_LONG_OPTIONS_OPTIND + 5 },     \
 {"target-argument",          required_argument, 0, HTIF_LONG_OPTIONS_OPTIND + 6 },     \
 {"symbol-elf",               required_argument, 0, HTIF_LONG_OPTIONS_OPTIND + 7 },     \
+{"intrinsic-label-log",      required_argument, 0, HTIF_LONG_OPTIONS_OPTIND + 8 },     \
 {0, 0, 0, 0}
 
 #endif // __HTIF_H

--- a/riscv/execute.cc
+++ b/riscv/execute.cc
@@ -289,12 +289,16 @@ void processor_t::step(size_t n)
             throw wait_for_interrupt_t();
           }
 
+          sim->process_intrinsic_labels_pre_addr(state, state.pc);
+
           in_wfi = false;
           insn_fetch_t fetch = mmu->load_insn(pc);
           if (debug && !state.serialized)
             disasm(fetch.insn);
           pc = execute_insn_logged(this, pc, fetch);
           advance_pc();
+
+          sim->process_intrinsic_labels_post_addr(state, state.pc);
 
           // Resume from debug mode in critical error
           if (state.critical_error && !state.debug_mode) {
@@ -310,6 +314,8 @@ void processor_t::step(size_t n)
       }
       else while (instret < n)
       {
+        sim->process_intrinsic_labels_pre_addr(state, state.pc);
+        
         // Main simulation loop, fast path.
         for (auto ic_entry = _mmu->access_icache(pc); ; ) {
           auto fetch = ic_entry->data;
@@ -324,6 +330,8 @@ void processor_t::step(size_t n)
         }
 
         advance_pc();
+        
+        sim->process_intrinsic_labels_post_addr(state, state.pc);
       }
     }
     catch(trap_t& t)

--- a/riscv/sim.h
+++ b/riscv/sim.h
@@ -112,6 +112,10 @@ private:
   void set_rom();
 
   virtual const char* get_symbol(uint64_t paddr) override;
+  virtual std::vector<std::string> get_all_symbols(uint64_t paddr) override;
+
+  virtual void process_intrinsic_labels_pre_addr(const state_t &state, uint64_t addr) override;
+  virtual void process_intrinsic_labels_post_addr(const state_t &state, uint64_t addr) override;
 
   // presents a prompt for introspection into the simulation
   void interactive();
@@ -156,6 +160,11 @@ private:
   virtual size_t chunk_align() override { return 8; }
   virtual size_t chunk_max_size() override { return 8; }
   virtual endianness_t get_target_endianness() const override;
+
+private:
+  // label intrinsic handling
+  void process_label_intrinsic(const state_t &state, const std::string &sym);
+  void process_print_register_label_intrinsic(const state_t &state, const std::string &sym);
 
 public:
   // Initialize this after procs, because in debug_module_t::reset() we

--- a/riscv/simif.h
+++ b/riscv/simif.h
@@ -8,6 +8,7 @@
 #include "cfg.h"
 
 class processor_t;
+struct state_t;
 class mmu_t;
 
 // this is the interface to the simulator used by the processors and memory
@@ -24,10 +25,15 @@ public:
   // Callback for processors to let the simulation know they were reset.
   virtual void proc_reset(unsigned id) = 0;
 
+  // used to process intrinsic labels
+  virtual void process_intrinsic_labels_pre_addr(const state_t &state, uint64_t addr) = 0;
+  virtual void process_intrinsic_labels_post_addr(const state_t &state, uint64_t addr) = 0;
+
   virtual const cfg_t &get_cfg() const = 0;
   virtual const std::map<size_t, processor_t*>& get_harts() const = 0;
 
   virtual const char* get_symbol(uint64_t paddr) = 0;
+  virtual std::vector<std::string> get_all_symbols(uint64_t paddr) = 0;
 
   virtual ~simif_t() = default;
 


### PR DESCRIPTION
Allows insertion of labels like 'spike.pre.printreg.x1.id' to print a log of the value in register x1 to a file each time the pc matches the label position. The 'id' is used as a more human readable and also easier to process way to correlate entries in the log file to the inserted labels.