### PR TITLE
Fix scountovf read behavior in M-mode according to RISC-V Privileged SpecFix scountovf read behavior in M-mode according to RISC-V Privileged …

### DIFF
--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -1790,9 +1790,11 @@ reg_t scountovf_csr_t::read() const noexcept {
   /* In M and S modes, scountovf bit X is readable when mcounteren bit X is set, */
   /* and otherwise reads as zero. Similarly, in VS mode, scountovf bit X is readable */
   /* when mcounteren bit X and hcounteren bit X are both set, and otherwise reads as zero. */
-  val &= state->mcounteren->read();
-  if (state->v)
-    val &= state->hcounteren->read();
+  if (state->prv != PRV_M) {
+     val &= state->mcounteren->read();
+     if (state->v)
+        val &= state->hcounteren->read();
+   }
   return val;
 }
 


### PR DESCRIPTION
According to the RISC-V Privileged Specification, scountovf bits should
always be readable in M-mode.

The current implementation masks the value using mcounteren (and
hcounteren in VS-mode), which incorrectly restricts visibility in M-mode.

This patch updates scountovf_csr_t::read() so that counteren masking
is applied only when the current privilege mode is not M-mode.