### PR TITLE
misc: fix typo in zawrs incompatible error

### DIFF
--- a/disasm/isa_parser.cc
+++ b/disasm/isa_parser.cc
@@ -548,7 +548,7 @@ isa_parser_t::isa_parser_t(const char* str, const char *priv)
   }
 
   if (extension_table[EXT_ZAWRS] && !extension_table[EXT_ZALRSC]) {
-    bad_isa_string(str, "'Zabha' extension requires either the 'A' or the 'Zalrsc' extension");
+    bad_isa_string(str, "'Zawrs' extension requires either the 'A' or the 'Zalrsc' extension");
   }
 
   // When SSE is 0, Zicfiss behavior is defined by Zicmop


### PR DESCRIPTION
I believe this is a typo as the `if` above checks that zawrs is specified with zalrsc (according to the spec zawrs is only useful with LR instructions from zalrsc)

@ved-rivos fyi