### PR TITLE
Add support for Za64rs and Za128rs extensions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Spike supports the following RISC-V ISA features:
   - Zabha extension, v1.0
   - Zacas extension, v1.0
   - Zawrs extension, v1.0
+  - Za64rs, Za128rs extension, v1.0
   - Zicfiss extension, v1.0
   - Zicfilp extension, v1.0
   - Zca extension, v1.0

--- a/disasm/isa_parser.cc
+++ b/disasm/isa_parser.cc
@@ -115,6 +115,8 @@ static const extension_info_t extension_infos[] = {
   {"zacas", {EXT_ZACAS, EXT_ZAAMO}},
   {"zabha", {EXT_ZABHA, EXT_ZAAMO}},
   {"zawrs", {EXT_ZAWRS, EXT_ZALRSC}},
+  {"za64rs", {EXT_ZA64RS}, {"zalrsc"}},
+  {"za128rs", {EXT_ZA128RS}, {"zalrsc"}},
   {"zama16b", {EXT_ZAMA16B}},
   {"zmmul", {EXT_ZMMUL}},
   {"zba", {EXT_ZBA}},

--- a/riscv/isa_parser.h
+++ b/riscv/isa_parser.h
@@ -115,6 +115,8 @@ typedef enum {
   EXT_SSNPM,
   EXT_SMAIA,
   EXT_SSAIA,
+  EXT_ZA64RS,
+  EXT_ZA128RS,
   NUM_ISA_EXTENSIONS
 } isa_extension_t;
 


### PR DESCRIPTION
This patch adds support for Za64rs and Za128rs extensions.
See https://github.com/riscv/riscv-profiles/blob/main/src/rva23-profile.adoc