### PR TITLE
added is_client_connected method to remote_bitbang class

### DIFF
--- a/riscv/remote_bitbang.cc
+++ b/riscv/remote_bitbang.cc
@@ -184,3 +184,7 @@ void remote_bitbang_t::execute_commands()
     }
   }
 }
+
+bool remote_bitbang_t::is_client_connected() const{
+    return client_fd != 0;
+}

--- a/riscv/remote_bitbang.h
+++ b/riscv/remote_bitbang.h
@@ -15,6 +15,9 @@ public:
   // Do a bit of work.
   void tick();
 
+  // Check if any client is connected
+  bool is_client_connected() const;
+
 private:
   jtag_dtm_t *tap;
 


### PR DESCRIPTION
This "is_client_connected" method can be checked from an external "sim" loop to see if there is still active "OpenOCD" tcp session exists. This check helps to decide when the simulation can be gracefully finished and no further polling of "remote_bitbang->tick()" needed. 