### PR TITLE
Fix Svukte implementation

### DIFF
--- a/riscv/mmu.h
+++ b/riscv/mmu.h
@@ -453,7 +453,8 @@ private:
     check_triggers(operation, address, virt, address, data);
   }
   void check_triggers(triggers::operation_t operation, reg_t address, bool virt, reg_t tval, std::optional<reg_t> data);
-  bool check_svukte_qualified(reg_t addr, reg_t mode, bool forced_virt);
+  bool svukte_qualified(mem_access_info_t access_info);
+  bool svukte_fault(reg_t addr, mem_access_info_t access_info);
   reg_t translate(mem_access_info_t access_info, reg_t len);
 
   reg_t pte_load(reg_t pte_paddr, reg_t addr, bool virt, access_type trap_type, size_t ptesize) {


### PR DESCRIPTION
- Change polarity of svukte_qualified to match ISA spec
- Avoid address dependence of svukte_qualified, per ISA spec
- Move address check to separate routine