### PR TITLE
Add VLEN >= ELEN validation check

### DIFF
--- a/disasm/isa_parser.cc
+++ b/disasm/isa_parser.cc
@@ -524,7 +524,7 @@ isa_parser_t::isa_parser_t(const char* str, const char *priv)
     bad_isa_string(str, "Spike does not currently support VLEN > 4096b");
   }
 
-  if ((vlen != 0) ^ (elen != 0)) {
+  if ((vlen != 0) ^ (elen != 0) || vlen < elen) {
     bad_isa_string(str, "Invalid Zvl/Zve configuration");
   }
 


### PR DESCRIPTION
Prevents invalid configurations where VLEN < ELEN, such as combining zvl32b with zve64d.