### PR TITLE
Move CI to MacOS 15

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -40,7 +40,7 @@ jobs:
 
   test-macos:
     name: Test Spike build (MacOS)
-    runs-on: macos-13
+    runs-on: macos-15
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
The MacOS 13 runners have been retired.