### PR TITLE
Add missing set_fp_exceptions in Zvdota/Zvbdota implementations

### DIFF
--- a/riscv/v_ext_macros.h
+++ b/riscv/v_ext_macros.h
@@ -2253,7 +2253,8 @@ c_t generic_dot_product(const std::vector<a_t>& a, const std::vector<b_t>& b, c_
     b[i] = P.VU.elt<b_t>(insn.rs2(), i); \
   } \
   auto& acc = P.VU.elt<c_t>(insn.rd(), 0, true); \
-  acc = dot(a, b, acc)
+  acc = dot(a, b, acc); \
+  set_fp_exceptions;
 
 #define ZVLDOT_GENERIC_LOOP(a_t, b_t, c_t, macc) \
   auto dot = std::bind(generic_dot_product<a_t, b_t, c_t>, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3, macc); \
@@ -2275,6 +2276,7 @@ c_t generic_dot_product(const std::vector<a_t>& a, const std::vector<b_t>& b, c_
     } \
     auto& acc = P.VU.elt<c_t>(insn.rd(), i, true); \
     acc = dot(a, b, acc); \
+    set_fp_exceptions; \
   }
 
 #define ZVBDOT_GENERIC_LOOP(a_t, b_t, c_t, macc) \


### PR DESCRIPTION
Fixes https://github.com/riscv-software-src/riscv-isa-sim/issues/2294

According to the Zvdota/Zvbdota isa spec, RVBNA may raises invalid/overflow exceptions.

This PR adds the missing set_fp_exceptions after RVBNA in ZVLDOT_LOOP and ZVBDOT_LOOP to propagate softfloat exception flags to the processor state. Without this, FP exceptions raised during RVBNA accumulation are silently dropped.