### PR TITLE
zvfbfmin: fix contraint with zvfbfa

### DIFF
--- a/riscv/insns/vfncvtbf16_f_f_w.h
+++ b/riscv/insns/vfncvtbf16_f_f_w.h
@@ -5,5 +5,5 @@ VI_VFP_NCVT_FP_BF16_OFP8(
   },                                                                 // BODY16
   { vd = f32_to_bf16(vs2); },                                        // BODY32
   { require(p->extension_enabled(EXT_ZVFOFP8MIN)); },                // CHECK16
-  { require_zvfbfa; require(p->extension_enabled(EXT_ZVFBFMIN)); }   // CHECK32
+  { require_extension(EXT_ZVFBFMIN); }                               // CHECK32
 )

--- a/riscv/insns/vfwcvtbf16_f_f_v.h
+++ b/riscv/insns/vfwcvtbf16_f_f_v.h
@@ -3,5 +3,5 @@ VI_VFP_WCVT_OFP8_BF16_FP(
   { vd = P.VU.altfmt ? e5m2_to_bf16(vs2) : e4m3_to_bf16(vs2); },     // BODY8
   { vd = bf16_to_f32(vs2); },                                        // BODY16
   { require(p->extension_enabled(EXT_ZVFOFP8MIN)); },                // CHECK8
-  { require_zvfbfa_or_zvfhmin; }                                     // CHECK16
+  { require_extension(EXT_ZVFBFMIN); }                               // CHECK16
 )


### PR DESCRIPTION
vfncvtbf16_f_f_w and vfwcvtbf16_f_f_v only depend on Zvfbf16min but not Zvfbfa

ref:
  https://github.com/aswaterman/riscv-misc/blob/main/isa/zvfbfa.adoc

"
  vfwcvtbf16.f.f.v † (only if Zvfbfmin is implemented)
  vfncvtbf16.f.f.w † (only if Zvfbfmin is implemented)

  The instructions marked with † have the same semantics regardless of altfmt
"