### PR TITLE
Fix Q extension on big-endian targets

### DIFF
--- a/riscv/insns/flq.h
+++ b/riscv/insns/flq.h
@@ -1,3 +1,5 @@
 require_extension('Q');
 require_fp;
-WRITE_FRD(MMU.load_float128(RS1 + insn.i_imm()));
+uint128_t v = MMU.load<uint128_t>(RS1 + insn.i_imm());
+float128_t f = { uint64_t(v), uint64_t(v >> 64) };
+WRITE_FRD(f);

--- a/riscv/insns/fsq.h
+++ b/riscv/insns/fsq.h
@@ -1,3 +1,4 @@
 require_extension('Q');
 require_fp;
-MMU.store_float128(RS1 + insn.s_imm(), FRS2);
+uint128_t v = FRS2.v[0] | (uint128_t(FRS2.v[1]) << 64);
+MMU.store<uint128_t>(RS1 + insn.s_imm(), v);

--- a/riscv/mmu.h
+++ b/riscv/mmu.h
@@ -211,28 +211,6 @@ public:
     })
   }
 
-  void store_float128(reg_t addr, float128_t val)
-  {
-    if (unlikely(addr & (sizeof(float128_t)-1)) && !is_misaligned_enabled()) {
-      throw trap_store_address_misaligned((proc) ? proc->state.v : false, addr, 0, 0);
-    }
-
-    store<uint64_t>(addr, val.v[0]);
-    store<uint64_t>(addr + 8, val.v[1]);
-  }
-
-  float128_t load_float128(reg_t addr)
-  {
-    if (unlikely(addr & (sizeof(float128_t)-1)) && !is_misaligned_enabled()) {
-      throw trap_load_address_misaligned((proc) ? proc->state.v : false, addr, 0, 0);
-    }
-
-    float128_t res;
-    res.v[0] = load<uint64_t>(addr);
-    res.v[1] = load<uint64_t>(addr + 8);
-    return res;
-  }
-
   void cbo_zero(reg_t addr) {
     auto access_info = generate_access_info(addr, STORE, {});
     reg_t transformed_addr = access_info.transformed_vaddr;

--- a/riscv/riscv.mk.in
+++ b/riscv/riscv.mk.in
@@ -1149,7 +1149,7 @@ riscv_insn_list = \
 	$(riscv_insn_ext_f_zfa) \
 	$(riscv_insn_ext_h) \
 	$(riscv_insn_ext_k) \
-	$(riscv_insn_ext_q) \
+	$(if $(HAVE_INT128),$(riscv_insn_ext_q),) \
 	$(riscv_insn_ext_q_zfa) \
 	$(riscv_insn_ext_zacas) \
 	$(riscv_insn_ext_zabha) \


### PR DESCRIPTION
The previous routines always stored the low-order bits into the  low-order doubleword, which is only correct on little-endian targets.

@ved-rivos can you sanity-check this?  I spotted it after seeing your comment here: https://github.com/riscv/riscv-isa-manual/issues/2447#issuecomment-3616644330

The idea is to make FLQ/FSQ look more like AMOCAS.Q etc. rather than a special case.