### PR TITLE
Fix Incorrect Sign Extension in vmulhu.vx, vmulhsu.vx, vdivu.vx, and vremu.vx

### DIFF
--- a/riscv/insns/vdivu_vx.h
+++ b/riscv/insns/vdivu_vx.h
@@ -3,6 +3,8 @@ VI_VX_ULOOP
 ({
   if (rs1 == 0)
     vd = -1;
+  else if (xlen == 64)
+    vd = vs2 / (uint64_t)rs1;
   else
-    vd = vs2 / rs1;
+    vd = vs2 / (uint32_t)rs1;
 })

--- a/riscv/insns/vmulhsu_vx.h
+++ b/riscv/insns/vmulhsu_vx.h
@@ -2,5 +2,8 @@
 require(p->extension_enabled('V') || P.VU.vsew < e64);
 
 VI_VX_SU_LOOP({
-  vd = ((int128_t)vs2 * (uint128_t)rs1) >> sew;
+  if (xlen == 64)
+    vd = ((int128_t)(int64_t)vs2 * (uint64_t)rs1) >> sew;
+  else
+    vd = ((int128_t)(int64_t)vs2 * (uint32_t)rs1) >> sew;
 })

--- a/riscv/insns/vmulhu_vx.h
+++ b/riscv/insns/vmulhu_vx.h
@@ -3,5 +3,8 @@ require(p->extension_enabled('V') || P.VU.vsew < e64);
 
 VI_VX_ULOOP
 ({
-  vd = ((uint128_t)vs2 * rs1) >> sew;
+  if (xlen == 64)
+    vd = ((uint128_t)vs2 * (uint64_t)rs1) >> sew;
+  else
+    vd = ((uint128_t)vs2 * (uint32_t)rs1) >> sew;
 })

--- a/riscv/insns/vremu_vx.h
+++ b/riscv/insns/vremu_vx.h
@@ -3,6 +3,8 @@ VI_VX_ULOOP
 ({
   if (rs1 == 0)
     vd = vs2;
+  else if (xlen == 64)
+    vd = vs2 % (uint64_t)rs1;
   else
-    vd = vs2 % rs1;
+    vd = vs2 % (uint32_t)rs1;
 })


### PR DESCRIPTION
In vmulhu.vx, vmulhsu.vx, vdivu.vx, and vremu.vx, the scalar operand is being incorrectly sign-extended when xlen = 32, leading to the mismatches observed here: https://github.com/riscv/riscv-arch-test/issues/1474. This patch changes the casts in each of these operations so that the values are handled correctly in both xlen = 64 and xlen = 32 cases. 