### PR TITLE
rvv: Add checks the src registers have different EEW

### DIFF
--- a/riscv/insns/vcompress_vm.h
+++ b/riscv/insns/vcompress_vm.h
@@ -3,7 +3,7 @@ require(P.any_vector_extensions());
 require(P.VU.vstart->read() == 0);
 require_align(insn.rd(), P.VU.vflmul);
 require_align(insn.rs2(), P.VU.vflmul);
-require(insn.rd() != insn.rs2());
+require(insn.rd() != insn.rs2() && insn.rs1() != insn.rs2());
 require_noover(insn.rd(), P.VU.vflmul, insn.rs1(), 1);
 
 reg_t pos = 0;

--- a/riscv/insns/vrgatherei16_vv.h
+++ b/riscv/insns/vrgatherei16_vv.h
@@ -5,7 +5,7 @@ require_align(insn.rd(), P.VU.vflmul);
 require_align(insn.rs2(), P.VU.vflmul);
 require_align(insn.rs1(), vemul);
 require_noover(insn.rd(), P.VU.vflmul, insn.rs1(), vemul);
-require(insn.rd() != insn.rs2());
+require(insn.rd() != insn.rs2() && insn.rs1() != insn.rs2());
 require_vm;
 
 VI_LOOP_BASE


### PR DESCRIPTION
According to the specification[1], chapter "11.5.2 Vector Operands":
> A vector register cannot be used to provide source operands
> with more than one EEW for a single instruction. A mask
> register source is considered to have EEW=1 for this constraint.

vrgatherei16.vv vd, vs2, vs1 -- vs2_eew=sew, vs1_eew=16
vcompress.vm    vd, vs2, vs1 -- vs2_eew=sew, vs1_eew=1

[1]: The RISC-V Instruction Set Manual v202660416