### PR TITLE
Fix triggers for accesses wider than XLEN

### DIFF
--- a/riscv/mmu.cc
+++ b/riscv/mmu.cc
@@ -144,28 +144,12 @@ mmu_t::insn_parcel_t mmu_t::fetch_slow_path(reg_t vaddr)
 
 static reg_t reg_from_bytes(size_t len, const uint8_t* bytes)
 {
-  switch (len) {
-    case 1:
-      return bytes[0];
-    case 2:
-      return bytes[0] |
-        (((reg_t) bytes[1]) << 8);
-    case 4:
-      return bytes[0] |
-        (((reg_t) bytes[1]) << 8) |
-        (((reg_t) bytes[2]) << 16) |
-        (((reg_t) bytes[3]) << 24);
-    case 8:
-      return bytes[0] |
-        (((reg_t) bytes[1]) << 8) |
-        (((reg_t) bytes[2]) << 16) |
-        (((reg_t) bytes[3]) << 24) |
-        (((reg_t) bytes[4]) << 32) |
-        (((reg_t) bytes[5]) << 40) |
-        (((reg_t) bytes[6]) << 48) |
-        (((reg_t) bytes[7]) << 56);
-  }
-  abort();
+  assert(len <= sizeof(reg_t));
+
+  size_t res = 0;
+  for (size_t i = 0; i < len; i++)
+    res = (res << 8) | bytes[len - 1 - i];
+  return res;
 }
 
 bool mmu_t::mmio_ok(reg_t paddr, access_type UNUSED type)

--- a/riscv/mmu.cc
+++ b/riscv/mmu.cc
@@ -223,9 +223,8 @@ void mmu_t::check_triggers(triggers::operation_t operation,
   reg_t addr, bool virt, std::size_t data_size, const std::uint8_t* bytes)
 {
   assert(data_size > 0);
-  assert(data_size <= sizeof(reg_t));
-  check_triggers(operation, addr, virt,
-    data_size, reg_from_bytes(data_size, bytes));
+
+  check_triggers(operation, addr, virt, data_size, reg_from_bytes(std::min(data_size, sizeof(reg_t)), bytes));
 }
 
 void mmu_t::check_triggers(triggers::operation_t operation,


### PR DESCRIPTION
I believe that @en-sc's comment here is correct: https://github.com/riscv-software-src/riscv-isa-sim/pull/2161#discussion_r2564958203
    
Nevertheless, failing an assertion when someone sets a trigger on memory accessed by a wide access is not reasonable behavior for Spike.  Better to do something that follows the principle of least surprise, despite the debug spec's lack of clarity on this point.

This PR also fixes some unrelated code-quality issues in adjacent code.