### PR TITLE
indirection CSRs 'iprio0~iprio15' are defined by Smaia/Ssaia extensions

### DIFF
--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -77,7 +77,7 @@ typedef std::vector<std::tuple<reg_t, uint64_t, uint8_t>> commit_log_mem_t;
 // architectural state of a RISC-V hart
 struct state_t
 {
-  void add_ireg_proxy(processor_t* const proc, sscsrind_reg_csr_t::sscsrind_reg_csr_t_p ireg);
+  void add_iprio_proxy(processor_t* const proc, sscsrind_reg_csr_t::sscsrind_reg_csr_t_p ireg);
   void reset(processor_t* const proc, reg_t max_isa);
   void add_csr(reg_t addr, const csr_t_p& csr);
 


### PR DESCRIPTION
1. register indirection CSRs 'iprio0~iprio15' when Smaia/Ssaia supported
2. Smais/Ssaia requires Smcsrind/Sscsrind with mireg/sirge/vsireg supported but Smcsrind/Sscsrind does not indicates Smaia/Ssaia extensions at the same time