### PR TITLE
changed default clint size

### DIFF
--- a/riscv/platform.h
+++ b/riscv/platform.h
@@ -7,7 +7,7 @@
 #define DEFAULT_ISA        "rv64imafdc_zicntr_zihpm"
 #define DEFAULT_PRIV       "MSU"
 #define CLINT_BASE         0x02000000
-#define CLINT_SIZE         0x000c0000
+#define CLINT_SIZE         0x0000c000
 #define PLIC_BASE          0x0c000000
 #define PLIC_SIZE          0x01000000
 #define PLIC_NDEV          31


### PR DESCRIPTION
Since `clint` has only `msip` (offset 0x0), `mtimecmp` (offset 0x4000) and `mtime` (offset 0xbff8) there is no need to have size bigger than 0xc000