### PR TITLE
fix M-mode access scountovf according to Sscofpmf Version V1.0

### DIFF
--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -1787,10 +1787,12 @@ reg_t scountovf_csr_t::read() const noexcept {
     val |= of << (i + FIRST_HPMCOUNTER);
   }
 
-  /* In M and S modes, scountovf bit X is readable when mcounteren bit X is set, */
+  /* In M-mode, scountovf bit X is always readable. */
+  /* In S/HS-mode, scountovf bit X is readable when mcounteren bit X is set, */
   /* and otherwise reads as zero. Similarly, in VS mode, scountovf bit X is readable */
   /* when mcounteren bit X and hcounteren bit X are both set, and otherwise reads as zero. */
-  val &= state->mcounteren->read();
+  if (state->prv < PRV_M)
+    val &= state->mcounteren->read();
   if (state->v)
     val &= state->hcounteren->read();
   return val;


### PR DESCRIPTION
ISA Volume-I 20.2
> Read access to bit X is subject to the same mcounteren (or mcounteren and hcounteren) CSRs that
> mediate access to the hpmcounter CSRs by S-mode (or VS-mode). In M-mode, scountovf bit X is
> always readable. In S/HS-mode, scountovf bit X is readable when mcounteren bit X is set, and
> otherwise reads as zero. Similarly, in VS mode, scountovf bit X is readable when mcounteren bit X and
> hcounteren bit X are both set, and otherwise reads as zero.