### PR TITLE
DMI NOP operation should never cause busy status

### DIFF
--- a/riscv/jtag_dtm.cc
+++ b/riscv/jtag_dtm.cc
@@ -199,6 +199,6 @@ void jtag_dtm_t::update_dr()
     }
     D(fprintf(stderr, "dmi=0x%lx\n", dmi));
 
-    rti_remaining = required_rti_cycles;
+    rti_remaining = op == DMI_OP_NOP ? 0 : required_rti_cycles;
   }
 }


### PR DESCRIPTION
See RISC-V Debug Specification Version 1.0 [6.1.5. Debug Module Interface Access (`dmi`, at 0x11)], `op` field description:
> 0 (nop): Ignore data and address.
Don’t send anything over the DMI during Update-DR. This operation should never affect DMI busy or error status.