### PR TITLE
Fix regression introduced by #2050

### DIFF
--- a/riscv/v_ext_macros.h
+++ b/riscv/v_ext_macros.h
@@ -1896,7 +1896,7 @@ VI_VX_ULOOP({ \
   VI_VFP_LOOP_END
 
 #define VI_VFP_LOOP_SCALE_BASE \
-  VI_VFP_COMMON \
+  VI_VFP_BASE; \
   for (reg_t i = P.VU.vstart->read(); i < vl; ++i) { \
     VI_LOOP_ELEMENT_SKIP();
 


### PR DESCRIPTION
Don't assert SEW=8 for fp16 <> int8 conversions.