### PR TITLE
allow different clint size

### DIFF
--- a/riscv/cfg.cc
+++ b/riscv/cfg.cc
@@ -45,6 +45,7 @@ cfg_t::cfg_t()
   hartids          = std::vector<size_t>({0});
   explicit_hartids = false;
   real_time_clint  = false;
+  clint_size       = CLINT_SIZE;
   trigger_count    = 4;
   cache_blocksz    = 64;
 }

--- a/riscv/cfg.h
+++ b/riscv/cfg.h
@@ -91,6 +91,7 @@ public:
   std::vector<size_t>     hartids;
   bool                    explicit_hartids;
   bool                    real_time_clint;
+  reg_t                   clint_size;
   reg_t                   trigger_count;
   reg_t                   cache_blocksz;
   std::optional<abstract_sim_if_t*> external_simulator;

--- a/riscv/clint.cc
+++ b/riscv/clint.cc
@@ -6,8 +6,8 @@
 #include "sim.h"
 #include "dts.h"
 
-clint_t::clint_t(const simif_t* sim, uint64_t freq_hz, bool real_time)
-  : sim(sim), freq_hz(freq_hz), real_time(real_time), mtime(0)
+clint_t::clint_t(const simif_t* sim, uint64_t freq_hz, bool real_time, reg_t size)
+  : sim(sim), freq_hz(freq_hz), real_time(real_time), sz(size), mtime(0)
 {
   struct timeval base;
 
@@ -56,7 +56,7 @@ bool clint_t::load(reg_t addr, size_t len, uint8_t* bytes)
     read_little_endian_reg(res, addr, len, bytes);
   } else if (addr >= MTIME_BASE && addr < MTIME_BASE + sizeof(mtime_t)) {
     read_little_endian_reg(mtime, addr, len, bytes);
-  } else if (addr + len <= CLINT_SIZE) {
+  } else if (addr + len <= sz) {
     memset(bytes, 0, len);
   } else {
     return false;
@@ -90,7 +90,7 @@ bool clint_t::store(reg_t addr, size_t len, const uint8_t* bytes)
       write_little_endian_reg(&mtimecmp[hart_id], addr, len, bytes);
   } else if (addr >= MTIME_BASE && addr < MTIME_BASE + sizeof(mtime_t)) {
     write_little_endian_reg(&mtime, addr, len, bytes);
-  } else if (addr + len <= CLINT_SIZE) {
+  } else if (addr + len <= sz) {
     // Do nothing
   } else {
     return false;
@@ -120,10 +120,12 @@ void clint_t::tick(reg_t rtc_ticks)
 
 clint_t* clint_parse_from_fdt(const void* fdt, const sim_t* sim, reg_t* base,
     const std::vector<std::string>& sargs UNUSED) {
-  if (fdt_parse_clint(fdt, base, "riscv,clint0") == 0 || fdt_parse_clint(fdt, base, "sifive,clint0") == 0)
+  unsigned long size;
+  if (fdt_parse_clint(fdt, base, &size, "riscv,clint0") == 0 || fdt_parse_clint(fdt, base, &size, "sifive,clint0") == 0)
     return new clint_t(sim,
                        sim->CPU_HZ / sim->INSNS_PER_RTC_TICK,
-                       sim->get_cfg().real_time_clint);
+                       sim->get_cfg().real_time_clint,
+                       size);
   else
     return nullptr;
 }
@@ -137,7 +139,7 @@ std::string clint_generate_dts(const sim_t* sim, const std::vector<std::string>&
   for (size_t i = 0; i < sim->get_cfg().nprocs(); i++)
     s << "&CPU" << i << "_intc 3 &CPU" << i << "_intc 7 ";
   reg_t clintbs = CLINT_BASE;
-  reg_t clintsz = CLINT_SIZE;
+  reg_t clintsz = sim->get_cfg().clint_size;
   s << std::hex << ">;\n"
     "      reg = <0x" << (clintbs >> 32) << " 0x" << (clintbs & (uint32_t)-1) <<
     " 0x" << (clintsz >> 32) << " 0x" << (clintsz & (uint32_t)-1) << ">;\n"

--- a/riscv/devices.h
+++ b/riscv/devices.h
@@ -93,10 +93,10 @@ private:
 
 class clint_t : public abstract_device_t {
  public:
-  clint_t(const simif_t*, uint64_t freq_hz, bool real_time);
+  clint_t(const simif_t*, uint64_t freq_hz, bool real_time, reg_t size);
   bool load(reg_t addr, size_t len, uint8_t* bytes) override;
   bool store(reg_t addr, size_t len, const uint8_t* bytes) override;
-  reg_t size() override { return CLINT_SIZE; }
+  reg_t size() override { return sz; }
   void tick(reg_t rtc_ticks) override;
   uint64_t get_mtimecmp(reg_t hartid) { return mtimecmp[hartid]; }
   uint64_t get_mtime() { return mtime; }
@@ -107,6 +107,7 @@ class clint_t : public abstract_device_t {
   const simif_t* sim;
   uint64_t freq_hz;
   bool real_time;
+  reg_t sz;
   uint64_t real_time_ref_secs;
   uint64_t real_time_ref_usecs;
   mtime_t mtime;

--- a/riscv/dts.cc
+++ b/riscv/dts.cc
@@ -277,7 +277,7 @@ int fdt_get_next_subnode(const void *fdt, int node)
 }
 
 int fdt_parse_clint(const void *fdt, reg_t *clint_addr,
-                    const char *compatible)
+                    unsigned long *clint_size, const char *compatible)
 {
   int nodeoffset, rc;
 
@@ -285,7 +285,7 @@ int fdt_parse_clint(const void *fdt, reg_t *clint_addr,
   if (nodeoffset < 0)
     return nodeoffset;
 
-  rc = fdt_get_node_addr_size(fdt, nodeoffset, clint_addr, NULL, "reg");
+  rc = fdt_get_node_addr_size(fdt, nodeoffset, clint_addr, clint_size, "reg");
   if (rc < 0 || !clint_addr)
     return -ENODEV;
 

--- a/riscv/dts.h
+++ b/riscv/dts.h
@@ -21,7 +21,7 @@ int fdt_get_first_subnode(const void *fdt, int node);
 int fdt_get_next_subnode(const void *fdt, int node);
 
 int fdt_parse_clint(const void *fdt, reg_t *clint_addr,
-                    const char *compatible);
+                    unsigned long *clint_size, const char *compatible);
 int fdt_parse_plic(const void *fdt, reg_t *plic_addr, uint32_t *ndev,
                    const char *compatible);
 int fdt_parse_ns16550(const void *fdt, reg_t *ns16550_addr,

--- a/spike_main/spike.cc
+++ b/spike_main/spike.cc
@@ -71,6 +71,7 @@ static void help(int exit_code = 1)
   fprintf(stderr, "  --bootargs=<args>     Provide custom bootargs for kernel [default: %s]\n",
           DEFAULT_KERNEL_BOOTARGS);
   fprintf(stderr, "  --real-time-clint     Increment clint time at real-time rate\n");
+  fprintf(stderr, "  --clint-size=<n>      Set clint MMIO region size [default 0xc0000]\n");
   fprintf(stderr, "  --triggers=<n>        Number of supported triggers [default 4]\n");
   fprintf(stderr, "  --dm-progsize=<words> Progsize for the debug module [default 2]\n");
   fprintf(stderr, "  --dm-datacount=<n>    Number of data registers available for the debug module [default 2]\n");
@@ -426,6 +427,7 @@ int main(int argc, char** argv)
   parser.option(0, "initrd", 1, [&](const char* s){initrd = s;});
   parser.option(0, "bootargs", 1, [&](const char* s){cfg.bootargs = s;});
   parser.option(0, "real-time-clint", 0, [&](const char UNUSED *s){cfg.real_time_clint = true;});
+  parser.option(0, "clint-size", 1, [&](const char *s){cfg.clint_size = strtoull(s, nullptr, 0);});
   parser.option(0, "triggers", 1, [&](const char *s){cfg.trigger_count = atoul_safe(s);});
   parser.option(0, "extlib", 1, [&](const char *s){
     void *lib = dlopen(s, RTLD_NOW | RTLD_GLOBAL);


### PR DESCRIPTION
In some cases `clint` we use has different size. This PR allows setting `clint` size, rather than hacking `platform.h` file. Default value remains the same. 