### PR TITLE
dts: Fix unit addresses of FDT CPU nodes

### DIFF
--- a/riscv/dts.cc
+++ b/riscv/dts.cc
@@ -58,9 +58,9 @@ std::string make_dts(size_t insns_per_rtc_tick, size_t cpu_hz,
          "    #size-cells = <0>;\n"
          "    timebase-frequency = <" << (cpu_hz/insns_per_rtc_tick) << ">;\n";
     for (size_t i = 0; i < cfg->nprocs(); i++) {
-    s << "    CPU" << i << ": cpu@" << i << " {\n"
+    s << "    CPU" << i << ": cpu@" << std::hex << cfg->hartids[i] << std::dec << " {\n"
          "      device_type = \"cpu\";\n"
-         "      reg = <" << cfg->hartids[i] << ">;\n"
+         "      reg = <0x" << std::hex << cfg->hartids[i] << std::dec << ">;\n"
          "      status = \"okay\";\n"
          "      compatible = \"riscv\";\n"
          "      riscv,isa = \"" << isa.get_isa_string() << "\";\n"


### PR DESCRIPTION
The node unit addresses should be based on the reg value (i.e. hartid), rather than some arbitrary number [1]. Also, they should have been in hex, not decimal, as per de facto convention [2]. Fix them, and also make the reg field use hex for consistency and easier inspection.

The CPUn labels have not been changed, so all other users of these CPU nodes continue to use the labels with number in decimal, instead of the hartid.

Link: https://github.com/devicetree-org/devicetree-specification/blob/v0.4/source/chapter2-devicetree-basics.rst#devicetree-structure-and-conventions # [1]
Link: https://lore.kernel.org/devicetree-spec/CAL_JsqJFv3+UJ-bjLGk0i7Wc+spsowCrqQZ_s3P4gN8r1W-Q-w@mail.gmail.com/ # [2]

---

Example:

```console
$ ./repl-result-out/bin/spike --hartids 0,97 --dump-dts fw_jump.elf
/dts-v1/;

/ {
...
  cpus {
    #address-cells = <1>;
    #size-cells = <0>;
    timebase-frequency = <10000000>;
    CPU0: cpu@0 {                               /* <----- HERE */
      device_type = "cpu";
      reg = <0x0>;                              /* <----- HERE */
...
      CPU0_intc: interrupt-controller {
...
      };
    };
    CPU1: cpu@61 {                              /* <----- HERE */
      device_type = "cpu";
      reg = <0x61>;                             /* <----- HERE */
...
      CPU1_intc: interrupt-controller {
...
      };
    };
  };
...
  soc {
    #address-cells = <2>;
    #size-cells = <2>;
    compatible = "ucbbar,spike-bare-soc", "simple-bus";
    ranges;
    clint@2000000 {
      compatible = "riscv,clint0";
      interrupts-extended = <&CPU0_intc 3 &CPU0_intc 7 &CPU1_intc 3 &CPU1_intc 7 >;
      reg = <0x0 0x2000000 0x0 0xc0000>;
    };
    PLIC: plic@c000000 {
      compatible = "riscv,plic0";
      #address-cells = <2>;
      interrupts-extended = <&CPU0_intc 11 &CPU0_intc 9 &CPU1_intc 11 &CPU1_intc 9 >;
      reg = <0x0 0xc000000 0x0 0x1000000>;
      riscv,ndev = <0x1f>;
      riscv,max-priority = <0xf>;
      #interrupt-cells = <1>;
      interrupt-controller;
    };
...
  };
  htif {
    compatible = "ucb,htif0";
  };
};
```