### PR TITLE
Fix collapse when setting hartids from command line.

### DIFF
--- a/riscv/sim.cc
+++ b/riscv/sim.cc
@@ -278,7 +278,7 @@ int sim_t::run()
   if (!debug && log)
     set_procs_debug(true);
 
-  htif_t::set_expected_xlen(harts[0]->get_isa().get_max_xlen());
+  htif_t::set_expected_xlen(harts.begin()->second->get_isa().get_max_xlen());
 
   // htif_t::run() will repeatedly call back into sim_t::idle(), each
   // invocation of which will advance target time


### PR DESCRIPTION
When hartid is set to a value > 0 from command line, spike will collapse.