### PR TITLE
Add missing Ziccrse extension to disassembler fallback

### DIFF
--- a/disasm/isa_parser.cc
+++ b/disasm/isa_parser.cc
@@ -169,6 +169,7 @@ static const extension_info_t extension_infos[] = {
   {"zicbop"},
   {"ziccamoa"},
   {"zicclsm", {EXT_ZICCLSM}},
+  {"ziccrse"},
   {"zicntr", {EXT_ZICNTR}},
   {"zicond", {EXT_ZICOND}},
   {"zihpm", {EXT_ZIHPM}},


### PR DESCRIPTION
[Ziccrse](https://github.com/riscv/riscv-unified-db/blob/d5c88128ad7f3f3367fc58d5d85bf956c24870c3/spec/std/isa/ext/Ziccrse.yaml) is implemented in Spike unconditionally/