### PR TITLE
Fix: Enforce virtual_instruction trap for VU-mode indirect CSR access

### DIFF
--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -1852,6 +1852,10 @@ sscsrind_reg_csr_t::sscsrind_reg_csr_t(processor_t* const proc, const reg_t addr
 }
 
 void sscsrind_reg_csr_t::verify_permissions(insn_t insn, bool write) const {
+  if (state->v && state->prv == PRV_U) {
+     throw trap_virtual_instruction(insn.bits());
+  }
+
   if (proc->extension_enabled(EXT_SMSTATEEN)) {
     if ((state->prv < PRV_M) && !(state->mstateen[0]->read() & MSTATEEN0_CSRIND))
       throw trap_illegal_instruction(insn.bits());


### PR DESCRIPTION
This PR enforces a `virtual_instruction` exception when accessing `sireg`/`vsireg` from VU-mode.

**Implementation Details:**
Added a privilege check at the entry of `sscsrind_reg_csr_t::verify_permissions`.

**Reasoning:**
VU-mode cannot access HS-mode resources. Trapping early resolves ambiguity and ensures correct virtualization behavior. Verified build passes locally.