### PR TITLE
feat: support zvkb vector cryptography bitmanip subset extension

### DIFF
--- a/disasm/isa_parser.cc
+++ b/disasm/isa_parser.cc
@@ -290,7 +290,10 @@ isa_parser_t::isa_parser_t(const char* str, const char *priv)
       extension_table[EXT_ZILSD] = true;
     } else if (ext_str == "zclsd") {
       extension_table[EXT_ZCLSD] = true;
+    } else if (ext_str == "zvkb") {
+      extension_table[EXT_ZVKB] = true;
     } else if (ext_str == "zvbb") {
+      extension_table[EXT_ZVKB] = true;
       extension_table[EXT_ZVBB] = true;
     } else if (ext_str == "zvbc") {
       extension_table[EXT_ZVBC] = true;
@@ -301,15 +304,18 @@ isa_parser_t::isa_parser_t(const char* str, const char *priv)
     } else if (ext_str == "zvkg") {
       extension_table[EXT_ZVKG] = true;
     } else if (ext_str == "zvkn") {
+      extension_table[EXT_ZVKB] = true;
       extension_table[EXT_ZVBB] = true;
       extension_table[EXT_ZVKNED] = true;
       extension_table[EXT_ZVKNHB] = true;
     } else if (ext_str == "zvknc") {
+      extension_table[EXT_ZVKB] = true;
       extension_table[EXT_ZVBB] = true;
       extension_table[EXT_ZVBC] = true;
       extension_table[EXT_ZVKNED] = true;
       extension_table[EXT_ZVKNHB] = true;
     } else if (ext_str == "zvkng") {
+      extension_table[EXT_ZVKB] = true;
       extension_table[EXT_ZVBB] = true;
       extension_table[EXT_ZVKG] = true;
       extension_table[EXT_ZVKNED] = true;
@@ -321,15 +327,18 @@ isa_parser_t::isa_parser_t(const char* str, const char *priv)
     } else if (ext_str == "zvknhb") {
       extension_table[EXT_ZVKNHB] = true;
     } else if (ext_str == "zvks") {
+      extension_table[EXT_ZVKB] = true;
       extension_table[EXT_ZVBB] = true;
       extension_table[EXT_ZVKSED] = true;
       extension_table[EXT_ZVKSH] = true;
     } else if (ext_str == "zvksc") {
+      extension_table[EXT_ZVKB] = true;
       extension_table[EXT_ZVBB] = true;
       extension_table[EXT_ZVBC] = true;
       extension_table[EXT_ZVKSED] = true;
       extension_table[EXT_ZVKSH] = true;
     } else if (ext_str == "zvksg") {
+      extension_table[EXT_ZVKB] = true;
       extension_table[EXT_ZVBB] = true;
       extension_table[EXT_ZVKG] = true;
       extension_table[EXT_ZVKSED] = true;

--- a/riscv/insns/vandn_vv.h
+++ b/riscv/insns/vandn_vv.h
@@ -2,7 +2,7 @@
 
 #include "zvk_ext_macros.h"
 
-require_zvbb;
+require_zvkb;
 
 VI_VV_LOOP
 ({

--- a/riscv/insns/vandn_vx.h
+++ b/riscv/insns/vandn_vx.h
@@ -2,7 +2,7 @@
 
 #include "zvk_ext_macros.h"
 
-require_zvbb;
+require_zvkb;
 
 VI_VX_LOOP
 ({

--- a/riscv/insns/vbrev8_v.h
+++ b/riscv/insns/vbrev8_v.h
@@ -2,7 +2,7 @@
 
 #include "zvk_ext_macros.h"
 
-require_zvbb;
+require_zvkb;
 
 VI_V_ULOOP
 ({

--- a/riscv/insns/vrev8_v.h
+++ b/riscv/insns/vrev8_v.h
@@ -2,7 +2,7 @@
 
 #include "zvk_ext_macros.h"
 
-require_zvbb;
+require_zvkb;
 
 VI_V_ULOOP
 ({

--- a/riscv/insns/vrol_vv.h
+++ b/riscv/insns/vrol_vv.h
@@ -2,7 +2,7 @@
 
 #include "zvk_ext_macros.h"
 
-require_zvbb;
+require_zvkb;
 
 // 'mask' selects the low log2(vsew) bits of the shift amount,
 // to limit the maximum shift to "vsew - 1" bits.

--- a/riscv/insns/vrol_vx.h
+++ b/riscv/insns/vrol_vx.h
@@ -2,7 +2,7 @@
 
 #include "zvk_ext_macros.h"
 
-require_zvbb;
+require_zvkb;
 
 // 'mask' selects the low log2(vsew) bits of the shift amount,
 // to limit the maximum shift to "vsew - 1" bits.

--- a/riscv/insns/vror_vi.h
+++ b/riscv/insns/vror_vi.h
@@ -2,7 +2,7 @@
 
 #include "zvk_ext_macros.h"
 
-require_zvbb;
+require_zvkb;
 
 // 'mask' selects the low log2(vsew) bits of the shift amount,
 // to limit the maximum shift to "vsew - 1" bits.

--- a/riscv/insns/vror_vv.h
+++ b/riscv/insns/vror_vv.h
@@ -2,7 +2,7 @@
 
 #include "zvk_ext_macros.h"
 
-require_zvbb;
+require_zvkb;
 
 // 'mask' selects the low log2(vsew) bits of the shift amount,
 // to limit the maximum shift to "vsew - 1" bits.

--- a/riscv/insns/vror_vx.h
+++ b/riscv/insns/vror_vx.h
@@ -2,7 +2,7 @@
 
 #include "zvk_ext_macros.h"
 
-require_zvbb;
+require_zvkb;
 
 // 'mask' selects the low log2(vsew) bits of the shift amount,
 // to limit the maximum shift to "vsew - 1" bits.

--- a/riscv/isa_parser.h
+++ b/riscv/isa_parser.h
@@ -64,6 +64,7 @@ typedef enum {
   EXT_ZIHPM,
   EXT_ZILSD,
   EXT_ZVBB,
+  EXT_ZVKB,
   EXT_ZVBC,
   EXT_ZVFBFMIN,
   EXT_ZVFBFWMA,

--- a/riscv/zvk_ext_macros.h
+++ b/riscv/zvk_ext_macros.h
@@ -13,6 +13,14 @@
 // Predicate Macros
 //
 
+// Ensures that the ZVKB extension (vector crypto bitmanip subset) is present,
+// and the vector unit is enabled and in a valid state.
+#define require_zvkb \
+  do { \
+    require_vector(true); \
+    require_extension(EXT_ZVKB); \
+  } while (0)
+
 // Ensures that the ZVBB extension (vector crypto bitmanip) is present,
 // and the vector unit is enabled and in a valid state.
 #define require_zvbb \


### PR DESCRIPTION
This commit gates Zvkb behind Zvkb extension. Previously they were attached to Zvbb which is Zvkb's superset