### PR TITLE
added jtag_dtm and remote_bitbang to riscv_install_hdrs

### DIFF
--- a/riscv/riscv.mk.in
+++ b/riscv/riscv.mk.in
@@ -33,11 +33,13 @@ riscv_install_hdrs = \
 	entropy_source.h \
 	extension.h \
 	isa_parser.h \
+	jtag_dtm.h \
 	log_file.h \
 	memtracer.h \
 	mmu.h \
 	platform.h \
 	processor.h \
+	remote_bitbang.h \
 	rocc.h \
 	sim.h \
 	simif.h \


### PR DESCRIPTION
Need to add those `jtag_dtm.h` and `remote_bitbang.h` to the list of files which will be installed in case I want to use Spike as a library with `GDB` attachment