### PR TITLE
fix: typo in makefile.in check

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -361,7 +361,7 @@ deps : $(deps)
 #-------------------------------------------------------------------------
 
 check : $(test_outs)
-	echo; grep -h -e'Unit Tests' -e'FAILED' -e'Segementation' $^ < /dev/null; echo
+	echo; grep -h -e'Unit Tests' -e'FAILED' -e'Segmentation' $^ < /dev/null; echo
 
 .PHONY : check
 


### PR DESCRIPTION
Just found this typo and consider it funny enough to fix
Another "segementation" was already fixed in 270f408a7be7f574048e0431f172e13140d88045 but not this one 

@aswaterman I am not sure what this check does. Is it even used?
