### PR TITLE
Decode args for `fcvtmod.w.d` in `zfa` extension

### DIFF
--- a/disasm/disasm.cc
+++ b/disasm/disasm.cc
@@ -123,6 +123,12 @@ struct : public arg_t {
 
 struct : public arg_t {
   std::string to_string(insn_t insn) const {
+    return frm_name(insn.rm());
+  }
+} rm;
+
+struct : public arg_t {
+  std::string to_string(insn_t insn) const {
     return fpr_name[insn.rd()];
   }
 } frd;
@@ -717,6 +723,11 @@ static void NOINLINE add_fx2type_insn(disassembler_t* d, const char* name, uint3
   d->add_insn(new disasm_insn_t(name, match, mask, {&xrd, &frs1, &frs2}));
 }
 
+static void NOINLINE add_fxrtype_insn(disassembler_t* d, const char* name, uint32_t match, uint32_t mask)
+{
+  d->add_insn(new disasm_insn_t(name, match, mask, {&xrd, &frs1, &rm}));
+}
+
 static void NOINLINE add_flitype_insn(disassembler_t* d, const char* name, uint32_t match, uint32_t mask)
 {
   d->add_insn(new disasm_insn_t(name, match, mask, {&xrd, &fli_imm}));
@@ -868,6 +879,7 @@ void disassembler_t::add_instructions(const isa_parser_t* isa, bool strict)
   #define DEFINE_FR3TYPE(code) add_fr3type_insn(this, #code, match_##code, mask_##code);
   #define DEFINE_FXTYPE(code) add_fxtype_insn(this, #code, match_##code, mask_##code);
   #define DEFINE_FX2TYPE(code) add_fx2type_insn(this, #code, match_##code, mask_##code);
+  #define DEFINE_FXRTYPE(code) add_fxrtype_insn(this, #code, match_##code, mask_##code);
   #define DEFINE_FLITYPE(code) add_flitype_insn(this, #code, match_##code, mask_##code);
   #define DEFINE_XFTYPE(code) add_xftype_insn(this, #code, match_##code, mask_##code);
   #define DEFINE_XF2TYPE(code) add_xf2type_insn(this, #code, match_##code, mask_##code);
@@ -1282,6 +1294,7 @@ void disassembler_t::add_instructions(const isa_parser_t* isa, bool strict)
       DEFINE_FR1TYPE(froundnx_d);
       DEFINE_FX2TYPE(fleq_d);
       DEFINE_FX2TYPE(fltq_d);
+      DEFINE_FXRTYPE(fcvtmod_w_d);
 
       if (xlen_eq(32)) {
         DEFINE_XF2TYPE(fmvp_d_x);

--- a/disasm/regnames.cc
+++ b/disasm/regnames.cc
@@ -31,3 +31,21 @@ const char* csr_name(int which) {
   }
   return "unknown-csr";
 }
+
+const char* frm_name(int which) {
+  switch (which) {
+    case 0:
+      return "rne";
+    case 1:
+      return "rtz";
+    case 2:
+      return "rdn";
+    case 3:
+      return "rup";
+    case 4:
+      return "rmm";
+    case 7:
+      return "dyn";
+  }
+  return "unknown-frm";
+}

--- a/riscv/disasm.h
+++ b/riscv/disasm.h
@@ -15,6 +15,7 @@ extern const char* xpr_name[NXPR];
 extern const char* fpr_name[NFPR];
 extern const char* vr_name[NVPR];
 extern const char* csr_name(int which);
+extern const char* frm_name(int which);
 
 class arg_t
 {


### PR DESCRIPTION
This should fix the "(args unknown)" issue reported in #2129.