### PR TITLE
fix VI_EXT_CHECK vl=0 behavior

### DIFF
--- a/riscv/v_ext_macros.h
+++ b/riscv/v_ext_macros.h
@@ -1405,7 +1405,6 @@ VI_VX_ULOOP({ \
 #define VI_EXT_CHECK(div) \
   require(insn.rd() != insn.rs2()); \
   require_vm; \
-  VI_LOOP_BASE \
   reg_t from = P.VU.vsew / div; \
   require(from >= e8 && from <= e64); \
   require(((float)P.VU.vflmul / div) >= 0.125 && ((float)P.VU.vflmul / div) <= 8 ); \
@@ -1415,7 +1414,8 @@ VI_VX_ULOOP({ \
     require_noover(insn.rd(), P.VU.vflmul, insn.rs2(), P.VU.vflmul / div); \
   } else { \
     require_noover_widen(insn.rd(), P.VU.vflmul, insn.rs2(), P.VU.vflmul / div); \
-  }
+  } \
+  VI_LOOP_BASE \
 
 // vector: sign/unsiged extension
 #define VI_VV_EXT(div, type) \

--- a/riscv/v_ext_macros.h
+++ b/riscv/v_ext_macros.h
@@ -1414,12 +1414,12 @@ VI_VX_ULOOP({ \
     require_noover(insn.rd(), P.VU.vflmul, insn.rs2(), P.VU.vflmul / div); \
   } else { \
     require_noover_widen(insn.rd(), P.VU.vflmul, insn.rs2(), P.VU.vflmul / div); \
-  } \
-  VI_LOOP_BASE \
+  }
 
 // vector: sign/unsiged extension
 #define VI_VV_EXT(div, type) \
   VI_EXT_CHECK(div); \
+  VI_LOOP_BASE \
   reg_t pat = (((P.VU.vsew >> 3) << 4) | from >> 3); \
     switch (pat) { \
       case 0x21: \
@@ -1467,6 +1467,7 @@ VI_VX_ULOOP({ \
 #define VI_VF_EXT(div, BODY) \
   require(div == 2 && P.VU.vsew == 8); \
   VI_EXT_CHECK(div); \
+  VI_LOOP_BASE \
   BODY; \
   VI_LOOP_END
 


### PR DESCRIPTION
Supersedes #2144 

Fixes https://github.com/riscv-software-src/riscv-isa-sim/issues/2142 and https://github.com/riscv-software-src/riscv-isa-sim/issues/2138