### PR TITLE
Modify in_bits to check in_valid before accessing

### DIFF
--- a/fesvr/tsi.h
+++ b/fesvr/tsi.h
@@ -26,8 +26,8 @@ class tsi_t : public htif_t
   uint32_t recv_word();
   void switch_to_host();
 
-  uint32_t in_bits() { return in_data.front(); }
   bool in_valid() { return !in_data.empty(); }
+  uint32_t in_bits() { return in_valid() ? in_data.front() : 0; }
   bool out_ready() { return true; }
   void tick(bool out_valid, uint32_t out_bits, bool in_ready);
 


### PR DESCRIPTION
Instead of retrieving stale data, if the `valid` is `false` then return 0. This avoids cases where the downstream testbench might read this data when there is none, causing a runtime error. While it's still up to the downstream code to properly verify that it doesn't use the `bits`, this avoids runtime errors (e.g., segfaults when accessing empty containers).
