### PR TITLE
Fix xtval when illegal instruction is triggered.

### DIFF
--- a/riscv/mmu.h
+++ b/riscv/mmu.h
@@ -315,7 +315,7 @@ public:
     unsigned length = insn_length(insn);
 
     for (unsigned pos = sizeof(insn_parcel_t); pos < length; pos += sizeof(insn_parcel_t)) {
-      insn |= fetch_insn_parcel(addr + pos) << (8 * pos);
+      insn |= (insn_bits_t)fetch_insn_parcel(addr + pos) << (8 * pos);
       length = insn_length(insn);
     }
 


### PR DESCRIPTION
The new refill_icache function has an implicit conversion bug. It result in the instruction sign expansion. When an illegal instruction exception is triggered, it manifests as an incorrect xtval. As shown in the following log:

```
core   0: 0x00007ff5942a0d80 (0xffffffffc2202573) csrr    a0, vlenb
core   0: exception trap_illegal_instruction, epc 0x00007ff5942a0d80
core   0:           tval 0xffffffffc2202573
```