### PR TITLE
fixed is_client_connected method in remote_bitbang class

### DIFF
--- a/riscv/remote_bitbang.cc
+++ b/riscv/remote_bitbang.cc
@@ -186,5 +186,5 @@ void remote_bitbang_t::execute_commands()
 }
 
 bool remote_bitbang_t::is_client_connected() const{
-    return client_fd != 0;
+    return client_fd > 0;
 }


### PR DESCRIPTION
return client_fd != 0; is not the correct way to check whether a TCP connection is active.
accept() returns -1 when no connection is available, and -1 != 0 evaluates to true, which is wrong.

To correctly detect whether remote_bitbang has an active client, the check must only succeed when client_fd represents a valid socket. In this codebase, that means:

client_fd > 0

This matches the logic already used in remote_bitbang_t::tick():
void remote_bitbang_t::tick()
{
  if (client_fd > 0) {
    execute_commands();
  } else {
    this->accept();
  }
}

So the correct condition for “we have an active TCP connection” is client_fd > 0, not client_fd != 0.