### PR TITLE
Enhance zve

### DIFF
--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -736,6 +736,7 @@ bool misa_csr_t::unlogged_write(const reg_t val) noexcept {
   const bool prev_h = old_misa & (1L << ('H' - 'A'));
   const reg_t new_misa = (adjusted_val & write_mask) | (old_misa & ~write_mask);
   const bool new_h = new_misa & (1L << ('H' - 'A'));
+  const bool new_v = proc->get_isa().has_any_vector();
 
   proc->set_extension_enable(EXT_ZCA, (new_misa & (1L << ('C' - 'A'))) || !proc->get_isa().extension_enabled('C'));
   proc->set_extension_enable(EXT_ZCF, (new_misa & (1L << ('F' - 'A'))) && proc->extension_enabled(EXT_ZCA) && proc->get_xlen() == 32);
@@ -745,8 +746,8 @@ bool misa_csr_t::unlogged_write(const reg_t val) noexcept {
   proc->set_extension_enable(EXT_ZCMT, proc->extension_enabled(EXT_ZCA));
   proc->set_extension_enable(EXT_ZFH, new_misa & (1L << ('F' - 'A')));
   proc->set_extension_enable(EXT_ZFHMIN, new_misa & (1L << ('F' - 'A')));
-  proc->set_extension_enable(EXT_ZVFH, (new_misa & (1L << ('V' - 'A'))) && proc->extension_enabled(EXT_ZFHMIN));
-  proc->set_extension_enable(EXT_ZVFHMIN, new_misa & (1L << ('V' - 'A')));
+  proc->set_extension_enable(EXT_ZVFH, new_v && proc->get_isa().get_zvf() && proc->extension_enabled(EXT_ZFHMIN));
+  proc->set_extension_enable(EXT_ZVFHMIN, new_v && proc->get_isa().get_zvf());
   proc->set_extension_enable(EXT_ZAAMO, (new_misa & (1L << ('A' - 'A'))) || !proc->get_isa().extension_enabled('A'));
   proc->set_extension_enable(EXT_ZALRSC, (new_misa & (1L << ('A' - 'A'))) || !proc->get_isa().extension_enabled('A'));
   proc->set_extension_enable(EXT_ZBA, (new_misa & (1L << ('B' - 'A'))) || !proc->get_isa().extension_enabled('B'));

--- a/riscv/insns/vfncvt_f_x_w.h
+++ b/riscv/insns/vfncvt_f_x_w.h
@@ -2,9 +2,9 @@
 VI_NON_ALTFMT_INSN
 
 VI_VFP_NCVT_INT_TO_FP(
-  { vd = i32_to_f16(vs2); },        // BODY32
-  { vd = i64_to_f32(vs2); },        // BODY64
-  { require_extension(EXT_ZVFH); }, // CHECK32
-  { require_extension('F'); },      // CHECK64
-  int                               // sign
+  { vd = i32_to_f16(vs2); },             // BODY32
+  { vd = i64_to_f32(vs2); },             // BODY64
+  { require_extension(EXT_ZVFH); },      // CHECK32
+  { require(p->get_isa().get_zvf()); },  // CHECK64
+  int                                    // sign
 )

--- a/riscv/insns/vfncvt_f_xu_w.h
+++ b/riscv/insns/vfncvt_f_xu_w.h
@@ -2,9 +2,9 @@
 VI_NON_ALTFMT_INSN
 
 VI_VFP_NCVT_INT_TO_FP(
-  { vd = ui32_to_f16(vs2); },       // BODY32
-  { vd = ui64_to_f32(vs2); },       // BODY64
-  { require_extension(EXT_ZVFH); }, // CHECK32
-  { require_extension('F'); },      // CHECK64
-  uint                              // sign
+  { vd = ui32_to_f16(vs2); },            // BODY32
+  { vd = ui64_to_f32(vs2); },            // BODY64
+  { require_extension(EXT_ZVFH); },      // CHECK32
+  { require(p->get_isa().get_zvf()); },  // CHECK64
+  uint                                   // sign
 )

--- a/riscv/insns/vfncvt_rtz_x_f_w.h
+++ b/riscv/insns/vfncvt_rtz_x_f_w.h
@@ -6,7 +6,7 @@ VI_VFP_NCVT_FP_TO_INT(
   { vd = f32_to_i16(vs2, softfloat_round_minMag, true); }, // BODY32
   { vd = f64_to_i32(vs2, softfloat_round_minMag, true); }, // BODY64
   { require_zvfbfa_or_zvfh; },                             // CHECK16
-  { require(p->extension_enabled('F')); },                 // CHECK32
-  { require(p->extension_enabled('D')); },                 // CHECK64
+  { require(p->get_isa().get_zvf()); },                    // CHECK32
+  { require(p->get_isa().get_zvd()); },                    // CHECK64
   int                                                      // sign
 )

--- a/riscv/insns/vfncvt_rtz_xu_f_w.h
+++ b/riscv/insns/vfncvt_rtz_xu_f_w.h
@@ -6,7 +6,7 @@ VI_VFP_NCVT_FP_TO_INT(
   { vd = f32_to_ui16(vs2, softfloat_round_minMag, true); }, // BODY32
   { vd = f64_to_ui32(vs2, softfloat_round_minMag, true); }, // BODY64
   { require_zvfbfa_or_zvfh; },                              // CHECK16
-  { require(p->extension_enabled('F')); },                  // CHECK32
-  { require(p->extension_enabled('D')); },                  // CHECK64
+  { require(p->get_isa().get_zvf()); },                     // CHECK32
+  { require(p->get_isa().get_zvd()); },                     // CHECK64
   uint                                                      // sign
 )

--- a/riscv/insns/vfncvt_x_f_w.h
+++ b/riscv/insns/vfncvt_x_f_w.h
@@ -6,7 +6,7 @@ VI_VFP_NCVT_FP_TO_INT(
   { vd = f32_to_i16(vs2, softfloat_roundingMode, true); }, // BODY32
   { vd = f64_to_i32(vs2, softfloat_roundingMode, true); }, // BODY64
   { require_zvfbfa_or_zvfh; },                             // CHECK16
-  { require(p->extension_enabled('F')); },                 // CHECK32
-  { require(p->extension_enabled('D')); },                 // CHECK64
+  { require(p->get_isa().get_zvf()); },                    // CHECK32
+  { require(p->get_isa().get_zvd()); },                    // CHECK64
   int                                                      // sign
 )

--- a/riscv/insns/vfncvt_xu_f_w.h
+++ b/riscv/insns/vfncvt_xu_f_w.h
@@ -6,7 +6,7 @@ VI_VFP_NCVT_FP_TO_INT(
   { vd = f32_to_ui16(vs2, softfloat_roundingMode, true); }, // BODY32
   { vd = f64_to_ui32(vs2, softfloat_roundingMode, true); }, // BODY64
   { require_zvfbfa_or_zvfh; },                              // CHECK16
-  { require(p->extension_enabled('F')); },                  // CHECK32
-  { require(p->extension_enabled('D')); },                  // CHECK64
+  { require(p->get_isa().get_zvf()); },                     // CHECK32
+  { require(p->get_isa().get_zvd()); },                     // CHECK64
   uint                                                      // sign
 )

--- a/riscv/insns/vfwcvt_f_x_v.h
+++ b/riscv/insns/vfwcvt_f_x_v.h
@@ -5,7 +5,7 @@ VI_VFP_WCVT_INT_TO_FP(
   { vd = i32_to_f32(vs2); },                    // BODY16
   { vd = i32_to_f64(vs2); },                    // BODY32
   { require_zvfbfa_or_zvfh; },                  // CHECK8
-  { require_extension('F'); },                  // CHECK16
-  { require_extension('D'); },                  // CHECK32
+  { require(p->get_isa().get_zvf()); },         // CHECK64
+  { require(p->get_isa().get_zvd()); },         // CHECK64
   int                                           // sign
 )

--- a/riscv/insns/vfwcvt_f_xu_v.h
+++ b/riscv/insns/vfwcvt_f_xu_v.h
@@ -5,7 +5,7 @@ VI_VFP_WCVT_INT_TO_FP(
   { vd = ui32_to_f32(vs2); },                    // BODY16
   { vd = ui32_to_f64(vs2); },                    // BODY32
   { require_zvfbfa_or_zvfh; },                   // CHECK8
-  { require_extension('F'); },                   // CHECK16
-  { require_extension('D'); },                   // CHECK32
+  { require(p->get_isa().get_zvf()); },          // CHECK32
+  { require(p->get_isa().get_zvd()); },          // CHECK64
   uint                                           // sign
 )

--- a/riscv/insns/vfwcvt_rtz_x_f_v.h
+++ b/riscv/insns/vfwcvt_rtz_x_f_v.h
@@ -5,6 +5,6 @@ VI_VFP_WCVT_FP_TO_INT(
   { vd = f16_to_i32(vs2, softfloat_round_minMag, true); }, // BODY16
   { vd = f32_to_i64(vs2, softfloat_round_minMag, true); }, // BODY32
   { require_extension(EXT_ZVFH); },                        // CHECK16
-  { require_extension('F'); },                             // CHECK32
+  { require(p->get_isa().get_zvf()); },                    // CHECK32
   int                                                      // sign
 )

--- a/riscv/insns/vfwcvt_rtz_xu_f_v.h
+++ b/riscv/insns/vfwcvt_rtz_xu_f_v.h
@@ -5,6 +5,6 @@ VI_VFP_WCVT_FP_TO_INT(
   { vd = f16_to_ui32(vs2, softfloat_round_minMag, true); }, // BODY16
   { vd = f32_to_ui64(vs2, softfloat_round_minMag, true); }, // BODY32
   { require_extension(EXT_ZVFH); },                         // CHECK16
-  { require_extension('F'); },                              // CHECK32
+  { require(p->get_isa().get_zvf()); },                     // CHECK32
   uint                                                      // sign
 )

--- a/riscv/insns/vfwcvt_x_f_v.h
+++ b/riscv/insns/vfwcvt_x_f_v.h
@@ -5,6 +5,6 @@ VI_VFP_WCVT_FP_TO_INT(
   { vd = f16_to_i32(vs2, softfloat_roundingMode, true); }, // BODY16
   { vd = f32_to_i64(vs2, softfloat_roundingMode, true); }, // BODY32
   { require_extension(EXT_ZVFH); },                        // CHECK16
-  { require_extension('F'); },                             // CHECK32
+  { require(p->get_isa().get_zvf()); },                    // CHECK32
   int                                                      // sign
 )

--- a/riscv/insns/vfwcvt_xu_f_v.h
+++ b/riscv/insns/vfwcvt_xu_f_v.h
@@ -5,6 +5,6 @@ VI_VFP_WCVT_FP_TO_INT(
   { vd = f16_to_ui32(vs2, softfloat_roundingMode, true); }, // BODY16
   { vd = f32_to_ui64(vs2, softfloat_roundingMode, true); }, // BODY32
   { require_extension(EXT_ZVFH); },                         // CHECK16
-  { require_extension('F'); },                              // CHECK32
+  { require(p->get_isa().get_zvf()); },                     // CHECK32
   uint                                                      // sign
 )

--- a/riscv/insns/vmulh_vv.h
+++ b/riscv/insns/vmulh_vv.h
@@ -1,4 +1,6 @@
 // vmulh vd, vs2, vs1
+require(p->extension_enabled('V') || P.VU.vsew < e64);
+
 VI_VV_LOOP
 ({
   vd = ((int128_t)vs2 * vs1) >> sew;

--- a/riscv/insns/vmulh_vx.h
+++ b/riscv/insns/vmulh_vx.h
@@ -1,4 +1,6 @@
 // vmulh vd, vs2, rs1
+require(p->extension_enabled('V') || P.VU.vsew < e64);
+
 VI_VX_LOOP
 ({
   vd = ((int128_t)vs2 * rs1) >> sew;

--- a/riscv/insns/vmulhsu_vv.h
+++ b/riscv/insns/vmulhsu_vv.h
@@ -1,4 +1,6 @@
 // vmulhsu.vv vd, vs2, vs1
+require(p->extension_enabled('V') || P.VU.vsew < e64);
+
 VI_VV_SU_LOOP({
   vd = ((int128_t)vs2 * (uint128_t)vs1) >> sew;
 })

--- a/riscv/insns/vmulhsu_vx.h
+++ b/riscv/insns/vmulhsu_vx.h
@@ -1,4 +1,6 @@
 // vmulhsu.vx vd, vs2, rs1
+require(p->extension_enabled('V') || P.VU.vsew < e64);
+
 VI_VX_SU_LOOP({
   vd = ((int128_t)vs2 * (uint128_t)rs1) >> sew;
 })

--- a/riscv/insns/vmulhu_vv.h
+++ b/riscv/insns/vmulhu_vv.h
@@ -1,4 +1,6 @@
 // vmulhu vd, vs2, vs1
+require(p->extension_enabled('V') || P.VU.vsew < e64);
+
 VI_VV_ULOOP
 ({
   vd = ((uint128_t)vs2 * vs1) >> sew;

--- a/riscv/insns/vmulhu_vx.h
+++ b/riscv/insns/vmulhu_vx.h
@@ -1,4 +1,6 @@
 // vmulhu vd ,vs2, rs1
+require(p->extension_enabled('V') || P.VU.vsew < e64);
+
 VI_VX_ULOOP
 ({
   vd = ((uint128_t)vs2 * rs1) >> sew;

--- a/riscv/insns/vsmul_vv.h
+++ b/riscv/insns/vsmul_vv.h
@@ -1,4 +1,6 @@
 // vsmul.vv vd, vs2, vs1
+require(p->extension_enabled('V') || P.VU.vsew < e64);
+
 VI_VV_LOOP
 ({
   VRM xrm = P.VU.get_vround_mode();

--- a/riscv/insns/vsmul_vx.h
+++ b/riscv/insns/vsmul_vx.h
@@ -1,4 +1,6 @@
 // vsmul.vx vd, vs2, rs1
+require(p->extension_enabled('V') || P.VU.vsew < e64);
+
 VI_VX_LOOP
 ({
   VRM xrm = P.VU.get_vround_mode();

--- a/riscv/v_ext_macros.h
+++ b/riscv/v_ext_macros.h
@@ -1790,8 +1790,15 @@ VI_VX_ULOOP({ \
   }; \
   VI_VFP_LOOP_CMP_END \
 
+#define VI_CHECK_VFP_WIDE \
+  if (P.VU.vsew == e16) \
+    require(p->get_isa().get_zvf()); \
+  else if (P.VU.vsew == e32) \
+    require(p->get_isa().get_zvd()); \
+
 #define VI_VFP_VF_LOOP_WIDE(BODY16, BODY32) \
   VI_CHECK_DSS(false); \
+  VI_CHECK_VFP_WIDE \
   VI_VFP_LOOP_BASE \
   switch (P.VU.vsew) { \
     case e16: { \
@@ -1841,6 +1848,7 @@ VI_VX_ULOOP({ \
 
 #define VI_VFP_VV_LOOP_WIDE(BODY16, BODY32) \
   VI_CHECK_DSS(true); \
+  VI_CHECK_VFP_WIDE \
   VI_VFP_LOOP_BASE \
   switch (P.VU.vsew) { \
     case e16: { \
@@ -1890,6 +1898,7 @@ VI_VX_ULOOP({ \
 
 #define VI_VFP_WF_LOOP_WIDE(BODY16, BODY32) \
   VI_CHECK_DDS(false); \
+  VI_CHECK_VFP_WIDE \
   VI_VFP_LOOP_BASE \
   switch (P.VU.vsew) { \
     case e16: { \
@@ -1918,6 +1927,7 @@ VI_VX_ULOOP({ \
 
 #define VI_VFP_WV_LOOP_WIDE(BODY16, BODY32) \
   VI_CHECK_DDS(true); \
+  VI_CHECK_VFP_WIDE \
   VI_VFP_LOOP_BASE \
   switch (P.VU.vsew) { \
     case e16: { \


### PR DESCRIPTION
There are some part of V that don't be covered by zveXXX configuration.  The patch set wants to handle 

1. add a zve state to present the vector capability is enabled by V or Zve
2. handle vector widening and narrow conversion with difference floating width
3. handle  vector index load with zve64 and rv32
4. handle widening integer arithmetic which may not be supported on zve64