### PR TITLE
csrs.cc: if no U-mode, mstatus.tw is read-only 0

### DIFF
--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -556,7 +556,8 @@ bool mstatus_csr_t::unlogged_write(const reg_t val) noexcept {
   const reg_t mask = adj_write_mask
                    | MSTATUS_MIE | MSTATUS_MPIE
                    | (proc->extension_enabled('U') ? MSTATUS_MPRV : 0)
-                   | MSTATUS_MPP | MSTATUS_TW
+                   | MSTATUS_MPP
+                   | (proc->extension_enabled('U') ? MSTATUS_TW : 0)
                    | (proc->extension_enabled('S') ? MSTATUS_TSR : 0)
                    | (has_page ? MSTATUS_TVM : 0)
                    | (has_gva ? MSTATUS_GVA : 0)


### PR DESCRIPTION
Fix https://github.com/riscv-software-src/riscv-isa-sim/issues/2215