### PR TITLE
Debug/Trace: stop execution when a timing-before trigger matches

### DIFF
--- a/riscv/execute.cc
+++ b/riscv/execute.cc
@@ -346,6 +346,10 @@ void processor_t::step(size_t n)
     catch (triggers::matched_t& t)
     {
       take_trigger_action(t.action, t.address, pc, t.gva);
+      // End this step at the trigger boundary.  In particular, a timing-before
+      // trigger retires no instruction, so continuing would immediately execute
+      // from the debug ROM or trap vector to consume the remaining step count.
+      n = instret;
     }
     catch(trap_debug_mode&)
     {


### PR DESCRIPTION
End the current processor step after taking the trigger action, preventing an extra debug-ROM or trap-handler instruction from executing before the caller observes the matched instruction’s architectural context.