### PR TITLE
Add Svukte extension support

### DIFF
--- a/disasm/isa_parser.cc
+++ b/disasm/isa_parser.cc
@@ -265,6 +265,10 @@ isa_parser_t::isa_parser_t(const char* str, const char *priv)
       extension_table[EXT_SVPBMT] = true;
     } else if (ext_str == "svinval") {
       extension_table[EXT_SVINVAL] = true;
+    } else if (ext_str == "svukte") {
+      if (max_xlen != 64)
+        bad_isa_string(str, "'svukte' requires RV64");
+      extension_table[EXT_SVUKTE] = true;
     } else if (ext_str == "zfa") {
       extension_table[EXT_ZFA] = true;
     } else if (ext_str == "zicbom") {

--- a/riscv/csr_init.cc
+++ b/riscv/csr_init.cc
@@ -329,6 +329,7 @@ void state_t::csr_init(processor_t* const proc, reg_t max_isa)
   }
   const reg_t senvcfg_mask = (proc->extension_enabled(EXT_ZICBOM) ? SENVCFG_CBCFE | SENVCFG_CBIE : 0) |
                             (proc->extension_enabled(EXT_ZICBOZ) ? SENVCFG_CBZE : 0) |
+                            (proc->extension_enabled(EXT_SVUKTE) ? SENVCFG_UKTE : 0) |
                             (proc->extension_enabled(EXT_SSNPM) ? SENVCFG_PMM : 0) |
                             (proc->extension_enabled(EXT_ZICFILP) ? SENVCFG_LPE : 0) |
                             (proc->extension_enabled(EXT_ZICFISS) ? SENVCFG_SSE : 0);

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -2020,7 +2020,8 @@ hstatus_csr_t::hstatus_csr_t(processor_t* const proc, const reg_t addr):
 }
 
 bool hstatus_csr_t::unlogged_write(const reg_t val) noexcept {
-  const reg_t mask = HSTATUS_VTSR | HSTATUS_VTW
+  const reg_t mask = (proc->extension_enabled(EXT_SVUKTE) ? HSTATUS_HUKTE  : 0)
+    | HSTATUS_VTSR | HSTATUS_VTW
     | (proc->supports_impl(IMPL_MMU) ? HSTATUS_VTVM : 0)
     | (proc->extension_enabled(EXT_SSNPM) ? HSTATUS_HUPMM : 0)
     | HSTATUS_HU | HSTATUS_SPVP | HSTATUS_SPV | HSTATUS_GVA;

--- a/riscv/isa_parser.h
+++ b/riscv/isa_parser.h
@@ -47,6 +47,7 @@ typedef enum {
   EXT_SVNAPOT,
   EXT_SVPBMT,
   EXT_SVINVAL,
+  EXT_SVUKTE,
   EXT_ZDINX,
   EXT_ZFA,
   EXT_ZFBFMIN,

--- a/riscv/mmu.h
+++ b/riscv/mmu.h
@@ -78,6 +78,7 @@ struct mem_access_info_t {
 };
 
 void throw_access_exception(bool virt, reg_t addr, access_type type);
+[[noreturn]] void throw_page_fault_exception(bool virt, reg_t addr, access_type type);
 
 // this class implements a processor's port into the virtual memory system.
 // an MMU and instruction cache are maintained for simulator performance.
@@ -447,6 +448,7 @@ private:
     check_triggers(operation, address, virt, address, data);
   }
   void check_triggers(triggers::operation_t operation, reg_t address, bool virt, reg_t tval, std::optional<reg_t> data);
+  bool check_svukte_qualified(reg_t addr, reg_t mode, bool forced_virt);
   reg_t translate(mem_access_info_t access_info, reg_t len);
 
   reg_t pte_load(reg_t pte_paddr, reg_t addr, bool virt, access_type trap_type, size_t ptesize) {


### PR DESCRIPTION
This adds support for the Svukte extension, which adds support for address-independent latency of user-mode faults to supervisor addresses.