### PR TITLE
Quiet the CI logs

### DIFF
--- a/ci-tests/test-spike
+++ b/ci-tests/test-spike
@@ -11,7 +11,7 @@ cd run
 wget https://github.com/riscv-software-src/riscv-isa-sim/releases/download/dummy-tag-for-ci-storage/spike-ci.tar
 tar xf spike-ci.tar
 time ../install/bin/spike --isa=rv64gc pk hello | grep "Hello, world!  Pi is approximately 3.141588."
-../install/bin/spike --log-commits --isa=rv64gc pk atomics | grep "First atomic counter is 1000, second is 100"
+../install/bin/spike --log-commits --isa=rv64gc pk atomics 2> /dev/null | grep "First atomic counter is 1000, second is 100"
 
 # check that including sim.h in an external project works
 g++ -std=c++2a -I../install/include -L../install/lib $DIR/testlib.cc -lriscv -o test-libriscv


### PR DESCRIPTION
Send instruction traces to /dev/null to make the CI logs readable.