### PR TITLE
Two Zicfilp improvements

### DIFF
--- a/riscv/decode_macros.h
+++ b/riscv/decode_macros.h
@@ -374,3 +374,10 @@ inline long double to_f(float128_t f) { long double r; memcpy(&r, &f, sizeof(r))
 #define ZICFILP_IS_LP_EXPECTED(reg_num) \
   (((reg_num) != 1 && (reg_num) != 5 && (reg_num) != 7) ? \
    elp_t::LP_EXPECTED : elp_t::NO_LP_EXPECTED)
+#define maybe_set_elp(reg_num) \
+  if (unlikely(p->extension_enabled(EXT_ZICFILP))) { \
+    if (unlikely(ZICFILP_IS_LP_EXPECTED(reg_num) == elp_t::LP_EXPECTED)) { \
+      serialize(); \
+      return p->set_lpad_expected(npc); \
+    } \
+  }

--- a/riscv/insns/c_jalr.h
+++ b/riscv/insns/c_jalr.h
@@ -4,7 +4,4 @@ reg_t tmp = npc;
 set_pc(RVC_RS1 & ~reg_t(1));
 WRITE_REG(X_RA, tmp);
 
-if (ZICFILP_xLPE(STATE.v, STATE.prv)) {
-  STATE.elp = ZICFILP_IS_LP_EXPECTED(insn.rvc_rs1());
-  serialize();
-}
+maybe_set_elp(insn.rvc_rs1());

--- a/riscv/insns/c_jr.h
+++ b/riscv/insns/c_jr.h
@@ -2,7 +2,4 @@ require_extension(EXT_ZCA);
 require(insn.rvc_rs1() != 0);
 set_pc(RVC_RS1 & ~reg_t(1));
 
-if (ZICFILP_xLPE(STATE.v, STATE.prv)) {
-  STATE.elp = ZICFILP_IS_LP_EXPECTED(insn.rvc_rs1());
-  serialize();
-}
+maybe_set_elp(insn.rvc_rs1());

--- a/riscv/insns/jalr.h
+++ b/riscv/insns/jalr.h
@@ -3,7 +3,4 @@ reg_t tmp = npc;
 set_pc((RS1 + insn.i_imm()) & ~reg_t(1));
 WRITE_RD(tmp);
 
-if (ZICFILP_xLPE(STATE.v, STATE.prv)) {
-  STATE.elp = ZICFILP_IS_LP_EXPECTED(insn.rs1());
-  serialize();
-}
+maybe_set_elp(insn.rs1());

--- a/riscv/mmu.h
+++ b/riscv/mmu.h
@@ -346,8 +346,7 @@ public:
 
   inline insn_fetch_t load_insn(reg_t addr)
   {
-    icache_entry_t entry;
-    return refill_icache(addr, &entry)->data;
+    return refill_icache(addr, &icache[icache_index(addr)])->data;
   }
 
   std::tuple<bool, uintptr_t, reg_t> ALWAYS_INLINE access_tlb(const dtlb_entry_t* tlb, reg_t vaddr, reg_t allowed_flags = 0, reg_t required_flags = 0)

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -572,6 +572,14 @@ void processor_t::check_if_lpad_required()
   }
 }
 
+reg_t processor_t::set_lpad_expected(reg_t pc)
+{
+  auto p = this;
+  if (ZICFILP_xLPE(state.v, state.prv))
+    state.elp = elp_t::LP_EXPECTED;
+  return pc;
+}
+
 void processor_t::disasm(insn_t insn)
 {
   uint64_t bits = insn.bits();

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -379,6 +379,7 @@ public:
   bool is_waiting_for_interrupt() { return in_wfi; };
 
   void check_if_lpad_required();
+  reg_t set_lpad_expected(reg_t pc);
 
   reg_t select_an_interrupt_with_default_priority(reg_t enabled_interrupts) const;
 


### PR DESCRIPTION
- Fix an escape where if the I$ was incoherent with main memory, the landing-pad MSBs would not be checked. (For obvious reasons, this was only possible with Ziccid turned off.)
- Significantly speed up function returns by moving most of the ELP overhead off the critical code path.