### PR TITLE
Fix PNCLIPUP.W by avoiding signed arithmetic

### DIFF
--- a/riscv/insns/pnclipiu_b.h
+++ b/riscv/insns/pnclipiu_b.h
@@ -1,4 +1,4 @@
 require_rv32;
 P_NARROW_RD_RS1_ULOOP(8, 16, {
-    p_rd = P_USAT_FULL(8, (sreg_t)(p_rs1 >> insn.shamth()));
+    p_rd = P_USAT_FULL(8, p_rs1 >> insn.shamth());
 })

--- a/riscv/insns/pnclipiu_h.h
+++ b/riscv/insns/pnclipiu_h.h
@@ -1,4 +1,4 @@
 require_rv32;
 P_NARROW_RD_RS1_ULOOP(16, 32, {
-    p_rd = P_USAT_FULL(16, (sreg_t)(p_rs1 >> insn.shamtw()));
+    p_rd = P_USAT_FULL(16, p_rs1 >> insn.shamtw());
 })

--- a/riscv/insns/pnclipp_b.h
+++ b/riscv/insns/pnclipp_b.h
@@ -6,7 +6,6 @@ reg_t s_high = RS2;
 for (int i = 0; i < 8; i++) {
   sreg_t s_h = (i < 4) ? P_FIELD(s_low, i, 16) : P_FIELD(s_high, i - 4, 16);
   sreg_t sat_val = P_SAT(8, s_h);
-  if (sat_val != s_h) P.set_vxsat();
   rd_tmp = set_field(rd_tmp, make_mask64(i * 8, 8), (uint8_t)sat_val);
 }
 WRITE_RD(rd_tmp);

--- a/riscv/insns/pnclipp_h.h
+++ b/riscv/insns/pnclipp_h.h
@@ -6,7 +6,6 @@ reg_t s_high = RS2;
 for (int i = 0; i < 4; i++) {
   sreg_t s_w = (i < 2) ? P_FIELD(s_low, i, 32) : P_FIELD(s_high, i - 2, 32);
   sreg_t sat_val = P_SAT(16, s_w);
-  if (sat_val != s_w) P.set_vxsat();
   rd_tmp = set_field(rd_tmp, make_mask64(i * 16, 16), (uint16_t)sat_val);
 }
 WRITE_RD(rd_tmp);

--- a/riscv/insns/pnclipp_w.h
+++ b/riscv/insns/pnclipp_w.h
@@ -4,10 +4,7 @@ int64_t s1 = (int64_t)RS1;
 int64_t s2 = (int64_t)RS2;
 
 sreg_t sat_w0 = P_SAT(32, s1);
-if (sat_w0 != s1) P.set_vxsat();
-
 sreg_t sat_w1 = P_SAT(32, s2);
-if (sat_w1 != s2) P.set_vxsat();
 
 WRITE_RD(((uint64_t)(uint32_t)sat_w1 << 32) | (uint32_t)sat_w0);
 

--- a/riscv/insns/pnclipriu_b.h
+++ b/riscv/insns/pnclipriu_b.h
@@ -9,5 +9,5 @@ P_NARROW_RD_RS1_ULOOP(8, 16, {
         uint32_t roundbit = (p_rs1 >> (shamt - 1)) & 1;
         result = shifted + roundbit;
     }
-    p_rd = P_USAT_FULL(8, (sreg_t)result);
+    p_rd = P_USAT_FULL(8, result);
 })

--- a/riscv/insns/pnclipriu_h.h
+++ b/riscv/insns/pnclipriu_h.h
@@ -9,5 +9,5 @@ P_NARROW_RD_RS1_ULOOP(16, 32, {
         uint32_t roundbit = (p_rs1 >> (shamt - 1)) & 1;
         result = shifted + roundbit;
     }
-    p_rd = P_USAT_FULL(16, (sreg_t)result);
+    p_rd = P_USAT_FULL(16, result);
 })

--- a/riscv/insns/pnclipru_bs.h
+++ b/riscv/insns/pnclipru_bs.h
@@ -9,5 +9,5 @@ P_NARROW_RD_RS1_ULOOP(8, 16, {
         uint32_t roundbit = (p_rs1 >> (shamt - 1)) & 1;
         result = shifted + roundbit;
     }
-    p_rd = P_USAT_FULL(8, (sreg_t)result);
+    p_rd = P_USAT_FULL(8, result);
 })

--- a/riscv/insns/pnclipru_hs.h
+++ b/riscv/insns/pnclipru_hs.h
@@ -9,5 +9,5 @@ P_NARROW_RD_RS1_ULOOP(16, 32, {
         uint32_t roundbit = (p_rs1 >> (shamt - 1)) & 1;
         result = shifted + roundbit;
     }
-    p_rd = P_USAT_FULL(16, (sreg_t)result);
+    p_rd = P_USAT_FULL(16, result);
 })

--- a/riscv/insns/pnclipu_bs.h
+++ b/riscv/insns/pnclipu_bs.h
@@ -1,4 +1,4 @@
 require_rv32;
 P_NARROW_RD_RS1_ULOOP(8, 16, {
-    p_rd = P_USAT_FULL(8, (sreg_t)(p_rs1 >> (P_UFIELD(RS2, 0, 8) & 0xF)));
+    p_rd = P_USAT_FULL(8, p_rs1 >> (P_UFIELD(RS2, 0, 8) & 0xF));
 })

--- a/riscv/insns/pnclipu_hs.h
+++ b/riscv/insns/pnclipu_hs.h
@@ -1,4 +1,4 @@
 require_rv32;
 P_NARROW_RD_RS1_ULOOP(16, 32, {
-    p_rd = P_USAT_FULL(16, (sreg_t)(p_rs1 >> (P_UFIELD(RS2, 0, 16) & 0X1F)));
+    p_rd = P_USAT_FULL(16, p_rs1 >> (P_UFIELD(RS2, 0, 16) & 0X1F));
 })

--- a/riscv/insns/pnclipup_b.h
+++ b/riscv/insns/pnclipup_b.h
@@ -5,7 +5,7 @@ reg_t s_low = RS1;
 reg_t s_high = RS2;
 for (int i = 0; i < 8; i++) {
   reg_t s_h = (i < 4) ? P_UFIELD(s_low, i, 16) : P_UFIELD(s_high, i - 4, 16);
-  reg_t sat_val = P_USAT_FULL(8, (sreg_t)s_h);
+  reg_t sat_val = P_USAT_FULL(8, s_h);
   if (sat_val != s_h) P.set_vxsat();
   rd_tmp = set_field(rd_tmp, make_mask64(i * 8, 8), (uint8_t)sat_val);
 }

--- a/riscv/insns/pnclipup_b.h
+++ b/riscv/insns/pnclipup_b.h
@@ -6,7 +6,6 @@ reg_t s_high = RS2;
 for (int i = 0; i < 8; i++) {
   reg_t s_h = (i < 4) ? P_UFIELD(s_low, i, 16) : P_UFIELD(s_high, i - 4, 16);
   reg_t sat_val = P_USAT_FULL(8, s_h);
-  if (sat_val != s_h) P.set_vxsat();
   rd_tmp = set_field(rd_tmp, make_mask64(i * 8, 8), (uint8_t)sat_val);
 }
 WRITE_RD(rd_tmp);

--- a/riscv/insns/pnclipup_h.h
+++ b/riscv/insns/pnclipup_h.h
@@ -6,7 +6,6 @@ reg_t s_high = RS2;
 for (int i = 0; i < 4; i++) {
   reg_t s_w = (i < 2) ? P_UFIELD(s_low, i, 32) : P_UFIELD(s_high, i - 2, 32);
   reg_t sat_val = P_USAT_FULL(16, s_w);
-  if (sat_val != s_w) P.set_vxsat();
   rd_tmp = set_field(rd_tmp, make_mask64(i * 16, 16), (uint16_t)sat_val);
 }
 WRITE_RD(rd_tmp);

--- a/riscv/insns/pnclipup_h.h
+++ b/riscv/insns/pnclipup_h.h
@@ -5,7 +5,7 @@ reg_t s_low = RS1;
 reg_t s_high = RS2;
 for (int i = 0; i < 4; i++) {
   reg_t s_w = (i < 2) ? P_UFIELD(s_low, i, 32) : P_UFIELD(s_high, i - 2, 32);
-  reg_t sat_val = P_USAT_FULL(16, (sreg_t)s_w);
+  reg_t sat_val = P_USAT_FULL(16, s_w);
   if (sat_val != s_w) P.set_vxsat();
   rd_tmp = set_field(rd_tmp, make_mask64(i * 16, 16), (uint16_t)sat_val);
 }

--- a/riscv/insns/pnclipup_w.h
+++ b/riscv/insns/pnclipup_w.h
@@ -3,10 +3,10 @@ require_rv64;
 uint64_t s1 = RS1;
 uint64_t s2 = RS2;
 
-reg_t sat_w0 = P_USAT_FULL(32, (sreg_t)s1);
+reg_t sat_w0 = P_USAT_FULL(32, s1);
 if (sat_w0 != s1) P.set_vxsat();
 
-reg_t sat_w1 = P_USAT_FULL(32, (sreg_t)s2);
+reg_t sat_w1 = P_USAT_FULL(32, s2);
 if (sat_w1 != s2) P.set_vxsat();
 
 WRITE_RD(((uint64_t)(uint32_t)sat_w1 << 32) | (uint32_t)sat_w0);

--- a/riscv/insns/pnclipup_w.h
+++ b/riscv/insns/pnclipup_w.h
@@ -4,10 +4,7 @@ uint64_t s1 = RS1;
 uint64_t s2 = RS2;
 
 reg_t sat_w0 = P_USAT_FULL(32, s1);
-if (sat_w0 != s1) P.set_vxsat();
-
 reg_t sat_w1 = P_USAT_FULL(32, s2);
-if (sat_w1 != s2) P.set_vxsat();
 
 WRITE_RD(((uint64_t)(uint32_t)sat_w1 << 32) | (uint32_t)sat_w0);
 

--- a/riscv/p_ext_macros.h
+++ b/riscv/p_ext_macros.h
@@ -767,11 +767,10 @@
 })
 
 #define P_USAT_FULL(BIT, R) ({ \
-  sreg_t _pusatf_in = (R); \
-  sreg_t _pusatf_out; \
-  if (_pusatf_in < 0) _pusatf_out = 0; \
-  else if ((BIT) >= 64) _pusatf_out = _pusatf_in; \
-  else if (_pusatf_in > (sreg_t)((reg_t(1) << (BIT)) - 1)) _pusatf_out = (sreg_t)((reg_t(1) << (BIT)) - 1); \
+  reg_t _pusatf_in = (R); \
+  reg_t _pusatf_out; \
+  if ((BIT) == 64) _pusatf_out = _pusatf_in; \
+  else if (_pusatf_in > (reg_t(1) << (BIT)) - 1) _pusatf_out = (reg_t(1) << (BIT)) - 1; \
   else _pusatf_out = _pusatf_in; \
   if (_pusatf_out != _pusatf_in) P.set_vxsat(); \
   _pusatf_out; \


### PR DESCRIPTION
The poorly named P_USAT_FULL macro is only used by the unsigned clip instructions, so using signed arithmetic never made sense, even though it was benign in cases where the inputs were narrower than 64 bits.

Fixes #2350

@mattiamirigaldi @chihminchao 