### PR TITLE
#2082 Reorder hstateen0 check for smcdeleg

### DIFF
--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -1854,16 +1854,14 @@ void sscsrind_reg_csr_t::verify_permissions(insn_t insn, bool write) const {
   if (proc->extension_enabled(EXT_SMSTATEEN)) {
     if ((state->prv < PRV_M) && !(state->mstateen[0]->read() & MSTATEEN0_CSRIND))
       throw trap_illegal_instruction(insn.bits());
+
+    if (state->v && !(state->hstateen[0]->read() & HSTATEEN0_CSRIND))
+      throw trap_virtual_instruction(insn.bits());
   }
 
   // Don't call base verify_permission for VS registers remapped to S-mode
   if (insn.csr() == address)
     csr_t::verify_permissions(insn, write);
-
-  if (proc->extension_enabled(EXT_SMSTATEEN)) {
-    if (state->v && !(state->hstateen[0]->read() & HSTATEEN0_CSRIND))
-      throw trap_virtual_instruction(insn.bits());
-  }
 
   if (proc->extension_enabled(EXT_SMCDELEG)) {
     if (address >= CSR_VSIREG && address <= CSR_VSIREG6) {


### PR DESCRIPTION
As mentioned in the following issue, the hstateen0 check should come before verifying base csr_t permissions:
https://github.com/riscv-software-src/riscv-isa-sim/issues/2082

/cc @binno 