### PR TITLE
Make abstractauto register optional in debug module

### DIFF
--- a/riscv/debug_module.cc
+++ b/riscv/debug_module.cc
@@ -1101,10 +1101,16 @@ bool debug_module_t::dmi_write(unsigned address, uint32_t value)
         return true;
 
       case DM_ABSTRACTAUTO:
-        abstractauto.autoexecprogbuf = get_field(value,
-            DM_ABSTRACTAUTO_AUTOEXECPROGBUF);
-        abstractauto.autoexecdata = get_field(value,
-            DM_ABSTRACTAUTO_AUTOEXECDATA);
+        if (config.support_abstractauto) {
+          abstractauto.autoexecprogbuf = get_field(value,
+              DM_ABSTRACTAUTO_AUTOEXECPROGBUF);
+          abstractauto.autoexecdata = get_field(value,
+              DM_ABSTRACTAUTO_AUTOEXECDATA);
+        }
+        else {
+          abstractauto.autoexecprogbuf = 0;
+          abstractauto.autoexecdata = 0;
+        }
         return true;
       case DM_SBCS:
         sbcs.readonaddr = get_field(value, DM_SBCS_SBREADONADDR);

--- a/riscv/debug_module.cc
+++ b/riscv/debug_module.cc
@@ -1040,8 +1040,6 @@ bool debug_module_t::dmi_write(unsigned address, uint32_t value)
           dmcontrol.ndmreset = get_field(value, DM_DMCONTROL_NDMRESET);
           if (config.support_hasel)
             dmcontrol.hasel = get_field(value, DM_DMCONTROL_HASEL);
-          else
-            dmcontrol.hasel = 0;
           dmcontrol.hartsel = get_field(value, DM_DMCONTROL_HARTSELHI) <<
             DM_DMCONTROL_HARTSELLO_LENGTH;
           dmcontrol.hartsel |= get_field(value, DM_DMCONTROL_HARTSELLO);
@@ -1106,10 +1104,6 @@ bool debug_module_t::dmi_write(unsigned address, uint32_t value)
               DM_ABSTRACTAUTO_AUTOEXECPROGBUF);
           abstractauto.autoexecdata = get_field(value,
               DM_ABSTRACTAUTO_AUTOEXECDATA);
-        }
-        else {
-          abstractauto.autoexecprogbuf = 0;
-          abstractauto.autoexecdata = 0;
         }
         return true;
       case DM_SBCS:

--- a/riscv/debug_module.h
+++ b/riscv/debug_module.h
@@ -24,6 +24,7 @@ struct debug_module_config_t {
   bool support_abstract_fpr_access = true;
   bool support_haltgroups = true;
   bool support_impebreak = true;
+  bool support_abstractauto = true;
 };
 
 struct dmcontrol_t {

--- a/spike_main/spike.cc
+++ b/spike_main/spike.cc
@@ -84,6 +84,7 @@ static void help(int exit_code = 1)
   fprintf(stderr, "  --dm-no-abstract-fpr  Debug module won't support abstract FPR access\n");
   fprintf(stderr, "  --dm-no-halt-groups   Debug module won't support halt groups\n");
   fprintf(stderr, "  --dm-no-impebreak     Debug module won't support implicit ebreak in program buffer\n");
+  fprintf(stderr, "  --dm-no-abstractauto  Debug module won't support the abstractauto register\n");
   fprintf(stderr, "  --blocksz=<size>      Cache block size (B) for CMO operations(powers of 2) [default 64]\n");
   fprintf(stderr, "  --instructions=<n>    Stop after n instructions\n");
 
@@ -434,6 +435,8 @@ int main(int argc, char** argv)
       [&](const char UNUSED *s){dm_config.support_abstract_fpr_access = false;});
   parser.option(0, "dm-no-halt-groups", 0,
       [&](const char UNUSED *s){dm_config.support_haltgroups = false;});
+  parser.option(0, "dm-no-abstractauto", 0,
+      [&](const char UNUSED *s){dm_config.support_abstractauto = false;});
   parser.option(0, "log-commits", 0,
                 [&](const char UNUSED *s){log_commits = true;});
   parser.option(0, "log", 1,


### PR DESCRIPTION
Add --dm-no-abstractauto flag to disable support for the optional abstractauto register. When disabled, writes to the register are ignored and the internal state is kept at 0.

Currently, neither riscv-openocd nor openocd support batch reads or writes for debug modules that don’t implement abstractauto, as both assume every debug module provides abstractauto support. However, work is underway to remove this dependency.