### PR TITLE
AIA: vstopi should only be used for AIA-extended interrupts

### DIFF
--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -415,7 +415,6 @@ private:
   unsigned ziccid_flush_count = 0;
   static const unsigned ZICCID_FLUSH_PERIOD = 10;
 
-  bool is_handled_in_vs();
   void take_pending_interrupt() { take_interrupt(state.mip->read() & state.mie->read()); }
   void take_interrupt(reg_t mask); // take first enabled interrupt in mask
   void take_trap(trap_t& t, reg_t epc); // take an exception


### PR DESCRIPTION
VSEIP/VSTIP/VSSIP should come in through the non-SSAIA path. vstopi will be used to throw VTI and IID > 13 interrupts.

@binno - let me know if I missed something.