### PR TITLE
Don't include built-in devices in mmio_device_map

### DIFF
--- a/riscv/abstract_device.h
+++ b/riscv/abstract_device.h
@@ -46,4 +46,11 @@ mmio_device_map_t& mmio_device_map();
   std::string generate_dts(const sim_t* sim, const std::vector<std::string>& sargs) const override { return generate(sim, sargs); } \
   }; device_factory_t *name##_factory = new name##_factory_t();
 
+#define REGISTER_BUILTIN_DEVICE(name, parse, generate) \
+  class name##_factory_t : public device_factory_t { \
+  public: \
+  name##_t* parse_from_fdt(const void* fdt, const sim_t* sim, reg_t* base, const std::vector<std::string>& sargs) const override { return parse(fdt, sim, base, sargs); } \
+  std::string generate_dts(const sim_t* sim, const std::vector<std::string>& sargs) const override { return generate(sim, sargs); } \
+  }; device_factory_t *name##_factory = new name##_factory_t();
+
 #endif

--- a/riscv/clint.cc
+++ b/riscv/clint.cc
@@ -145,4 +145,4 @@ std::string clint_generate_dts(const sim_t* sim, const std::vector<std::string>&
   return s.str();
 }
 
-REGISTER_DEVICE(clint, clint_parse_from_fdt, clint_generate_dts)
+REGISTER_BUILTIN_DEVICE(clint, clint_parse_from_fdt, clint_generate_dts)

--- a/riscv/ns16550.cc
+++ b/riscv/ns16550.cc
@@ -361,4 +361,4 @@ ns16550_t* ns16550_parse_from_fdt(const void* fdt, const sim_t* sim, reg_t* base
   }
 }
 
-REGISTER_DEVICE(ns16550, ns16550_parse_from_fdt, ns16550_generate_dts)
+REGISTER_BUILTIN_DEVICE(ns16550, ns16550_parse_from_fdt, ns16550_generate_dts)

--- a/riscv/plic.cc
+++ b/riscv/plic.cc
@@ -436,4 +436,4 @@ plic_t* plic_parse_from_fdt(const void* fdt, const sim_t* sim, reg_t* base, cons
     return nullptr;
 }
 
-REGISTER_DEVICE(plic, plic_parse_from_fdt, plic_generate_dts)
+REGISTER_BUILTIN_DEVICE(plic, plic_parse_from_fdt, plic_generate_dts)

--- a/riscv/sim.cc
+++ b/riscv/sim.cc
@@ -118,8 +118,8 @@ sim_t::sim_t(const cfg_t *cfg, bool halted,
   // particular, the default device tree configuration that you get without
   // setting the dtb_file argument has one.
   std::vector<device_factory_sargs_t> device_factories = {
-    {clint_factory, {}}, // clint must be element 0
-    {plic_factory, {}}, // plic must be element 1
+    {clint_factory, {}},
+    {plic_factory, {}},
     {ns16550_factory, {}}};
   device_factories.insert(device_factories.end(),
                           plugin_device_factories.begin(),
@@ -253,10 +253,15 @@ sim_t::sim_t(const cfg_t *cfg, bool halted,
       std::shared_ptr<abstract_device_t> dev_ptr(device);
       add_device(device_base, dev_ptr);
 
-      if (i == 0) // clint_factory
+      if (dynamic_cast<clint_t*>(&*dev_ptr)) {
+        assert(!clint);
         clint = std::static_pointer_cast<clint_t>(dev_ptr);
-      else if (i == 1) // plic_factory
+      }
+
+      if (dynamic_cast<plic_t*>(&*dev_ptr)) {
+        assert(!plic);
         plic = std::static_pointer_cast<plic_t>(dev_ptr);
+      }
     }
   }
 }


### PR DESCRIPTION
Only use mmio_device_map for plugin devices.

This fixes a collision caused by multiple static initializers if Spike depends on a library that depends on libriscv.so.

Fixes #2035

cc @youngar