### PR TITLE
riscv/decode_macros.h: adding xlen masking for READ_REG

### DIFF
--- a/riscv/decode_macros.h
+++ b/riscv/decode_macros.h
@@ -15,8 +15,8 @@
 #define STATE (*p->get_state())
 #define FLEN (p->get_flen())
 #define CHECK_REG(reg) ((void) 0)
-#define READ_REG(reg) (CHECK_REG(reg), STATE.XPR[reg])
-#define READ_FREG(reg) STATE.FPR[reg]
+#define READ_REG(reg) (CHECK_REG(reg), zext(STATE.XPR[reg], p->get_const_xlen()))
+#define READ_FREG(reg) (STATE.FPR[reg])
 #define RD READ_REG(insn.rd())
 #define RS1 READ_REG(insn.rs1())
 #define RS2 READ_REG(insn.rs2())


### PR DESCRIPTION
In case of rv32 simulation spike will meet not expected behavior, when any of instruction will perform WRITE_RD() which will lead to signed extension for 64bit, which could cause not expected behavior, in case of implementing any instruction which expects unsigned extension up to 32 bits.
To reproduce:
Lets implement `bitrevi` instruction according to P-ext Version 0.9.11 where bitrevi result should be ZE32 for RV32, for example, like this:

```
sreg_t rs1 = RS1;
sreg_t rs2 = insn.p_imm5();

rs1 = ((rs1 & 0x00ff00ff00ff00ffull) << 8) | ((rs1 & 0xff00ff00ff00ff00ull) >> 8);
rs1 = ((rs1 & 0x0000ffff0000ffffull) << 16) | ((rs1 & 0xffff0000ffff0000ull) >> 16);

rs1 = ((rs1 & 0xf0f0f0f0f0f0f0f0ull) >> 4)
      | ((rs1 & 0x0f0f0f0f0f0f0f0full) << 4);
rs1 = ((rs1 & 0x8888888888888888ull) >> 3)
      | ((rs1 & 0x4444444444444444ull) >> 1)
      | ((rs1 & 0x2222222222222222ull) << 1)
      | ((rs1 & 0x1111111111111111ull) << 3);

WRITE_RD(zext_xlen((uint32_t)rs1 >> (32 - rs2 - 1)));
```
than with such test we will see a *problem*:

```
.text
  .global _start
_start:
  nop
main:
  li x5, 0xffffffff
  .word 0xe9f28a77
  li a0, 0xffffffff
  beq x20, a0, _sim_end
  li x0, 0xdeadbeaf
  j _sim_fail

_sim_end:
  j _sim_end

_sim_fail:
  j _sim_fail

```
To prevent such issues in the future - lets mask reading from registers by xlen.