### PR TITLE
Remove sign extension from hlvx.wu instruction.

### DIFF
--- a/riscv/insns/hlvx_wu.h
+++ b/riscv/insns/hlvx_wu.h
@@ -1,4 +1,4 @@
 require_extension('H');
 require_novirt();
 require_privilege(get_field(STATE.hstatus->read(), HSTATUS_HU) ? PRV_U : PRV_S);
-WRITE_RD(sext_xlen(MMU.guest_load_x<uint32_t>(RS1)));
+WRITE_RD(MMU.guest_load_x<uint32_t>(RS1));


### PR DESCRIPTION
hlvx.wu is not supposed to sign extend the value.