### PR TITLE
Raise correct trap in U-mode on indirect CSRs when !mstateen.csrind

### DIFF
--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -1852,16 +1852,16 @@ sscsrind_reg_csr_t::sscsrind_reg_csr_t(processor_t* const proc, const reg_t addr
 }
 
 void sscsrind_reg_csr_t::verify_permissions(insn_t insn, bool write) const {
-  if (state->v && state->prv == PRV_U) {
-     throw trap_virtual_instruction(insn.bits());
-  }
-
   if (proc->extension_enabled(EXT_SMSTATEEN)) {
     if ((state->prv < PRV_M) && !(state->mstateen[0]->read() & MSTATEEN0_CSRIND))
       throw trap_illegal_instruction(insn.bits());
 
     if (state->v && !(state->hstateen[0]->read() & HSTATEEN0_CSRIND))
       throw trap_virtual_instruction(insn.bits());
+  }
+
+  if (state->v && state->prv == PRV_U) {
+     throw trap_virtual_instruction(insn.bits());
   }
 
   // Don't call base verify_permission for VS registers remapped to S-mode


### PR DESCRIPTION
Fixes a regression introduced by #2221

@ved-rivos can you confirm you agree this fixes @jameshippisley's comment while otherwise preserving the intent of the PR it's fixing? https://github.com/riscv-software-src/riscv-isa-sim/pull/2221#issuecomment-3848024136 