### PR TITLE
Clean up VA size handling

### DIFF
--- a/riscv/decode_macros.h
+++ b/riscv/decode_macros.h
@@ -163,7 +163,6 @@ static inline bool is_aligned(const unsigned val, const unsigned pos)
 #define require_rv32 require(xlen == 32)
 #define require_extension(s) require(p->extension_enabled(s))
 #define require_either_extension(A,B) require(p->extension_enabled(A) || p->extension_enabled(B));
-#define require_impl(s) require(p->supports_impl(s))
 #define require_fp          STATE.fflags->verify_permissions(insn, false)
 #define require_accelerator require(STATE.sstatus->enabled(SSTATUS_XS))
 #define require_vector_vs   require(p->any_vector_extensions() && STATE.sstatus->enabled(SSTATUS_VS))

--- a/riscv/insns/sfence_inval_ir.h
+++ b/riscv/insns/sfence_inval_ir.h
@@ -1,4 +1,4 @@
 require_extension('S');
 require_extension(EXT_SVINVAL);
-require_impl(IMPL_MMU);
+require(p->has_mmu());
 require_privilege_hs_qualified(PRV_S);

--- a/riscv/insns/sfence_vma.h
+++ b/riscv/insns/sfence_vma.h
@@ -1,5 +1,5 @@
 require_extension('S');
-require_impl(IMPL_MMU);
+require(p->has_mmu());
 if (STATE.v) {
   if (STATE.prv == PRV_U || get_field(STATE.hstatus->read(), HSTATUS_VTVM))
     require_novirt();

--- a/riscv/isa_parser.h
+++ b/riscv/isa_parser.h
@@ -114,12 +114,6 @@ typedef enum {
 } isa_extension_t;
 
 typedef enum {
-  IMPL_MMU_SV32,
-  IMPL_MMU_SV39,
-  IMPL_MMU_SV48,
-  IMPL_MMU_SV57,
-  IMPL_MMU_SBARE,
-  IMPL_MMU,
   IMPL_MMU_VMID,
   IMPL_MMU_ASID,
 } impl_extension_t;

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -290,6 +290,9 @@ public:
     extension_enable_table[ext] = enable && isa.extension_enabled(ext);
   }
   void set_impl(uint8_t impl, bool val) { impl_table[impl] = val; }
+  bool has_mmu() const { return max_vaddr_bits != 0; }
+  unsigned get_max_vaddr_bits() const { return max_vaddr_bits; }
+  void set_max_vaddr_bits(unsigned);
   bool supports_impl(uint8_t impl) const {
     return impl_table[impl];
   }
@@ -358,6 +361,7 @@ private:
   state_t state;
   uint32_t id;
   unsigned xlen;
+  unsigned max_vaddr_bits;
   bool histogram_enabled;
   bool log_commits_enabled;
   FILE *log_file;

--- a/riscv/sim.cc
+++ b/riscv/sim.cc
@@ -214,16 +214,16 @@ sim_t::sim_t(const cfg_t *cfg, bool halted,
     // handle mmu-type
     const char *mmu_type;
     rc = fdt_parse_mmu_type(fdt, cpu_offset, &mmu_type);
+    procs[cpu_idx]->set_max_vaddr_bits(0);
     if (rc == 0) {
-      procs[cpu_idx]->set_mmu_capability(IMPL_MMU_SBARE);
       if (strncmp(mmu_type, "riscv,sv32", strlen("riscv,sv32")) == 0) {
-        procs[cpu_idx]->set_mmu_capability(IMPL_MMU_SV32);
+        procs[cpu_idx]->set_max_vaddr_bits(32);
       } else if (strncmp(mmu_type, "riscv,sv39", strlen("riscv,sv39")) == 0) {
-        procs[cpu_idx]->set_mmu_capability(IMPL_MMU_SV39);
+        procs[cpu_idx]->set_max_vaddr_bits(39);
       } else if (strncmp(mmu_type, "riscv,sv48", strlen("riscv,sv48")) == 0) {
-        procs[cpu_idx]->set_mmu_capability(IMPL_MMU_SV48);
+        procs[cpu_idx]->set_max_vaddr_bits(48);
       } else if (strncmp(mmu_type, "riscv,sv57", strlen("riscv,sv57")) == 0) {
-        procs[cpu_idx]->set_mmu_capability(IMPL_MMU_SV57);
+        procs[cpu_idx]->set_max_vaddr_bits(57);
       } else if (strncmp(mmu_type, "riscv,sbare", strlen("riscv,sbare")) == 0) {
         // has been set in the beginning
       } else {
@@ -233,8 +233,6 @@ sim_t::sim_t(const cfg_t *cfg, bool halted,
                   << mmu_type << ").\n";
         exit(1);
       }
-    } else {
-      procs[cpu_idx]->set_mmu_capability(IMPL_MMU_SBARE);
     }
 
     procs[cpu_idx]->reset();


### PR DESCRIPTION
Representing the VA size as a feature set rather than an integer allows for internal inconsistency and is inelegant.  It gives the impression that e.g. MMU_SV48, MMU_SV39, and MMU are orthogonal features, when in reality each implies the next.