### PR TITLE
Implement Ziccid (I$ coherence)

### DIFF
--- a/riscv/bloom_filter.h
+++ b/riscv/bloom_filter.h
@@ -1,0 +1,64 @@
+// See LICENSE for license details.
+
+#ifndef _RISCV_BLOOM_FILTER_H
+#define _RISCV_BLOOM_FILTER_H
+
+#include <bitset>
+#include <cstdint>
+
+struct simple_hash1 {
+  uint64_t operator()(uint64_t x) const
+  {
+    x = (x ^ (x >> 33)) * 0xff51afd7ed558ccd;
+    x = (x ^ (x >> 33)) * 0xc4ceb9fe1a85ec53;
+    return x ^ (x >> 33);
+  }
+};
+
+struct simple_hash2 {
+  uint64_t operator()(uint64_t x) const
+  {
+    x = (x ^ (x >> 30)) * 0xbf58476d1ce4e5b9;
+    x = (x ^ (x >> 27)) * 0x94d049b13c66a8ed;
+    return x ^ (x >> 31);
+  }
+};
+
+template <typename T, typename H1, typename H2, size_t M, size_t K> // M: bit array size, K: number of hash functions
+class bloom_filter_t {
+ public:
+  void clear()
+  {
+    bits.reset();
+  }
+
+  void insert(T value)
+  {
+    uint64_t h1 = H1()(value);
+    uint64_t h2 = H2()(value);
+
+    for (size_t i = 0; i < K; i++) {
+      size_t idx = (h1 + i * h2) % M;
+      bits[idx] = true;
+    }
+  }
+
+  bool contains(T value) const
+  {
+    uint64_t h1 = H1()(value);
+    uint64_t h2 = H2()(value);
+
+    for (size_t i = 0; i < K; i++) {
+      size_t idx = (h1 + i * h2) % M;
+      if (!bits[idx])
+        return false;
+    }
+
+    return true;
+  }
+
+ private:
+  std::bitset<M> bits;
+};
+
+#endif

--- a/riscv/execute.cc
+++ b/riscv/execute.cc
@@ -223,15 +223,6 @@ void processor_t::step(size_t n)
     }
   }
 
-  if (extension_enabled(EXT_ZICCID)) {
-    // Ziccid requires stores eventually become visible to instruction fetch,
-    // so periodically flush the I$
-    if (ziccid_flush_count-- == 0) {
-      ziccid_flush_count += ZICCID_FLUSH_PERIOD;
-      _mmu->flush_icache();
-    }
-  }
-
   while (n > 0) {
     size_t instret = 0;
     reg_t pc = state.pc;

--- a/riscv/execute.cc
+++ b/riscv/execute.cc
@@ -314,7 +314,7 @@ void processor_t::step(size_t n)
         for (auto ic_entry = _mmu->access_icache(pc); ; ) {
           auto fetch = ic_entry->data;
           pc = execute_insn_fast(this, pc, fetch);
-          ic_entry = ic_entry->next;
+          ic_entry = &_mmu->icache[_mmu->icache_index(pc)];
           if (unlikely(ic_entry->tag != pc))
             break;
           if (unlikely(instret + 1 == n))

--- a/riscv/mmu.h
+++ b/riscv/mmu.h
@@ -3,6 +3,7 @@
 #ifndef _RISCV_MMU_H
 #define _RISCV_MMU_H
 
+#include "bloom_filter.h"
 #include "decode.h"
 #include "trap.h"
 #include "common.h"
@@ -405,6 +406,14 @@ private:
   dtlb_entry_t tlb_load[TLB_ENTRIES];
   dtlb_entry_t tlb_store[TLB_ENTRIES];
   dtlb_entry_t tlb_insn[TLB_ENTRIES];
+
+  typedef bloom_filter_t<reg_t, simple_hash1, simple_hash2, TLB_ENTRIES * 16, 3> reverse_tags_t;
+  reverse_tags_t tlb_store_reverse_tags;
+  reverse_tags_t tlb_insn_reverse_tags;
+
+  bool flush_tlb_ppn(reg_t ppn, dtlb_entry_t* tlb, reverse_tags_t& filter);
+  void flush_itlb_ppn(reg_t ppn);
+  void flush_stlb_ppn(reg_t ppn);
 
   // finish translation on a TLB miss and update the TLB
   tlb_entry_t refill_tlb(reg_t vaddr, reg_t paddr, char* host_addr, access_type type);

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -414,9 +414,6 @@ private:
   static const size_t OPCODE_CACHE_SIZE = 4095;
   opcode_cache_entry_t opcode_cache[OPCODE_CACHE_SIZE];
 
-  unsigned ziccid_flush_count = 0;
-  static const unsigned ZICCID_FLUSH_PERIOD = 10;
-
   void take_pending_interrupt() { take_interrupt(state.mip->read() & state.mie->read()); }
   void take_interrupt(reg_t mask); // take first enabled interrupt in mask
   void take_trap(trap_t& t, reg_t epc); // take an exception


### PR DESCRIPTION
The algorithm is as follows:
- An instruction-side Bloom filter knows which PPNs might be in the I$
- A store-side Bloom filter knows which PPNs might get store TLB hits
- When refilling the store TLB, search the I-Bloom filter; on a hit, remove the ITLB entry, rebuild the I-Bloom filter, and flush the I$
- When refilling the ITLB, search the store-Bloom filter; on a hit, remove the store TLB entry and rebuild the store-Bloom filter
    
The effect is that any word that can be stored-to cannot be in any I$.
  
The old scheme (periodically flush I$) was hacky and didn't correctly respect the in-order fetch rule (i.e. fetches are in-order wrt. each other, and so they see ordered stores in order).

cc @jerryz123 - this is just a proof of concept for the moment.  It is possible to be smarter with the data structures, e.g. build two snoop filters (one global set that remembers all PPNs that might be in any I$, and another global set that remembers all PPNs that might be in any store TLB).  If you have any cleverer ideas, LMK.