### PR TITLE
ci: update apt repo

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -26,7 +26,9 @@ jobs:
           fetch-depth: 0
 
       - name: Install Dependencies
-        run: sudo xargs apt-get install -y < .github/workflows/apt-packages.txt
+        run: |
+          sudo apt-get update
+          sudo xargs apt-get install -y < .github/workflows/apt-packages.txt
 
       - run: |
           for commit in $(git rev-list origin/master..HEAD | tac); do

--- a/.github/workflows/debug-smoke.yml
+++ b/.github/workflows/debug-smoke.yml
@@ -19,6 +19,7 @@ jobs:
 
       - name: Install Dependencies
         run: |
+          sudo apt-get update
           sudo xargs apt-get install -y < .github/workflows/apt-packages.txt
 
       - name: Download OpenOCD


### PR DESCRIPTION
The lack of apt repository update caused a lot of CI failures lately. Examples are:
https://github.com/riscv-software-src/riscv-isa-sim/actions/runs/19093526126/job/54548598071?pr=2125
https://github.com/riscv-software-src/riscv-isa-sim/actions/runs/19095864688/job/54557066968?pr=2126
Where job failed with:
```
E: Failed to fetch mirror+file:/etc/apt/apt-mirrors.txt/pool/main/b/binutils/binutils-riscv64-linux-gnu_2.42-4ubuntu2.5_amd64.deb  404  Not Found
```

This commit fixes that issue