### PR TITLE
Fix incorrect mip.SEIP handling by adding hardware SEIP latch & correcting PLIC aliasing

### DIFF
--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -821,10 +821,29 @@ void mip_csr_t::write_with_mask(const reg_t mask, const reg_t val) noexcept {
 }
 
 reg_t mip_csr_t::read() const noexcept {
-  return val | state->hvip->basic_csr_t::read() | ((state->mvien->read() & MIP_SEIP) ? 0 : (state->mvip->basic_csr_t::read() & MIP_SEIP));
+  reg_t result = val;
+
+  // Merge hypervisor virtual interrupts (unchanged behavior)
+  result |= state->hvip->basic_csr_t::read();
+
+  // Merge hardware SEIP latch (external interrupt pending)
+  result |= seip_hw_latch & MIP_SEIP;
+
+  // Merge mvip alias when mvien.SEIP == 0
+  if (!(state->mvien->read() & MIP_SEIP)) {
+    result |= (state->mvip->basic_csr_t::read() & MIP_SEIP);
+  }
+
+  return result;
 }
 
 void mip_csr_t::backdoor_write_with_mask(const reg_t mask, const reg_t val) noexcept {
+  // Handle SEIP: hardware sources must update the latch, not overwrite CSRs
+  if (mask & MIP_SEIP) {
+    seip_hw_latch = (val & MIP_SEIP) ? MIP_SEIP : 0;
+  }
+
+  // For all other bits, perform the normal backdoor write
   this->val = (this->val & ~mask) | (val & mask);
 }
 

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -843,8 +843,9 @@ void mip_csr_t::backdoor_write_with_mask(const reg_t mask, const reg_t val) noex
     seip_hw_latch = (val & MIP_SEIP) ? MIP_SEIP : 0;
   }
 
-  // For all other bits, perform the normal backdoor write
-  this->val = (this->val & ~mask) | (val & mask);
+  // Write all bits except SEIP into val; SEIP must only go into seip_hw_latch
+  reg_t non_seip_mask = mask & ~MIP_SEIP;
+  this->val = (this->val & ~non_seip_mask) | (val & non_seip_mask);
 }
 
 reg_t mip_csr_t::write_mask() const noexcept {

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -379,8 +379,13 @@ class mip_csr_t: public mip_or_mie_csr_t {
 
   // Does not log. Used by external things (clint) that wiggle bits in mip.
   void backdoor_write_with_mask(const reg_t mask, const reg_t val) noexcept;
+
+  // Setter for hardware SEIP latch
+  void set_seip_hw_latch(reg_t v) noexcept { seip_hw_latch = v; }
  private:
   virtual reg_t write_mask() const noexcept override;
+  // Hardware-pending SEIP latch (for external interrupts)
+  reg_t seip_hw_latch = 0;
 };
 
 typedef std::shared_ptr<mip_csr_t> mip_csr_t_p;

--- a/riscv/plic.cc
+++ b/riscv/plic.cc
@@ -127,10 +127,20 @@ uint32_t plic_t::context_best_pending(const plic_context_t *c)
 
 void plic_t::context_update(const plic_context_t *c)
 {
-  uint32_t best_id = context_best_pending(c);
-  reg_t mask = c->mmode ? MIP_MEIP : MIP_SEIP;
+  // Machine-mode external interrupt (MEIP) must bypass SEIP/vien/vip logic
+  if (c->mmode) {
+    uint32_t best_id = context_best_pending(c);
+    reg_t pending = best_id ? MIP_MEIP : 0;
+    // Directly update mip.MEIP without touching SEIP or mvip
+    c->proc->state.mip->backdoor_write_with_mask(MIP_MEIP, pending);
+    return;
+  }
 
-  // Determine SEIP pending status from PLIC
+  // Supervisor-mode external interrupt (SEIP) handling
+  uint32_t best_id = context_best_pending(c);
+  reg_t mask = MIP_SEIP;
+
+  // Determine external interrupt status from PLIC (MEIP for machine mode, SEIP for supervisor mode)
   reg_t pending = best_id ? mask : 0;
 
   // Access mip CSR object


### PR DESCRIPTION
This PR fixes a long-standing correctness issue in Spike’s handling of the
Supervisor External Interrupt Pending bit (mip.SEIP).

### Root Cause
SEIP was incorrectly read/written directly through `mip->val`,
causing mismatches when:
- `mvien.SEIP = 0` (SEIP is aliased to mvip)
- `mvien.SEIP = 1` (SEIP must come only from hardware/PLIC)
- PLIC needs to set/clear SEIP independently of software writes

### Fix
This PR introduces a **hardware SEIP latch** inside `mip_csr_t` and updates all
call sites to follow the correct read/write ordering.

#### Changes:
- Added `seip_hw_latch` field to `mip_csr_t`
- Updated `mip_csr_t::read()` to merge hvip + mvip alias + hardware latch
- Updated `mip_csr_t::backdoor_write_with_mask()` to route SEIP writes properly
- Fixed `plic_t::context_update()` to respect mvien.SEIP aliasing rules
- Added `set_seip_hw_latch()` for safe PLIC updates

### Result
This restores correct SEIP semantics according to privileged spec 1.12, improves
behavior under virtualization (H-extension), and eliminates SEIP mis-ordering.

This is a correctness fix (not a functional extension), and has no effect unless
SEIP is toggled via hardware or mvien.
