### PR TITLE
zvfbfa: fix contraint for corner cases

### DIFF
--- a/riscv/insns/vfncvt_rtz_x_f_w.h
+++ b/riscv/insns/vfncvt_rtz_x_f_w.h
@@ -1,4 +1,6 @@
 // vfncvt.rtz.x.f.w vd, vs2, vm
+if (p->extension_enabled(EXT_ZVFBFA) && P.VU.vsew >= 16 && P.VU.altfmt)
+  require(false);
 
 VI_VFP_NCVT_FP_TO_INT(
   { vd = P.VU.altfmt ? bf16_to_i8(vs2, softfloat_round_minMag, true)

--- a/riscv/insns/vfncvt_rtz_xu_f_w.h
+++ b/riscv/insns/vfncvt_rtz_xu_f_w.h
@@ -1,4 +1,6 @@
 // vfncvt.rtz.xu.f.w vd, vs2, vm
+if (p->extension_enabled(EXT_ZVFBFA) && P.VU.vsew >= 16 && P.VU.altfmt)
+  require(false);
 
 VI_VFP_NCVT_FP_TO_INT(
   { vd = P.VU.altfmt ? bf16_to_ui8(vs2, softfloat_round_minMag, true)

--- a/riscv/insns/vfncvt_x_f_w.h
+++ b/riscv/insns/vfncvt_x_f_w.h
@@ -1,4 +1,6 @@
 // vfncvt.x.f.w vd, vs2, vm
+if (p->extension_enabled(EXT_ZVFBFA) && P.VU.vsew >= 16 && P.VU.altfmt)
+  require(false);
 
 VI_VFP_NCVT_FP_TO_INT(
   { vd = P.VU.altfmt ? bf16_to_i8(vs2, softfloat_roundingMode, true)

--- a/riscv/insns/vfncvt_xu_f_w.h
+++ b/riscv/insns/vfncvt_xu_f_w.h
@@ -1,4 +1,6 @@
 // vfncvt.xu.f.w vd, vs2, vm
+if (p->extension_enabled(EXT_ZVFBFA) && P.VU.vsew >= 16 && P.VU.altfmt)
+  require(false);
 
 VI_VFP_NCVT_FP_TO_INT(
   { vd = P.VU.altfmt ? bf16_to_ui8(vs2, softfloat_roundingMode, true)

--- a/riscv/insns/vfwcvt_f_x_v.h
+++ b/riscv/insns/vfwcvt_f_x_v.h
@@ -1,4 +1,6 @@
 // vfwcvt.f.x.v vd, vs2, vm
+if (p->extension_enabled(EXT_ZVFBFA) && P.VU.vsew >= 16 && P.VU.altfmt)
+  require(false);
 
 VI_VFP_WCVT_INT_TO_FP(
   { vd = P.VU.altfmt ? i32_to_bf16(vs2) : i32_to_f16(vs2); },                    // BODY8

--- a/riscv/insns/vfwcvt_f_xu_v.h
+++ b/riscv/insns/vfwcvt_f_xu_v.h
@@ -1,4 +1,6 @@
 // vfwcvt.f.xu.v vd, vs2, vm
+if (p->extension_enabled(EXT_ZVFBFA) && P.VU.vsew >= 16 && P.VU.altfmt)
+  require(false);
 
 VI_VFP_WCVT_INT_TO_FP(
   { vd = P.VU.altfmt ? ui32_to_bf16(vs2) : ui32_to_f16(vs2); },                    // BODY8


### PR DESCRIPTION
Based on
https://github.com/aswaterman/riscv-misc/blob/main/isa/zvfbfa.adoc

"When altfmt=1 and SEW=8, all vector floating-point instructions become reserved, except for the following, which are redefined to use the BF16 format for any operand that would otherwise have used the FP16 format:

  vfwcvt.f.x[u].v
  vfncvt.x[u].f.w
  vfncvt.rtz.x[u].f.w
"

This is to resolve https://github.com/riscv-software-src/riscv-isa-sim/issues/2271