### PR TITLE
Fix execution when trigger/debug matched at interactive mode

### DIFF
--- a/riscv/execute.cc
+++ b/riscv/execute.cc
@@ -345,10 +345,12 @@ void processor_t::step(size_t n)
     }
     catch (triggers::matched_t& t)
     {
+      n = instret;
       take_trigger_action(t.action, t.address, pc, t.gva);
     }
     catch(trap_debug_mode&)
     {
+      n = instret;
       enter_debug_mode(DCSR_CAUSE_SWBP, 0);
     }
     catch (wait_for_interrupt_t &t)


### PR DESCRIPTION
1. when instruction trigger with TIMING_BEFORE matched, hart should be in trap stage and exception handler (CSR xtvec) should be executed at next step.
2. interactive mode will service the potential co-simulation environment to check hart context at any step (including instruction exception point and debug entrance)