### PR TITLE
Dynamically link all libraries in spike

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -237,7 +237,7 @@ $(2)_reverse_deps   := $$(call reverse_list,$$($(2)_subproject_deps))
 # Build a library for this subproject
 
 $(2)_lib_libs       := $$($(2)_reverse_deps)
-$(2)_lib_libnames   := $$(patsubst %, lib%.a, $$($(2)_lib_libs))
+$(2)_lib_libnames   := $$(patsubst %, lib%.so, $$($(2)_lib_libs))
 $(2)_lib_libarg     := $$(patsubst %, -l%, $$($(2)_lib_libs))
 $(2)_lib_libnames_shared	:= $$(if $$($(2)_install_shared_lib),lib$(1).so,)
 
@@ -247,7 +247,7 @@ lib$(1).a : $$($(2)_objs) $$($(2)_c_objs)
 lib$(1).so : $$($(2)_objs) $$($(2)_c_objs) $$($(2)_lib_libnames_shared) $$($(2)_lib_libnames)
 	$(LINK) -shared -o $$@ $(if $(filter Darwin,$(shell uname -s)),-install_name $(install_libs_dir)/$$@) $$^ $$($(2)_lib_libnames) $(LIBS)
 
-$(2)_junk += lib$(1).a
+$(2)_junk += lib$(1).so
 $(2)_junk += $$(if $$($(2)_install_shared_lib),lib$(1).so,)
 
 # Build unit tests
@@ -256,8 +256,8 @@ $(2)_test_objs      := $$(patsubst %.cc, %.o, $$($(2)_test_srcs))
 $(2)_test_deps      := $$(patsubst %.o, %.d, $$($(2)_test_objs))
 $(2)_test_exes      := $$(patsubst %.t.cc, %-utst, $$($(2)_test_srcs))
 $(2)_test_outs      := $$(patsubst %, %.out, $$($(2)_test_exes))
-$(2)_test_libs      := $(1) $$($(2)_reverse_deps)
-$(2)_test_libnames  := $$(patsubst %, lib%.a, $$($(2)_test_libs))
+$(2)_test_libs      := $$($(2)_reverse_deps)
+$(2)_test_libnames  := lib%(1).a $$(patsubst %, lib%.so, $$($(2)_test_libs))
 $(2)_test_libarg    := $$(patsubst %, -l%, $$($(2)_test_libs))
 
 $$($(2)_test_objs) : %.o : %.cc
@@ -284,8 +284,8 @@ $(2)_junk += $$($(2)_test_outs)
 $(2)_prog_objs      := $$(patsubst %.cc, %.o, $$($(2)_prog_srcs))
 $(2)_prog_deps      := $$(patsubst %.o, %.d, $$($(2)_prog_objs))
 $(2)_prog_exes      := $$(patsubst %.cc, %, $$($(2)_prog_srcs))
-$(2)_prog_libs      := $(1) $$($(2)_reverse_deps)
-$(2)_prog_libnames  := $$(patsubst %, lib%.a, $$($(2)_prog_libs))
+$(2)_prog_libs      := $$($(2)_reverse_deps)
+$(2)_prog_libnames  := lib$(1).a $$(patsubst %, lib%.so, $$($(2)_prog_libs))
 $(2)_prog_libarg    := $$(patsubst %, -l%, $$($(2)_prog_libs))
 
 $$($(2)_prog_objs) : %.o : %.cc
@@ -335,8 +335,7 @@ test_outs += $$($(2)_test_outs)
 
 install_config_hdrs += $$(if $$($(2)_install_config_hdr),$(1),)
 install_hdrs += $$(addprefix $(src_dir)/$(1)/, $$($(2)_install_hdrs))
-install_libs += $$(if $$($(2)_install_lib),lib$(1).a,)
-install_libs += $$(if $$($(2)_install_shared_lib),lib$(1).so,)
+install_libs += lib$(1).so
 install_exes += $$($(2)_install_prog_exes)
 install_pcs  += $$(if $$($(2)_install_pcs),riscv-$(1).pc,)
 


### PR DESCRIPTION
This PR is not currently complete, but I was hoping to start a discussion of #2035.

This changes spike to dynamically link all libraries. The main benefit of this change is that we can build extension libraries using the system installed spike by linking them against `libriscv.so`.  Without this change, we are [doubly running static initializers/constructors](https://stackoverflow.com/questions/45335499/c-link-library-twice-are-global-constructors-run-twice) when we do this.

The main negatives of this change are:
1. We now need to install more libraries
2. If you want to run spike directly out of the `build` directory instead of the `install` directory, you will have to set `LD_LIBRARY_PATH=<dir>` to the `build` directory

Some ideas follow up work:
- We don't *have* to dynamically link all libraries, its just the build system isn't set up to make that easy right now. This way we don't have to install everything. We will probably have to tread very carefully to avoid triggering the same issue again.
- We can remove the `-Wl,--export-dynamic` flag which exports symbols from the executable
- We can remove the [hack](https://github.com/riscv-software-src/riscv-isa-sim/blob/master/spike_main/spike_main.mk.in#L18) to ensure that certain symbols make it into the final executable 
- If setting `LD_LIBRARY_PATH` is too onerous, we can probably set the `rpath` to the build directory and rewrite when installing.  Things like `libtool` and `cmake` do handle this automagically.
