### PR TITLE
Fix BFloat16 vector extension dependencies and requirements

### DIFF
--- a/disasm/isa_parser.cc
+++ b/disasm/isa_parser.cc
@@ -460,11 +460,11 @@ isa_parser_t::isa_parser_t(const char* str, const char *priv)
     extension_table[EXT_INTERNAL_ZFH_MOVE] = true;
   }
 
-  if (extension_table[EXT_ZFBFMIN] && (!extension_table['F'] || !extension_table[EXT_INTERNAL_ZFH_MOVE])) {
+  if (extension_table[EXT_ZFBFMIN] && (!extension_table['F'])) {
     bad_isa_string(str, "'Zfbfmin' extension requires 'F' extension");
   }
 
-  if (extension_table[EXT_ZVFBFMIN] && (vlen == 0 || elen == 0 || !zvf)) {
+  if (extension_table[EXT_ZVFBFMIN] && (vlen == 0 || !zvf)) {
     bad_isa_string(str, "'Zvfbfmin' extension requires 'Zve32f' extension");
   }
 

--- a/disasm/isa_parser.cc
+++ b/disasm/isa_parser.cc
@@ -456,16 +456,20 @@ isa_parser_t::isa_parser_t(const char* str, const char *priv)
     bad_isa_string(str, "'Zclsd' extension requires 'Zca' and 'Zilsd' extensions");
   }
 
-  if (extension_table[EXT_ZFBFMIN] && !extension_table['F']) {
+  if (extension_table[EXT_ZFBFMIN] || extension_table[EXT_ZFHMIN]) {
+    extension_table[EXT_INTERNAL_ZFH_MOVE] = true;
+  }
+
+  if (extension_table[EXT_ZFBFMIN] && (!extension_table['F'] || !extension_table[EXT_INTERNAL_ZFH_MOVE])) {
     bad_isa_string(str, "'Zfbfmin' extension requires 'F' extension");
   }
 
-  if ((extension_table[EXT_ZVFBFMIN] || extension_table[EXT_ZVFBFWMA]) && !extension_table['V']) {
-    bad_isa_string(str, "'Zvfbfmin/Zvfbfwma' extension requires 'V' extension");
+  if (extension_table[EXT_ZVFBFMIN] && (vlen == 0 || elen == 0 || !zvf)) {
+    bad_isa_string(str, "'Zvfbfmin' extension requires 'Zve32f' extension");
   }
 
-  if (extension_table[EXT_ZFBFMIN] || extension_table[EXT_ZVFBFMIN] || extension_table[EXT_ZFHMIN]) {
-    extension_table[EXT_INTERNAL_ZFH_MOVE] = true;
+  if (extension_table[EXT_ZVFBFWMA] && (!extension_table[EXT_ZFBFMIN] || !extension_table[EXT_ZVFBFMIN])) {
+    bad_isa_string(str, "'Zvfbfwma' extension requires 'Zfbfmin' and 'Zvfbfmin' extensions");
   }
 
   if (extension_table[EXT_ZFINX] && extension_table['F']) {


### PR DESCRIPTION
Update requirements for the Bfloat16 extensions including:

* Enable EXT_INTERNAL_ZFH_MOVE when either Zfbfmin or Zfhmin is enabled
* Zvfbfmin now requires Zve32f instead of the V extension.
* Zvfbfwma now requires both Zvfbfmin and Zfbfmin, not just the V extension.