### PR TITLE
Add missing header in make install

### DIFF
--- a/riscv/riscv.mk.in
+++ b/riscv/riscv.mk.in
@@ -18,6 +18,7 @@ riscv_install_prog_srcs = \
 riscv_install_hdrs = \
 	abstract_device.h \
 	abstract_interrupt_controller.h \
+	bloom_filter.h \
 	cachesim.h \
 	cfg.h \
 	common.h \


### PR DESCRIPTION
Fix missing bloom_filter.h include in riscv/mmu.h (introduced in c76d1e1)