### PR TITLE
Gate Zaamo,Zalrsc instructions behind corresponding extensions, not M…

### DIFF
--- a/riscv/insns/amoadd_d.h
+++ b/riscv/insns/amoadd_d.h
@@ -1,3 +1,3 @@
-require_extension('A');
+require_extension(EXT_ZAAMO);
 require_rv64;
 WRITE_RD(MMU.amo<uint64_t>(RS1, [&](uint64_t lhs) { return lhs + RS2; }));

--- a/riscv/insns/amoadd_w.h
+++ b/riscv/insns/amoadd_w.h
@@ -1,2 +1,2 @@
-require_extension('A');
+require_extension(EXT_ZAAMO);
 WRITE_RD(sext32(MMU.amo<uint32_t>(RS1, [&](uint32_t lhs) { return lhs + RS2; })));

--- a/riscv/insns/amoand_d.h
+++ b/riscv/insns/amoand_d.h
@@ -1,3 +1,3 @@
-require_extension('A');
+require_extension(EXT_ZAAMO);
 require_rv64;
 WRITE_RD(MMU.amo<uint64_t>(RS1, [&](uint64_t lhs) { return lhs & RS2; }));

--- a/riscv/insns/amoand_w.h
+++ b/riscv/insns/amoand_w.h
@@ -1,2 +1,2 @@
-require_extension('A');
+require_extension(EXT_ZAAMO);
 WRITE_RD(sext32(MMU.amo<uint32_t>(RS1, [&](uint32_t lhs) { return lhs & RS2; })));

--- a/riscv/insns/amomax_d.h
+++ b/riscv/insns/amomax_d.h
@@ -1,3 +1,3 @@
-require_extension('A');
+require_extension(EXT_ZAAMO);
 require_rv64;
 WRITE_RD(MMU.amo<uint64_t>(RS1, [&](int64_t lhs) { return std::max(lhs, int64_t(RS2)); }));

--- a/riscv/insns/amomax_w.h
+++ b/riscv/insns/amomax_w.h
@@ -1,2 +1,2 @@
-require_extension('A');
+require_extension(EXT_ZAAMO);
 WRITE_RD(sext32(MMU.amo<uint32_t>(RS1, [&](int32_t lhs) { return std::max(lhs, int32_t(RS2)); })));

--- a/riscv/insns/amomaxu_d.h
+++ b/riscv/insns/amomaxu_d.h
@@ -1,3 +1,3 @@
-require_extension('A');
+require_extension(EXT_ZAAMO);
 require_rv64;
 WRITE_RD(MMU.amo<uint64_t>(RS1, [&](uint64_t lhs) { return std::max(lhs, RS2); }));

--- a/riscv/insns/amomaxu_w.h
+++ b/riscv/insns/amomaxu_w.h
@@ -1,2 +1,2 @@
-require_extension('A');
+require_extension(EXT_ZAAMO);
 WRITE_RD(sext32(MMU.amo<uint32_t>(RS1, [&](uint32_t lhs) { return std::max(lhs, uint32_t(RS2)); })));

--- a/riscv/insns/amomin_d.h
+++ b/riscv/insns/amomin_d.h
@@ -1,3 +1,3 @@
-require_extension('A');
+require_extension(EXT_ZAAMO);
 require_rv64;
 WRITE_RD(MMU.amo<uint64_t>(RS1, [&](int64_t lhs) { return std::min(lhs, int64_t(RS2)); }));

--- a/riscv/insns/amomin_w.h
+++ b/riscv/insns/amomin_w.h
@@ -1,2 +1,2 @@
-require_extension('A');
+require_extension(EXT_ZAAMO);
 WRITE_RD(sext32(MMU.amo<uint32_t>(RS1, [&](int32_t lhs) { return std::min(lhs, int32_t(RS2)); })));

--- a/riscv/insns/amominu_d.h
+++ b/riscv/insns/amominu_d.h
@@ -1,3 +1,3 @@
-require_extension('A');
+require_extension(EXT_ZAAMO);
 require_rv64;
 WRITE_RD(MMU.amo<uint64_t>(RS1, [&](uint64_t lhs) { return std::min(lhs, RS2); }));

--- a/riscv/insns/amominu_w.h
+++ b/riscv/insns/amominu_w.h
@@ -1,2 +1,2 @@
-require_extension('A');
+require_extension(EXT_ZAAMO);
 WRITE_RD(sext32(MMU.amo<uint32_t>(RS1, [&](uint32_t lhs) { return std::min(lhs, uint32_t(RS2)); })));

--- a/riscv/insns/amoor_d.h
+++ b/riscv/insns/amoor_d.h
@@ -1,3 +1,3 @@
-require_extension('A');
+require_extension(EXT_ZAAMO);
 require_rv64;
 WRITE_RD(MMU.amo<uint64_t>(RS1, [&](uint64_t lhs) { return lhs | RS2; }));

--- a/riscv/insns/amoor_w.h
+++ b/riscv/insns/amoor_w.h
@@ -1,2 +1,2 @@
-require_extension('A');
+require_extension(EXT_ZAAMO);
 WRITE_RD(sext32(MMU.amo<uint32_t>(RS1, [&](uint32_t lhs) { return lhs | RS2; })));

--- a/riscv/insns/amoswap_d.h
+++ b/riscv/insns/amoswap_d.h
@@ -1,3 +1,3 @@
-require_extension('A');
+require_extension(EXT_ZAAMO);
 require_rv64;
 WRITE_RD(MMU.amo<uint64_t>(RS1, [&](uint64_t UNUSED lhs) { return RS2; }));

--- a/riscv/insns/amoswap_w.h
+++ b/riscv/insns/amoswap_w.h
@@ -1,2 +1,2 @@
-require_extension('A');
+require_extension(EXT_ZAAMO);
 WRITE_RD(sext32(MMU.amo<uint32_t>(RS1, [&](uint32_t UNUSED lhs) { return RS2; })));

--- a/riscv/insns/amoxor_d.h
+++ b/riscv/insns/amoxor_d.h
@@ -1,3 +1,3 @@
-require_extension('A');
+require_extension(EXT_ZAAMO);
 require_rv64;
 WRITE_RD(MMU.amo<uint64_t>(RS1, [&](uint64_t lhs) { return lhs ^ RS2; }));

--- a/riscv/insns/amoxor_w.h
+++ b/riscv/insns/amoxor_w.h
@@ -1,2 +1,2 @@
-require_extension('A');
+require_extension(EXT_ZAAMO);
 WRITE_RD(sext32(MMU.amo<uint32_t>(RS1, [&](uint32_t lhs) { return lhs ^ RS2; })));

--- a/riscv/insns/lr_d.h
+++ b/riscv/insns/lr_d.h
@@ -1,3 +1,3 @@
-require_extension('A');
+require_extension(EXT_ZALRSC);
 require_rv64;
 WRITE_RD(MMU.load_reserved<int64_t>(RS1));

--- a/riscv/insns/lr_w.h
+++ b/riscv/insns/lr_w.h
@@ -1,2 +1,2 @@
-require_extension('A');
+require_extension(EXT_ZALRSC);
 WRITE_RD(MMU.load_reserved<int32_t>(RS1));

--- a/riscv/insns/sc_d.h
+++ b/riscv/insns/sc_d.h
@@ -1,4 +1,4 @@
-require_extension('A');
+require_extension(EXT_ZALRSC);
 require_rv64;
 
 bool have_reservation = MMU.store_conditional<uint64_t>(RS1, RS2);

--- a/riscv/insns/sc_w.h
+++ b/riscv/insns/sc_w.h
@@ -1,4 +1,4 @@
-require_extension('A');
+require_extension(EXT_ZALRSC);
 
 bool have_reservation = MMU.store_conditional<uint32_t>(RS1, RS2);
 

--- a/riscv/insns/ssamoswap_d.h
+++ b/riscv/insns/ssamoswap_d.h
@@ -1,5 +1,5 @@
 require_extension(EXT_ZICFISS);
-require_extension('A');
+require_extension(EXT_ZAAMO);
 require_rv64;
 
 DECLARE_XENVCFG_VARS(SSE);

--- a/riscv/insns/ssamoswap_w.h
+++ b/riscv/insns/ssamoswap_w.h
@@ -1,7 +1,6 @@
 require_extension(EXT_ZICFISS);
-require_extension('A');
+require_extension(EXT_ZAAMO);
 
 DECLARE_XENVCFG_VARS(SSE);
 require_envcfg(SSE);
 WRITE_RD(sext32(MMU.ssamoswap<uint32_t>(RS1, RS2)));
-


### PR DESCRIPTION
…ISA A

This is already done for the disassembler (disasm/disasm.cc:882), but the actual implementations haven't been updated.

A already implies Zaamo,Zalrsc and the other way around (both enabled imply A). Makes the implementation slightly more correct for when only one standard extensions is enabled out of the two.