### PR TITLE
[RFC] perf: Significant speedups throughout various benchmarks

### DIFF
--- a/riscv/csr_init.cc
+++ b/riscv/csr_init.cc
@@ -4,6 +4,15 @@
 void state_t::add_csr(reg_t addr, const csr_t_p& csr)
 {
   csrmap[addr] = csr;
+  if (addr < csrmap_cache.size())
+    csrmap_cache[addr] = csr.get();
+}
+
+void state_t::remove_csr(reg_t addr)
+{
+  csrmap.erase(addr);
+  if (addr < csrmap_cache.size())
+    csrmap_cache[addr] = nullptr;
 }
 
 #define add_const_ext_csr(ext, addr, csr) do { auto csr__ = (csr); if (proc->extension_enabled_const(ext)) { add_csr(addr, csr__); } } while (0)

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -2114,10 +2114,9 @@ bool sscsrind_reg_csr_t::unlogged_write(const reg_t val) noexcept {
 
 // Returns the actual CSR that maps to value in *siselect or nullptr if no mapping exists
 csr_t_p sscsrind_reg_csr_t::get_reg() const noexcept {
-  auto proxy = ireg_proxy;
   auto isel = iselect->read();
-  auto it = proxy.find(isel);
-  return it != proxy.end() ? it->second : nullptr;
+  auto it = ireg_proxy.find(isel);
+  return it != ireg_proxy.end() ? it->second : nullptr;
 }
 
 void sscsrind_reg_csr_t::add_ireg_proxy(const reg_t iselect_value, csr_t_p csr) {

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -682,10 +682,6 @@ reg_t sstatus_proxy_csr_t::read() const noexcept {
   return mstatus->read() & adj_read_mask;
 }
 
-reg_t sstatus_proxy_csr_t::read_status_bits(const reg_t bits) const noexcept {
-  return mstatus->read_raw() & bits;
-}
-
 // implement class mstatus_csr_t
 mstatus_csr_t::mstatus_csr_t(processor_t* const proc, const reg_t addr):
   base_status_csr_t(proc, addr),

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -1758,6 +1758,10 @@ void vector_csr_t::write_raw(const reg_t val) noexcept {
     log_write();
 }
 
+void vector_csr_t::write_without_logging(const reg_t val) noexcept {
+  vector_csr_t::unlogged_write(val);
+}
+
 bool vector_csr_t::unlogged_write(const reg_t val) noexcept {
   if (mask == 0) return false;
   if (unlikely(STATE.v || (STATE.mstatus->read_raw() & SSTATUS_VS) != SSTATUS_VS))

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -323,7 +323,7 @@ bool mpmpdeleg_csr_t::unlogged_write(const reg_t val) noexcept {
   bool write_success = false;
   if (max_locked_pmp_index < (int)new_val) {
     for (size_t i = 0; i < proc->n_pmp; ++i)
-      state->csrmap.erase(CSR_PMPADDR0 + i);
+      state->remove_csr(CSR_PMPADDR0 + i);
 
     proc->n_pmp = new_val;
     for (size_t i = 0; i < proc->n_pmp; ++i) {

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -682,6 +682,10 @@ reg_t sstatus_proxy_csr_t::read() const noexcept {
   return mstatus->read() & adj_read_mask;
 }
 
+reg_t sstatus_proxy_csr_t::read_status_bits(const reg_t bits) const noexcept {
+  return mstatus->read_raw() & bits;
+}
+
 // implement class mstatus_csr_t
 mstatus_csr_t::mstatus_csr_t(processor_t* const proc, const reg_t addr):
   base_status_csr_t(proc, addr),
@@ -821,8 +825,8 @@ sstatus_csr_t::sstatus_csr_t(processor_t* const proc, sstatus_proxy_csr_t_p orig
 
 void sstatus_csr_t::dirty(const reg_t dirties) {
   // As an optimization, return early if already dirty.
-  if ((orig_sstatus->read() & dirties) == dirties) {
-    if (likely(!state->v || (virt_sstatus->read() & dirties) == dirties))
+  if (orig_sstatus->read_status_bits(dirties) == dirties) {
+    if (likely(!state->v || virt_sstatus->read_status_bits(dirties) == dirties))
       return;
   }
 
@@ -837,8 +841,8 @@ void sstatus_csr_t::dirty(const reg_t dirties) {
 }
 
 bool sstatus_csr_t::enabled(const reg_t which) {
-  if ((orig_sstatus->read() & which) != 0) {
-    if (!state->v || (virt_sstatus->read() & which) != 0)
+  if (orig_sstatus->read_status_bits(which) != 0) {
+    if (!state->v || virt_sstatus->read_status_bits(which) != 0)
       return true;
   }
   return false;

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -1760,7 +1760,8 @@ void vector_csr_t::write_raw(const reg_t val) noexcept {
 
 bool vector_csr_t::unlogged_write(const reg_t val) noexcept {
   if (mask == 0) return false;
-  STATE.sstatus->dirty(SSTATUS_VS);
+  if (unlikely(STATE.v || (STATE.mstatus->read_raw() & SSTATUS_VS) != SSTATUS_VS))
+    STATE.sstatus->dirty(SSTATUS_VS);
   return basic_csr_t::unlogged_write(val & mask);
 }
 
@@ -1774,7 +1775,8 @@ void vxsat_csr_t::verify_permissions(insn_t insn, bool write) const {
 }
 
 bool vxsat_csr_t::unlogged_write(const reg_t val) noexcept {
-  if (proc->any_vector_extensions())
+  if (proc->any_vector_extensions() &&
+      unlikely(STATE.v || (STATE.mstatus->read_raw() & SSTATUS_VS) != SSTATUS_VS))
     STATE.sstatus->dirty(SSTATUS_VS);
   return masked_csr_t::unlogged_write(val);
 }

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -1343,6 +1343,10 @@ bool wide_counter_csr_t::unlogged_write(const reg_t val) noexcept {
 // Returns true if counting is not inhibited by Smcntrpmf.
 // Note that minstretcfg / mcyclecfg / mhpmevent* share the same inhibit bits.
 bool wide_counter_csr_t::is_counting_enabled() const noexcept {
+  const reg_t config = config_csr->read_prev();
+  if (likely(config == 0))
+    return true;
+
   auto prv = state->prv_changed ? state->prev_prv : state->prv;
   auto v = state->v_changed ? state->prev_v : state->v;
   auto mask = MHPMEVENT_MINH;
@@ -1351,7 +1355,7 @@ bool wide_counter_csr_t::is_counting_enabled() const noexcept {
   } else if (prv == PRV_U) {
     mask = v ? MHPMEVENT_VUINH : MHPMEVENT_UINH;
   }
-  return (config_csr->read_prev() & mask) == 0;
+  return (config & mask) == 0;
 }
 
 // implement class time_counter_csr_t
@@ -2118,8 +2122,9 @@ smcntrpmf_csr_t::smcntrpmf_csr_t(processor_t* const proc, const reg_t addr) : ba
 }
 
 reg_t smcntrpmf_csr_t::read_prev() const noexcept {
-  reg_t val = prev_val.value_or(read());
-  return val;
+  if (likely(!prev_val))
+    return read();
+  return *prev_val;
 }
 
 void smcntrpmf_csr_t::reset_prev() noexcept {

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -2126,18 +2126,34 @@ void sscsrind_reg_csr_t::add_ireg_proxy(const reg_t iselect_value, csr_t_p csr) 
 smcntrpmf_csr_t::smcntrpmf_csr_t(processor_t* const proc, const reg_t addr) : basic_csr_t(proc, addr, 0) {
 }
 
-reg_t smcntrpmf_csr_t::read_prev() const noexcept {
+#ifdef __clang__
+# define SMCNTRPMF_READ_PREV_NOINLINE NOINLINE
+#else
+# define SMCNTRPMF_READ_PREV_NOINLINE
+#endif
+
+reg_t SMCNTRPMF_READ_PREV_NOINLINE smcntrpmf_csr_t::read_prev() const noexcept {
   if (likely(!prev_val))
+#ifdef __clang__
+    return basic_csr_t::read();
+#else
     return read();
+#endif
   return *prev_val;
 }
+
+#undef SMCNTRPMF_READ_PREV_NOINLINE
 
 void smcntrpmf_csr_t::reset_prev() noexcept {
   prev_val.reset();
 }
 
 bool smcntrpmf_csr_t::unlogged_write(const reg_t val) noexcept {
+#ifdef __clang__
+  prev_val = basic_csr_t::read();
+#else
   prev_val = read();
+#endif
 
   const reg_t mask = !proc->extension_enabled_const(EXT_SMCNTRPMF) ? 0 :
     MHPMEVENT_MINH |

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -1419,6 +1419,11 @@ bool counter_proxy_csr_t::myenable(csr_t_p counteren) const noexcept {
 }
 
 void counter_proxy_csr_t::verify_permissions(insn_t insn, bool write) const {
+#ifdef __clang__
+  if (!write && likely(state->prv == PRV_M) && likely(!state->v))
+    return;
+#endif
+
   proxy_csr_t::verify_permissions(insn, write);
 
   const bool mctr_ok = (state->prv < PRV_M) ? myenable(state->mcounteren) : true;

--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -1649,6 +1649,12 @@ float_csr_t::float_csr_t(processor_t* const proc, const reg_t addr, const reg_t 
 }
 
 void float_csr_t::verify_permissions(insn_t insn, bool write) const {
+  if (!write && likely(!state->v) &&
+      likely(!proc->extension_enabled(EXT_ZFINX)) &&
+      likely(proc->extension_enabled('F')) &&
+      likely((state->mstatus->read_raw() & SSTATUS_FS) != 0))
+    return;
+
   masked_csr_t::verify_permissions(insn, write);
 
   if (!((proc->extension_enabled('F') && STATE.sstatus->enabled(SSTATUS_FS))

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -798,6 +798,8 @@ class vector_csr_t: public basic_csr_t {
   virtual void verify_permissions(insn_t insn, bool write) const override;
   // Write without regard to mask, and without touching mstatus.VS
   void write_raw(const reg_t val) noexcept;
+  // Internal write for instruction implementations with commit logging disabled.
+  void write_without_logging(const reg_t val) noexcept;
  protected:
   virtual bool unlogged_write(const reg_t val) noexcept override;
  private:

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -332,7 +332,9 @@ class sstatus_proxy_csr_t final: public base_status_csr_t {
   sstatus_proxy_csr_t(processor_t* const proc, const reg_t addr, mstatus_csr_t_p mstatus);
 
   virtual reg_t read() const noexcept override;
-  reg_t read_status_bits(const reg_t bits) const noexcept;
+  reg_t read_status_bits(const reg_t bits) const noexcept {
+    return mstatus->read_raw() & bits;
+  }
 
  protected:
   virtual bool unlogged_write(const reg_t val) noexcept override;

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -796,6 +796,8 @@ class vector_csr_t: public basic_csr_t {
  public:
   vector_csr_t(processor_t* const proc, const reg_t addr, const reg_t mask, const reg_t init=0);
   virtual void verify_permissions(insn_t insn, bool write) const override;
+  // Internal stored-value read for vector instruction implementations.
+  reg_t read_raw() const noexcept { return basic_csr_t::read(); }
   // Write without regard to mask, and without touching mstatus.VS
   void write_raw(const reg_t val) noexcept;
   // Internal write for instruction implementations with commit logging disabled.

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -257,6 +257,9 @@ class vsstatus_csr_t final: public base_status_csr_t {
   vsstatus_csr_t(processor_t* const proc, const reg_t addr);
 
   virtual reg_t read() const noexcept override;
+  reg_t read_status_bits(const reg_t bits) const noexcept {
+    return val & bits;
+  }
 
  protected:
   virtual bool unlogged_write(const reg_t val) noexcept override;
@@ -271,6 +274,9 @@ class mstatus_csr_t final: public base_status_csr_t {
   mstatus_csr_t(processor_t* const proc, const reg_t addr);
 
   reg_t read() const noexcept override;
+  reg_t read_raw() const noexcept {
+    return val;
+  }
 
  protected:
   virtual bool unlogged_write(const reg_t val) noexcept override;
@@ -326,6 +332,7 @@ class sstatus_proxy_csr_t final: public base_status_csr_t {
   sstatus_proxy_csr_t(processor_t* const proc, const reg_t addr, mstatus_csr_t_p mstatus);
 
   virtual reg_t read() const noexcept override;
+  reg_t read_status_bits(const reg_t bits) const noexcept;
 
  protected:
   virtual bool unlogged_write(const reg_t val) noexcept override;

--- a/riscv/decode_macros.h
+++ b/riscv/decode_macros.h
@@ -129,7 +129,13 @@
 #define FRS3_D READ_FREG_D(insn.rs3())
 #define dirty_fp_state  STATE.sstatus->dirty(SSTATUS_FS)
 #define dirty_ext_state STATE.sstatus->dirty(SSTATUS_XS)
-#define DO_WRITE_FREG(reg, value) (STATE.FPR.write(reg, value), dirty_fp_state)
+#define DO_WRITE_FREG(reg, value) ({ \
+  STATE.FPR.write(reg, value); \
+  if constexpr (DECODE_MACRO_USAGE_LOGGED) \
+    dirty_fp_state; \
+  else if (unlikely(!fp_state_was_dirty)) \
+    dirty_fp_state; \
+})
 #define WRITE_FRD(value) WRITE_FREG(insn.rd(), value)
 #define WRITE_FRD_H(value) \
 do { \
@@ -181,7 +187,21 @@ static inline bool is_aligned(const unsigned val, const unsigned pos)
 #define require_rv32 require(xlen == 32)
 #define require_extension(s) require(p->extension_enabled(s))
 #define require_either_extension(A,B) require(p->extension_enabled(A) || p->extension_enabled(B));
-#define require_fp          STATE.fflags->verify_permissions(insn, false)
+// Reuse the permission check's status snapshot when the instruction writes an FPR.
+#define require_fp \
+const reg_t fp_status_before_insn = STATE.mstatus->read_raw(); \
+const bool UNUSED fp_state_was_dirty = !STATE.v && \
+  (fp_status_before_insn & SSTATUS_FS) == SSTATUS_FS; \
+do { \
+  if constexpr (DECODE_MACRO_USAGE_LOGGED) { \
+    STATE.fflags->verify_permissions(insn, false); \
+  } else if (unlikely(STATE.v) || \
+             unlikely(p->extension_enabled(EXT_ZFINX)) || \
+             unlikely(!p->extension_enabled('F')) || \
+             unlikely((fp_status_before_insn & SSTATUS_FS) == 0)) { \
+    STATE.fflags->verify_permissions(insn, false); \
+  } \
+} while (0)
 #define require_accelerator require(STATE.sstatus->enabled(SSTATUS_XS))
 #define require_vector_vs   require(p->any_vector_extensions() && STATE.sstatus->enabled(SSTATUS_VS))
 #define require_vector(alu) \

--- a/riscv/decode_macros.h
+++ b/riscv/decode_macros.h
@@ -41,7 +41,9 @@
     if (DECODE_MACRO_USAGE_LOGGED) STATE.log_reg_write[((reg) << 4) | 1] = wdata; \
     DO_WRITE_FREG(reg, wdata); \
   })
-#define WRITE_VSTATUS STATE.log_reg_write[3] = {0, 0};
+#define WRITE_VSTATUS do { \
+    if (DECODE_MACRO_USAGE_LOGGED) STATE.log_reg_write[3] = {0, 0}; \
+  } while (0)
 
 /* the value parameter needs to be evaluated before writing to the registers */
 #define WRITE_REG_PAIR(reg, value) \

--- a/riscv/execute.cc
+++ b/riscv/execute.cc
@@ -208,7 +208,7 @@ bool processor_t::slow_path() const
 }
 
 // fetch/decode/execute loop
-void processor_t::step(size_t n)
+void __attribute__((aligned(64))) processor_t::step(size_t n)
 {
   mmu_t* _mmu = mmu;
 

--- a/riscv/execute.cc
+++ b/riscv/execute.cc
@@ -364,10 +364,11 @@ void processor_t::step(size_t n)
     }
 
 serialize:
-    state.minstret->bump((state.mcountinhibit->read() & MCOUNTINHIBIT_IR) ? 0 : instret);
+    const reg_t mcountinhibit = state.mcountinhibit->read();
+    state.minstret->bump((mcountinhibit & MCOUNTINHIBIT_IR) ? 0 : instret);
 
     // Model a hart whose CPI is 1.
-    state.mcycle->bump((state.mcountinhibit->read() & MCOUNTINHIBIT_CY) ? 0 : instret);
+    state.mcycle->bump((mcountinhibit & MCOUNTINHIBIT_CY) ? 0 : instret);
 
     n -= instret;
   }

--- a/riscv/insn_template.h
+++ b/riscv/insn_template.h
@@ -12,5 +12,7 @@
 #include "debug_defines.h"
 #include <assert.h>
 
+reg_t fast_rv64i_add(processor_t*, insn_t, reg_t)
+  __attribute__((aligned(64)));
 reg_t fast_rv64i_csrrs(processor_t*, insn_t, reg_t)
   __attribute__((aligned(64)));

--- a/riscv/insn_template.h
+++ b/riscv/insn_template.h
@@ -16,3 +16,7 @@ reg_t fast_rv64i_add(processor_t*, insn_t, reg_t)
   __attribute__((aligned(64)));
 reg_t fast_rv64i_csrrs(processor_t*, insn_t, reg_t)
   __attribute__((aligned(64)));
+reg_t fast_rv64i_vslidedown_vx(processor_t*, insn_t, reg_t)
+  __attribute__((aligned(64)));
+reg_t fast_rv64i_vslideup_vx(processor_t*, insn_t, reg_t)
+  __attribute__((aligned(64)));

--- a/riscv/insn_template.h
+++ b/riscv/insn_template.h
@@ -11,3 +11,6 @@
 #include "v_ext_macros.h"
 #include "debug_defines.h"
 #include <assert.h>
+
+reg_t fast_rv64i_csrrs(processor_t*, insn_t, reg_t)
+  __attribute__((aligned(64)));

--- a/riscv/insns/csrrs.h
+++ b/riscv/insns/csrrs.h
@@ -1,8 +1,25 @@
 bool write = insn.rs1() != 0;
 int csr = validate_csr(insn.csr(), write);
-reg_t old = p->get_csr(csr, insn, write);
+reg_t old;
+#ifdef __clang__
+if (likely(!write && STATE.prv == PRV_M && !STATE.v && STATE.csrmap_cache[csr] != nullptr)) {
+  switch (csr) {
+    case CSR_CYCLE:
+      old = STATE.mcycle->read();
+      goto csrrs_read_done;
+    case CSR_INSTRET:
+      old = STATE.minstret->read();
+      goto csrrs_read_done;
+    case CSR_TIME:
+      old = STATE.time->read();
+      goto csrrs_read_done;
+  }
+}
+#endif
+old = p->get_csr(csr, insn, write);
 if (write) {
   p->put_csr(csr, old | RS1);
 }
+csrrs_read_done:
 WRITE_RD(sext_xlen(old));
 serialize();

--- a/riscv/insns/vcompress_vm.h
+++ b/riscv/insns/vcompress_vm.h
@@ -12,16 +12,16 @@ VI_GENERAL_LOOP_BASE
   if (P.VU.mask_elt(rs1_num, i)) {
     switch (sew) {
     case e8:
-      P.VU.elt<uint8_t>(rd_num, pos, true) = P.VU.elt<uint8_t>(rs2_num, i);
+      P.VU.elt<uint8_t>(rd_num, pos, DECODE_MACRO_USAGE_LOGGED) = P.VU.elt<uint8_t>(rs2_num, i);
       break;
     case e16:
-      P.VU.elt<uint16_t>(rd_num, pos, true) = P.VU.elt<uint16_t>(rs2_num, i);
+      P.VU.elt<uint16_t>(rd_num, pos, DECODE_MACRO_USAGE_LOGGED) = P.VU.elt<uint16_t>(rs2_num, i);
       break;
     case e32:
-      P.VU.elt<uint32_t>(rd_num, pos, true) = P.VU.elt<uint32_t>(rs2_num, i);
+      P.VU.elt<uint32_t>(rd_num, pos, DECODE_MACRO_USAGE_LOGGED) = P.VU.elt<uint32_t>(rs2_num, i);
       break;
     default:
-      P.VU.elt<uint64_t>(rd_num, pos, true) = P.VU.elt<uint64_t>(rs2_num, i);
+      P.VU.elt<uint64_t>(rd_num, pos, DECODE_MACRO_USAGE_LOGGED) = P.VU.elt<uint64_t>(rs2_num, i);
       break;
     }
 

--- a/riscv/insns/vrgather_vv.h
+++ b/riscv/insns/vrgather_vv.h
@@ -10,22 +10,22 @@ VI_LOOP_BASE
   case e8: {
     auto vs1 = P.VU.elt<uint8_t>(rs1_num, i);
     //if (i > 255) continue;
-    P.VU.elt<uint8_t>(rd_num, i, true) = vs1 >= P.VU.vlmax ? 0 : P.VU.elt<uint8_t>(rs2_num, vs1);
+    P.VU.elt<uint8_t>(rd_num, i, DECODE_MACRO_USAGE_LOGGED) = vs1 >= P.VU.vlmax ? 0 : P.VU.elt<uint8_t>(rs2_num, vs1);
     break;
   }
   case e16: {
     auto vs1 = P.VU.elt<uint16_t>(rs1_num, i);
-    P.VU.elt<uint16_t>(rd_num, i, true) = vs1 >= P.VU.vlmax ? 0 : P.VU.elt<uint16_t>(rs2_num, vs1);
+    P.VU.elt<uint16_t>(rd_num, i, DECODE_MACRO_USAGE_LOGGED) = vs1 >= P.VU.vlmax ? 0 : P.VU.elt<uint16_t>(rs2_num, vs1);
     break;
   }
   case e32: {
     auto vs1 = P.VU.elt<uint32_t>(rs1_num, i);
-    P.VU.elt<uint32_t>(rd_num, i, true) = vs1 >= P.VU.vlmax ? 0 : P.VU.elt<uint32_t>(rs2_num, vs1);
+    P.VU.elt<uint32_t>(rd_num, i, DECODE_MACRO_USAGE_LOGGED) = vs1 >= P.VU.vlmax ? 0 : P.VU.elt<uint32_t>(rs2_num, vs1);
     break;
   }
   default: {
     auto vs1 = P.VU.elt<uint64_t>(rs1_num, i);
-    P.VU.elt<uint64_t>(rd_num, i, true) = vs1 >= P.VU.vlmax ? 0 : P.VU.elt<uint64_t>(rs2_num, vs1);
+    P.VU.elt<uint64_t>(rd_num, i, DECODE_MACRO_USAGE_LOGGED) = vs1 >= P.VU.vlmax ? 0 : P.VU.elt<uint64_t>(rs2_num, vs1);
     break;
   }
   }

--- a/riscv/insns/vslideup_vi.h
+++ b/riscv/insns/vslideup_vi.h
@@ -3,7 +3,7 @@ VI_CHECK_SLIDE(true);
 
 const reg_t offset = insn.v_zimm5();
 VI_LOOP_BASE
-if (P.VU.vstart->read() < offset && i < offset)
+if (P.VU.vstart->read_raw() < offset && i < offset)
   continue;
 
 switch (sew) {

--- a/riscv/insns/vslideup_vx.h
+++ b/riscv/insns/vslideup_vx.h
@@ -2,8 +2,9 @@
 VI_CHECK_SLIDE(true);
 
 const reg_t offset = RS1;
+const reg_t vstart = P.VU.vstart->read_raw();
 VI_LOOP_BASE
-if (P.VU.vstart->read() < offset && i < offset)
+if (vstart < offset && i < offset)
   continue;
 
 switch (sew) {

--- a/riscv/mmu.h
+++ b/riscv/mmu.h
@@ -97,25 +97,32 @@ private:
   reg_t get_pmlen(bool effective_virt, reg_t effective_priv, xlate_flags_t flags) const;
   mem_access_info_t generate_access_info(reg_t addr, access_type type, xlate_flags_t xlate_flags);
 
+  template<typename T>
+  T NOINLINE load_slow_path_value(reg_t addr, xlate_flags_t xlate_flags) {
+    target_endian<T> res;
+    load_slow_path(addr, sizeof(T), (uint8_t*)&res, xlate_flags);
+    return from_target(res);
+  }
+
 public:
   mmu_t(simif_t* sim, endianness_t endianness, processor_t* proc, reg_t cache_blocksz);
   ~mmu_t();
 
   template<typename T>
   T ALWAYS_INLINE load(reg_t addr, xlate_flags_t xlate_flags = {}) {
-    target_endian<T> res;
+    T res;
     bool aligned = (addr & (sizeof(T) - 1)) == 0;
     auto [tlb_hit, host_addr, _] = access_tlb(tlb_load, addr);
 
     if (likely(!xlate_flags.is_special_access() && aligned && tlb_hit)) {
-      res = *(target_endian<T>*)host_addr;
+      res = from_target(*(target_endian<T>*)host_addr);
     } else {
-      load_slow_path(addr, sizeof(T), (uint8_t*)&res, xlate_flags);
+      res = load_slow_path_value<T>(addr, xlate_flags);
     }
 
-    MMU_OBSERVE_LOAD(addr,from_target(res),sizeof(T));
+    MMU_OBSERVE_LOAD(addr,res,sizeof(T));
 
-    return from_target(res);
+    return res;
   }
 
   template<typename T>

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -102,6 +102,8 @@ void state_t::reset(processor_t* const proc, reg_t max_isa)
   pc = DEFAULT_RSTVEC;
   XPR.reset();
   FPR.reset();
+  csrmap.clear();
+  csrmap_cache.fill(nullptr);
 
   prv = prev_prv = PRV_M;
   v = prev_v = false;
@@ -625,8 +627,16 @@ void processor_t::disasm(insn_t insn)
 void processor_t::put_csr(int which, reg_t val)
 {
   val = zext_xlen(val);
+  const unsigned which_u = static_cast<unsigned>(which);
+  if (likely(which_u < state.csrmap_cache.size())) {
+    if (csr_t* csr = state.csrmap_cache[which_u]) {
+      csr->write(val);
+      return;
+    }
+  }
+
   auto search = state.csrmap.find(which);
-  if (search != state.csrmap.end()) {
+  if (unlikely(search != state.csrmap.end())) {
     search->second->write(val);
     return;
   }
@@ -637,8 +647,17 @@ void processor_t::put_csr(int which, reg_t val)
 // side effects on reads.
 reg_t processor_t::get_csr(int which, insn_t insn, bool write, bool peek)
 {
+  const unsigned which_u = static_cast<unsigned>(which);
+  if (likely(which_u < state.csrmap_cache.size())) {
+    if (csr_t* csr = state.csrmap_cache[which_u]) {
+      if (!peek)
+        csr->verify_permissions(insn, write);
+      return csr->read();
+    }
+  }
+
   auto search = state.csrmap.find(which);
-  if (search != state.csrmap.end()) {
+  if (unlikely(search != state.csrmap.end())) {
     if (!peek)
       search->second->verify_permissions(insn, write);
     return search->second->read();

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -17,6 +17,7 @@
 #include "triggers.h"
 #include "../fesvr/memif.h"
 #include "vector_unit.h"
+#include <array>
 
 #define FIRST_HPMCOUNTER 3
 #define N_HPMCOUNTERS 29
@@ -80,6 +81,7 @@ struct state_t
   void add_iprio_proxy(processor_t* const proc, sscsrind_reg_csr_t_p ireg);
   void reset(processor_t* const proc, reg_t max_isa);
   void add_csr(reg_t addr, const csr_t_p& csr);
+  void remove_csr(reg_t addr);
 
   reg_t pc;
   regfile_t<reg_t, NXPR, true> XPR;
@@ -87,6 +89,7 @@ struct state_t
 
   // control and status registers
   std::unordered_map<reg_t, csr_t_p> csrmap;
+  std::array<csr_t*, NCSR> csrmap_cache;
   reg_t prv;    // TODO: Can this be an enum instead?
   reg_t prev_prv;
   bool prv_changed;

--- a/riscv/riscv.mk.in
+++ b/riscv/riscv.mk.in
@@ -9,6 +9,21 @@ riscv_subproject_deps = \
 
 riscv_CFLAGS = -fPIC -I$(src_dir)/fdt
 
+# Optional target tuning for simple integer handlers.  Keeping these flags
+# scoped avoids changing branch and memory instruction code generation.
+riscv_fast_alu_objs = \
+	and.o \
+	andi.o \
+	or.o \
+	slli.o \
+	sltu.o \
+	srli.o \
+	sub.o \
+	xor.o \
+	xori.o \
+
+$(riscv_fast_alu_objs): private riscv_CFLAGS += $(RISCV_FAST_ALU_CFLAGS)
+
 riscv_install_shared_lib = yes
 
 riscv_install_pcs = yes

--- a/riscv/v_ext_macros.h
+++ b/riscv/v_ext_macros.h
@@ -14,6 +14,17 @@
     P.VU.vstart->write_without_logging(value); \
 } while (0)
 
+#define VI_LDST_PREPARE_VSTART(index) do { \
+  if constexpr (DECODE_MACRO_USAGE_LOGGED) \
+    WRITE_VSTART(index); \
+} while (0)
+
+#define VI_LDST_RETHROW(index) catch (...) { \
+  if constexpr (!DECODE_MACRO_USAGE_LOGGED) \
+    WRITE_VSTART(index); \
+  throw; \
+}
+
 //
 // vector: masking skip helper
 //
@@ -1252,12 +1263,14 @@ VI_VX_ULOOP({ \
   for (reg_t i = 0; i < vl; ++i) { \
     VI_ELEMENT_SKIP; \
     VI_STRIP(i); \
-    WRITE_VSTART(i); \
-    for (reg_t fn = 0; fn < nf; ++fn) { \
-      elt_width##_t val = MMU.load<elt_width##_t>( \
-        baseAddr + (stride) + (offset) * sizeof(elt_width##_t)); \
-      P.VU.elt<elt_width##_t>(vd + fn * emul, vreg_inx, true) = val; \
-    } \
+    VI_LDST_PREPARE_VSTART(i); \
+    try { \
+      for (reg_t fn = 0; fn < nf; ++fn) { \
+        elt_width##_t val = MMU.load<elt_width##_t>( \
+          baseAddr + (stride) + (offset) * sizeof(elt_width##_t)); \
+        P.VU.elt<elt_width##_t>(vd + fn * emul, vreg_inx, true) = val; \
+      } \
+    } VI_LDST_RETHROW(i); \
   } \
   VECTOR_END;
 
@@ -1290,27 +1303,29 @@ VI_VX_ULOOP({ \
     VI_LDST_GET_INDEX(elt_width); \
     VI_ELEMENT_SKIP; \
     VI_STRIP(i); \
-    WRITE_VSTART(i); \
-    for (reg_t fn = 0; fn < nf; ++fn) { \
-      switch (P.VU.vsew) { \
-        case e8: \
-          P.VU.elt<uint8_t>(vd + fn * flmul, vreg_inx, true) = \
-            MMU.load<uint8_t>(baseAddr + index + fn * 1); \
-          break; \
-        case e16: \
-          P.VU.elt<uint16_t>(vd + fn * flmul, vreg_inx, true) = \
-            MMU.load<uint16_t>(baseAddr + index + fn * 2); \
-          break; \
-        case e32: \
-          P.VU.elt<uint32_t>(vd + fn * flmul, vreg_inx, true) = \
-            MMU.load<uint32_t>(baseAddr + index + fn * 4); \
-          break; \
-        default: \
-          P.VU.elt<uint64_t>(vd + fn * flmul, vreg_inx, true) = \
-            MMU.load<uint64_t>(baseAddr + index + fn * 8); \
-          break; \
+    VI_LDST_PREPARE_VSTART(i); \
+    try { \
+      for (reg_t fn = 0; fn < nf; ++fn) { \
+        switch (P.VU.vsew) { \
+          case e8: \
+            P.VU.elt<uint8_t>(vd + fn * flmul, vreg_inx, true) = \
+              MMU.load<uint8_t>(baseAddr + index + fn * 1); \
+            break; \
+          case e16: \
+            P.VU.elt<uint16_t>(vd + fn * flmul, vreg_inx, true) = \
+              MMU.load<uint16_t>(baseAddr + index + fn * 2); \
+            break; \
+          case e32: \
+            P.VU.elt<uint32_t>(vd + fn * flmul, vreg_inx, true) = \
+              MMU.load<uint32_t>(baseAddr + index + fn * 4); \
+            break; \
+          default: \
+            P.VU.elt<uint64_t>(vd + fn * flmul, vreg_inx, true) = \
+              MMU.load<uint64_t>(baseAddr + index + fn * 8); \
+            break; \
+        } \
       } \
-    } \
+    } VI_LDST_RETHROW(i); \
   } \
   VECTOR_END;
 
@@ -1323,12 +1338,14 @@ VI_VX_ULOOP({ \
   for (reg_t i = 0; i < vl; ++i) { \
     VI_STRIP(i) \
     VI_ELEMENT_SKIP; \
-    WRITE_VSTART(i); \
-    for (reg_t fn = 0; fn < nf; ++fn) { \
-      elt_width##_t val = P.VU.elt<elt_width##_t>(vs3 + fn * emul, vreg_inx); \
-      MMU.store<elt_width##_t>( \
-        baseAddr + (stride) + (offset) * sizeof(elt_width##_t), val); \
-    } \
+    VI_LDST_PREPARE_VSTART(i); \
+    try { \
+      for (reg_t fn = 0; fn < nf; ++fn) { \
+        elt_width##_t val = P.VU.elt<elt_width##_t>(vs3 + fn * emul, vreg_inx); \
+        MMU.store<elt_width##_t>( \
+          baseAddr + (stride) + (offset) * sizeof(elt_width##_t), val); \
+      } \
+    } VI_LDST_RETHROW(i); \
   } \
   VECTOR_END;
 
@@ -1344,27 +1361,29 @@ VI_VX_ULOOP({ \
     VI_LDST_GET_INDEX(elt_width); \
     VI_STRIP(i) \
     VI_ELEMENT_SKIP; \
-    WRITE_VSTART(i); \
-    for (reg_t fn = 0; fn < nf; ++fn) { \
-      switch (P.VU.vsew) { \
-      case e8: \
-        MMU.store<uint8_t>(baseAddr + index + fn * 1, \
-          P.VU.elt<uint8_t>(vs3 + fn * flmul, vreg_inx)); \
-        break; \
-      case e16: \
-        MMU.store<uint16_t>(baseAddr + index + fn * 2, \
-          P.VU.elt<uint16_t>(vs3 + fn * flmul, vreg_inx)); \
-        break; \
-      case e32: \
-        MMU.store<uint32_t>(baseAddr + index + fn * 4, \
-          P.VU.elt<uint32_t>(vs3 + fn * flmul, vreg_inx)); \
-        break; \
-      default: \
-        MMU.store<uint64_t>(baseAddr + index + fn * 8, \
-          P.VU.elt<uint64_t>(vs3 + fn * flmul, vreg_inx)); \
-        break; \
+    VI_LDST_PREPARE_VSTART(i); \
+    try { \
+      for (reg_t fn = 0; fn < nf; ++fn) { \
+        switch (P.VU.vsew) { \
+        case e8: \
+          MMU.store<uint8_t>(baseAddr + index + fn * 1, \
+            P.VU.elt<uint8_t>(vs3 + fn * flmul, vreg_inx)); \
+          break; \
+        case e16: \
+          MMU.store<uint16_t>(baseAddr + index + fn * 2, \
+            P.VU.elt<uint16_t>(vs3 + fn * flmul, vreg_inx)); \
+          break; \
+        case e32: \
+          MMU.store<uint32_t>(baseAddr + index + fn * 4, \
+            P.VU.elt<uint32_t>(vs3 + fn * flmul, vreg_inx)); \
+          break; \
+        default: \
+          MMU.store<uint64_t>(baseAddr + index + fn * 8, \
+            P.VU.elt<uint64_t>(vs3 + fn * flmul, vreg_inx)); \
+          break; \
+        } \
       } \
-    } \
+    } VI_LDST_RETHROW(i); \
   } \
   VECTOR_END;
 
@@ -1413,9 +1432,11 @@ VI_VX_ULOOP({ \
   const reg_t elt_per_reg = P.VU.vlenb / sizeof(elt_width ## _t); \
   const reg_t size = len * elt_per_reg; \
   for (reg_t i = P.VU.vstart->read(); i < size; i++) { \
-    WRITE_VSTART(i); \
-    auto val = MMU.load<elt_width##_t>(baseAddr + i * sizeof(elt_width ## _t)); \
-    P.VU.elt<elt_width ## _t>(vd, i, true) = val; \
+    VI_LDST_PREPARE_VSTART(i); \
+    try { \
+      auto val = MMU.load<elt_width##_t>(baseAddr + i * sizeof(elt_width ## _t)); \
+      P.VU.elt<elt_width ## _t>(vd, i, true) = val; \
+    } VI_LDST_RETHROW(i); \
   } \
   VECTOR_END;
 
@@ -1427,9 +1448,11 @@ VI_VX_ULOOP({ \
   require_align(vs3, len); \
   const reg_t size = len * P.VU.vlenb; \
   for (reg_t i = P.VU.vstart->read(); i < size; i++) { \
-    WRITE_VSTART(i); \
-    auto val = P.VU.elt<uint8_t>(vs3, i); \
-    MMU.store<uint8_t>(baseAddr + i, val); \
+    VI_LDST_PREPARE_VSTART(i); \
+    try { \
+      auto val = P.VU.elt<uint8_t>(vs3, i); \
+      MMU.store<uint8_t>(baseAddr + i, val); \
+    } VI_LDST_RETHROW(i); \
   } \
   VECTOR_END;
 

--- a/riscv/v_ext_macros.h
+++ b/riscv/v_ext_macros.h
@@ -7,6 +7,13 @@
 #include "zvbdot.h"
 #include <functional>
 
+#define WRITE_VSTART(value) do { \
+  if constexpr (DECODE_MACRO_USAGE_LOGGED) \
+    P.VU.vstart->write(value); \
+  else \
+    P.VU.vstart->write_without_logging(value); \
+} while (0)
+
 //
 // vector: masking skip helper
 //
@@ -240,7 +247,7 @@ static inline bool is_overlapped_widen(const int astart, int asize,
  }
 
 #define VECTOR_END \
-  P.VU.vstart->write(0)
+  WRITE_VSTART(0)
 
 #define VI_LOOP_END \
   VI_LOOP_END_BASE \
@@ -1245,7 +1252,7 @@ VI_VX_ULOOP({ \
   for (reg_t i = 0; i < vl; ++i) { \
     VI_ELEMENT_SKIP; \
     VI_STRIP(i); \
-    P.VU.vstart->write(i); \
+    WRITE_VSTART(i); \
     for (reg_t fn = 0; fn < nf; ++fn) { \
       elt_width##_t val = MMU.load<elt_width##_t>( \
         baseAddr + (stride) + (offset) * sizeof(elt_width##_t)); \
@@ -1283,7 +1290,7 @@ VI_VX_ULOOP({ \
     VI_LDST_GET_INDEX(elt_width); \
     VI_ELEMENT_SKIP; \
     VI_STRIP(i); \
-    P.VU.vstart->write(i); \
+    WRITE_VSTART(i); \
     for (reg_t fn = 0; fn < nf; ++fn) { \
       switch (P.VU.vsew) { \
         case e8: \
@@ -1316,7 +1323,7 @@ VI_VX_ULOOP({ \
   for (reg_t i = 0; i < vl; ++i) { \
     VI_STRIP(i) \
     VI_ELEMENT_SKIP; \
-    P.VU.vstart->write(i); \
+    WRITE_VSTART(i); \
     for (reg_t fn = 0; fn < nf; ++fn) { \
       elt_width##_t val = P.VU.elt<elt_width##_t>(vs3 + fn * emul, vreg_inx); \
       MMU.store<elt_width##_t>( \
@@ -1337,7 +1344,7 @@ VI_VX_ULOOP({ \
     VI_LDST_GET_INDEX(elt_width); \
     VI_STRIP(i) \
     VI_ELEMENT_SKIP; \
-    P.VU.vstart->write(i); \
+    WRITE_VSTART(i); \
     for (reg_t fn = 0; fn < nf; ++fn) { \
       switch (P.VU.vsew) { \
       case e8: \
@@ -1379,7 +1386,7 @@ VI_VX_ULOOP({ \
           baseAddr + (i * nf + fn) * sizeof(elt_width##_t)); \
       } catch (trap_t& t) { \
         if (i == 0) { \
-          P.VU.vstart->write(0); /* dirty VS */ \
+          WRITE_VSTART(0); /* dirty VS */ \
           throw; /* Only take exception on zeroth element */ \
         } \
         /* Reduce VL if an exception occurs on a later element */ \
@@ -1406,7 +1413,7 @@ VI_VX_ULOOP({ \
   const reg_t elt_per_reg = P.VU.vlenb / sizeof(elt_width ## _t); \
   const reg_t size = len * elt_per_reg; \
   for (reg_t i = P.VU.vstart->read(); i < size; i++) { \
-    P.VU.vstart->write(i); \
+    WRITE_VSTART(i); \
     auto val = MMU.load<elt_width##_t>(baseAddr + i * sizeof(elt_width ## _t)); \
     P.VU.elt<elt_width ## _t>(vd, i, true) = val; \
   } \
@@ -1420,7 +1427,7 @@ VI_VX_ULOOP({ \
   require_align(vs3, len); \
   const reg_t size = len * P.VU.vlenb; \
   for (reg_t i = P.VU.vstart->read(); i < size; i++) { \
-    P.VU.vstart->write(i); \
+    WRITE_VSTART(i); \
     auto val = P.VU.elt<uint8_t>(vs3, i); \
     MMU.store<uint8_t>(baseAddr + i, val); \
   } \

--- a/riscv/v_ext_macros.h
+++ b/riscv/v_ext_macros.h
@@ -39,7 +39,7 @@
 #define VI_ELEMENT_SKIP \
   if (i >= vl) { \
     continue; \
-  } else if (i < P.VU.vstart->read()) { \
+  } else if (i < P.VU.vstart->read_raw()) { \
     continue; \
   } else { \
     VI_LOOP_ELEMENT_SKIP(); \
@@ -228,7 +228,7 @@ static inline bool is_overlapped_widen(const int astart, int asize,
     require(P.VU.vsew * 2 <= P.VU.ELEN); \
   } \
   require_align(insn.rs2(), P.VU.vflmul); \
-  require(P.VU.vstart->read() == 0); \
+  require(P.VU.vstart->read_raw() == 0); \
 
 #define VI_CHECK_SLIDE(is_over) \
   require_align(insn.rs2(), P.VU.vflmul); \
@@ -243,12 +243,12 @@ static inline bool is_overlapped_widen(const int astart, int asize,
 #define VI_GENERAL_LOOP_BASE \
   require(P.VU.vsew >= e8 && P.VU.vsew <= e64); \
   require_vector(true); \
-  reg_t vl = P.VU.vl->read(); \
+  reg_t vl = P.VU.vl->read_raw(); \
   reg_t UNUSED sew = P.VU.vsew; \
   reg_t UNUSED rd_num = insn.rd(); \
   reg_t UNUSED rs1_num = insn.rs1(); \
   reg_t rs2_num = insn.rs2(); \
-  for (reg_t i = P.VU.vstart->read(); i < vl; ++i) {
+  for (reg_t i = P.VU.vstart->read_raw(); i < vl; ++i) {
 
 #define VI_LOOP_BASE \
     VI_GENERAL_LOOP_BASE \
@@ -289,12 +289,12 @@ static inline bool is_overlapped_widen(const int astart, int asize,
 #define VI_LOOP_CMP_BASE \
   require(P.VU.vsew >= e8 && P.VU.vsew <= e64); \
   require_vector(true); \
-  reg_t vl = P.VU.vl->read(); \
+  reg_t vl = P.VU.vl->read_raw(); \
   reg_t sew = P.VU.vsew; \
   reg_t UNUSED rd_num = insn.rd(); \
   reg_t UNUSED rs1_num = insn.rs1(); \
   reg_t rs2_num = insn.rs2(); \
-  for (reg_t i = P.VU.vstart->read(); i < vl; ++i) { \
+  for (reg_t i = P.VU.vstart->read_raw(); i < vl; ++i) { \
     VI_LOOP_ELEMENT_SKIP(); \
     bool res = false;
 
@@ -306,8 +306,8 @@ static inline bool is_overlapped_widen(const int astart, int asize,
 #define VI_LOOP_MASK(op) \
   require(P.VU.vsew <= e64); \
   require_vector(true); \
-  reg_t vl = P.VU.vl->read(); \
-  for (reg_t i = P.VU.vstart->read(); i < vl; ++i) { \
+  reg_t vl = P.VU.vl->read_raw(); \
+  for (reg_t i = P.VU.vstart->read_raw(); i < vl; ++i) { \
     bool vs2 = P.VU.mask_elt(insn.rs2(), i); \
     bool vs1 = P.VU.mask_elt(insn.rs1(), i); \
     P.VU.set_mask_elt(insn.rd(), i, (op)); \
@@ -620,7 +620,7 @@ static inline bool is_overlapped_widen(const int astart, int asize,
 #define VI_VF_MERGE_LOOP(BODY) \
   VI_CHECK_SSS(false); \
   VI_VFP_COMMON \
-  for (reg_t i = P.VU.vstart->read(); i < vl; ++i) { \
+  for (reg_t i = P.VU.vstart->read_raw(); i < vl; ++i) { \
   VI_MERGE_VARS \
   if (P.VU.vsew == e16) { \
     VFP_VF_PARAMS(16); \
@@ -637,13 +637,13 @@ static inline bool is_overlapped_widen(const int astart, int asize,
 // reduction loop - signed
 #define VI_LOOP_REDUCTION_BASE(x) \
   require(x >= e8 && x <= e64); \
-  reg_t vl = P.VU.vl->read(); \
+  reg_t vl = P.VU.vl->read_raw(); \
   reg_t rd_num = insn.rd(); \
   reg_t rs1_num = insn.rs1(); \
   reg_t rs2_num = insn.rs2(); \
   auto &vd_0_des = P.VU.elt<type_sew_t<x>::type>(rd_num, 0, vl > 0); \
   auto vd_0_res = P.VU.elt<type_sew_t<x>::type>(rs1_num, 0); \
-  for (reg_t i = P.VU.vstart->read(); i < vl; ++i) { \
+  for (reg_t i = P.VU.vstart->read_raw(); i < vl; ++i) { \
     VI_LOOP_ELEMENT_SKIP(); \
     auto vs2 = P.VU.elt<type_sew_t<x>::type>(rs2_num, i); \
 
@@ -668,13 +668,13 @@ static inline bool is_overlapped_widen(const int astart, int asize,
 // reduction loop - unsigned
 #define VI_ULOOP_REDUCTION_BASE(x) \
   require(x >= e8 && x <= e64); \
-  reg_t vl = P.VU.vl->read(); \
+  reg_t vl = P.VU.vl->read_raw(); \
   reg_t rd_num = insn.rd(); \
   reg_t rs1_num = insn.rs1(); \
   reg_t rs2_num = insn.rs2(); \
   auto &vd_0_des = P.VU.elt<type_usew_t<x>::type>(rd_num, 0, vl > 0); \
   auto vd_0_res = P.VU.elt<type_usew_t<x>::type>(rs1_num, 0); \
-  for (reg_t i = P.VU.vstart->read(); i < vl; ++i) { \
+  for (reg_t i = P.VU.vstart->read_raw(); i < vl; ++i) { \
     VI_LOOP_ELEMENT_SKIP(); \
     auto vs2 = P.VU.elt<type_usew_t<x>::type>(rs2_num, i);
 
@@ -1088,13 +1088,13 @@ static inline bool is_overlapped_widen(const int astart, int asize,
 
 // wide reduction loop - signed
 #define VI_LOOP_WIDE_REDUCTION_BASE(sew1, sew2) \
-  reg_t vl = P.VU.vl->read(); \
+  reg_t vl = P.VU.vl->read_raw(); \
   reg_t rd_num = insn.rd(); \
   reg_t rs1_num = insn.rs1(); \
   reg_t rs2_num = insn.rs2(); \
   auto &vd_0_des = P.VU.elt<type_sew_t<sew2>::type>(rd_num, 0, vl > 0); \
   auto vd_0_res = P.VU.elt<type_sew_t<sew2>::type>(rs1_num, 0); \
-  for (reg_t i = P.VU.vstart->read(); i < vl; ++i) { \
+  for (reg_t i = P.VU.vstart->read_raw(); i < vl; ++i) { \
     VI_LOOP_ELEMENT_SKIP(); \
     auto vs2 = P.VU.elt<type_sew_t<sew1>::type>(rs2_num, i);
 
@@ -1116,13 +1116,13 @@ static inline bool is_overlapped_widen(const int astart, int asize,
 
 // wide reduction loop - unsigned
 #define VI_ULOOP_WIDE_REDUCTION_BASE(sew1, sew2) \
-  reg_t vl = P.VU.vl->read(); \
+  reg_t vl = P.VU.vl->read_raw(); \
   reg_t rd_num = insn.rd(); \
   reg_t rs1_num = insn.rs1(); \
   reg_t rs2_num = insn.rs2(); \
   auto &vd_0_des = P.VU.elt<type_usew_t<sew2>::type>(rd_num, 0, vl > 0); \
   auto vd_0_res = P.VU.elt<type_usew_t<sew2>::type>(rs1_num, 0); \
-  for (reg_t i = P.VU.vstart->read(); i < vl; ++i) { \
+  for (reg_t i = P.VU.vstart->read_raw(); i < vl; ++i) { \
     VI_LOOP_ELEMENT_SKIP(); \
     auto vs2 = P.VU.elt<type_usew_t<sew1>::type>(rs2_num, i);
 
@@ -1257,7 +1257,7 @@ VI_VX_ULOOP({ \
 #define VI_LD(stride, offset, elt_width, is_mask_ldst) \
   const reg_t nf = insn.v_nf() + 1; \
   VI_CHECK_LOAD(elt_width, is_mask_ldst); \
-  const reg_t vl = is_mask_ldst ? ((P.VU.vl->read() + 7) / 8) : P.VU.vl->read(); \
+  const reg_t vl = is_mask_ldst ? ((P.VU.vl->read_raw() + 7) / 8) : P.VU.vl->read_raw(); \
   const reg_t baseAddr = RS1; \
   const reg_t vd = insn.rd(); \
   for (reg_t i = 0; i < vl; ++i) { \
@@ -1294,7 +1294,7 @@ VI_VX_ULOOP({ \
 #define VI_LD_INDEX(elt_width, is_seg) \
   const reg_t nf = insn.v_nf() + 1; \
   VI_CHECK_LD_INDEX(elt_width); \
-  const reg_t vl = P.VU.vl->read(); \
+  const reg_t vl = P.VU.vl->read_raw(); \
   const reg_t baseAddr = RS1; \
   const reg_t vd = insn.rd(); \
   if (!is_seg) \
@@ -1332,7 +1332,7 @@ VI_VX_ULOOP({ \
 #define VI_ST(stride, offset, elt_width, is_mask_ldst) \
   const reg_t nf = insn.v_nf() + 1; \
   VI_CHECK_STORE(elt_width, is_mask_ldst); \
-  const reg_t vl = is_mask_ldst ? ((P.VU.vl->read() + 7) / 8) : P.VU.vl->read(); \
+  const reg_t vl = is_mask_ldst ? ((P.VU.vl->read_raw() + 7) / 8) : P.VU.vl->read_raw(); \
   const reg_t baseAddr = RS1; \
   const reg_t vs3 = insn.rd(); \
   for (reg_t i = 0; i < vl; ++i) { \
@@ -1352,7 +1352,7 @@ VI_VX_ULOOP({ \
 #define VI_ST_INDEX(elt_width, is_seg) \
   const reg_t nf = insn.v_nf() + 1; \
   VI_CHECK_ST_INDEX(elt_width); \
-  const reg_t vl = P.VU.vl->read(); \
+  const reg_t vl = P.VU.vl->read_raw(); \
   const reg_t baseAddr = RS1; \
   const reg_t vs3 = insn.rd(); \
   if (!is_seg) \
@@ -1390,11 +1390,11 @@ VI_VX_ULOOP({ \
 #define VI_LDST_FF(elt_width) \
   const reg_t nf = insn.v_nf() + 1; \
   VI_CHECK_LOAD(elt_width, false); \
-  const reg_t vl = p->VU.vl->read(); \
+  const reg_t vl = p->VU.vl->read_raw(); \
   const reg_t baseAddr = RS1; \
   const reg_t rd_num = insn.rd(); \
   bool early_stop = false; \
-  for (reg_t i = p->VU.vstart->read(); i < vl; ++i) { \
+  for (reg_t i = p->VU.vstart->read_raw(); i < vl; ++i) { \
     VI_STRIP(i); \
     VI_ELEMENT_SKIP; \
     \
@@ -1431,7 +1431,7 @@ VI_VX_ULOOP({ \
   require_align(vd, len); \
   const reg_t elt_per_reg = P.VU.vlenb / sizeof(elt_width ## _t); \
   const reg_t size = len * elt_per_reg; \
-  for (reg_t i = P.VU.vstart->read(); i < size; i++) { \
+  for (reg_t i = P.VU.vstart->read_raw(); i < size; i++) { \
     VI_LDST_PREPARE_VSTART(i); \
     try { \
       auto val = MMU.load<elt_width##_t>(baseAddr + i * sizeof(elt_width ## _t)); \
@@ -1447,7 +1447,7 @@ VI_VX_ULOOP({ \
   const reg_t len = insn.v_nf() + 1; \
   require_align(vs3, len); \
   const reg_t size = len * P.VU.vlenb; \
-  for (reg_t i = P.VU.vstart->read(); i < size; i++) { \
+  for (reg_t i = P.VU.vstart->read_raw(); i < size; i++) { \
     VI_LDST_PREPARE_VSTART(i); \
     try { \
       auto val = P.VU.elt<uint8_t>(vs3, i); \
@@ -1505,7 +1505,7 @@ VI_VX_ULOOP({ \
 #define VI_VFP_BASE \
   require_fp; \
   require_vector(true); \
-  reg_t UNUSED vl = P.VU.vl->read(); \
+  reg_t UNUSED vl = P.VU.vl->read_raw(); \
   reg_t UNUSED rd_num = insn.rd(); \
   reg_t UNUSED rs1_num = insn.rs1(); \
   reg_t UNUSED rs2_num = insn.rs2(); \
@@ -1531,17 +1531,17 @@ VI_VX_ULOOP({ \
 
 #define VI_VFP_LOOP_BASE \
   VI_VFP_COMMON \
-  for (reg_t i = P.VU.vstart->read(); i < vl; ++i) { \
+  for (reg_t i = P.VU.vstart->read_raw(); i < vl; ++i) { \
     VI_LOOP_ELEMENT_SKIP();
 
 #define VI_VFP_BF16_LOOP_BASE \
   VI_VFP_BF16_COMMON \
-  for (reg_t i = P.VU.vstart->read(); i < vl; ++i) { \
+  for (reg_t i = P.VU.vstart->read_raw(); i < vl; ++i) { \
     VI_LOOP_ELEMENT_SKIP();
 
 #define VI_VFP_LOOP_CMP_BASE \
   VI_VFP_COMMON \
-  for (reg_t i = P.VU.vstart->read(); i < vl; ++i) { \
+  for (reg_t i = P.VU.vstart->read_raw(); i < vl; ++i) { \
     VI_LOOP_ELEMENT_SKIP(); \
     bool res = false;
 
@@ -1550,7 +1550,7 @@ VI_VX_ULOOP({ \
   float##width##_t vs1_0 = P.VU.elt<float##width##_t>(rs1_num, 0); \
   vd_0 = vs1_0; \
   bool is_active = false; \
-  for (reg_t i = P.VU.vstart->read(); i < vl; ++i) { \
+  for (reg_t i = P.VU.vstart->read_raw(); i < vl; ++i) { \
     VI_LOOP_ELEMENT_SKIP(); \
     float##width##_t vs2 = P.VU.elt<float##width##_t>(rs2_num, i); \
     is_active = true; \
@@ -1558,7 +1558,7 @@ VI_VX_ULOOP({ \
 #define VI_VFP_LOOP_WIDE_REDUCTION_BASE \
   VI_VFP_COMMON \
   float64_t vd_0 = f64(P.VU.elt<float64_t>(rs1_num, 0).v); \
-  for (reg_t i = P.VU.vstart->read(); i < vl; ++i) { \
+  for (reg_t i = P.VU.vstart->read_raw(); i < vl; ++i) { \
     VI_LOOP_ELEMENT_SKIP();
 
 #define VI_VFP_LOOP_END \
@@ -1727,7 +1727,7 @@ VI_VX_ULOOP({ \
   switch (P.VU.vsew) { \
     case e16: { \
       float32_t vd_0 = P.VU.elt<float32_t>(rs1_num, 0); \
-      for (reg_t i = P.VU.vstart->read(); i < vl; ++i) { \
+      for (reg_t i = P.VU.vstart->read_raw(); i < vl; ++i) { \
         VI_LOOP_ELEMENT_SKIP(); \
         is_active = true; \
         float32_t vs2 = f16_to_f32(P.VU.elt<float16_t>(rs2_num, i)); \
@@ -1738,7 +1738,7 @@ VI_VX_ULOOP({ \
     } \
     case e32: { \
       float64_t vd_0 = P.VU.elt<float64_t>(rs1_num, 0); \
-      for (reg_t i = P.VU.vstart->read(); i < vl; ++i) { \
+      for (reg_t i = P.VU.vstart->read_raw(); i < vl; ++i) { \
         VI_LOOP_ELEMENT_SKIP(); \
         is_active = true; \
         float64_t vs2 = f32_to_f64(P.VU.elt<float32_t>(rs2_num, i)); \
@@ -2009,7 +2009,7 @@ VI_VX_ULOOP({ \
 
 #define VI_VFP_LOOP_SCALE_BASE \
   VI_VFP_BASE; \
-  for (reg_t i = P.VU.vstart->read(); i < vl; ++i) { \
+  for (reg_t i = P.VU.vstart->read_raw(); i < vl; ++i) { \
     VI_LOOP_ELEMENT_SKIP();
 
 #define VI_VFP_CVT_LOOP(CVT_PARAMS, CHECK, BODY) \
@@ -2245,7 +2245,7 @@ default: \
 
 #define ZVLDOT_INIT(widen) \
   require_vector(true); \
-  require(P.VU.vstart->read() == 0); \
+  require(P.VU.vstart->read_raw() == 0); \
   require_align(insn.rs1(), P.VU.vflmul); \
   require_align(insn.rs2(), P.VU.vflmul); \
   require_vm; \
@@ -2258,7 +2258,7 @@ default: \
   unsigned vd_emul = std::max(1U, unsigned((8 * vd_eew) / P.VU.VLEN)); \
   unsigned vs2 = insn.rs2() & ~7; \
   unsigned ci = (insn.rs2() & 7) * 8; \
-  require(P.VU.vstart->read() == 0); \
+  require(P.VU.vstart->read_raw() == 0); \
   require(P.VU.vflmul == 1); \
   require(ci * vd_eew < P.VU.VLEN); \
   require_align(insn.rd(), vd_emul); \
@@ -2277,7 +2277,7 @@ c_t generic_dot_product(const std::vector<a_t>& a, const std::vector<b_t>& b, c_
 #define ZVLDOT_LOOP(a_t, b_t, c_t, dot) \
   std::vector<a_t> a(P.VU.vlmax, a_t()); \
   std::vector<b_t> b(P.VU.vlmax, b_t()); \
-  for (reg_t i = 0, vl = P.VU.vl->read(); i < vl; i++) { \
+  for (reg_t i = 0, vl = P.VU.vl->read_raw(); i < vl; i++) { \
     VI_LOOP_ELEMENT_SKIP(); \
     a[i] = P.VU.elt<a_t>(insn.rs1(), i); \
     b[i] = P.VU.elt<b_t>(insn.rs2(), i); \
@@ -2300,7 +2300,7 @@ c_t generic_dot_product(const std::vector<a_t>& a, const std::vector<b_t>& b, c_
     VI_LOOP_ELEMENT_SKIP(); \
     std::vector<a_t> a(P.VU.vlmax, a_t()); \
     std::vector<b_t> b(P.VU.vlmax, b_t()); \
-    for (reg_t k = 0, vl = P.VU.vl->read(); k < vl; k++) { \
+    for (reg_t k = 0, vl = P.VU.vl->read_raw(); k < vl; k++) { \
       a[k] = P.VU.elt<a_t>(insn.rs1(), k); \
       b[k] = P.VU.elt<b_t>(vs2 + idx, k); \
     } \

--- a/riscv/v_ext_macros.h
+++ b/riscv/v_ext_macros.h
@@ -347,61 +347,61 @@ static inline bool is_overlapped_widen(const int astart, int asize,
 // vector: integer and masking operand access helper
 //
 #define VXI_PARAMS(x) \
-  type_sew_t<x>::type &vd = P.VU.elt<type_sew_t<x>::type>(rd_num, i, true); \
+  type_sew_t<x>::type &vd = P.VU.elt<type_sew_t<x>::type>(rd_num, i, DECODE_MACRO_USAGE_LOGGED); \
   type_sew_t<x>::type vs1 = P.VU.elt<type_sew_t<x>::type>(rs1_num, i); \
   type_sew_t<x>::type vs2 = P.VU.elt<type_sew_t<x>::type>(rs2_num, i); \
   type_sew_t<x>::type rs1 = (type_sew_t<x>::type)RS1; \
   type_sew_t<x>::type simm5 = (type_sew_t<x>::type)insn.v_simm5();
 
 #define VV_U_PARAMS(x) \
-  type_usew_t<x>::type &vd = P.VU.elt<type_usew_t<x>::type>(rd_num, i, true); \
+  type_usew_t<x>::type &vd = P.VU.elt<type_usew_t<x>::type>(rd_num, i, DECODE_MACRO_USAGE_LOGGED); \
   type_usew_t<x>::type vs1 = P.VU.elt<type_usew_t<x>::type>(rs1_num, i); \
   type_usew_t<x>::type vs2 = P.VU.elt<type_usew_t<x>::type>(rs2_num, i);
 
 #define V_U_PARAMS(x) \
-  type_usew_t<x>::type &vd = P.VU.elt<type_usew_t<x>::type>(rd_num, i, true); \
+  type_usew_t<x>::type &vd = P.VU.elt<type_usew_t<x>::type>(rd_num, i, DECODE_MACRO_USAGE_LOGGED); \
   type_usew_t<x>::type vs2 = P.VU.elt<type_usew_t<x>::type>(rs2_num, i);
 
 #define VX_U_PARAMS(x) \
-  type_usew_t<x>::type &vd = P.VU.elt<type_usew_t<x>::type>(rd_num, i, true); \
+  type_usew_t<x>::type &vd = P.VU.elt<type_usew_t<x>::type>(rd_num, i, DECODE_MACRO_USAGE_LOGGED); \
   type_usew_t<x>::type rs1 = (type_usew_t<x>::type)RS1; \
   type_usew_t<x>::type vs2 = P.VU.elt<type_usew_t<x>::type>(rs2_num, i);
 
 #define VI_U_PARAMS(x) \
-  type_usew_t<x>::type &vd = P.VU.elt<type_usew_t<x>::type>(rd_num, i, true); \
+  type_usew_t<x>::type &vd = P.VU.elt<type_usew_t<x>::type>(rd_num, i, DECODE_MACRO_USAGE_LOGGED); \
   type_usew_t<x>::type UNUSED zimm5 = (type_usew_t<x>::type)insn.v_zimm5(); \
   type_usew_t<x>::type vs2 = P.VU.elt<type_usew_t<x>::type>(rs2_num, i);
 
 #define VV_PARAMS(x) \
-  type_sew_t<x>::type UNUSED &vd = P.VU.elt<type_sew_t<x>::type>(rd_num, i, true); \
+  type_sew_t<x>::type UNUSED &vd = P.VU.elt<type_sew_t<x>::type>(rd_num, i, DECODE_MACRO_USAGE_LOGGED); \
   type_sew_t<x>::type vs1 = P.VU.elt<type_sew_t<x>::type>(rs1_num, i); \
   type_sew_t<x>::type UNUSED vs2 = P.VU.elt<type_sew_t<x>::type>(rs2_num, i);
 
 #define V_PARAMS(x) \
-  type_sew_t<x>::type &vd = P.VU.elt<type_sew_t<x>::type>(rd_num, i, true); \
+  type_sew_t<x>::type &vd = P.VU.elt<type_sew_t<x>::type>(rd_num, i, DECODE_MACRO_USAGE_LOGGED); \
   type_sew_t<x>::type vs2 = P.VU.elt<type_sew_t<x>::type>(rs2_num, i);
 
 #define VX_PARAMS(x) \
-  type_sew_t<x>::type UNUSED &vd = P.VU.elt<type_sew_t<x>::type>(rd_num, i, true); \
+  type_sew_t<x>::type UNUSED &vd = P.VU.elt<type_sew_t<x>::type>(rd_num, i, DECODE_MACRO_USAGE_LOGGED); \
   type_sew_t<x>::type rs1 = (type_sew_t<x>::type)RS1; \
   type_sew_t<x>::type UNUSED vs2 = P.VU.elt<type_sew_t<x>::type>(rs2_num, i);
 
 #define VI_PARAMS(x) \
-  type_sew_t<x>::type &vd = P.VU.elt<type_sew_t<x>::type>(rd_num, i, true); \
+  type_sew_t<x>::type &vd = P.VU.elt<type_sew_t<x>::type>(rd_num, i, DECODE_MACRO_USAGE_LOGGED); \
   type_sew_t<x>::type UNUSED simm5 = (type_sew_t<x>::type)insn.v_simm5(); \
   type_sew_t<x>::type UNUSED vs2 = P.VU.elt<type_sew_t<x>::type>(rs2_num, i);
 
 #define XV_PARAMS(x) \
-  type_sew_t<x>::type &vd = P.VU.elt<type_sew_t<x>::type>(rd_num, i, true); \
+  type_sew_t<x>::type &vd = P.VU.elt<type_sew_t<x>::type>(rd_num, i, DECODE_MACRO_USAGE_LOGGED); \
   type_usew_t<x>::type vs2 = P.VU.elt<type_usew_t<x>::type>(rs2_num, RS1);
 
 #define VV_SU_PARAMS(x) \
-  type_sew_t<x>::type &vd = P.VU.elt<type_sew_t<x>::type>(rd_num, i, true); \
+  type_sew_t<x>::type &vd = P.VU.elt<type_sew_t<x>::type>(rd_num, i, DECODE_MACRO_USAGE_LOGGED); \
   type_usew_t<x>::type vs1 = P.VU.elt<type_usew_t<x>::type>(rs1_num, i); \
   type_sew_t<x>::type vs2 = P.VU.elt<type_sew_t<x>::type>(rs2_num, i);
 
 #define VX_SU_PARAMS(x) \
-  type_sew_t<x>::type &vd = P.VU.elt<type_sew_t<x>::type>(rd_num, i, true); \
+  type_sew_t<x>::type &vd = P.VU.elt<type_sew_t<x>::type>(rd_num, i, DECODE_MACRO_USAGE_LOGGED); \
   type_usew_t<x>::type rs1 = (type_usew_t<x>::type)RS1; \
   type_sew_t<x>::type vs2 = P.VU.elt<type_sew_t<x>::type>(rs2_num, i);
 
@@ -429,27 +429,27 @@ static inline bool is_overlapped_widen(const int astart, int asize,
   type_sew_t<x>::type vs2 = P.VU.elt<type_sew_t<x>::type>(rs2_num, i);
 
 #define VI_XI_SLIDEDOWN_PARAMS(x, off) \
-  auto &vd = P.VU.elt<type_sew_t<x>::type>(rd_num, i, true); \
+  auto &vd = P.VU.elt<type_sew_t<x>::type>(rd_num, i, DECODE_MACRO_USAGE_LOGGED); \
   auto vs2 = P.VU.elt<type_sew_t<x>::type>(rs2_num, i + off);
 
 #define VI_XI_SLIDEUP_PARAMS(x, offset) \
-  auto &vd = P.VU.elt<type_sew_t<x>::type>(rd_num, i, true); \
+  auto &vd = P.VU.elt<type_sew_t<x>::type>(rd_num, i, DECODE_MACRO_USAGE_LOGGED); \
   auto vs2 = P.VU.elt<type_sew_t<x>::type>(rs2_num, i - offset);
 
 #define VI_NARROW_PARAMS(sew1, sew2) \
-  auto &vd = P.VU.elt<type_usew_t<sew1>::type>(rd_num, i, true); \
+  auto &vd = P.VU.elt<type_usew_t<sew1>::type>(rd_num, i, DECODE_MACRO_USAGE_LOGGED); \
   auto UNUSED vs2_u = P.VU.elt<type_usew_t<sew2>::type>(rs2_num, i); \
   auto UNUSED vs2 = P.VU.elt<type_sew_t<sew2>::type>(rs2_num, i); \
   auto zimm5 = (type_usew_t<sew1>::type)insn.v_zimm5();
 
 #define VX_NARROW_PARAMS(sew1, sew2) \
-  auto &vd = P.VU.elt<type_usew_t<sew1>::type>(rd_num, i, true); \
+  auto &vd = P.VU.elt<type_usew_t<sew1>::type>(rd_num, i, DECODE_MACRO_USAGE_LOGGED); \
   auto UNUSED vs2_u = P.VU.elt<type_usew_t<sew2>::type>(rs2_num, i); \
   auto UNUSED vs2 = P.VU.elt<type_sew_t<sew2>::type>(rs2_num, i); \
   auto rs1 = (type_sew_t<sew1>::type)RS1;
 
 #define VV_NARROW_PARAMS(sew1, sew2) \
-  auto &vd = P.VU.elt<type_usew_t<sew1>::type>(rd_num, i, true); \
+  auto &vd = P.VU.elt<type_usew_t<sew1>::type>(rd_num, i, DECODE_MACRO_USAGE_LOGGED); \
   auto UNUSED vs2_u = P.VU.elt<type_usew_t<sew2>::type>(rs2_num, i); \
   auto UNUSED vs2 = P.VU.elt<type_sew_t<sew2>::type>(rs2_num, i); \
   auto vs1 = P.VU.elt<type_sew_t<sew1>::type>(rs1_num, i);
@@ -467,15 +467,15 @@ static inline bool is_overlapped_widen(const int astart, int asize,
   auto vs2 = P.VU.elt<type_sew_t<x>::type>(rs2_num, i); \
   auto UNUSED rs1 = (type_sew_t<x>::type)RS1; \
   auto UNUSED simm5 = (type_sew_t<x>::type)insn.v_simm5(); \
-  auto &vd = P.VU.elt<type_sew_t<x>::type>(rd_num, i, true);
+  auto &vd = P.VU.elt<type_sew_t<x>::type>(rd_num, i, DECODE_MACRO_USAGE_LOGGED);
 
 #define VV_WITH_CARRY_PARAMS(x) \
   auto vs2 = P.VU.elt<type_sew_t<x>::type>(rs2_num, i); \
   auto vs1 = P.VU.elt<type_sew_t<x>::type>(rs1_num, i); \
-  auto &vd = P.VU.elt<type_sew_t<x>::type>(rd_num, i, true);
+  auto &vd = P.VU.elt<type_sew_t<x>::type>(rd_num, i, DECODE_MACRO_USAGE_LOGGED);
 
 #define VFP_V_PARAMS(width) \
-  float##width##_t &vd = P.VU.elt<float##width##_t>(rd_num, i, true); \
+  float##width##_t &vd = P.VU.elt<float##width##_t>(rd_num, i, DECODE_MACRO_USAGE_LOGGED); \
   float##width##_t vs2 = P.VU.elt<float##width##_t>(rs2_num, i);
 
 #define VFP_VV_CMP_PARAMS(width) \
@@ -483,7 +483,7 @@ static inline bool is_overlapped_widen(const int astart, int asize,
   float##width##_t vs2 = P.VU.elt<float##width##_t>(rs2_num, i);
 
 #define VFP_VV_PARAMS(width) \
-  float##width##_t &vd = P.VU.elt<float##width##_t>(rd_num, i, true); \
+  float##width##_t &vd = P.VU.elt<float##width##_t>(rd_num, i, DECODE_MACRO_USAGE_LOGGED); \
   VFP_VV_CMP_PARAMS(width)
 
 #define VFP_VF_CMP_PARAMS(width) \
@@ -491,20 +491,20 @@ static inline bool is_overlapped_widen(const int astart, int asize,
   float##width##_t UNUSED vs2 = P.VU.elt<float##width##_t>(rs2_num, i);
 
 #define VFP_VF_PARAMS(width) \
-  float##width##_t &vd = P.VU.elt<float##width##_t>(rd_num, i, true); \
+  float##width##_t &vd = P.VU.elt<float##width##_t>(rd_num, i, DECODE_MACRO_USAGE_LOGGED); \
   VFP_VF_CMP_PARAMS(width)
 
 #define CVT_FP_TO_FP_PARAMS(from_width, to_width) \
   auto vs2 = P.VU.elt<float##from_width##_t>(rs2_num, i); \
-  auto &vd = P.VU.elt<float##to_width##_t>(rd_num, i, true);
+  auto &vd = P.VU.elt<float##to_width##_t>(rd_num, i, DECODE_MACRO_USAGE_LOGGED);
 
 #define CVT_INT_TO_FP_PARAMS(from_width, to_width, sign) \
   auto vs2 = P.VU.elt<sign##from_width##_t>(rs2_num, i); \
-  auto &vd = P.VU.elt<float##to_width##_t>(rd_num, i, true);
+  auto &vd = P.VU.elt<float##to_width##_t>(rd_num, i, DECODE_MACRO_USAGE_LOGGED);
 
 #define CVT_FP_TO_INT_PARAMS(from_width, to_width, sign) \
   auto vs2 = P.VU.elt<float##from_width##_t>(rs2_num, i); \
-  auto &vd = P.VU.elt<sign##to_width##_t>(rd_num, i, true);
+  auto &vd = P.VU.elt<sign##to_width##_t>(rd_num, i, DECODE_MACRO_USAGE_LOGGED);
 
 //
 // vector: integer and masking operation loop
@@ -1002,19 +1002,19 @@ static inline bool is_overlapped_widen(const int astart, int asize,
   switch (P.VU.vsew) { \
   case e8: { \
     sign##16_t UNUSED vd_w = P.VU.elt<sign##16_t>(rd_num, i); \
-    P.VU.elt<uint16_t>(rd_num, i, true) = \
+    P.VU.elt<uint16_t>(rd_num, i, DECODE_MACRO_USAGE_LOGGED) = \
       op1((sign##16_t)(sign##8_t)var0 op0 (sign##16_t)(sign##8_t)var1) + var2; \
     } \
     break; \
   case e16: { \
     sign##32_t UNUSED vd_w = P.VU.elt<sign##32_t>(rd_num, i); \
-    P.VU.elt<uint32_t>(rd_num, i, true) = \
+    P.VU.elt<uint32_t>(rd_num, i, DECODE_MACRO_USAGE_LOGGED) = \
       op1((sign##32_t)(sign##16_t)var0 op0 (sign##32_t)(sign##16_t)var1) + var2; \
     } \
     break; \
   default: { \
     sign##64_t UNUSED vd_w = P.VU.elt<sign##64_t>(rd_num, i); \
-    P.VU.elt<uint64_t>(rd_num, i, true) = \
+    P.VU.elt<uint64_t>(rd_num, i, DECODE_MACRO_USAGE_LOGGED) = \
       op1((sign##64_t)(sign##32_t)var0 op0 (sign##64_t)(sign##32_t)var1) + var2; \
     } \
     break; \
@@ -1024,19 +1024,19 @@ static inline bool is_overlapped_widen(const int astart, int asize,
   switch (P.VU.vsew) { \
   case e8: { \
     sign##16_t UNUSED vd_w = P.VU.elt<sign##16_t>(rd_num, i); \
-    P.VU.elt<uint16_t>(rd_num, i, true) = \
+    P.VU.elt<uint16_t>(rd_num, i, DECODE_MACRO_USAGE_LOGGED) = \
       op((sign##16_t)(sign##8_t)var0, (sign##16_t)(sign##8_t)var1) + var2; \
     } \
     break; \
   case e16: { \
     sign##32_t UNUSED vd_w = P.VU.elt<sign##32_t>(rd_num, i); \
-    P.VU.elt<uint32_t>(rd_num, i, true) = \
+    P.VU.elt<uint32_t>(rd_num, i, DECODE_MACRO_USAGE_LOGGED) = \
       op((sign##32_t)(sign##16_t)var0, (sign##32_t)(sign##16_t)var1) + var2; \
     } \
     break; \
   default: { \
     sign##64_t UNUSED vd_w = P.VU.elt<sign##64_t>(rd_num, i); \
-    P.VU.elt<uint64_t>(rd_num, i, true) = \
+    P.VU.elt<uint64_t>(rd_num, i, DECODE_MACRO_USAGE_LOGGED) = \
       op((sign##64_t)(sign##32_t)var0, (sign##64_t)(sign##32_t)var1) + var2; \
     } \
     break; \
@@ -1046,19 +1046,19 @@ static inline bool is_overlapped_widen(const int astart, int asize,
   switch (P.VU.vsew) { \
   case e8: { \
     sign_d##16_t UNUSED vd_w = P.VU.elt<sign_d##16_t>(rd_num, i); \
-    P.VU.elt<uint16_t>(rd_num, i, true) = \
+    P.VU.elt<uint16_t>(rd_num, i, DECODE_MACRO_USAGE_LOGGED) = \
       op1((sign_1##16_t)(sign_1##8_t)var0 op0 (sign_2##16_t)(sign_2##8_t)var1) + var2; \
     } \
     break; \
   case e16: { \
     sign_d##32_t UNUSED vd_w = P.VU.elt<sign_d##32_t>(rd_num, i); \
-    P.VU.elt<uint32_t>(rd_num, i, true) = \
+    P.VU.elt<uint32_t>(rd_num, i, DECODE_MACRO_USAGE_LOGGED) = \
       op1((sign_1##32_t)(sign_1##16_t)var0 op0 (sign_2##32_t)(sign_2##16_t)var1) + var2; \
     } \
     break; \
   default: { \
     sign_d##64_t UNUSED vd_w = P.VU.elt<sign_d##64_t>(rd_num, i); \
-    P.VU.elt<uint64_t>(rd_num, i, true) = \
+    P.VU.elt<uint64_t>(rd_num, i, DECODE_MACRO_USAGE_LOGGED) = \
       op1((sign_1##64_t)(sign_1##32_t)var0 op0 (sign_2##64_t)(sign_2##32_t)var1) + var2; \
     } \
     break; \
@@ -1067,19 +1067,19 @@ static inline bool is_overlapped_widen(const int astart, int asize,
 #define VI_WIDE_WVX_OP(var0, op0, sign) \
   switch (P.VU.vsew) { \
   case e8: { \
-    sign##16_t &vd_w = P.VU.elt<sign##16_t>(rd_num, i, true); \
+    sign##16_t &vd_w = P.VU.elt<sign##16_t>(rd_num, i, DECODE_MACRO_USAGE_LOGGED); \
     sign##16_t vs2_w = P.VU.elt<sign##16_t>(rs2_num, i); \
     vd_w = vs2_w op0 (sign##16_t)(sign##8_t)var0; \
     } \
     break; \
   case e16: { \
-    sign##32_t &vd_w = P.VU.elt<sign##32_t>(rd_num, i, true); \
+    sign##32_t &vd_w = P.VU.elt<sign##32_t>(rd_num, i, DECODE_MACRO_USAGE_LOGGED); \
     sign##32_t vs2_w = P.VU.elt<sign##32_t>(rs2_num, i); \
     vd_w = vs2_w op0 (sign##32_t)(sign##16_t)var0; \
     } \
     break; \
   default: { \
-    sign##64_t &vd_w = P.VU.elt<sign##64_t>(rd_num, i, true); \
+    sign##64_t &vd_w = P.VU.elt<sign##64_t>(rd_num, i, DECODE_MACRO_USAGE_LOGGED); \
     sign##64_t vs2_w = P.VU.elt<sign##64_t>(rs2_num, i); \
     vd_w = vs2_w op0 (sign##64_t)(sign##32_t)var0; \
     } \
@@ -1268,7 +1268,7 @@ VI_VX_ULOOP({ \
       for (reg_t fn = 0; fn < nf; ++fn) { \
         elt_width##_t val = MMU.load<elt_width##_t>( \
           baseAddr + (stride) + (offset) * sizeof(elt_width##_t)); \
-        P.VU.elt<elt_width##_t>(vd + fn * emul, vreg_inx, true) = val; \
+        P.VU.elt<elt_width##_t>(vd + fn * emul, vreg_inx, DECODE_MACRO_USAGE_LOGGED) = val; \
       } \
     } VI_LDST_RETHROW(i); \
   } \
@@ -1308,19 +1308,19 @@ VI_VX_ULOOP({ \
       for (reg_t fn = 0; fn < nf; ++fn) { \
         switch (P.VU.vsew) { \
           case e8: \
-            P.VU.elt<uint8_t>(vd + fn * flmul, vreg_inx, true) = \
+            P.VU.elt<uint8_t>(vd + fn * flmul, vreg_inx, DECODE_MACRO_USAGE_LOGGED) = \
               MMU.load<uint8_t>(baseAddr + index + fn * 1); \
             break; \
           case e16: \
-            P.VU.elt<uint16_t>(vd + fn * flmul, vreg_inx, true) = \
+            P.VU.elt<uint16_t>(vd + fn * flmul, vreg_inx, DECODE_MACRO_USAGE_LOGGED) = \
               MMU.load<uint16_t>(baseAddr + index + fn * 2); \
             break; \
           case e32: \
-            P.VU.elt<uint32_t>(vd + fn * flmul, vreg_inx, true) = \
+            P.VU.elt<uint32_t>(vd + fn * flmul, vreg_inx, DECODE_MACRO_USAGE_LOGGED) = \
               MMU.load<uint32_t>(baseAddr + index + fn * 4); \
             break; \
           default: \
-            P.VU.elt<uint64_t>(vd + fn * flmul, vreg_inx, true) = \
+            P.VU.elt<uint64_t>(vd + fn * flmul, vreg_inx, DECODE_MACRO_USAGE_LOGGED) = \
               MMU.load<uint64_t>(baseAddr + index + fn * 8); \
             break; \
         } \
@@ -1413,7 +1413,7 @@ VI_VX_ULOOP({ \
         P.VU.vl->write_raw(i); \
         break; \
       } \
-      p->VU.elt<elt_width##_t>(rd_num + fn * emul, vreg_inx, true) = val; \
+      p->VU.elt<elt_width##_t>(rd_num + fn * emul, vreg_inx, DECODE_MACRO_USAGE_LOGGED) = val; \
     } \
     \
     if (early_stop) { \
@@ -1435,7 +1435,7 @@ VI_VX_ULOOP({ \
     VI_LDST_PREPARE_VSTART(i); \
     try { \
       auto val = MMU.load<elt_width##_t>(baseAddr + i * sizeof(elt_width ## _t)); \
-      P.VU.elt<elt_width ## _t>(vd, i, true) = val; \
+      P.VU.elt<elt_width ## _t>(vd, i, DECODE_MACRO_USAGE_LOGGED) = val; \
     } VI_LDST_RETHROW(i); \
   } \
   VECTOR_END;
@@ -1477,22 +1477,22 @@ VI_VX_ULOOP({ \
   reg_t pat = (((P.VU.vsew >> 3) << 4) | from >> 3); \
     switch (pat) { \
       case 0x21: \
-        P.VU.elt<type##16_t>(rd_num, i, true) = P.VU.elt<type##8_t>(rs2_num, i); \
+        P.VU.elt<type##16_t>(rd_num, i, DECODE_MACRO_USAGE_LOGGED) = P.VU.elt<type##8_t>(rs2_num, i); \
         break; \
       case 0x41: \
-        P.VU.elt<type##32_t>(rd_num, i, true) = P.VU.elt<type##8_t>(rs2_num, i); \
+        P.VU.elt<type##32_t>(rd_num, i, DECODE_MACRO_USAGE_LOGGED) = P.VU.elt<type##8_t>(rs2_num, i); \
         break; \
       case 0x81: \
-        P.VU.elt<type##64_t>(rd_num, i, true) = P.VU.elt<type##8_t>(rs2_num, i); \
+        P.VU.elt<type##64_t>(rd_num, i, DECODE_MACRO_USAGE_LOGGED) = P.VU.elt<type##8_t>(rs2_num, i); \
         break; \
       case 0x42: \
-        P.VU.elt<type##32_t>(rd_num, i, true) = P.VU.elt<type##16_t>(rs2_num, i); \
+        P.VU.elt<type##32_t>(rd_num, i, DECODE_MACRO_USAGE_LOGGED) = P.VU.elt<type##16_t>(rs2_num, i); \
         break; \
       case 0x82: \
-        P.VU.elt<type##64_t>(rd_num, i, true) = P.VU.elt<type##16_t>(rs2_num, i); \
+        P.VU.elt<type##64_t>(rd_num, i, DECODE_MACRO_USAGE_LOGGED) = P.VU.elt<type##16_t>(rs2_num, i); \
         break; \
       case 0x84: \
-        P.VU.elt<type##64_t>(rd_num, i, true) = P.VU.elt<type##32_t>(rs2_num, i); \
+        P.VU.elt<type##64_t>(rd_num, i, DECODE_MACRO_USAGE_LOGGED) = P.VU.elt<type##32_t>(rs2_num, i); \
         break; \
       default: \
         break; \
@@ -1578,9 +1578,9 @@ VI_VX_ULOOP({ \
                 softfloat_exceptionFlags |= softfloat_flag_invalid; \
                 set_fp_exceptions; \
               } \
-              P.VU.elt<uint16_t>(rd_num, 0, true) = defaultNaNF16UI; \
+              P.VU.elt<uint16_t>(rd_num, 0, DECODE_MACRO_USAGE_LOGGED) = defaultNaNF16UI; \
             } else { \
-              P.VU.elt<uint16_t>(rd_num, 0, true) = vd_0.v; \
+              P.VU.elt<uint16_t>(rd_num, 0, DECODE_MACRO_USAGE_LOGGED) = vd_0.v; \
             } \
           } \
           break; \
@@ -1591,9 +1591,9 @@ VI_VX_ULOOP({ \
                 softfloat_exceptionFlags |= softfloat_flag_invalid; \
                 set_fp_exceptions; \
               } \
-              P.VU.elt<uint32_t>(rd_num, 0, true) = defaultNaNF32UI; \
+              P.VU.elt<uint32_t>(rd_num, 0, DECODE_MACRO_USAGE_LOGGED) = defaultNaNF32UI; \
             } else { \
-              P.VU.elt<uint32_t>(rd_num, 0, true) = vd_0.v; \
+              P.VU.elt<uint32_t>(rd_num, 0, DECODE_MACRO_USAGE_LOGGED) = vd_0.v; \
             } \
           } \
           break; \
@@ -1604,15 +1604,15 @@ VI_VX_ULOOP({ \
                 softfloat_exceptionFlags |= softfloat_flag_invalid; \
                 set_fp_exceptions; \
               } \
-              P.VU.elt<uint64_t>(rd_num, 0, true) = defaultNaNF64UI; \
+              P.VU.elt<uint64_t>(rd_num, 0, DECODE_MACRO_USAGE_LOGGED) = defaultNaNF64UI; \
             } else { \
-              P.VU.elt<uint64_t>(rd_num, 0, true) = vd_0.v; \
+              P.VU.elt<uint64_t>(rd_num, 0, DECODE_MACRO_USAGE_LOGGED) = vd_0.v; \
             } \
           } \
           break; \
       } \
     } else { \
-      P.VU.elt<type_sew_t<x>::type>(rd_num, 0, true) = vd_0.v; \
+      P.VU.elt<type_sew_t<x>::type>(rd_num, 0, DECODE_MACRO_USAGE_LOGGED) = vd_0.v; \
     } \
   }
 
@@ -1857,7 +1857,7 @@ VI_VX_ULOOP({ \
   switch (P.VU.vsew) { \
     case e16: { \
       require_zvfbfa_or_zvfh; \
-      float32_t &vd = P.VU.elt<float32_t>(rd_num, i, true); \
+      float32_t &vd = P.VU.elt<float32_t>(rd_num, i, DECODE_MACRO_USAGE_LOGGED); \
       float32_t vs2 = P.VU.altfmt ? bf16_to_f32(P.VU.elt<bfloat16_t>(rs2_num, i)) \
                                   :  f16_to_f32(P.VU.elt<float16_t>(rs2_num, i)); \
       float32_t rs1 = P.VU.altfmt ? bf16_to_f32(FRS1_BF) \
@@ -1867,7 +1867,7 @@ VI_VX_ULOOP({ \
       break; \
     } \
     case e32: { \
-      float64_t &vd = P.VU.elt<float64_t>(rd_num, i, true); \
+      float64_t &vd = P.VU.elt<float64_t>(rd_num, i, DECODE_MACRO_USAGE_LOGGED); \
       float64_t vs2 = f32_to_f64(P.VU.elt<float32_t>(rs2_num, i)); \
       float64_t rs1 = f32_to_f64(FRS1_F); \
       BODY32; \
@@ -1886,7 +1886,7 @@ VI_VX_ULOOP({ \
   VI_VFP_BF16_LOOP_BASE \
   switch (P.VU.vsew) { \
     case e16: { \
-      float32_t &vd = P.VU.elt<float32_t>(rd_num, i, true); \
+      float32_t &vd = P.VU.elt<float32_t>(rd_num, i, DECODE_MACRO_USAGE_LOGGED); \
       float32_t vs2 = bf16_to_f32(P.VU.elt<bfloat16_t>(rs2_num, i)); \
       float32_t rs1 = bf16_to_f32(FRS1_BF); \
       BODY; \
@@ -1907,7 +1907,7 @@ VI_VX_ULOOP({ \
   switch (P.VU.vsew) { \
     case e16: { \
       require_zvfbfa; \
-      float32_t &vd = P.VU.elt<float32_t>(rd_num, i, true); \
+      float32_t &vd = P.VU.elt<float32_t>(rd_num, i, DECODE_MACRO_USAGE_LOGGED); \
       float32_t vs2 = P.VU.altfmt ? bf16_to_f32(P.VU.elt<float16_t>(rs2_num, i)) \
                                   :  f16_to_f32(P.VU.elt<float16_t>(rs2_num, i)); \
       float32_t vs1 = P.VU.altfmt ? bf16_to_f32(P.VU.elt<float16_t>(rs1_num, i)) \
@@ -1917,7 +1917,7 @@ VI_VX_ULOOP({ \
       break; \
     } \
     case e32: { \
-      float64_t &vd = P.VU.elt<float64_t>(rd_num, i, true); \
+      float64_t &vd = P.VU.elt<float64_t>(rd_num, i, DECODE_MACRO_USAGE_LOGGED); \
       float64_t vs2 = f32_to_f64(P.VU.elt<float32_t>(rs2_num, i)); \
       float64_t vs1 = f32_to_f64(P.VU.elt<float32_t>(rs1_num, i)); \
       BODY32; \
@@ -1936,7 +1936,7 @@ VI_VX_ULOOP({ \
   VI_VFP_BF16_LOOP_BASE \
   switch (P.VU.vsew) { \
     case e16: { \
-      float32_t &vd = P.VU.elt<float32_t>(rd_num, i, true); \
+      float32_t &vd = P.VU.elt<float32_t>(rd_num, i, DECODE_MACRO_USAGE_LOGGED); \
       float32_t vs2 = bf16_to_f32(P.VU.elt<bfloat16_t>(rs2_num, i)); \
       float32_t vs1 = bf16_to_f32(P.VU.elt<bfloat16_t>(rs1_num, i)); \
       BODY; \
@@ -1957,7 +1957,7 @@ VI_VX_ULOOP({ \
   switch (P.VU.vsew) { \
     case e16: { \
       require_zvfbfa; \
-      float32_t &vd = P.VU.elt<float32_t>(rd_num, i, true); \
+      float32_t &vd = P.VU.elt<float32_t>(rd_num, i, DECODE_MACRO_USAGE_LOGGED); \
       float32_t vs2 = P.VU.elt<float32_t>(rs2_num, i); \
       float32_t rs1 = P.VU.altfmt ? bf16_to_f32(FRS1_BF) \
                                   :  f16_to_f32(FRS1_H); \
@@ -1966,7 +1966,7 @@ VI_VX_ULOOP({ \
       break; \
     } \
     case e32: { \
-      float64_t &vd = P.VU.elt<float64_t>(rd_num, i, true); \
+      float64_t &vd = P.VU.elt<float64_t>(rd_num, i, DECODE_MACRO_USAGE_LOGGED); \
       float64_t vs2 = P.VU.elt<float64_t>(rs2_num, i); \
       float64_t rs1 = f32_to_f64(FRS1_F); \
       BODY32; \
@@ -1985,7 +1985,7 @@ VI_VX_ULOOP({ \
   VI_VFP_LOOP_BASE \
   switch (P.VU.vsew) { \
     case e16: { \
-      float32_t &vd = P.VU.elt<float32_t>(rd_num, i, true); \
+      float32_t &vd = P.VU.elt<float32_t>(rd_num, i, DECODE_MACRO_USAGE_LOGGED); \
       float32_t vs2 = P.VU.elt<float32_t>(rs2_num, i); \
       float32_t vs1 = P.VU.altfmt ? bf16_to_f32(P.VU.elt<bfloat16_t>(rs1_num, i)) \
                                   :  f16_to_f32(P.VU.elt<float16_t>(rs1_num, i)); \
@@ -1994,7 +1994,7 @@ VI_VX_ULOOP({ \
       break; \
     } \
     case e32: { \
-      float64_t &vd = P.VU.elt<float64_t>(rd_num, i, true); \
+      float64_t &vd = P.VU.elt<float64_t>(rd_num, i, DECODE_MACRO_USAGE_LOGGED); \
       float64_t vs2 = P.VU.elt<float64_t>(rs2_num, i); \
       float64_t vs1 = f32_to_f64(P.VU.elt<float32_t>(rs1_num, i)); \
       BODY32; \
@@ -2282,7 +2282,7 @@ c_t generic_dot_product(const std::vector<a_t>& a, const std::vector<b_t>& b, c_
     a[i] = P.VU.elt<a_t>(insn.rs1(), i); \
     b[i] = P.VU.elt<b_t>(insn.rs2(), i); \
   } \
-  auto& acc = P.VU.elt<c_t>(insn.rd(), 0, true); \
+  auto& acc = P.VU.elt<c_t>(insn.rd(), 0, DECODE_MACRO_USAGE_LOGGED); \
   acc = dot(a, b, acc); \
   set_fp_exceptions;
 
@@ -2304,7 +2304,7 @@ c_t generic_dot_product(const std::vector<a_t>& a, const std::vector<b_t>& b, c_
       a[k] = P.VU.elt<a_t>(insn.rs1(), k); \
       b[k] = P.VU.elt<b_t>(vs2 + idx, k); \
     } \
-    auto& acc = P.VU.elt<c_t>(insn.rd(), i, true); \
+    auto& acc = P.VU.elt<c_t>(insn.rd(), i, DECODE_MACRO_USAGE_LOGGED); \
     acc = dot(a, b, acc); \
     set_fp_exceptions; \
   }

--- a/riscv/vector_unit.h
+++ b/riscv/vector_unit.h
@@ -104,19 +104,21 @@ public:
   // vector element for various SEW
   template<typename T> T& elt(reg_t vReg, reg_t n, bool is_write = false) {
     assert(vsew != 0);
-    assert((VLEN >> 3)/sizeof(T) > 0);
-    reg_t elts_per_reg = (VLEN >> 3) / (sizeof(T));
-    vReg += n / elts_per_reg;
-    n = n % elts_per_reg;
+    assert(vlenb / sizeof(T) > 0);
+    static_assert((sizeof(T) & (sizeof(T) - 1)) == 0);
+    const reg_t elements_per_reg = vlenb / sizeof(T);
+    const unsigned elements_per_reg_log2 = __builtin_ctzll(elements_per_reg);
+    vReg += n >> elements_per_reg_log2;
+    n &= elements_per_reg - 1;
 #ifdef WORDS_BIGENDIAN
     // "V" spec 0.7.1 requires lower indices to map to lower significant
     // bits when changing SEW, thus we need to index from the end on BE.
-    n ^= elts_per_reg - 1;
+    n ^= elements_per_reg - 1;
 #endif
     if (is_write)
       log_elt_write_if_needed(vReg);
 
-    T *regStart = (T*)((char*)reg_file + vReg * (VLEN >> 3));
+    T *regStart = (T*)((char*)reg_file + vReg * vlenb);
     return regStart[n];
   }
 

--- a/riscv/vector_unit.h
+++ b/riscv/vector_unit.h
@@ -170,15 +170,28 @@ public:
     return *(EG*)((char*)reg_file + vReg * (VLEN >> 3) + start_byte);
   }
 
+private:
+  uint8_t& mask_byte(reg_t vReg, reg_t n)
+  {
+    reg_t byte = n >> 3;
+#ifdef WORDS_BIGENDIAN
+    byte ^= vlenb - 1;
+#endif
+    return static_cast<uint8_t*>(reg_file)[vReg * vlenb + byte];
+  }
+
+public:
   bool mask_elt(reg_t vReg, reg_t n)
   {
-    return (elt<uint8_t>(vReg, n / 8) >> (n % 8)) & 1;
+    return (mask_byte(vReg, n) >> (n & 7)) & 1;
   }
 
   void set_mask_elt(reg_t vReg, reg_t n, bool value)
   {
-    auto& e = elt<uint8_t>(vReg, n / 8, true);
-    e = (e & ~(1U << (n % 8))) | (value << (n % 8));
+    log_elt_write_if_needed(vReg);
+    auto& e = mask_byte(vReg, n);
+    const uint8_t bit = 1U << (n & 7);
+    e = (e & ~bit) | (value ? bit : 0);
   }
 
 private:

--- a/riscv/zvzip_ext_macros.h
+++ b/riscv/zvzip_ext_macros.h
@@ -44,7 +44,7 @@
 
 #define VI_VZIP_VV_LOOP_END \
   } \
-  P.VU.vstart->write(0);
+  WRITE_VSTART(0);
 
 #define VI_VZIP_VV_LOOP(VS1_IDX, VS2_IDX) \
   VI_VZIP_VV_CHECK \

--- a/scripts/build-clang-perf.sh
+++ b/scripts/build-clang-perf.sh
@@ -1,0 +1,147 @@
+#!/bin/sh
+
+set -eu
+
+usage()
+{
+  cat <<'EOF'
+Usage: scripts/build-clang-perf.sh [CONFIGURE-OPTION...]
+
+Configure and build an optimized Spike binary with Clang and ThinLTO.  The
+build directory must be empty so that objects compiled with different flags
+cannot be reused accidentally.
+
+Environment variables:
+  SPIKE_BUILD_DIR          Build directory (default: build-clang-perf)
+  SPIKE_PREFIX             Install prefix (default: BUILD_DIR/install)
+  SPIKE_LLVM_VERSION       Versioned LLVM tool suffix (default: 21)
+  SPIKE_JOBS               Parallel build jobs (default: online CPUs, max 16)
+  SPIKE_PERF_FLAGS         C/C++ optimization flags
+                           (default: -O3 -march=native -flto=thin)
+  SPIKE_EXTRA_CFLAGS       Additional C compiler flags
+  SPIKE_EXTRA_CXXFLAGS     Additional C++ compiler flags
+  SPIKE_EXTRA_LDFLAGS      Additional linker flags
+  SPIKE_PGO_GENERATE_DIR   Build an instrumented binary writing raw profiles
+  SPIKE_PGO_PROFILE        Build using an existing merged .profdata file
+  RISCV_FAST_ALU_CFLAGS    Optional flags for selected integer handlers
+  CC, CXX, AR, RANLIB      LLVM tool overrides
+  MAKE                     Make implementation (default: make)
+
+SPIKE_PGO_GENERATE_DIR and SPIKE_PGO_PROFILE are mutually exclusive.  Train
+an instrumented binary with representative workloads, merge its .profraw
+files with llvm-profdata, then use a separate build directory with
+SPIKE_PGO_PROFILE set to the merged file.
+
+Zen 2 benchmark configuration:
+  RISCV_FAST_ALU_CFLAGS=-mno-bmi scripts/build-clang-perf.sh
+EOF
+}
+
+die()
+{
+  echo "build-clang-perf: $*" >&2
+  exit 1
+}
+
+require_tool()
+{
+  command -v "$1" >/dev/null 2>&1 || die "required tool not found: $1"
+}
+
+case "${1-}" in
+  -h|--help)
+    usage
+    exit 0
+    ;;
+esac
+
+src_dir=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+build_dir=${SPIKE_BUILD_DIR:-"$src_dir/build-clang-perf"}
+
+if test -d "$build_dir" &&
+   test -n "$(find "$build_dir" -mindepth 1 -maxdepth 1 -print -quit)"; then
+  die "build directory is not empty: $build_dir"
+fi
+
+mkdir -p "$build_dir"
+build_dir=$(CDPATH= cd -- "$build_dir" && pwd)
+prefix=${SPIKE_PREFIX:-"$build_dir/install"}
+
+llvm_version=${SPIKE_LLVM_VERSION:-21}
+cc=${CC:-clang-$llvm_version}
+cxx=${CXX:-clang++-$llvm_version}
+ar=${AR:-llvm-ar-$llvm_version}
+ranlib=${RANLIB:-llvm-ranlib-$llvm_version}
+make=${MAKE:-make}
+
+require_tool "$cc"
+require_tool "$cxx"
+require_tool "$ar"
+require_tool "$ranlib"
+require_tool "$make"
+
+clang_version=$($cc --version | sed -n '1p')
+case "$clang_version" in
+  *"clang version $llvm_version."*|*"clang version $llvm_version "*) ;;
+  *) die "expected Clang $llvm_version, found: $clang_version" ;;
+esac
+
+jobs=${SPIKE_JOBS:-}
+if test -z "$jobs"; then
+  jobs=$(getconf _NPROCESSORS_ONLN 2>/dev/null || echo 1)
+fi
+case "$jobs" in
+  ''|*[!0-9]*) die "SPIKE_JOBS must be a positive integer" ;;
+esac
+test "$jobs" -gt 0 || die "SPIKE_JOBS must be a positive integer"
+if test -z "${SPIKE_JOBS:-}" && test "$jobs" -gt 16; then
+  jobs=16
+fi
+
+perf_flags=${SPIKE_PERF_FLAGS:-"-O3 -march=native -flto=thin"}
+cflags="$perf_flags${SPIKE_EXTRA_CFLAGS:+ $SPIKE_EXTRA_CFLAGS}"
+cxxflags="$perf_flags${SPIKE_EXTRA_CXXFLAGS:+ $SPIKE_EXTRA_CXXFLAGS}"
+ldflags="-flto=thin${SPIKE_EXTRA_LDFLAGS:+ $SPIKE_EXTRA_LDFLAGS}"
+
+pgo_generate_dir=${SPIKE_PGO_GENERATE_DIR:-}
+pgo_profile=${SPIKE_PGO_PROFILE:-}
+if test -n "$pgo_generate_dir" && test -n "$pgo_profile"; then
+  die "SPIKE_PGO_GENERATE_DIR and SPIKE_PGO_PROFILE are mutually exclusive"
+fi
+
+if test -n "$pgo_generate_dir"; then
+  mkdir -p "$pgo_generate_dir"
+  pgo_generate_dir=$(CDPATH= cd -- "$pgo_generate_dir" && pwd)
+  pgo_flag="-fprofile-generate=$pgo_generate_dir"
+  cflags="$cflags $pgo_flag"
+  cxxflags="$cxxflags $pgo_flag"
+  ldflags="$ldflags $pgo_flag"
+elif test -n "$pgo_profile"; then
+  test -f "$pgo_profile" || die "PGO profile not found: $pgo_profile"
+  pgo_profile_dir=$(CDPATH= cd -- "$(dirname -- "$pgo_profile")" && pwd)
+  pgo_profile="$pgo_profile_dir/$(basename -- "$pgo_profile")"
+  pgo_flag="-fprofile-use=$pgo_profile"
+  profile_warnings="-Wno-profile-instr-unprofiled -Wno-profile-instr-out-of-date"
+  cflags="$cflags $pgo_flag $profile_warnings"
+  cxxflags="$cxxflags $pgo_flag $profile_warnings"
+  ldflags="$ldflags $pgo_flag"
+fi
+
+echo "Configuring Clang $llvm_version ThinLTO build in $build_dir"
+(
+  cd "$build_dir"
+  CC="$cc" \
+  CXX="$cxx" \
+  AR="$ar" \
+  RANLIB="$ranlib" \
+  CFLAGS="$cflags" \
+  CXXFLAGS="$cxxflags" \
+  LDFLAGS="$ldflags" \
+    "$src_dir/configure" --prefix="$prefix" "$@"
+)
+
+echo "Building Spike with $jobs jobs"
+"$make" -C "$build_dir" -j"$jobs" \
+  RISCV_FAST_ALU_CFLAGS="${RISCV_FAST_ALU_CFLAGS:-}" spike
+
+echo "Built $build_dir/spike"


### PR DESCRIPTION
I was doing some work that required heavy use of this simulator, and did some work to speed it up.

The speedups are mostly small code interventions, not major rewrites. Spread across ~28 commits.
Some lanes don't speed up at all on ARM64 arch.

As far as I can see, all tests pass and all output logs are byte-identical from start to end.

## Speedups

| Benchmark lane | Zen 2 reduction | Zen 2 speedup | Neoverse V3AE reduction | Neoverse V3AE speedup |
| --- | ---: | ---: | ---: | ---: |
| Integer | 25.2% | 1.34x | 0.2% | 1.00x |
| Branch | 11.4% | 1.13x | -1.0% | 0.99x |
| Memory | 8.9% | 1.10x | 0.6% | 1.01x |
| Floating point | 77.2% | 4.39x | 64.0% | 2.78x |
| CSR | 66.0% | 2.94x | 32.6% | 1.48x |
| Indirect CSR | 62.9% | 2.69x | 69.0% | 3.23x |
| Vector | 77.0% | 4.34x | 72.3% | 3.62x |
| Vector mask | 66.9% | 3.02x | 62.0% | 2.63x |
| Vector slide | 67.0% | 3.03x | 60.6% | 2.54x |

Notably, the winning builds uses Clang 21 with ThinLTO. 
That build path is in the PR as `scripts/build-clang-perf.sh`, but could/should be reworked into a build system PR.