### PR TITLE
Adding Ziccamoa extension to disassembler 

### DIFF
--- a/disasm/isa_parser.cc
+++ b/disasm/isa_parser.cc
@@ -167,6 +167,7 @@ static const extension_info_t extension_infos[] = {
   {"zicbom", {EXT_ZICBOM}},
   {"zicboz", {EXT_ZICBOZ}},
   {"zicbop"},
+  {"ziccamoa"},
   {"zicclsm", {EXT_ZICCLSM}},
   {"zicntr", {EXT_ZICNTR}},
   {"zicond", {EXT_ZICOND}},


### PR DESCRIPTION
closing https://github.com/riscv-software-src/riscv-isa-sim/issues/2328 