### PR TITLE
Switch exception bits by correspond extensions

### DIFF
--- a/riscv/csr_init.cc
+++ b/riscv/csr_init.cc
@@ -265,8 +265,10 @@ void state_t::csr_init(processor_t* const proc, reg_t max_isa)
     (1 << CAUSE_FETCH_PAGE_FAULT) |
     (1 << CAUSE_LOAD_PAGE_FAULT) |
     (1 << CAUSE_STORE_PAGE_FAULT) |
-    (1 << CAUSE_SOFTWARE_CHECK_FAULT) |
-    (1 << CAUSE_HARDWARE_ERROR_FAULT);
+    ((proc->extension_enabled(EXT_ZICFISS) || proc->extension_enabled(EXT_ZICFILP))?
+     (1 << CAUSE_SOFTWARE_CHECK_FAULT) : 0) |
+    (proc->extension_enabled(EXT_ZICNTR)?
+     (1 << CAUSE_HARDWARE_ERROR_FAULT) : 0);
   add_hypervisor_csr(CSR_HEDELEG, hedeleg = std::make_shared<masked_csr_t>(proc, CSR_HEDELEG, hedeleg_mask, 0));
   add_hypervisor_csr(CSR_HCOUNTEREN, hcounteren = std::make_shared<masked_csr_t>(proc, CSR_HCOUNTEREN, counteren_mask, 0));
   htimedelta = std::make_shared<basic_csr_t>(proc, CSR_HTIMEDELTA, 0);

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -1147,8 +1147,10 @@ bool medeleg_csr_t::unlogged_write(const reg_t val) noexcept {
     | (1 << CAUSE_SUPERVISOR_ECALL)
     | (proc->has_mmu() ? mmu_exceptions : 0)
     | (proc->extension_enabled('H') ? hypervisor_exceptions : 0)
-    | (1 << CAUSE_SOFTWARE_CHECK_FAULT)
-    | (1 << CAUSE_HARDWARE_ERROR_FAULT)
+    | ((proc->extension_enabled(EXT_ZICFISS) || proc->extension_enabled(EXT_ZICFILP))?
+        (1 << CAUSE_SOFTWARE_CHECK_FAULT) : 0)
+    | (proc->extension_enabled(EXT_ZICNTR)?
+        (1 << CAUSE_HARDWARE_ERROR_FAULT) : 0)
     ;
   return basic_csr_t::unlogged_write(val & mask);
 }


### PR DESCRIPTION
if zicfi extension is enabled, software check fault existed.
if zicntr extension is enabled, hardware error fault existed.