### PR TITLE
Fix linker warnings about duplicate libraries

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -239,13 +239,12 @@ $(2)_reverse_deps   := $$(call reverse_list,$$($(2)_subproject_deps))
 $(2)_lib_libs       := $$($(2)_reverse_deps)
 $(2)_lib_libnames   := $$(patsubst %, lib%.a, $$($(2)_lib_libs))
 $(2)_lib_libarg     := $$(patsubst %, -l%, $$($(2)_lib_libs))
-$(2)_lib_libnames_shared	:= $$(if $$($(2)_install_shared_lib),lib$(1).so,)
 
 lib$(1).a : $$($(2)_objs) $$($(2)_c_objs)
 	rm -f $$@
 	$(AR) rcs $$@ $$^
-lib$(1).so : $$($(2)_objs) $$($(2)_c_objs) $$($(2)_lib_libnames_shared) $$($(2)_lib_libnames)
-	$(LINK) -shared -o $$@ $(if $(filter Darwin,$(shell uname -s)),-install_name $(install_libs_dir)/$$@) $$^ $$($(2)_lib_libnames) $(LIBS)
+lib$(1).so : $$($(2)_objs) $$($(2)_c_objs) $$($(2)_lib_libnames)
+	$(LINK) -shared -o $$@ $(if $(filter Darwin,$(shell uname -s)),-install_name $(install_libs_dir)/$$@) $$^ $(LIBS)
 
 $(2)_junk += lib$(1).a
 $(2)_junk += $$(if $$($(2)_install_shared_lib),lib$(1).so,)

--- a/configure
+++ b/configure
@@ -5456,6 +5456,57 @@ fi
 
 
 #-------------------------------------------------------------------------
+# Checks for libraries
+#-------------------------------------------------------------------------
+
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for pthread_create in -lpthread" >&5
+printf %s "checking for pthread_create in -lpthread... " >&6; }
+if test ${ac_cv_lib_pthread_pthread_create+y}
+then :
+  printf %s "(cached) " >&6
+else case e in #(
+  e) ac_check_lib_save_LIBS=$LIBS
+LIBS="-lpthread  $LIBS"
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+namespace conftest {
+  extern "C" int pthread_create ();
+}
+int
+main (void)
+{
+return conftest::pthread_create ();
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_cxx_try_link "$LINENO"
+then :
+  ac_cv_lib_pthread_pthread_create=yes
+else case e in #(
+  e) ac_cv_lib_pthread_pthread_create=no ;;
+esac
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.beam \
+    conftest$ac_exeext conftest.$ac_ext
+LIBS=$ac_check_lib_save_LIBS ;;
+esac
+fi
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_pthread_pthread_create" >&5
+printf "%s\n" "$ac_cv_lib_pthread_pthread_create" >&6; }
+if test "x$ac_cv_lib_pthread_pthread_create" = xyes
+then :
+  printf "%s\n" "#define HAVE_LIBPTHREAD 1" >>confdefs.h
+
+  LIBS="-lpthread $LIBS"
+
+else case e in #(
+  e) as_fn_error $? "libpthread is required" "$LINENO" 5 ;;
+esac
+fi
+
+#-------------------------------------------------------------------------
 # MCPPBS subproject list
 #-------------------------------------------------------------------------
 # Order list so that subprojects only depend on those listed earlier.
@@ -5516,54 +5567,6 @@ printf "%s\n" "$as_me: configuring default subproject : fesvr" >&6;}
       subprojects_enabled="$subprojects_enabled fesvr"
 
 printf "%s\n" "#define FESVR_ENABLED /**/" >>confdefs.h
-
-      { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for pthread_create in -lpthread" >&5
-printf %s "checking for pthread_create in -lpthread... " >&6; }
-if test ${ac_cv_lib_pthread_pthread_create+y}
-then :
-  printf %s "(cached) " >&6
-else case e in #(
-  e) ac_check_lib_save_LIBS=$LIBS
-LIBS="-lpthread  $LIBS"
-cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-namespace conftest {
-  extern "C" int pthread_create ();
-}
-int
-main (void)
-{
-return conftest::pthread_create ();
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_cxx_try_link "$LINENO"
-then :
-  ac_cv_lib_pthread_pthread_create=yes
-else case e in #(
-  e) ac_cv_lib_pthread_pthread_create=no ;;
-esac
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam \
-    conftest$ac_exeext conftest.$ac_ext
-LIBS=$ac_check_lib_save_LIBS ;;
-esac
-fi
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_pthread_pthread_create" >&5
-printf "%s\n" "$ac_cv_lib_pthread_pthread_create" >&6; }
-if test "x$ac_cv_lib_pthread_pthread_create" = xyes
-then :
-  printf "%s\n" "#define HAVE_LIBPTHREAD 1" >>confdefs.h
-
-  LIBS="-lpthread $LIBS"
-
-else case e in #(
-  e) as_fn_error $? "libpthread is required" "$LINENO" 5 ;;
-esac
-fi
-
 
 ac_fn_cxx_check_member "$LINENO" "struct statx" "stx_ino" "ac_cv_member_struct_statx_stx_ino" "$ac_includes_default"
 if test "x$ac_cv_member_struct_statx_stx_ino" = xyes
@@ -6609,54 +6612,6 @@ printf "%s\n" "#define HAVE_DLOPEN /**/" >>confdefs.h
   HAVE_DLOPEN=yes
 
 
-fi
-
-
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for pthread_create in -lpthread" >&5
-printf %s "checking for pthread_create in -lpthread... " >&6; }
-if test ${ac_cv_lib_pthread_pthread_create+y}
-then :
-  printf %s "(cached) " >&6
-else case e in #(
-  e) ac_check_lib_save_LIBS=$LIBS
-LIBS="-lpthread  $LIBS"
-cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-namespace conftest {
-  extern "C" int pthread_create ();
-}
-int
-main (void)
-{
-return conftest::pthread_create ();
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_cxx_try_link "$LINENO"
-then :
-  ac_cv_lib_pthread_pthread_create=yes
-else case e in #(
-  e) ac_cv_lib_pthread_pthread_create=no ;;
-esac
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam \
-    conftest$ac_exeext conftest.$ac_ext
-LIBS=$ac_check_lib_save_LIBS ;;
-esac
-fi
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_pthread_pthread_create" >&5
-printf "%s\n" "$ac_cv_lib_pthread_pthread_create" >&6; }
-if test "x$ac_cv_lib_pthread_pthread_create" = xyes
-then :
-  printf "%s\n" "#define HAVE_LIBPTHREAD 1" >>confdefs.h
-
-  LIBS="-lpthread $LIBS"
-
-else case e in #(
-  e) as_fn_error $? "libpthread is required" "$LINENO" 5 ;;
-esac
 fi
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -92,6 +92,13 @@ AX_APPEND_LINK_FLAGS([-Wl,--export-dynamic])
 AX_CHECK_COMPILE_FLAG([-relocatable-pch], AC_SUBST([HAVE_CLANG_PCH],[yes]))
 
 #-------------------------------------------------------------------------
+# Checks for libraries
+#-------------------------------------------------------------------------
+
+AC_CHECK_LIB([pthread], [pthread_create], [],
+  [AC_MSG_ERROR([libpthread is required])])
+
+#-------------------------------------------------------------------------
 # MCPPBS subproject list
 #-------------------------------------------------------------------------
 # Order list so that subprojects only depend on those listed earlier.

--- a/fesvr/fesvr.ac
+++ b/fesvr/fesvr.ac
@@ -1,5 +1,3 @@
-AC_CHECK_LIB(pthread, pthread_create, [], [AC_MSG_ERROR([libpthread is required])])
-
 AC_CHECK_MEMBER(struct statx.stx_ino,
   AC_DEFINE_UNQUOTED(HAVE_STATX, 1, [Define to 1 if struct statx exists.]),
   ,

--- a/riscv/riscv.ac
+++ b/riscv/riscv.ac
@@ -19,8 +19,6 @@ AC_SEARCH_LIBS([dlopen], [dl dld], [
   AC_SUBST([HAVE_DLOPEN], [yes])
 ])
 
-AC_CHECK_LIB(pthread, pthread_create, [], [AC_MSG_ERROR([libpthread is required])])
-
 AC_ARG_ENABLE([dual-endian], AS_HELP_STRING([--enable-dual-endian], [Enable support for running target in either endianness]))
 AS_IF([test "x$enable_dual_endian" = "xyes"], [
   AC_DEFINE([RISCV_ENABLE_DUAL_ENDIAN],,[Enable support for running target in either endianness])


### PR DESCRIPTION
Stop appending dependency .a files twice when linking shared libraries, and drop the redundant AC_CHECK_LIB(pthread) in riscv.ac so -lpthread is only added once (still checked in fesvr.ac).