### PR TITLE
Raise illegal-instruction (not virtual) for indirect-CSR permission failures under V=1

### DIFF
--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -1835,6 +1835,17 @@ virtualized_indirect_csr_t::virtualized_indirect_csr_t(processor_t* const proc, 
 }
 
 void virtualized_indirect_csr_t::verify_permissions(insn_t insn, bool write) const {
+  // Check Smstateen.CSRIND before the wrapper's base priv check so a
+  // below-M access with mstateen0.CSRIND=0 raises illegal-instruction
+  // (per the Smstateen spec) rather than being converted to virtual
+  // by the H-ext priv-class rule. The same check exists in
+  // sscsrind_reg_csr_t::verify_permissions for the M-priv mireg path
+  // that doesn't go through this wrapper; leaving both is idempotent.
+  if (proc->extension_enabled(EXT_SMSTATEEN)) {
+    if ((state->prv < PRV_M) && !(state->mstateen[0]->read() & MSTATEEN0_CSRIND))
+      throw trap_illegal_instruction(insn.bits());
+  }
+
   virtualized_csr_t::verify_permissions(insn, write);
   if (state->v)
     virt_csr->verify_permissions(insn, write);

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -1848,6 +1848,12 @@ sscsrind_reg_csr_t::sscsrind_reg_csr_t(processor_t* const proc, const reg_t addr
 }
 
 void sscsrind_reg_csr_t::verify_permissions(insn_t insn, bool write) const {
+  // This class includes mireg / mireg2..6, for which access from
+  // below M always gives illegal not virtual instruction exception.
+  if (((address >> 8) & 3) > PRV_HS && state->prv < PRV_M) {
+    throw trap_illegal_instruction(insn.bits());
+  }
+
   if (proc->extension_enabled(EXT_SMSTATEEN)) {
     if ((state->prv < PRV_M) && !(state->mstateen[0]->read() & MSTATEEN0_CSRIND))
       throw trap_illegal_instruction(insn.bits());


### PR DESCRIPTION
## Summary

`sscsrind_reg_csr_t::verify_permissions` and the `virtualized_indirect_csr_t` wrapper around `sireg`/`vsireg` contain three H-extension `V=1` illegal→virtual conversions that misfire on cases the spec says should be illegal-instruction:

1. **VU `mireg` returns virtual** instead of illegal. The unconditional `state->v && state->prv == PRV_U → virtual` rule added in #2221 for the S/HS-priv siblings also fires for the M-priv `mireg`, which `sscsrind_reg_csr_t` also serves.

2. **VS `mireg` with `hstateen0.CSRIND=0` returns virtual** instead of illegal — same class, same root cause: the Smstateen H-ext gate fires for M-priv `mireg`.

3. **VU `sireg` with `mstateen0.CSRIND=0` returns virtual** instead of illegal. `virtualized_indirect_csr_t` calls the base `virtualized_csr_t::verify_permissions` first, which runs the H-ext priv-class conversion before the inner `sscsrind_reg_csr_t` ever gets to enforce Smstateen.

The H-ext `csr_priv ≤ HS` conversion rule does not apply to M-priv CSRs, and Smstateen requires illegal regardless of `V`. Both cases must short-circuit to illegal-instruction.

## Fix

Two commits, one bug class each:

- **Keep M-priv access to indirect CSRs as illegal-instruction** — early carve-out at the top of `sscsrind_reg_csr_t::verify_permissions` for `csr_priv == M && prv < M`. Address bits `[9:8]` are used to derive the CSR's priv class because `csr_priv` is private to `csr_t`. Fixes (1) and (2).

- **Honor `mstateen0.CSRIND` in `virtualized_indirect_csr_t` wrapper** — Smstateen check at the top of the wrapper, before the priv-class conversion runs. Fixes (3). The inner copy in `sscsrind_reg_csr_t` stays in place for `mireg`/`mireg2..6` and `vsireg`/`vsireg2..6`, which are registered without this wrapper; leaving both is idempotent.

## Testing

Three-phase RV64GH assembly testcase, each phase expects `mcause=2` (illegal-instruction):

- Phase 1: VU `mireg`, `mstateen=1`, `hstateen=1` — exercises (1)
- Phase 2: VS `mireg`, `mstateen=1`, `hstateen=0` — exercises (2)
- Phase 3: VU `sireg`, `mstateen=0` — exercises (3)

Build:

```
riscv64-unknown-elf-gcc -nostdlib -nostartfiles -static \
    -march=rv64gh -mabi=lp64d \
    -Wl,-N -Wl,-Ttext=0x80000000 \
    -o mireg-vu-bug spike-mireg-vu-bug.S
```

Run:

```
spike -l --log-commits --isa=rv64gh_zicsr_smstateen_smcsrind_sscsrind \
    mireg-vu-bug 2>&1 | grep -E "trap_|csrr.*(mireg|sireg)|FAILED"
```

<details>
<summary>Testcase source (<code>spike-mireg-vu-bug.S</code>)</summary>

```asm
# Three trap-class bugs in spike's CSR-indirect machinery — all
# convert what should be an illegal-instruction exception into a
# virtual-instruction one for accesses that the H-extension's V=1
# illegal->virtual conversion is NOT supposed to apply to:
#
#   sscsrind_reg_csr_t::verify_permissions, Smstateen H-ext gate:
#       state->v && !hstateen0.CSRIND -> virtual
#     Wrong for mireg (M-priv): VS mireg with hstateen=0
#     returns virtual instead of illegal-too-low.
#   sscsrind_reg_csr_t::verify_permissions, PR #2221 VU rule:
#       state->v && state->prv == U -> virtual
#     Wrong for mireg (M-priv): VU mireg returns virtual
#     instead of illegal-too-low.
#   virtualized_indirect_csr_t::verify_permissions:
#       no Smstateen.CSRIND check before priv-class
#       conversion runs in csr_t::verify_permissions
#     Wrong for sireg / vsireg (S/HS-priv) when
#     mstateen0.CSRIND=0: VU sireg returns virtual via
#     the H-ext priv conversion instead of illegal per
#     the Smstateen rule.
#
# Three phases, each must trap mcause=2 (illegal-instruction):
#
#   Phase 1: VU mireg, mstateen=1, hstateen=1   (PR #2221 VU rule)
#   Phase 2: VS mireg, mstateen=1, hstateen=0   (Smstateen H-ext gate)
#   Phase 3: VU sireg, mstateen=0               (wrapper priv-first)
#
# Build:
#   riscv64-unknown-elf-gcc -nostdlib -nostartfiles -static \
#     -march=rv64gh -mabi=lp64d \
#     -Wl,-N -Wl,-Ttext=0x80000000 \
#     -o mireg-vu-bug spike-mireg-vu-bug.S
#
# Run (-l --log-commits emits a per-instruction trace including
# trap_virtual_instruction / trap_illegal_instruction, so a failing
# run shows which phase fired and what trap class spike returned):
#   spike -l --log-commits --isa=rv64gh_zicsr_smstateen_smcsrind_sscsrind \
#     mireg-vu-bug 2>&1 | grep -E "trap_|csrr.*(mireg|sireg)|FAILED"
#
# Example unpatched output (phase 1 fails first and short-circuits):
#   core 0: 0x...80000060 (0x351022f3) csrr    t0, mireg
#   core 0: exception trap_virtual_instruction, epc 0x...80000060
#   *** FAILED *** (tohost = 1)
#
# Exit status (read from tohost):
#   1 = PASS — all three phases trapped illegal (cause = 2)
#   3 = FAIL — at least one phase returned virtual (cause = 22)
#
# Stock upstream-spike fails. With the proposed fixes applied
# (M-priv carve-out at top of sscsrind_reg_csr_t::verify_permissions
# AND Smstateen.CSRIND check at top of
# virtualized_indirect_csr_t::verify_permissions) all three phases
# pass.

.option norvc
.global _start
.text

# === M-mode common setup ===
_start:
        # Bare translation, full R/W/X PMP.
        csrw     satp, zero
        csrw     vsatp, zero
        csrw     hgatp, zero
        li       t0, -1
        csrw     pmpaddr0, t0
        li       t0, 0x1f                       # NAPOT | R | W | X
        csrw     pmpcfg0, t0

        # mstateen0.CSRIND = 1 for phases 1+2 — phase 3 will clear it.
        li       t0, 1
        slli     t0, t0, 60
        csrs     mstateen0, t0

# === Phase 1: VU mireg, mstateen=1, hstateen=1 (PR #2221 VU rule) ===
        csrs     hstateen0, t0                  # hstateen.CSRIND=1
        la       t0, phase1_handler
        csrw     mtvec, t0
        li       t0, 0x1800                     # MPP[12:11] mask
        csrc     mstatus, t0                    # MPP=0 (U)
        li       t0, 1
        slli     t0, t0, 39                     # MPV
        csrs     mstatus, t0
        la       t0, vu_mireg_probe
        csrw     mepc, t0
        mret                                    # -> vu_mireg_probe in VU

vu_mireg_probe:                                 # priv=VU
        csrrs    t0, mireg, zero                # M-priv CSR; must trap
        j        fail                           # access must trap

        .balign  4
phase1_handler:                                 # priv=M (after trap)
        csrr     t0, mcause
        li       t1, 2                          # CAUSE_ILLEGAL_INSTRUCTION
        bne      t0, t1, fail
        # fall through to phase 2 setup

# === Phase 2: VS mireg, mstateen=1, hstateen=0 (Smstateen H-ext gate) ===
        li       t0, 1
        slli     t0, t0, 60
        csrc     hstateen0, t0                  # hstateen.CSRIND=0
        la       t0, phase2_handler
        csrw     mtvec, t0
        li       t0, 0x1800
        csrc     mstatus, t0
        li       t0, 0x800                      # MPP=01 (S)
        csrs     mstatus, t0
        li       t0, 1
        slli     t0, t0, 39                     # MPV
        csrs     mstatus, t0
        la       t0, vs_mireg_probe
        csrw     mepc, t0
        mret                                    # -> vs_mireg_probe in VS

vs_mireg_probe:                                 # priv=VS
        csrrs    t0, mireg, zero                # M-priv CSR; must trap
        j        fail

        .balign  4
phase2_handler:                                 # priv=M (after trap)
        csrr     t0, mcause
        li       t1, 2
        bne      t0, t1, fail
        # fall through to phase 3 setup

# === Phase 3: VU sireg, mstateen=0 (wrapper priv-first) ===
# sireg is S-priv (csr_priv=S); the M-priv carve-out doesn't apply.
# The Smstateen.CSRIND=0 rule should fire illegal at the wrapper
# before the H-ext priv-class conversion converts it to virtual.
        li       t0, 1
        slli     t0, t0, 60
        csrc     mstateen0, t0                  # mstateen.CSRIND=0
        la       t0, phase3_handler
        csrw     mtvec, t0
        li       t0, 0x1800                     # MPP[12:11] mask
        csrc     mstatus, t0                    # MPP=0 (U)
        li       t0, 1
        slli     t0, t0, 39                     # MPV
        csrs     mstatus, t0
        la       t0, vu_sireg_probe
        csrw     mepc, t0
        mret                                    # -> vu_sireg_probe in VU

vu_sireg_probe:                                 # priv=VU
        csrrs    t0, sireg, zero                # S-priv CSR; must trap illegal
        j        fail                           # access must trap

        .balign  4
phase3_handler:                                 # priv=M (after trap)
        csrr     t0, mcause
        li       t1, 2
        bne      t0, t1, fail
        # fall through to pass

# === Pass: all three phases trapped illegal ===
        li       t0, 1
        la       t1, tohost
        sd       t0, 0(t1)
1:      j        1b

fail:
        li       t0, 3                          # FAIL
        la       t1, tohost
        sd       t0, 0(t1)
1:      j        1b

        .balign  64
        .global  tohost
tohost: .8byte   0
        .global  fromhost
fromhost: .8byte 0
```

</details>
