### PR TITLE
Fix pmpaddr read

### DIFF
--- a/riscv/encoding.h
+++ b/riscv/encoding.h
@@ -358,7 +358,9 @@
 #define PMP_A     0x18
 #define PMP_L     0x80
 #define PMP_SHIFT 2
+#define PMP_ADDR_BITS  54
 
+#define PMP_OFF   0x00
 #define PMP_TOR   0x08
 #define PMP_NA4   0x10
 #define PMP_NAPOT 0x18


### PR DESCRIPTION
As the spec said

- When G>=1, the NA4 mode is not selectable.
- When G>=2 and pmpcfg[i]A[1] is set, i.e. the mode is NAPOT,
  then bits pmpaddr[i][G-2:0] read as all ones.
- When G>=2 and pmpaddr[i]A[1] is clear, i.e. the mode is OFF or TOR,
  then bits pmpaddr[i][G-1:0] read as all zeros.

and [63, 54] bits of pmpaddr are WARL

---

When I was comparing spike and sail, I found the return value of read_pmpaddr are different.

I think the issue should came from spike, and this PR mainly references the [sail implementation](https://github.com/riscv/sail-riscv/blob/87eb6fb8f5db66f52cc570948acd78a1ffec0f1d/model/riscv_pmp_regs.sail).
