### PR TITLE
Further speed up instruction fetch

### DIFF
--- a/riscv/common.h
+++ b/riscv/common.h
@@ -19,4 +19,16 @@
 # define UNUSED
 #endif
 
+#ifndef __has_builtin
+# define __has_builtin(x) 0
+#endif
+
+#if __has_cpp_attribute(assume)
+# define assume(x) [[assume(x)]]
+#elif __has_builtin(__builtin_assume)
+# define assume(x) __builtin_assume(x)
+#else
+# define assume(x) ((void) 0)
+#endif
+
 #endif

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -773,6 +773,8 @@ bool misa_csr_t::unlogged_write(const reg_t val) noexcept {
     }
   }
 
+  proc->get_mmu()->flush_tlb();
+
   return basic_csr_t::unlogged_write(new_misa);
 }
 

--- a/riscv/decode_macros.h
+++ b/riscv/decode_macros.h
@@ -225,7 +225,8 @@ static inline bool is_aligned(const unsigned val, const unsigned pos)
 #define zext_xlen(x) zext(x, xlen)
 
 #define set_pc(x) \
-  do { p->check_pc_alignment(x); \
+  do { if (unlikely((x) & ~p->pc_alignment_mask())) \
+        return p->throw_instruction_address_misaligned(x); \
        npc = sext_xlen(x); \
      } while (0)
 

--- a/riscv/execute.cc
+++ b/riscv/execute.cc
@@ -229,7 +229,7 @@ void processor_t::step(size_t n)
     state.prv_changed = false;
     state.v_changed = false;
 
-    #define advance_pc() \
+    #define advance_pc() { \
       if (unlikely(invalid_pc(pc))) { \
         switch (pc) { \
           case PC_SERIALIZE_BEFORE: state.serialized = true; break; \
@@ -237,11 +237,11 @@ void processor_t::step(size_t n)
           default: abort(); \
         } \
         pc = state.pc; \
-        break; \
+        goto serialize; \
       } else { \
         state.pc = pc; \
         instret++; \
-      }
+      }}
 
     try
     {
@@ -302,26 +302,21 @@ void processor_t::step(size_t n)
       else while (instret < n)
       {
         // Main simulation loop, fast path.
-        for (auto ic_entry = _mmu->access_icache(pc); ; ) {
+        for (auto ic_entry = _mmu->access_icache(pc); instret < n; instret++) {
           auto fetch = ic_entry->data;
           ic_entry = ic_entry->next;
           auto new_pc = execute_insn_fast(this, pc, fetch);
           if (unlikely(ic_entry->tag != new_pc)) {
             ic_entry = &_mmu->icache[_mmu->icache_index(new_pc)];
+            _mmu->icache[_mmu->icache_index(pc)].next = ic_entry;
             if (ic_entry->tag != new_pc) {
               pc = new_pc;
+              advance_pc();
               break;
             }
-            _mmu->icache[_mmu->icache_index(pc)].next = ic_entry;
           }
-          pc = ic_entry->tag;
-          if (unlikely(instret + 1 == n))
-            break;
-          instret++;
-          state.pc = pc;
+          state.pc = pc = ic_entry->tag;
         }
-
-        advance_pc();
       }
     }
     catch(trap_t& t)
@@ -368,6 +363,7 @@ void processor_t::step(size_t n)
       in_wfi = true;
     }
 
+serialize:
     state.minstret->bump((state.mcountinhibit->read() & MCOUNTINHIBIT_IR) ? 0 : instret);
 
     // Model a hart whose CPI is 1.

--- a/riscv/execute.cc
+++ b/riscv/execute.cc
@@ -304,10 +304,17 @@ void processor_t::step(size_t n)
         // Main simulation loop, fast path.
         for (auto ic_entry = _mmu->access_icache(pc); ; ) {
           auto fetch = ic_entry->data;
-          pc = execute_insn_fast(this, pc, fetch);
-          ic_entry = &_mmu->icache[_mmu->icache_index(pc)];
-          if (unlikely(ic_entry->tag != pc))
-            break;
+          ic_entry = ic_entry->next;
+          auto new_pc = execute_insn_fast(this, pc, fetch);
+          if (unlikely(ic_entry->tag != new_pc)) {
+            ic_entry = &_mmu->icache[_mmu->icache_index(new_pc)];
+            if (ic_entry->tag != new_pc) {
+              pc = new_pc;
+              break;
+            }
+            _mmu->icache[_mmu->icache_index(pc)].next = ic_entry;
+          }
+          pc = ic_entry->tag;
           if (unlikely(instret + 1 == n))
             break;
           instret++;

--- a/riscv/insn_template.cc
+++ b/riscv/insn_template.cc
@@ -6,7 +6,8 @@
 #define DECODE_MACRO_USAGE_LOGGED 0
 
 #define PROLOGUE \
-  reg_t npc = sext_xlen(pc + insn_length(OPCODE))
+  reg_t npc = sext_xlen(pc + insn_length(OPCODE)); \
+  if (!p->extension_enabled(EXT_ZCA)) assume(insn_length(OPCODE) % 4 == 0)
 
 #define EPILOGUE \
   trace_opcode(p, OPCODE, insn); \

--- a/riscv/insns/c_add.h
+++ b/riscv/insns/c_add.h
@@ -1,3 +1,2 @@
 require_extension(EXT_ZCA);
-require(insn.rvc_rs2() != 0);
 WRITE_RD(sext_xlen(RVC_RS1 + RVC_RS2));

--- a/riscv/insns/c_jalr.h
+++ b/riscv/insns/c_jalr.h
@@ -1,5 +1,4 @@
 require_extension(EXT_ZCA);
-require(insn.rvc_rs1() != 0);
 reg_t tmp = npc;
 set_pc(RVC_RS1 & ~reg_t(1));
 WRITE_REG(X_RA, tmp);

--- a/riscv/insns/c_mv.h
+++ b/riscv/insns/c_mv.h
@@ -1,3 +1,2 @@
 require_extension(EXT_ZCA);
-require(insn.rvc_rs2() != 0);
 WRITE_RD(RVC_RS2);

--- a/riscv/mmu.cc
+++ b/riscv/mmu.cc
@@ -39,6 +39,7 @@ void mmu_t::flush_tlb()
   memset(tlb_insn, -1, sizeof(tlb_insn));
   memset(tlb_load, -1, sizeof(tlb_load));
   memset(tlb_store, -1, sizeof(tlb_store));
+  memset(pte_cache, -1, sizeof(pte_cache));
 
   flush_icache();
 }

--- a/riscv/mmu.h
+++ b/riscv/mmu.h
@@ -43,6 +43,7 @@ struct insn_fetch_t
 
 struct icache_entry_t {
   reg_t tag;
+  icache_entry_t* next;
   insn_fetch_t data;
 };
 
@@ -321,6 +322,7 @@ public:
 
     insn_fetch_t fetch = {proc->decode_insn(insn), insn};
     entry->tag = addr;
+    entry->next = &icache[icache_index(addr + length)];
     entry->data = fetch;
 
     auto [check_tracer, _, paddr] = access_tlb(tlb_insn, addr, TLB_FLAGS, TLB_CHECK_TRACER);

--- a/riscv/mmu.h
+++ b/riscv/mmu.h
@@ -135,7 +135,7 @@ public:
   T ss_load(reg_t addr) {
     if ((addr & (sizeof(T) - 1)) != 0)
       throw trap_store_access_fault((proc) ? proc->state.v : false, addr, 0, 0);
-    return load<T>(addr, {.forced_virt=false, .hlvx=false, .lr=false, .ss_access=true});
+    return load<T>(addr, {.ss_access=true});
   }
 
   template<typename T>
@@ -162,7 +162,7 @@ public:
   void ss_store(reg_t addr, T val) {
     if ((addr & (sizeof(T) - 1)) != 0)
       throw trap_store_access_fault((proc) ? proc->state.v : false, addr, 0, 0);
-    store<T>(addr, val, {.forced_virt=false, .hlvx=false, .lr=false, .ss_access=true});
+    store<T>(addr, val, {.ss_access=true});
   }
 
   // AMO/Zicbom faults should be reported as store faults
@@ -194,13 +194,9 @@ public:
   // for shadow stack amoswap
   template<typename T>
   T ssamoswap(reg_t addr, reg_t value) {
-      bool forced_virt = false;
-      bool hlvx = false;
-      bool lr = false;
-      bool ss_access = true;
-      store_slow_path(addr, sizeof(T), nullptr, {forced_virt, hlvx, lr, ss_access}, false, true);
-      auto data = load<T>(addr, {forced_virt, hlvx, lr, ss_access});
-      store<T>(addr, value, {forced_virt, hlvx, lr, ss_access});
+      store_slow_path(addr, sizeof(T), nullptr, {.ss_access=true}, false, true);
+      auto data = load<T>(addr, {.ss_access=true});
+      store<T>(addr, value, {.ss_access=true});
       return data;
   }
 

--- a/riscv/mmu.h
+++ b/riscv/mmu.h
@@ -274,7 +274,10 @@ public:
       store_slow_path(vaddr, size, nullptr, {}, false, true);
     }
 
-    reg_t paddr = translate(generate_access_info(vaddr, STORE, {}), 1);
+    auto [tlb_hit, host_addr, paddr] = access_tlb(tlb_store, vaddr);
+    if (!tlb_hit)
+      paddr = translate(generate_access_info(vaddr, STORE, {}), 1);
+
     if (sim->reservable(paddr))
       return load_reservation_address == paddr;
     else

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -662,6 +662,9 @@ reg_t processor_t::throw_instruction_address_misaligned(reg_t pc)
 
 insn_func_t processor_t::decode_insn(insn_t insn)
 {
+  if (!extension_enabled(EXT_ZCA) && insn_length(insn.bits()) % 4)
+    return &::illegal_instruction;
+
   // look up opcode in hash table
   size_t idx = insn.bits() % OPCODE_CACHE_SIZE;
   auto [hit, desc] = opcode_cache[idx].lookup(insn.bits());

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -655,6 +655,11 @@ reg_t illegal_instruction(processor_t UNUSED *p, insn_t insn, reg_t UNUSED pc)
   throw trap_illegal_instruction(insn.bits() & 0xffffffffULL);
 }
 
+reg_t processor_t::throw_instruction_address_misaligned(reg_t pc)
+{
+  throw trap_instruction_address_misaligned(state.v, pc, 0, 0);
+}
+
 insn_func_t processor_t::decode_insn(insn_t insn)
 {
   // look up opcode in hash table

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -331,10 +331,7 @@ public:
     const int ialign = extension_enabled(EXT_ZCA) ? 16 : 32;
     return ~(reg_t)(ialign == 16 ? 0 : 2);
   }
-  void check_pc_alignment(reg_t pc) {
-    if (unlikely(pc & ~pc_alignment_mask()))
-      throw trap_instruction_address_misaligned(state.v, pc, 0, 0);
-  }
+  reg_t throw_instruction_address_misaligned(reg_t pc);
   reg_t legalize_privilege(reg_t);
   void set_privilege(reg_t, bool);
   const char* get_privilege_string() const;


### PR DESCRIPTION
Dataflow through the PC is an ILP bottleneck.  Reduce the critical code path by memoizing the likely next PC.

Shorten code paths through branch instructions by turning uncommon cases into tail calls (which gets rid of stack-frame allocations) and avoiding checking whether the Zca extension on every execution of a Zca branch.