### PR TITLE
Add Zvabd extension.

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Spike supports the following RISC-V ISA features:
   - Zfbfmin extension, v0.6
   - Zvfbfmin extension, v0.6
   - Zvfbfwma extension, v0.6
+  - Zvabd extension, v0.7
   - Zvbb extension, v1.0
   - Zvbc extension, v1.0
   - Zvkg extension, v1.0

--- a/disasm/disasm.cc
+++ b/disasm/disasm.cc
@@ -2175,6 +2175,14 @@ void disassembler_t::add_instructions(const isa_parser_t* isa, bool strict)
     DEFINE_R1TYPE(sm3p1);
   }
 
+  if (ext_enabled(EXT_ZVABD)) {
+    DEFINE_VECTOR_V(vabs_v);
+    DEFINE_VECTOR_VV(vabd_vv);
+    DEFINE_VECTOR_VV(vabdu_vv);
+    DEFINE_VECTOR_MULTIPLYADD_VV(vwabda_vv);
+    DEFINE_VECTOR_MULTIPLYADD_VV(vwabdau_vv);
+  }
+
   if (ext_enabled(EXT_ZVBB)) {
 #define DEFINE_VECTOR_VIU_ZIMM6(code) \
   add_vector_viu_z6_insn(this, #code, match_##code, mask_##code)

--- a/disasm/isa_parser.cc
+++ b/disasm/isa_parser.cc
@@ -244,6 +244,8 @@ void isa_parser_t::add_extension(const std::string& ext_str, const char* str)
     extension_table[EXT_ZCLSD] = true;
     extension_table[EXT_ZCA] = true;
     extension_table[EXT_ZILSD] = true;
+  } else if (ext_str == "zvabd") {
+    extension_table[EXT_ZVABD] = true;
   } else if (ext_str == "zvkb") {
     extension_table[EXT_ZVKB] = true;
   } else if (ext_str == "zvbb") {

--- a/riscv/insns/vabd_vv.h
+++ b/riscv/insns/vabd_vv.h
@@ -1,0 +1,9 @@
+// vabd.vv vd, vs1, vs2, vm
+
+require_zvabd;
+require(P.VU.vsew <= e16);
+
+VI_VV_LOOP
+({
+  vd = DO_ABD(vs1, vs2);
+})

--- a/riscv/insns/vabdu_vv.h
+++ b/riscv/insns/vabdu_vv.h
@@ -1,0 +1,9 @@
+// vabdu.vv vd, vs1, vs2, vm
+
+require_zvabd;
+require(P.VU.vsew <= e16);
+
+VI_VV_ULOOP
+({
+  vd = DO_ABD(vs1, vs2);
+})

--- a/riscv/insns/vabs_v.h
+++ b/riscv/insns/vabs_v.h
@@ -1,0 +1,8 @@
+// vabs.v vd, vs2, vm
+
+require_zvabd;
+
+VI_V_LOOP
+({
+  vd = vs2 > 0 ? vs2 : -vs2;
+})

--- a/riscv/insns/vwabda_vv.h
+++ b/riscv/insns/vwabda_vv.h
@@ -1,0 +1,10 @@
+// vwabda.vv vd, vs2, vs1, vm
+
+require_zvabd;
+require(P.VU.vsew <= e16);
+VI_CHECK_DSS(true);
+
+VI_VV_LOOP_WIDEN
+({
+  VI_WIDE_OP_MACRO_AND_ASSIGN(vs2, vs1, vd_w, DO_ABD, int);
+})

--- a/riscv/insns/vwabdau_vv.h
+++ b/riscv/insns/vwabdau_vv.h
@@ -1,0 +1,10 @@
+// vwabdau.vv vd, vs2, vs1, vm
+
+require_zvabd;
+require(P.VU.vsew <= e16);
+VI_CHECK_DSS(true);
+
+VI_VV_LOOP_WIDEN
+({
+  VI_WIDE_OP_MACRO_AND_ASSIGN(vs2, vs1, vd_w, DO_ABD, uint);
+})

--- a/riscv/isa_parser.h
+++ b/riscv/isa_parser.h
@@ -66,6 +66,7 @@ typedef enum {
   EXT_ZICOND,
   EXT_ZIHPM,
   EXT_ZILSD,
+  EXT_ZVABD,
   EXT_ZVBB,
   EXT_ZVKB,
   EXT_ZVBC,

--- a/riscv/riscv.mk.in
+++ b/riscv/riscv.mk.in
@@ -1136,6 +1136,13 @@ riscv_insn_ext_zvk = \
 	$(riscv_insn_ext_zvksed) \
 	$(riscv_insn_ext_zvksh) \
 
+riscv_insn_ext_zvabd = \
+	vabs_v \
+	vabd_vv \
+	vabdu_vv \
+	vwabda_vv \
+	vwabdau_vv \
+
 riscv_insn_list = \
 	$(riscv_insn_ext_i) \
 	$(riscv_insn_ext_c) \
@@ -1166,6 +1173,7 @@ riscv_insn_list = \
 	$(riscv_insn_ext_zvk) \
 	$(riscv_insn_ext_zvbdot) \
 	$(riscv_insn_ext_zvldot) \
+	$(riscv_insn_ext_zvabd) \
 	$(riscv_insn_priv) \
 	$(riscv_insn_smrnmi) \
 	$(riscv_insn_svinval) \

--- a/riscv/v_ext_macros.h
+++ b/riscv/v_ext_macros.h
@@ -72,6 +72,12 @@ static inline bool is_overlapped_widen(const int astart, int asize,
 #define require_zvfbfa_or_zvfhmin \
  require_extension(P.VU.altfmt ? EXT_ZVFBFA : EXT_ZVFHMIN); \
 
+#define require_zvabd \
+  do { \
+    require_vector(true); \
+    require_extension(EXT_ZVABD); \
+  } while (0)
+
 #define VI_NARROW_CHECK_COMMON(factor) \
   require_vector(true); \
   require(P.VU.vflmul <= (8 / factor)); \
@@ -352,6 +358,10 @@ static inline bool is_overlapped_widen(const int astart, int asize,
   type_sew_t<x>::type UNUSED &vd = P.VU.elt<type_sew_t<x>::type>(rd_num, i, true); \
   type_sew_t<x>::type vs1 = P.VU.elt<type_sew_t<x>::type>(rs1_num, i); \
   type_sew_t<x>::type UNUSED vs2 = P.VU.elt<type_sew_t<x>::type>(rs2_num, i);
+
+#define V_PARAMS(x) \
+  type_sew_t<x>::type &vd = P.VU.elt<type_sew_t<x>::type>(rd_num, i, true); \
+  type_sew_t<x>::type vs2 = P.VU.elt<type_sew_t<x>::type>(rs2_num, i);
 
 #define VX_PARAMS(x) \
   type_sew_t<x>::type UNUSED &vd = P.VU.elt<type_sew_t<x>::type>(rd_num, i, true); \
@@ -723,6 +733,24 @@ static inline bool is_overlapped_widen(const int astart, int asize,
   } \
   VI_LOOP_END
 
+#define VI_V_LOOP(BODY) \
+  VI_CHECK_SSS(false) \
+  VI_LOOP_BASE \
+  if (sew == e8) { \
+    V_PARAMS(e8); \
+    BODY; \
+  } else if (sew == e16) { \
+    V_PARAMS(e16); \
+    BODY; \
+  } else if (sew == e32) { \
+    V_PARAMS(e32); \
+    BODY; \
+  } else if (sew == e64) { \
+    V_PARAMS(e64); \
+    BODY; \
+  } \
+  VI_LOOP_END
+
 #define VI_VX_ULOOP(BODY) \
   VI_CHECK_SSS(false) \
   VI_LOOP_BASE \
@@ -970,6 +998,28 @@ static inline bool is_overlapped_widen(const int astart, int asize,
     sign##64_t UNUSED vd_w = P.VU.elt<sign##64_t>(rd_num, i); \
     P.VU.elt<uint64_t>(rd_num, i, true) = \
       op1((sign##64_t)(sign##32_t)var0 op0 (sign##64_t)(sign##32_t)var1) + var2; \
+    } \
+    break; \
+  }
+
+#define VI_WIDE_OP_MACRO_AND_ASSIGN(var0, var1, var2, op, sign) \
+  switch (P.VU.vsew) { \
+  case e8: { \
+    sign##16_t UNUSED vd_w = P.VU.elt<sign##16_t>(rd_num, i); \
+    P.VU.elt<uint16_t>(rd_num, i, true) = \
+      op((sign##16_t)(sign##8_t)var0, (sign##16_t)(sign##8_t)var1) + var2; \
+    } \
+    break; \
+  case e16: { \
+    sign##32_t UNUSED vd_w = P.VU.elt<sign##32_t>(rd_num, i); \
+    P.VU.elt<uint32_t>(rd_num, i, true) = \
+      op((sign##32_t)(sign##16_t)var0, (sign##32_t)(sign##16_t)var1) + var2; \
+    } \
+    break; \
+  default: { \
+    sign##64_t UNUSED vd_w = P.VU.elt<sign##64_t>(rd_num, i); \
+    P.VU.elt<uint64_t>(rd_num, i, true) = \
+      op((sign##64_t)(sign##32_t)var0, (sign##64_t)(sign##32_t)var1) + var2; \
     } \
     break; \
   }
@@ -2237,5 +2287,7 @@ c_t generic_dot_product(const std::vector<a_t>& a, const std::vector<b_t>& b, c_
 
 #define P_SET_OV(ov) \
   if (ov) P.VU.vxsat->write(1);
+
+#define DO_ABD(N, M)  ((N) > (M) ? (N) - (M) : (M) - (N))
 
 #endif


### PR DESCRIPTION
This patch adds support for the zvabd extension. 
See https://github.com/riscv/integer-vector-absolute-difference