### PR TITLE
disasm: Do not imply Zvbb from RVV crypto groups (#146)

### DIFF
--- a/disasm/isa_parser.cc
+++ b/disasm/isa_parser.cc
@@ -264,18 +264,15 @@ void isa_parser_t::add_extension(const std::string& ext_str, const char* str)
     extension_table[EXT_ZVKG] = true;
   } else if (ext_str == "zvkn") {
     extension_table[EXT_ZVKB] = true;
-    extension_table[EXT_ZVBB] = true;
     extension_table[EXT_ZVKNED] = true;
     extension_table[EXT_ZVKNHB] = true;
   } else if (ext_str == "zvknc") {
     extension_table[EXT_ZVKB] = true;
-    extension_table[EXT_ZVBB] = true;
     extension_table[EXT_ZVBC] = true;
     extension_table[EXT_ZVKNED] = true;
     extension_table[EXT_ZVKNHB] = true;
   } else if (ext_str == "zvkng") {
     extension_table[EXT_ZVKB] = true;
-    extension_table[EXT_ZVBB] = true;
     extension_table[EXT_ZVKG] = true;
     extension_table[EXT_ZVKNED] = true;
     extension_table[EXT_ZVKNHB] = true;
@@ -287,18 +284,15 @@ void isa_parser_t::add_extension(const std::string& ext_str, const char* str)
     extension_table[EXT_ZVKNHB] = true;
   } else if (ext_str == "zvks") {
     extension_table[EXT_ZVKB] = true;
-    extension_table[EXT_ZVBB] = true;
     extension_table[EXT_ZVKSED] = true;
     extension_table[EXT_ZVKSH] = true;
   } else if (ext_str == "zvksc") {
     extension_table[EXT_ZVKB] = true;
-    extension_table[EXT_ZVBB] = true;
     extension_table[EXT_ZVBC] = true;
     extension_table[EXT_ZVKSED] = true;
     extension_table[EXT_ZVKSH] = true;
   } else if (ext_str == "zvksg") {
     extension_table[EXT_ZVKB] = true;
-    extension_table[EXT_ZVBB] = true;
     extension_table[EXT_ZVKG] = true;
     extension_table[EXT_ZVKSED] = true;
     extension_table[EXT_ZVKSH] = true;


### PR DESCRIPTION
Since Vector Crypto Sepcification 1.0.0-rc3, Zvkn and Zvks (add all extensions that subsume these) include Zvkb (instead of Zvbb).

Remove EXT_ZVBB enablement from Zvkn, Zvknc, Zvkng, Zvks, Zvksc, Zvksg

• Zvkn = Zvkned + Zvknhb + Zvkb + Zvkt
• Zvknc = Zvkn + Zvbc
• Zvkng = Zvkn + Zvkg
• Zvks = Zvksed + Zvksh + Zvkb + Zvkt
• Zvksc = Zvks + Zvbc
• Zvksg = Zvks + Zvkg