### PR TITLE
WRS instructions should trap when Zawrs is not implemented

### DIFF
--- a/riscv/insns/wrs_nto.h
+++ b/riscv/insns/wrs_nto.h
@@ -1,3 +1,5 @@
+require_extension(EXT_ZAWRS);
+
 if (get_field(STATE.mstatus->read(), MSTATUS_TW)) {
   require_privilege(PRV_M);
 } else if (STATE.v) {

--- a/riscv/insns/wrs_sto.h
+++ b/riscv/insns/wrs_sto.h
@@ -1,1 +1,3 @@
+require_extension(EXT_ZAWRS);
+
 // WRS.STO stalls for a short duration


### PR DESCRIPTION
This is technically not a bug, since the behavior is reserved rather than mandatorily illegal, but it's still best to be strict in Spike. 

Fixes https://github.com/riscv-software-src/riscv-isa-sim/commit/c5229c3f5f4b6404977bb4134f1a0bda5207ff90#r168406871

cc @ved-rivos @JJ-Gaisler