### PR TITLE
Relax VLEN/ELEN checking

### DIFF
--- a/disasm/isa_parser.cc
+++ b/disasm/isa_parser.cc
@@ -383,7 +383,7 @@ isa_parser_t::isa_parser_t(const char* str, const char *priv)
       vlen = std::max(vlen, new_vlen);
     } else if (ext_str.substr(0, 3) == "zve") {
       if (ext_str.size() != 6) {
-	bad_isa_string(str, ("Invalid Zve string: " + ext_str).c_str());
+        bad_isa_string(str, ("Invalid Zve string: " + ext_str).c_str());
       }
       reg_t new_elen;
       try {

--- a/disasm/isa_parser.cc
+++ b/disasm/isa_parser.cc
@@ -531,7 +531,7 @@ isa_parser_t::isa_parser_t(const char* str, const char *priv)
 #endif
 
   if (vlen > 4096) {
-    bad_isa_string(str, "Spike does not currently support VLEN > 4096b");
+    bad_isa_string(str, "Spike does not support VLEN > 4096");
   }
 
   if ((vlen != 0) ^ (elen != 0) || vlen < elen) {

--- a/disasm/isa_parser.cc
+++ b/disasm/isa_parser.cc
@@ -403,6 +403,7 @@ isa_parser_t::isa_parser_t(const char* str, const char *priv)
       if (new_elen != 32 && new_elen != 64)
         bad_isa_string(str, ("Invalid Zve string: " + ext_str).c_str());
       elen = std::max(elen, new_elen);
+      vlen = std::max(vlen, new_elen);
     } else if (ext_str == "ssdbltrp") {
       extension_table[EXT_SSDBLTRP] = true;
     } else if (ext_str == "smdbltrp") {
@@ -532,10 +533,6 @@ isa_parser_t::isa_parser_t(const char* str, const char *priv)
 
   if (vlen > 4096) {
     bad_isa_string(str, "Spike does not support VLEN > 4096");
-  }
-
-  if ((vlen != 0) ^ (elen != 0) || vlen < elen) {
-    bad_isa_string(str, "Invalid Zvl/Zve configuration");
   }
 
   if (extension_table[EXT_ZVFHMIN] && (vlen == 0 || elen == 0 || !zvf)) {


### PR DESCRIPTION
We should allow ISA strings like rv64gc_zve32f.  Per the spec, the various Zve extensions imply a minimum VLEN, so rv64gc_zve32f is unambiguously equivalent to rv64gc_zve32f_zvl32b. Similarly, rv64gc_zve64x, rv64gc_zve64x_zvl64b, and rv64gc_zve64x_zvl32b are all unambiguously equivalent.

@nadime15 This is different from what we discussed, but it is supported by the spec and is obviously easier on users.

Fixes #2068 