### PR TITLE
Fixed dtc_compile API hangs as child process waits to perform "exit()" instead of "_exit()".

### DIFF
--- a/riscv/dts.cc
+++ b/riscv/dts.cc
@@ -122,11 +122,11 @@ static std::string dtc_compile(const std::string& dtc_input, bool compile)
       step = write(dtc_input_pipe[1], buf+done, len-done);
       if (step == -1) {
         std::cerr << "Failed to write dtc_input: " << strerror(errno) << std::endl;
-        exit(1);
+        _exit(1);
       }
     }
     close(dtc_input_pipe[1]);
-    exit(0);
+    _exit(0);
   }
 
   pid_t dtc_output_pid;
@@ -146,7 +146,7 @@ static std::string dtc_compile(const std::string& dtc_input, bool compile)
     close(dtc_output_pipe[1]);
     execlp(DTC, DTC, "-O", output_type, "-I", input_type, nullptr);
     std::cerr << "Failed to run " DTC ": " << strerror(errno) << std::endl;
-    exit(1);
+    _exit(1);
   }
 
   close(dtc_input_pipe[1]);


### PR DESCRIPTION
Issue Link: https://github.com/riscv-software-src/riscv-isa-sim/issues/2260

TLDR;
**Problem:**
The two child processes one to output dtc_input and other to output dtc_output uses “exit()” instead of “_exit()” which is the recommended way of exiting a child process so as to avoid any unnecessary IO flushing, and memory deletion from “exit()”.

**Solution:**
The recommended fix is to replace “exit()” with “_exit()” for both child processes.