### PR TITLE
small correction to VI_EXT_CHECK to fix vl=0 cornercase

### DIFF
--- a/riscv/v_ext_macros.h
+++ b/riscv/v_ext_macros.h
@@ -1405,7 +1405,6 @@ VI_VX_ULOOP({ \
 #define VI_EXT_CHECK(div) \
   require(insn.rd() != insn.rs2()); \
   require_vm; \
-  VI_LOOP_BASE \
   reg_t from = P.VU.vsew / div; \
   require(from >= e8 && from <= e64); \
   require(((float)P.VU.vflmul / div) >= 0.125 && ((float)P.VU.vflmul / div) <= 8 ); \
@@ -1415,7 +1414,8 @@ VI_VX_ULOOP({ \
     require_noover(insn.rd(), P.VU.vflmul, insn.rs2(), P.VU.vflmul / div); \
   } else { \
     require_noover_widen(insn.rd(), P.VU.vflmul, insn.rs2(), P.VU.vflmul / div); \
-  }
+  } \
+  VI_LOOP_BASE \
 
 // vector: sign/unsiged extension
 #define VI_VV_EXT(div, type) \


### PR DESCRIPTION
In case `vl=0` checks from https://github.com/riscv-software-src/riscv-isa-sim/blob/6fc3463587c8ec52eb00bd1817c6c9e21f9fa1ab/riscv/v_ext_macros.h#L1409-L1418 are going to be skipped. 

addresses issues https://github.com/riscv-software-src/riscv-isa-sim/issues/2142 and https://github.com/riscv-software-src/riscv-isa-sim/issues/2138 