### PR TITLE
Apply PMM-transformed address to SC access-fault tval

### DIFF
--- a/riscv/mmu.h
+++ b/riscv/mmu.h
@@ -268,8 +268,10 @@ public:
 
     if (sim->reservable(paddr))
       return load_reservation_address == paddr;
-    else
-      throw trap_store_access_fault((proc) ? proc->state.v : false, vaddr, 0, 0);
+
+    // SC to non-reservable region: report the PMM-masked effective vaddr.
+    auto access_info = generate_access_info(vaddr, STORE, {});
+    throw trap_store_access_fault(access_info.effective_virt, access_info.transformed_vaddr, 0, 0);
   }
 
   template<typename T>


### PR DESCRIPTION
Fixes #2305.

When `sc.w` / `sc.d` targets a non-reservable region under pointer
masking, `check_load_reservation` was passing the raw rs1 value to
`trap_store_access_fault`, which ends up in mtval/stval/vstval. The
Zpm spec is normative on this:

> ...pointer masking, when applicable, **is applied** for hardware
> writes to a CSR (e.g., when the hardware writes the transformed
> address to `stval` when taking an exception).

https://github.com/riscv/riscv-isa-manual/blob/fc9cf1ceade4384f11cc791ad79bd33583a2f486/src/priv/zpm.adoc?plain=1#L178-L180

Compute `access_info` via `generate_access_info` on the throw branch
and hand its `transformed_vaddr` / `effective_virt` to the trap, matching
the pattern already used at `load_slow_path_intrapage`'s
LR-non-reservable throw and at `translate()`'s PMP failure throw.