### PR TITLE
Raise an illegal-instruction exception upon accessing sireg* (really vsireg*) from VS-mode, while vsiselect holds a value unimplemented

### DIFF
--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -1919,11 +1919,7 @@ void sscsrind_reg_csr_t::verify_permissions(insn_t insn, bool write) const {
 
   csr_t_p proxy_csr = get_reg();
   if (proxy_csr == nullptr) {
-    if (!state->v) {
-      throw trap_illegal_instruction(insn.bits());
-    } else {
-      throw trap_virtual_instruction(insn.bits());
-    }
+    throw trap_illegal_instruction(insn.bits());
   }
   proxy_csr->verify_permissions(insn, write);
 }


### PR DESCRIPTION
The behavior upon accessing vsireg* from M-mode or HS-mode, or accessing sireg* (really vsireg*)
from VS-mode, while vsiselect holds a value that is not implemented at HS level, is UNSPECIFIED.
 It is recommended that implementations raise an illegal-instruction exception for
such accesses, to facilitate possible emulation (by M-mode) of these accesses.