### PR TITLE
remove unnecessary dtb to dts operation

### DIFF
--- a/riscv/sim.cc
+++ b/riscv/sim.cc
@@ -135,7 +135,6 @@ sim_t::sim_t(const cfg_t *cfg, bool halted,
     std::stringstream strstream;
     strstream << fin.rdbuf();
     dtb = strstream.str();
-    dts = dtb_to_dts(dtb);
   } else {
     std::string device_nodes;
     for (const device_factory_sargs_t& factory_sargs: device_factories) {
@@ -303,7 +302,10 @@ void sim_t::step(size_t n)
     }
   }
 }
-
+const char* sim_t::get_dts() {
+  dts = dtb_to_dts(dtb);
+  return dts.c_str(); 
+}
 void sim_t::add_device(reg_t addr, std::shared_ptr<abstract_device_t> dev) {
   bus.add_device(addr, dev.get());
   devices.push_back(dev);

--- a/riscv/sim.h
+++ b/riscv/sim.h
@@ -55,7 +55,7 @@ public:
   void set_remote_bitbang(remote_bitbang_t* remote_bitbang) {
     this->remote_bitbang = remote_bitbang;
   }
-  const char* get_dts() { return dts.c_str(); }
+  const char* get_dts();
   processor_t* get_core(size_t i) { return procs.at(i); }
   abstract_interrupt_controller_t* get_intctrl() const { assert(plic.get()); return plic.get(); }
   virtual const cfg_t &get_cfg() const override { return *cfg; }


### PR DESCRIPTION
This clears the unnecessary dtb_to_dts process and only used when it is needed. It also drop the dtc requirement which users use only their own dtb file.

Fixes #2196