### PR TITLE
Get rid of leaking pointers in examples for custom extension

### DIFF
--- a/ci-tests/custom-csr.cc
+++ b/ci-tests/custom-csr.cc
@@ -37,7 +37,7 @@ struct xdummycsr_t : public extension_t {
   }
 };
 
-REGISTER_EXTENSION(dummycsr, []() { return new xdummycsr_t; })
+REGISTER_EXTENSION(dummycsr, []() { static xdummycsr_t ext; return &ext; })
 
 // Copied from spike main.
 // TODO: This should really be provided in libriscv

--- a/ci-tests/test-customext.cc
+++ b/ci-tests/test-customext.cc
@@ -46,7 +46,7 @@ struct xslliuw_dummy_t : public extension_t {
   }
 };
 
-REGISTER_EXTENSION(dummyslliuw, []() { return new xslliuw_dummy_t; })
+REGISTER_EXTENSION(dummyslliuw, []() { static xslliuw_dummy_t ext; return &ext; })
 
 // Copied from spike main.
 // TODO: This should really be provided in libriscv

--- a/customext/cflush.cc
+++ b/customext/cflush.cc
@@ -40,4 +40,4 @@ class cflush_t : public extension_t
   }
 };
 
-REGISTER_EXTENSION(cflush, []() { return new cflush_t; })
+REGISTER_EXTENSION(cflush, []() { static cflush_t ext; return &ext; })

--- a/customext/dummy_rocc.cc
+++ b/customext/dummy_rocc.cc
@@ -44,4 +44,4 @@ class dummy_rocc_t : public rocc_t
   reg_t acc[num_acc];
 };
 
-REGISTER_EXTENSION(dummy_rocc, []() { return new dummy_rocc_t; })
+REGISTER_EXTENSION(dummy_rocc, []() { static dummy_rocc_t ext; return &ext; })


### PR DESCRIPTION
Building of spike-based simulator with memory sanitizer reports leaking pointers if custom extension are used. This is because existing facilities do not have a proper destructor procedure, so the objects representing custom extentions are leaked. This commit implements quick-and-dirty fix for the problem.